### PR TITLE
Bind `hotkeys` to Alt-F1 as well

### DIFF
--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -4,6 +4,7 @@
 
 # show all current key bindings
 keybinding add Ctrl-F1 hotkeys
+keybinding add Alt-F1 hotkeys
 
 # toggle the display of water level as 1-7 tiles
 keybinding add Ctrl-W twaterlvl


### PR DESCRIPTION
Ctrl-F1 is a system-wide shortcut by default on OS X
