### PR TITLE
Updating `dfhack.init-example` to enable UI plugins and add some keybindings

### DIFF
--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -17,6 +17,9 @@ keybinding add Ctrl-C spotclean
 # destroy items designated for dump in the selected tile
 keybinding add Ctrl-Shift-K autodump-destroy-here
 
+# set the zone or cage under the cursor as the default
+keybinding add Alt-Shift-I@dwarfmode/Zones "zone set"
+
 # with an item selected:
 
 # destroy the selected item
@@ -33,6 +36,13 @@ keybinding add Ctrl-Shift-T "gui/rename unit-profession"
 
 # a dfhack prompt in df. Sublime text like.
 keybinding add Ctrl-Shift-P command-prompt
+
+# show information collected by dwarfmonitor
+keybinding add Alt-M@dwarfmode/Default "dwarfmonitor prefs"
+keybinding add Ctrl-F@dwarfmode/Default "dwarfmonitor stats"
+
+# export a Dwarf's preferences screen in BBCode to post ot a forum
+keybinding add Ctrl-Shift-F@dwarfmode forum-dwarves
 
 ##############################
 # Generic adv mode bindings  #
@@ -170,7 +180,7 @@ enable search
 enable automaterial
 
 # Other interface improvement tools
-#enable dwarfmonitor mousequery autotrade buildingplan resume zone
+enable dwarfmonitor mousequery autotrade buildingplan resume zone
 
 # allow the fortress bookkeeper to queue jobs through the manager
 stockflow enable


### PR DESCRIPTION
The UI plugins are one of the major reasons for most players to use dfhack, so they should be enabled by default.   The other additions seem to be semi-standard keybindings for those functions - see eg http://redd.it/2fuaaf

I'd also consider renaming the file `example-dfhack.init`, which is easier for many users to rename (it's also the same filetype as `dfhack.init`).  
