### PR TITLE
Repairing the log-region script

### DIFF
--- a/scripts/log-region.lua
+++ b/scripts/log-region.lua
@@ -21,7 +21,7 @@ else
                 local site = df.world_site.find(df.global.ui.site_id)
                 local fort_ent = df.global.ui.main.fortress_entity
                 local civ_ent = df.historical_entity.find(df.global.ui.civ_id)
-                local worldname = df.global.world.world_data
+                local world = df.global.world
                 -- site positions
                 -- site  .pos.x  .pos.y
                 -- site  .rgn_min_x  .rgn_min_y  .rgn_max_x  .rgn_max.y
@@ -30,12 +30,12 @@ else
                 --fort_ent.name
                 --civ_ent.name
                 
-                write_gamelog('Loaded '..df.global.world.cur_savegame.save_dir..', '..fullname(worldname)..
+                write_gamelog('Loaded '..world.cur_savegame.save_dir..', '..fullname(world.world_data)..
                   ' at coordinates ('..site.pos.x..','..site.pos.y..')'..NEWLINE..
                   'Loaded the fortress '..fullname(site)..
                   (fort_ent and ', colonized by the group '..fullname(fort_ent) or '')..
                   (civ_ent and ' of the civilization '..fullname(civ_ent) or '')..'.'..NEWLINE)
             end
-    end
+        end
     end
 end


### PR DESCRIPTION
A typo was causing the gamelog to always omit the fortress group's untranslated name, while failing to fully prevent the error message caused by unloading the fortress.
