### PR TITLE
Fix for random memory read failures on 32-bit linux.

### DIFF
--- a/library/private/Internal.h
+++ b/library/private/Internal.h
@@ -34,6 +34,11 @@ distribution.
 #define _QUOTEME(x) #x
 #define QUOT(x) _QUOTEME(x)
 
+#ifdef LINUX_BUILD
+    #define __USE_FILE_OFFSET64
+    #define _FILE_OFFSET_BITS 64
+#endif
+
 // one file for globals
 #include "dfhack/DFGlobal.h"
 
@@ -60,8 +65,6 @@ using namespace std;
     #include <sys/types.h>
     #include <sys/ptrace.h>
     #include <dirent.h>
-    #define __USE_FILE_OFFSET64
-    #define _FILE_OFFSET_BITS 64
     #include <unistd.h>
     #include <sys/stat.h>
     #include <fcntl.h>


### PR DESCRIPTION
The reason for random read failures is that the 64-bit offset defines are only effective if they are placed before any system headers, especially sys/types.h; in the old version they didn't work, and pread was expecting a signed 32-bit offset.

The reproducibility of this issue obviously depends on the way the kernel allocates address space for relevant parts of DF's heap.
