### PR TITLE
Stable sorting for Dwarf Manipulator

### DIFF
--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -363,7 +363,7 @@ bool sortBySkill (const UnitInfo *d1, const UnitInfo *d2)
         else
             return d1->unit->status.labors[sort_labor] < d2->unit->status.labors[sort_labor];
     }
-    return sortByName(d1, d2);
+    return false;
 }
 
 enum display_columns {


### PR DESCRIPTION
I occasionally like to sort dwarves by two or more skills.  With a stable sort, this can be done by applying the less-important sort first, then the more important.  It also allows you to bunch all dwarves with any of a certain set of skills at the top of the screen.
