### PR TITLE
update exportlegends for DF40.x

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 DFHack future
 
+    Misc improvements:
+        updated exportlegends.lua to work with new maps, dfhack 40.11 r1+
+
+
 DFHack 0.40.11-r1
 
     Internals:

--- a/Readme.rst
+++ b/Readme.rst
@@ -1424,7 +1424,7 @@ Exports data from legends mode; allowing a set-and-forget export of large worlds
 
 Options:
 
-:maps: Exports all fifteen detailed maps
+:maps: Exports all seventeen detailed maps
 :all: first exports the world/gen info, then the XML, then all detailed maps
 
 

--- a/scripts/exportlegends.lua
+++ b/scripts/exportlegends.lua
@@ -1,18 +1,14 @@
 -- Export everything from legends mode
--- Based on the script 'exportmaps'
--- Suggested keybinding:  keybinding add Shift-A@legends "exportlegends all"
+-- use "exportlegends maps" for detailed maps, or "exportlegends all" to also export legends
 
 gui = require 'gui'
 
 local args = {...}
 local vs = dfhack.gui.getCurViewscreen()
-local i = 0
-
-if args[1] then print('   A script which exports data from legends mode.  Valid arguments are "maps" (detailed maps) or "all" (detailed maps, world/gen info, XML).') end
-
+local i = 1
 
 local MAPS = {
-    [0] = "Standard biome+site map",
+    "Standard biome+site map",
     "Elevations including lake and ocean floors",
     "Elevations respecting water level",
     "Biome",
@@ -27,12 +23,14 @@ local MAPS = {
     "Salinity",
     "Structures/fields/roads/etc.",
     "Trade",
+    "Nobility and Holdings",
+    "Diplomacy",
 }
 function wait_for_legends_vs()
     vs = dfhack.gui.getCurViewscreen()
-    if i < 15 then
+    if i <= #MAPS then
         if df.viewscreen_legendsst:is_instance(vs) then
-            gui.simulateInput(vs, 'LEGENDS_EXPORT_DETAILED_MAP') -- "d" on screen some number internally 
+            gui.simulateInput(vs, 'LEGENDS_EXPORT_DETAILED_MAP')
             dfhack.timeout(10,'frames',wait_for_export_maps_vs)
         else
             dfhack.timeout(10,'frames',wait_for_legends_vs)
@@ -42,10 +40,10 @@ end
 function wait_for_export_maps_vs()
     vs = dfhack.gui.getCurViewscreen()
     if df.viewscreen_export_graphical_mapst:is_instance(vs) then
-        vs.anon_13 = i -- anon_13 appears to be the selection cursor for this viewscreen
-        print('Exporting:  '..MAPS[i])
+        vs.sel_idx = i
+        print('    Exporting:  '..MAPS[i]..' map')
         i = i + 1
-        gui.simulateInput(vs, 'SELECT') -- 1 internally, enter on screen
+        gui.simulateInput(vs, 'SELECT')
         dfhack.timeout(10,'frames',wait_for_legends_vs)
     else
         dfhack.timeout(10,'frames',wait_for_export_maps_vs)
@@ -55,14 +53,14 @@ end
 if df.viewscreen_legendsst:is_instance( vs ) then -- dfhack.gui.getCurFocus() == "legends" 
     if args[1] == "all" then 
         gui.simulateInput(vs, df.interface_key.LEGENDS_EXPORT_MAP)
-        print('Exporting:  world map/gen info')
+        print('    Exporting:  world map/gen info')
         gui.simulateInput(vs, df.interface_key.LEGENDS_EXPORT_XML)
-        print('Exporting:  legends xml')
+        print('    Exporting:  legends xml')
         wait_for_legends_vs()
     elseif args[1] == "maps" then wait_for_legends_vs()
     end
 elseif df.viewscreen_export_graphical_mapst:is_instance(vs) then
-    if args[1] == "maps" or "all" then wait_for_export_maps_vs() end
+    if args[1] == "maps" or args[1] == "all" then wait_for_export_maps_vs() end
 else
     dfhack.printerr('Not in legends view')
 end


### PR DESCRIPTION
Several fixes to the code following feedback from Lethosor.  Nicer structure in a few places, cleaner output, less dependant on a single version of DF or dfhack, easier to update in future.  Exports the new detailed maps.  

I'd love it to also export site maps, but I've got no idea how to do that.  

Fixes #286.
