### PR TITLE
Deal with third flag group in creatures

### DIFF
--- a/library/include/dfhack-c/modules/Creatures_C.h
+++ b/library/include/dfhack-c/modules/Creatures_C.h
@@ -54,6 +54,7 @@ DFHACK_EXPORT int32_t Creatures_GetDwarfCivId(DFHackObject* cPtr);
 DFHACK_EXPORT int Creatures_WriteLabors(DFHackObject* cPtr, const uint32_t index, uint8_t labors[NUM_CREATURE_LABORS]);
 DFHACK_EXPORT int Creatures_WriteHappiness(DFHackObject* cPtr, const uint32_t index, const uint32_t happiness_value);
 DFHACK_EXPORT int Creatures_WriteFlags(DFHackObject* cPtr, const uint32_t index, const uint32_t flags1, const uint32_t flags2);
+DFHACK_EXPORT int Creatures_WriteFlags3(DFHackObject* cPtr, const uint32_t index, const uint32_t flags1, const uint32_t flags2, const uint32_t flags3);
 DFHACK_EXPORT int Creatures_WriteSkills(DFHackObject* cPtr, const uint32_t index, const t_soul* soul);
 DFHACK_EXPORT int Creatures_WriteAttributes(DFHackObject* cPtr, const uint32_t index, const t_creature* creature);
 DFHACK_EXPORT int Creatures_WriteSex(DFHackObject* cPtr, const uint32_t index, const uint8_t sex);

--- a/library/include/dfhack/modules/Creatures.h
+++ b/library/include/dfhack/modules/Creatures.h
@@ -111,6 +111,40 @@ namespace DFHack
         } bits;
     };
 
+    union t_creaturflags3
+    {
+        uint32_t whole; /*!< Access all flags as a single 32bit number. */
+        struct
+        {
+            unsigned int unk0 : 1; /*!< Is 1 for new and dead creatures,
+                                     periodicaly set to 0 for non-dead creatures.
+                                     */
+            unsigned int unk1 : 1; /*!< Is 1 for new creatures, periodically set
+                                     to 0 for non-dead creatures. */
+            unsigned int unk2 : 1; /*!< Is set to 1 every tick for non-dead
+                                     creatures. */
+            unsigned int unk3 : 1; /*!< Is periodically set to 0 for non-dead
+                                     creatures. */
+            unsigned int announce_titan : 1; /*!< Announces creature like an
+                                               FB or titan. */
+            unsigned int unk5 : 1; 
+            unsigned int unk6 : 1; 
+            unsigned int unk7 : 1; 
+            unsigned int unk8 : 1; /*!< Is set to 1 every tick for non-dead
+                                     creatures. */
+            unsigned int unk9 : 1; /*!< Is set to 0 every tick for non-dead
+                                     creatures. */
+            unsigned int scuttle : 1; /*!< Scuttle creature: causes creature
+                                        to be killed, leaving a behind corpse
+                                        and generating negative thoughts like
+                                        a real kill. */
+            unsigned int unk11 : 1;
+            unsigned int ghostly : 1; /*!< Creature is a ghost. */
+
+            unsigned int unk13_31 : 19;
+        } bits;
+    };
+
     // FIXME: WTF IS THIS SHIT?
     /*
     struct t_labor
@@ -261,6 +295,7 @@ namespace DFHack
 
         t_creaturflags1 flags1;
         t_creaturflags2 flags2;
+        t_creaturflags3 flags3;
 
         t_name name;
 
@@ -335,6 +370,7 @@ namespace DFHack
         bool WriteLabors(const uint32_t index, uint8_t labors[NUM_CREATURE_LABORS]);
         bool WriteHappiness(const uint32_t index, const uint32_t happinessValue);
         bool WriteFlags(const uint32_t index, const uint32_t flags1, const uint32_t flags2);
+        bool WriteFlags(const uint32_t index, const uint32_t flags1, const uint32_t flags2, uint32_t flags3);
         bool WriteSkills(const uint32_t index, const t_soul &soul);
         bool WriteAttributes(const uint32_t index, const t_creature &creature);
         bool WriteSex(const uint32_t index, const uint8_t sex);

--- a/library/modules/Creatures.cpp
+++ b/library/modules/Creatures.cpp
@@ -68,6 +68,7 @@ struct Creatures::Private
         int32_t civ_offset;
         uint32_t flags1_offset;
         uint32_t flags2_offset;
+        uint32_t flags3_offset;
         uint32_t name_offset;
         uint32_t sex_offset;
         uint32_t caste_offset;
@@ -156,6 +157,7 @@ Creatures::Creatures(DFContextShared* _d)
         creatures.pos_offset = OG_creature->getOffset ("position");
         creatures.flags1_offset = OG_creature->getOffset ("flags1");
         creatures.flags2_offset = OG_creature->getOffset ("flags2");
+        creatures.flags3_offset = OG_creature->getOffset ("flags3");
         creatures.sex_offset = OG_creature->getOffset ("sex");
         creatures.caste_offset = OG_creature->getOffset ("caste");
         creatures.id_offset = OG_creature->getOffset ("id");
@@ -284,6 +286,7 @@ bool Creatures::ReadCreature (const int32_t index, t_creature & furball)
         p->readWord (addr_cr + offs.caste_offset, furball.caste);
         p->readDWord (addr_cr + offs.flags1_offset, furball.flags1.whole);
         p->readDWord (addr_cr + offs.flags2_offset, furball.flags2.whole);
+        p->readDWord (addr_cr + offs.flags3_offset, furball.flags3.whole);
         // custom profession
         p->readSTLString(addr_cr + offs.custom_profession_offset, furball.custom_profession, sizeof(furball.custom_profession));
         // profession
@@ -488,6 +491,21 @@ bool Creatures::WriteFlags(const uint32_t index,
     Process * p = d->owner;
     p->writeDWord (temp + d->creatures.flags1_offset, flags1);
     p->writeDWord (temp + d->creatures.flags2_offset, flags2);
+    return true;
+}
+
+bool Creatures::WriteFlags(const uint32_t index,
+                           const uint32_t flags1,
+                           const uint32_t flags2,
+                           const uint32_t flags3)
+{
+    if(!d->Started || !d->Ft_basic) return false;
+
+    uint32_t temp = d->p_cre->at (index);
+    Process * p = d->owner;
+    p->writeDWord (temp + d->creatures.flags1_offset, flags1);
+    p->writeDWord (temp + d->creatures.flags2_offset, flags2);
+    p->writeDWord (temp + d->creatures.flags3_offset, flags3);
     return true;
 }
 

--- a/library/modules/Creatures_C.cpp
+++ b/library/modules/Creatures_C.cpp
@@ -212,6 +212,17 @@ int Creatures_WriteFlags(DFHackObject* cPtr, const uint32_t index, const uint32_
 	return -1;
 }
 
+int Creatures_WriteFlags3(DFHackObject* cPtr, const uint32_t index, const uint32_t flags1, const uint32_t flags2, const uint32_t flags3)
+{
+	if(cPtr != NULL)
+	{
+		return ((DFHack::Creatures*)cPtr)->WriteFlags(index, flags1, flags2,
+                                                      flags3);
+	}
+	
+	return -1;
+}
+
 int Creatures_WriteSkills(DFHackObject* cPtr, const uint32_t index, const t_soul* soul)
 {
 	if(cPtr != NULL && soul != NULL)


### PR DESCRIPTION
Added support for reading and writing the third creature flag group,
t_creaturflags3 (the offest already exists in Memory.xml).  So far I've
only figured out three of the flags (out of an apparent 13):

1) announce_titan, which causes the creature to be announced as if
   it was a titan or FB which had just arrived.

2) scuttle, which causes the creature to be die like it had been
   killed in the game.  That is, it leaves behind a corpse, and
   will generate unhappy thoughts in dwarves if approriate.

3) ghostly, for creatures which are the ghosts of dead dwarves.

I updated creaturemanager to use scuttle for --kill, and added the
action --erase to kill in the old way which doesn't leave a corpse or
creatre unhappy thoughts.
