### PR TITLE
Use DYLD_LIBRARY_PATH on OS X instead of LD_LIBRARY_PATH

### DIFF
--- a/package/darwin/dfhack-run
+++ b/package/darwin/dfhack-run
@@ -3,6 +3,6 @@
 DF_DIR=$(dirname "$0")
 cd "${DF_DIR}"
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"./stonesense/deplibs":"./hack"
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:"./stonesense/deplibs":"./hack"
 
 exec hack/dfhack-run "$@"


### PR DESCRIPTION
Fixes DFHack/dfhack#235
