### PR TITLE
No longer prints -e when DF finishes.

### DIFF
--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -72,7 +72,7 @@ esac
 
 # Restore previous terminal settings
 stty "$old_tty_settings"
-echo -e "\n"
+echo
 
 if [ -n "$DF_POST_CMD" ]; then
     eval $DF_POST_CMD


### PR DESCRIPTION
That echo option is a bash-specific extension, unavailable under other shells.
Fortunately, a bare echo with no arguments prints the single newline required here.
