### PR TITLE
incremental: deal with shifting Linux maps (Issue #88)

### DIFF
--- a/tools/supported/SegmentedFinder.h
+++ b/tools/supported/SegmentedFinder.h
@@ -27,7 +27,13 @@ class SegmentFinder
                 free(mr_.buffer);
                 valid = false;
                 mr.valid = false; // mark the range passed in as bad
-                cout << "Range 0x" << hex << mr_.start << " - 0x" <<  mr_.end << dec << " not readable." << endl;
+                cout << "Range 0x" << hex << mr_.start << " - 0x" <<  mr_.end;
+
+                if (strlen(mr_.name) != 0)
+                    cout << " (" << mr_.name << ")";
+
+                cout << dec << " not readable." << endl;
+                cout << "Skipping this range on future scans." << endl;
             }
         }
     }


### PR DESCRIPTION
Issue #88: sometimes the end of the heap of the DF process will change
between detaching and re-attaching to the process.  To deal with this,
/proc/PID/maps is re-read every time the process is attached.

Also, made semgent finder give a little more info if there's an error
doing a memory read.
