### PR TITLE
Dfhack.init example fixes

### DIFF
--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -60,9 +60,7 @@ keybinding add Ctrl-Shift-Z@dwarfmode/Default "stocks show"
 keybinding add Ctrl-Shift-I@dwarfmode/Default dfstatus
 
 # Workflow
-keybinding add Ctrl-W@dwarfmode/QueryBuilding/Some/Workshop/Job gui/workflow
 keybinding add Alt-W@dwarfmode/QueryBuilding/Some/Workshop/Job gui/workflow
-keybinding add Ctrl-I "gui/workflow status"
 keybinding add Alt-W@overallstatus "gui/workflow status"
 
 # q->stockpile; p - copy & paste stockpiles


### PR DESCRIPTION
The keybindings for script `gui/rename` were active in invalid contexts (all of them), including the default view with no cursor.  I added constrained keybindings for `LookAround` and `ViewUnits` (`k`,`v`).  

There were two pairs of keybindings for Workflow.  I moved these to adjacent lines and further constrained one.  I think that one pair should be deleted, but didn't want to unilaterally decide which pair to keep.  The `Alt-W` bindings are probably better-known. 
