### PR TITLE
Start of material flags code

### DIFF
--- a/library/include/dfhack/modules/Materials.h
+++ b/library/include/dfhack/modules/Materials.h
@@ -182,6 +182,8 @@ namespace DFHack
         uint16_t wall_tile;    // Tile when a natural wall
         uint16_t boulder_tile; // Tile when a dug-out stone;
 
+        std::vector<uint32_t> flags;
+
     public:
         t_matgloss();
     };


### PR DESCRIPTION
The matgloss class now contains a copy of the material's flag array, and
isGem() uses that; IS_GEM is the only flag supported so far.  There
doesn't appear to be any IS_ORE flag, so isOre() must look at the smelt
and strand chance vectors.

Inorganic materials currently use 40 bytes worth of flags, but Quietust
only document 10 bytes worth.
