### PR TITLE
Removing duplicate world and map loading events.

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -61,6 +61,7 @@ using namespace DFHack;
 #include "df/world_data.h"
 #include "df/interfacest.h"
 #include "df/viewscreen_dwarfmodest.h"
+#include "df/viewscreen_game_cleanerst.h"
 #include "df/viewscreen_loadgamest.h"
 #include "df/viewscreen_savegamest.h"
 #include <df/graphic.h>
@@ -1280,6 +1281,7 @@ void Core::doUpdate(color_ostream &out, bool first_update)
     }
 
     bool is_load_save =
+        strict_virtual_cast<df::viewscreen_game_cleanerst>(screen) ||
         strict_virtual_cast<df::viewscreen_loadgamest>(screen) ||
         strict_virtual_cast<df::viewscreen_savegamest>(screen);
 


### PR DESCRIPTION
Saving a game in progress now goes through an extra viewscreen before reaching the condition that had been used to indicate whether the world was still valid, causing the core to emit bogus WORLD_LOADED, MAP_LOADED, MAP_UNLOADED, and WORLD_UNLOADED events.  Adding that viewscreen to the list of loading/saving screens prevents those duplicate events from firing.

Granted, if the game_cleaner viewscreen ever gets hit in play, this fix will cause more bogus events...
