### PR TITLE
Allow console to be disabled by setting an environment variable

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1027,12 +1027,15 @@ bool Core::Init()
 
     cerr << "Initializing Console.\n";
     // init the console.
-    bool is_text_mode = false;
-    if(init && init->display.flag.is_set(init_display_flags::TEXT))
+    bool is_text_mode = (init && init->display.flag.is_set(init_display_flags::TEXT));
+    if (is_text_mode || getenv("DFHACK_DISABLE_CONSOLE"))
     {
-        is_text_mode = true;
         con.init(true);
         cerr << "Console is not available. Use dfhack-run to send commands.\n";
+        if (!is_text_mode)
+        {
+            cout << "Console disabled.\n";
+        }
     }
     else if(con.init(false))
         cerr << "Console is running.\n";


### PR DESCRIPTION
This allows the console to be disabled when `dfhack` is run in the background on *nix systems, for example, allowing the infinite loop the console enters when the terminal is inaccessible to be avoided. (A better solution would be to detect this situation and shut down the console, but I'm not sure if that's safe or how to implement it.)
