### PR TITLE
init stocks and autochop

### DIFF
--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -183,7 +183,7 @@ enable search
 enable automaterial
 
 # Other interface improvement tools
-enable dwarfmonitor mousequery automelt autotrade buildingplan resume zone
+enable dwarfmonitor mousequery automelt autotrade buildingplan resume zone stocks autochop
 
 # allow the fortress bookkeeper to queue jobs through the manager
 stockflow enable


### PR DESCRIPTION
The line enabling all interface tools missed these ones.  Neither has any mechanical effect by default - just adding a UI element to enable - so it's safe to include in the init.
