### PR TITLE
Add <algorithm> includes and use min/max to get them into global scope

### DIFF
--- a/depends/md5/md5wrapper.cpp
+++ b/depends/md5/md5wrapper.cpp
@@ -22,6 +22,7 @@
 
 //----------------------------------------------------------------------
 //basic includes
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <errno.h>

--- a/depends/protobuf/google/protobuf/stubs/common.h
+++ b/depends/protobuf/google/protobuf/stubs/common.h
@@ -47,6 +47,10 @@
 #elif !defined(_MSC_VER)
 #include <stdint.h>
 #endif
+#include <algorithm>
+
+using std::min;
+using std::max;
 
 // make MSVC shut up about some things
 #ifdef _MSC_VER


### PR DESCRIPTION
Same as #370 but for the dependencies protobuf and md5wrapper.

Put this as a separate pull request because I'm not sure if you want patches to your dependencies
