### PR TITLE
Stockflow Repairs

### DIFF
--- a/plugins/lua/stockflow.lua
+++ b/plugins/lua/stockflow.lua
@@ -978,10 +978,10 @@ end
 function findItemsAtTile(x, y, z)
     -- There should be a faster and easier way to do this...
     local found = {}
-    for _, item in ipairs(df.global.world.items.all) do
-        -- local ix, iy, iz = dfhack.items.getPosition(item)
-        if item.pos.x == x and item.pos.y == y and
-            item.pos.z == z and item.flags.on_ground then
+    local items = dfhack.maps.getTileBlock(x, y, z).items
+    for _, item_id in ipairs(items) do
+        local item = df.item.find(item_id)
+        if item.pos.x == x and item.pos.y == y and item.flags.on_ground then
             found[#found+1] = item
         end
     end


### PR DESCRIPTION
Removes another reference to an obsolete item type, and speeds up stockpile checks.
