### PR TITLE
Amended Readme

### DIFF
--- a/Readme.html
+++ b/Readme.html
@@ -554,9 +554,8 @@ access DF memory and allow for easier development of new tools.</p>
 </div>
 <div class="section" id="getting-dfhack">
 <h1><a class="toc-backref" href="#id3">Getting DFHack</a></h1>
-<p>The project is currently hosted on <a class="reference external" href="http://www.github.com/">github</a>, for both source and
-binaries at  <a class="reference external" href="http://github.com/peterix/dfhack">http://github.com/peterix/dfhack</a></p>
-<p>Releases can be downloaded from here: <a class="reference external" href="https://github.com/peterix/dfhack/downloads">https://github.com/peterix/dfhack/downloads</a></p>
+<p>The project is currently hosted on <a class="reference external" href="http://www.github.com/">github</a> at <a class="reference external" href="http://github.com/peterix/dfhack">http://github.com/peterix/dfhack</a></p>
+<p>Releases can be downloaded from here: <a class="reference external" href="http://dethware.org/dfhack/download">http://dethware.org/dfhack/download</a></p>
 <p>All new releases are announced in the bay12 thread: <a class="reference external" href="http://tinyurl.com/dfhack-ng">http://tinyurl.com/dfhack-ng</a></p>
 </div>
 <div class="section" id="compatibility">

--- a/Readme.rst
+++ b/Readme.rst
@@ -16,12 +16,12 @@ access DF memory and allow for easier development of new tools.
 ==============
 Getting DFHack
 ==============
-The project is currently hosted on github_, for both source and
-binaries at  http://github.com/peterix/dfhack
+The project is currently hosted on github_
+at http://github.com/peterix/dfhack
 
 .. _github: http://www.github.com/
 
-Releases can be downloaded from here: https://github.com/peterix/dfhack/downloads
+Releases can be downloaded from here: http://dethware.org/dfhack/download
 
 All new releases are announced in the bay12 thread: http://tinyurl.com/dfhack-ng
 


### PR DESCRIPTION
GitHub's deprecating their Downloads feature, and the latest dfhack binaries are located elsewhere. I've updated the Readme to reflect this so that new users don't need to go to the thread to get the latest version.
