### PR TITLE
Define a static variable to fix debug mode crash.

### DIFF
--- a/library/modules/MapCache.cpp
+++ b/library/modules/MapCache.cpp
@@ -74,6 +74,8 @@ using df::global::world;
 
 extern bool GetLocalFeature(t_feature &feature, df::coord2d rgn_pos, int32_t index);
 
+const unsigned MapExtras::BiomeInfo::MAX_LAYERS;
+
 const BiomeInfo MapCache::biome_stub = {
     df::coord2d(),
     -1, -1, -1, -1,


### PR DESCRIPTION
Fixes #404 - Missing static variable definition crashes DFHack compiled in debug mode
