### PR TITLE
Command-prompt improvements

### DIFF
--- a/plugins/command-prompt.cpp
+++ b/plugins/command-prompt.cpp
@@ -62,7 +62,7 @@ public:
         std::string part;
         while (std::getline(ss, part))
         {
-            responses.push_back(std::make_pair(v, part));
+            responses.push_back(std::make_pair(v, part + '\n'));
         }
     }
 protected:


### PR DESCRIPTION
- Prevented command prompt output from stacking (requiring multiple `esc`'s to get back to the game)
- Made newline characters in command output create line breaks ([before](http://i.imgur.com/iOwDUf0.png)/[after](http://i.imgur.com/nARq6Ra.png))
