### PR TITLE
Change search key from 's' to 'q' on unit/job lists

### DIFF
--- a/plugins/search.cpp
+++ b/plugins/search.cpp
@@ -998,6 +998,11 @@ private:
         return true;
     }
 
+    char get_search_select_key()
+    {
+        return 'q';
+    }
+
     vector<df::job*> *get_secondary_list() 
     {
         return &viewscreen->jobs[viewscreen->page];
@@ -1566,6 +1571,11 @@ private:
             desc += "Inactive";
 
         return desc;
+    }
+
+    char get_search_select_key()
+    {
+        return 'q';
     }
 
     vector<df::unit*> *get_secondary_list() 


### PR DESCRIPTION
Avoids a conflict with `BUILDJOB_SUSPEND` (added to these screens in 0.40.12)
