### PR TITLE
Allow plugins to easily specify required globals

### DIFF
--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -257,7 +257,7 @@ bool Plugin::load(color_ostream &con)
         if (missing_globals.size())
         {
             con.printerr("Plugin %s is missing required globals: %s\n",
-                filename.c_str(), join_strings(", ", missing_globals).c_str());
+                *plug_name, join_strings(", ", missing_globals).c_str());
             ClosePlugin(plug);
             state = PS_BROKEN;
             return false;

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -30,6 +30,7 @@ distribution.
 #include "RemoteServer.h"
 #include "Console.h"
 #include "Types.h"
+#include "VersionInfo.h"
 
 #include "DataDefs.h"
 #include "MiscUtils.h"
@@ -167,6 +168,7 @@ Plugin::Plugin(Core * core, const std::string & filepath, const std::string & _f
     }
     plugin_lib = 0;
     plugin_init = 0;
+    plugin_globals = 0;
     plugin_shutdown = 0;
     plugin_status = 0;
     plugin_onupdate = 0;
@@ -235,12 +237,31 @@ bool Plugin::load(color_ostream &con)
     *plug_self = this;
     RefAutolock lock(access);
     plugin_init = (command_result (*)(color_ostream &, std::vector <PluginCommand> &)) LookupPlugin(plug, "plugin_init");
-    if(!plugin_init)
+    std::vector<std::string>** plugin_globals_ptr = (std::vector<std::string>**) LookupPlugin(plug, "plugin_globals");
+    if(!plugin_init || !plugin_globals_ptr)
     {
-        con.printerr("Plugin %s has no init function.\n", filename.c_str());
+        con.printerr("Plugin %s has no init function or globals vector.\n", filename.c_str());
         ClosePlugin(plug);
         state = PS_BROKEN;
         return false;
+    }
+    plugin_globals = *plugin_globals_ptr;
+    if (plugin_globals->size())
+    {
+        std::vector<std::string> missing_globals;
+        for (auto it = plugin_globals->begin(); it != plugin_globals->end(); ++it)
+        {
+            if (!Core::getInstance().vinfo->getAddress(it->c_str()))
+                missing_globals.push_back(*it);
+        }
+        if (missing_globals.size())
+        {
+            con.printerr("Plugin %s is missing required globals: %s\n",
+                filename.c_str(), join_strings(", ", missing_globals).c_str());
+            ClosePlugin(plug);
+            state = PS_BROKEN;
+            return false;
+        }
     }
     plugin_status = (command_result (*)(color_ostream &, std::string &)) LookupPlugin(plug, "plugin_status");
     plugin_onupdate = (command_result (*)(color_ostream &)) LookupPlugin(plug, "plugin_onupdate");

--- a/library/include/PluginManager.h
+++ b/library/include/PluginManager.h
@@ -205,6 +205,7 @@ namespace DFHack
         void reset_lua();
 
         bool *plugin_is_enabled;
+        std::vector<std::string>* plugin_globals;
         command_result (*plugin_init)(color_ostream &, std::vector <PluginCommand> &);
         command_result (*plugin_status)(color_ostream &, std::string &);
         command_result (*plugin_shutdown)(color_ostream &);
@@ -264,7 +265,9 @@ namespace DFHack
 #define DFHACK_PLUGIN(plugin_name) \
     DFhackDataExport const char * version = DFHACK_VERSION;\
     DFhackDataExport const char * name = plugin_name;\
-    DFhackDataExport Plugin *plugin_self = NULL;
+    DFhackDataExport Plugin *plugin_self = NULL;\
+    std::vector<std::string> _plugin_globals;\
+    DFhackDataExport std::vector<std::string>* plugin_globals = &_plugin_globals;
 
 #define DFHACK_PLUGIN_IS_ENABLED(varname) \
     DFhackDataExport bool plugin_is_enabled = false; \
@@ -281,3 +284,8 @@ namespace DFHack
 #define DFHACK_LUA_FUNCTION(name) { #name, df::wrap_function(name,true) }
 #define DFHACK_LUA_EVENT(name) { #name, &name##_event }
 #define DFHACK_LUA_END { NULL, NULL }
+
+#define REQUIRE_GLOBAL(global_name) \
+    using df::global::global_name; \
+    static int VARIABLE_IS_NOT_USED CONCAT_TOKENS(required_globals_, __LINE__) = \
+        (plugin_globals->push_back(#global_name), 0);

--- a/library/include/PluginManager.h
+++ b/library/include/PluginManager.h
@@ -27,6 +27,7 @@ distribution.
 #include "Export.h"
 #include "Hooks.h"
 #include "ColorText.h"
+#include "MiscUtils.h"
 #include <map>
 #include <string>
 #include <vector>

--- a/plugins/3dveins.cpp
+++ b/plugins/3dveins.cpp
@@ -41,12 +41,11 @@ using namespace DFHack;
 using namespace MapExtras;
 using namespace DFHack::Random;
 
-using df::global::world;
-using df::global::gametype;
+DFHACK_PLUGIN("3dveins");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(gametype);
 
 command_result cmd_3dveins(color_ostream &out, std::vector <std::string> & parameters);
-
-DFHACK_PLUGIN("3dveins");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/add-spatter.cpp
+++ b/plugins/add-spatter.cpp
@@ -41,14 +41,13 @@ using std::stack;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::gps;
-using df::global::world;
-using df::global::ui;
-
-typedef df::reaction_product_item_improvementst improvement_product;
-
 DFHACK_PLUGIN("add-spatter");
 DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+
+typedef df::reaction_product_item_improvementst improvement_product;
 
 struct ReagentSource {
     int idx;

--- a/plugins/advtools.cpp
+++ b/plugins/advtools.cpp
@@ -37,13 +37,14 @@
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::ui_advmode;
-
 using df::nemesis_record;
 using df::historical_figure;
 
 using namespace DFHack::Translation;
+
+DFHACK_PLUGIN("advtools");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui_advmode);
 
 /*********************
  *  PLUGIN INTERFACE *
@@ -53,8 +54,6 @@ static bool bodyswap_hotkey(df::viewscreen *top);
 
 command_result adv_bodyswap (color_ostream &out, std::vector <std::string> & parameters);
 command_result adv_tools (color_ostream &out, std::vector <std::string> & parameters);
-
-DFHACK_PLUGIN("advtools");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -36,12 +36,10 @@ using std::set;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::ui;
-
 #define PLUGIN_VERSION 0.3
 DFHACK_PLUGIN("autochop");
-
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
 
 static bool autochop_enabled = false;
 static int min_logs, max_logs;

--- a/plugins/autodump.cpp
+++ b/plugins/autodump.cpp
@@ -34,10 +34,10 @@ using namespace df::enums;
 using MapExtras::Block;
 using MapExtras::MapCache;
 
-using df::global::world;
 using df::building_stockpilest;
 
 DFHACK_PLUGIN("autodump");
+REQUIRE_GLOBAL(world);
 
 // Stockpile interface START
 static const string PERSISTENCE_KEY = "autodump/stockpiles";

--- a/plugins/autolabor.cpp
+++ b/plugins/autolabor.cpp
@@ -44,8 +44,10 @@ using std::endl;
 using std::vector;
 using namespace DFHack;
 using namespace df::enums;
-using df::global::ui;
-using df::global::world;
+
+DFHACK_PLUGIN("autolabor");
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(world);
 
 #define ARRAY_COUNT(array) (sizeof(array)/sizeof((array)[0]))
 
@@ -90,10 +92,6 @@ enum ConfigFlags {
 // Here go all the command declarations...
 // mostly to allow having the mandatory stuff on top of the file and commands on the bottom
 command_result autolabor (color_ostream &out, std::vector <std::string> & parameters);
-
-// A plugin must be able to return its name and version.
-// The name string provided must correspond to the filename - autolabor.plug.so or autolabor.plug.dll in this case
-DFHACK_PLUGIN("autolabor");
 
 static void generate_labor_to_skill_map();
 

--- a/plugins/automaterial.cpp
+++ b/plugins/automaterial.cpp
@@ -43,11 +43,11 @@ using std::vector;
 
 using namespace DFHack;
 using namespace df::enums;
-using df::global::gps;
-using df::global::ui;
-using df::global::ui_build_selector;
 
 DFHACK_PLUGIN("automaterial");
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
 
 struct MaterialDescriptor
 {

--- a/plugins/automelt.cpp
+++ b/plugins/automelt.cpp
@@ -14,13 +14,13 @@
 #include "modules/World.h"
 #include "df/item_quality.h"
 
-using df::global::world;
-using df::global::cursor;
-using df::global::ui;
 using df::building_stockpilest;
 
 DFHACK_PLUGIN("automelt");
 #define PLUGIN_VERSION 0.3
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
+REQUIRE_GLOBAL(ui);
 
 static const string PERSISTENCE_KEY = "automelt/stockpiles";
 

--- a/plugins/autotrade.cpp
+++ b/plugins/autotrade.cpp
@@ -19,12 +19,12 @@
 #include "df/mandate.h"
 #include "modules/Maps.h"
 
-using df::global::world;
-using df::global::cursor;
-using df::global::ui;
 using df::building_stockpilest;
 
 DFHACK_PLUGIN("autotrade");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
+REQUIRE_GLOBAL(ui);
 
 static const string PERSISTENCE_KEY = "autotrade/stockpiles";
 

--- a/plugins/building-hacks.cpp
+++ b/plugins/building-hacks.cpp
@@ -24,9 +24,10 @@
 
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
 
 DFHACK_PLUGIN("building-hacks");
+REQUIRE_GLOBAL(world);
+
 struct graphic_tile //could do just 31x31 and be done, but it's nicer to have flexible imho.
 {
     int16_t tile; //originally uint8_t but we need to indicate non-animated tiles

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -35,12 +35,11 @@
 #include "df/building.h"
 #include "df/building_doorst.h"
 
-using df::global::ui;
-using df::global::ui_build_selector;
-using df::global::world;
-
 DFHACK_PLUGIN("buildingplan");
 #define PLUGIN_VERSION 0.14
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
+REQUIRE_GLOBAL(world);
 
 struct MaterialDescriptor
 {

--- a/plugins/burrows.cpp
+++ b/plugins/burrows.cpp
@@ -37,17 +37,16 @@ using namespace DFHack;
 using namespace df::enums;
 using namespace dfproto;
 
-using df::global::ui;
-using df::global::world;
-using df::global::gamemode;
+DFHACK_PLUGIN("burrows");
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(gamemode);
 
 /*
  * Initialization.
  */
 
 static command_result burrow(color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("burrows");
 
 static void init_map(color_ostream &out);
 static void deinit_map(color_ostream &out);

--- a/plugins/catsplosion.cpp
+++ b/plugins/catsplosion.cpp
@@ -25,11 +25,11 @@ using namespace std;
 #include <df/unit_genes.h>
 
 using namespace DFHack;
-using df::global::world;
-
-command_result catsplosion (color_ostream &out, std::vector <std::string> & parameters);
 
 DFHACK_PLUGIN("catsplosion");
+REQUIRE_GLOBAL(world);
+
+command_result catsplosion (color_ostream &out, std::vector <std::string> & parameters);
 
 // Mandatory init function. If you have some global state, create it here.
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)

--- a/plugins/changeitem.cpp
+++ b/plugins/changeitem.cpp
@@ -31,9 +31,9 @@ using namespace df::enums;
 
 using MapExtras::Block;
 using MapExtras::MapCache;
-using df::global::world;
 
 DFHACK_PLUGIN("changeitem");
+REQUIRE_GLOBAL(world);
 
 command_result df_changeitem(color_ostream &out, vector <string> & parameters);
 

--- a/plugins/changelayer.cpp
+++ b/plugins/changelayer.cpp
@@ -28,8 +28,9 @@ using namespace std;
 using std::vector;
 using std::string;
 
-using df::global::world;
-using df::global::cursor;
+DFHACK_PLUGIN("changelayer");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
 
 const string changelayer_help = 
     "  Allows to change the material of whole geology layers.\n" 
@@ -82,8 +83,6 @@ const string changelayer_trouble =
 
 
 command_result changelayer (color_ostream &out, std::vector <std::string> & parameters);
-
-DFHACK_PLUGIN("changelayer");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/changevein.cpp
+++ b/plugins/changevein.cpp
@@ -15,8 +15,9 @@ using std::string;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::cursor;
+DFHACK_PLUGIN("changevein");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
 
 command_result df_changevein (color_ostream &out, vector <string> & parameters)
 {
@@ -76,8 +77,6 @@ command_result df_changevein (color_ostream &out, vector <string> & parameters)
 
     return CR_OK;
 }
-
-DFHACK_PLUGIN("changevein");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/cleanconst.cpp
+++ b/plugins/cleanconst.cpp
@@ -16,9 +16,8 @@
 using namespace std;
 using namespace DFHack;
 
-using df::global::world;
-
 DFHACK_PLUGIN("cleanconst");
+REQUIRE_GLOBAL(world);
 
 command_result df_cleanconst(color_ostream &out, vector <string> & parameters)
 {

--- a/plugins/cleaners.cpp
+++ b/plugins/cleaners.cpp
@@ -18,10 +18,9 @@ using std::string;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::cursor;
-
 DFHACK_PLUGIN("cleaners");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
 
 command_result cleanmap (color_ostream &out, bool snow, bool mud, bool item_spatter)
 {

--- a/plugins/cleanowned.cpp
+++ b/plugins/cleanowned.cpp
@@ -23,11 +23,10 @@ using namespace std;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("cleanowned");
+REQUIRE_GLOBAL(world);
 
 command_result df_cleanowned (color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("cleanowned");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/colonies.cpp
+++ b/plugins/colonies.cpp
@@ -14,6 +14,7 @@ using namespace DFHack;
 command_result colonies (color_ostream &out, vector <string> & parameters);
 
 DFHACK_PLUGIN("colonies");
+REQUIRE_GLOBAL(world);  // used by Materials
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/command-prompt.cpp
+++ b/plugins/command-prompt.cpp
@@ -22,9 +22,10 @@
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::ui;
-using df::global::gps;
-using df::global::enabler;
+DFHACK_PLUGIN("command-prompt");
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(enabler);
 
 std::vector<std::string> command_history;
 
@@ -303,7 +304,7 @@ void viewscreen_commandpromptst::feed(std::set<df::interface_key> *events)
         frame = 0;
 
 }
-DFHACK_PLUGIN("command-prompt");
+
 command_result show_prompt(color_ostream &out, std::vector <std::string> & parameters)
 {
     if (Gui::getCurFocus() == "dfhack/commandprompt")

--- a/plugins/createitem.cpp
+++ b/plugins/createitem.cpp
@@ -31,11 +31,10 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::ui;
-using df::global::gametype;
-
 DFHACK_PLUGIN("createitem");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(gametype);
 
 int dest_container = -1, dest_building = -1;
 

--- a/plugins/cursecheck.cpp
+++ b/plugins/cursecheck.cpp
@@ -48,12 +48,12 @@ using std::vector;
 using std::string;
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
-using df::global::cursor;
-
-command_result cursecheck (color_ostream &out, vector <string> & parameters);
 
 DFHACK_PLUGIN("cursecheck");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
+
+command_result cursecheck (color_ostream &out, vector <string> & parameters);
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/deramp.cpp
+++ b/plugins/deramp.cpp
@@ -14,9 +14,8 @@ using std::string;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-
 DFHACK_PLUGIN("deramp");
+REQUIRE_GLOBAL(world);
 
 command_result df_deramp (color_ostream &out, vector <string> & parameters)
 {

--- a/plugins/dfstream.cpp
+++ b/plugins/dfstream.cpp
@@ -18,8 +18,10 @@ using namespace df::enums;
 
 using std::string;
 using std::vector;
-using df::global::gps;
-using df::global::enabler;
+
+DFHACK_PLUGIN("dfstream");
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(enabler);
 
 // The error messages are taken from the clsocket source code
 const char * translate_socket_error(CSimpleSocket::CSocketError err) {
@@ -282,8 +284,6 @@ public:
         delete dec;
     }
 };
-
-DFHACK_PLUGIN("dfstream");
 
 inline df::renderer *& active_renderer() {
     return enabler->renderer;

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -27,6 +27,7 @@ command_result digcircle (color_ostream &out, vector <string> & parameters);
 command_result digtype (color_ostream &out, vector <string> & parameters);
 
 DFHACK_PLUGIN("dig");
+REQUIRE_GLOBAL(world);
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/digFlood.cpp
+++ b/plugins/digFlood.cpp
@@ -21,13 +21,10 @@
 using namespace DFHack;
 using namespace std;
 
-using df::global::world;
-// using df::global::process_jobs;
-// using df::global::process_dig;
+DFHACK_PLUGIN("digFlood");
+REQUIRE_GLOBAL(world);
 
 command_result digFlood (color_ostream &out, std::vector <std::string> & parameters);
-
-DFHACK_PLUGIN("digFlood");
 
 void onDig(color_ostream& out, void* ptr);
 void maybeExplore(color_ostream& out, MapExtras::MapCache& cache, df::coord pt, set<df::coord>& jobLocations);

--- a/plugins/diggingInvaders/diggingInvaders.cpp
+++ b/plugins/diggingInvaders/diggingInvaders.cpp
@@ -77,6 +77,7 @@ void findAndAssignInvasionJob(color_ostream& out, void*);
 
 DFHACK_PLUGIN_IS_ENABLED(enabled);
 DFHACK_PLUGIN("diggingInvaders");
+REQUIRE_GLOBAL(world);
 
 //TODO: when world unloads
 static int32_t lastInvasionJob=-1;
@@ -386,8 +387,8 @@ void findAndAssignInvasionJob(color_ostream& out, void* tickTime) {
         unordered_set<uint16_t> localConnectivity;
 
         //find all locals and invaders
-        for ( size_t a = 0; a < df::global::world->units.all.size(); a++ ) {
-            df::unit* unit = df::global::world->units.all[a];
+        for ( size_t a = 0; a < world->units.all.size(); a++ ) {
+            df::unit* unit = world->units.all[a];
             if ( unit->flags1.bits.dead )
                 continue;
             if ( Units::isCitizen(unit) ) {
@@ -597,7 +598,7 @@ void findAndAssignInvasionJob(color_ostream& out, void* tickTime) {
     lastInvasionDigger = firstInvader->id;
     lastInvasionJob = firstInvader->job.current_job ? firstInvader->job.current_job->id : -1;
     invaderJobs.erase(lastInvasionJob);
-    for ( df::job_list_link* link = &df::global::world->job_list; link != NULL; link = link->next ) {
+    for ( df::job_list_link* link = &world->job_list; link != NULL; link = link->next ) {
         if ( link->item == NULL )
             continue;
         df::job* job = link->item;

--- a/plugins/drybuckets.cpp
+++ b/plugins/drybuckets.cpp
@@ -15,9 +15,8 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-
 DFHACK_PLUGIN("drybuckets");
+REQUIRE_GLOBAL(world);
 
 command_result df_drybuckets (color_ostream &out, vector <string> & parameters)
 {

--- a/plugins/dwarfmonitor.cpp
+++ b/plugins/dwarfmonitor.cpp
@@ -43,9 +43,11 @@
 
 using std::deque;
 
-using df::global::current_weather;
-using df::global::world;
-using df::global::ui;
+DFHACK_PLUGIN("dwarfmonitor");
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+REQUIRE_GLOBAL(current_weather);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
 
 typedef int16_t activity_type;
 
@@ -1774,9 +1776,6 @@ struct dwarf_monitor_hook : public df::viewscreen_dwarfmodest
 
 IMPLEMENT_VMETHOD_INTERPOSE(dwarf_monitor_hook, feed);
 IMPLEMENT_VMETHOD_INTERPOSE(dwarf_monitor_hook, render);
-
-DFHACK_PLUGIN("dwarfmonitor");
-DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 static bool set_monitoring_mode(const string &mode, const bool &state)
 {

--- a/plugins/eventful.cpp
+++ b/plugins/eventful.cpp
@@ -34,13 +34,12 @@ using std::stack;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::gps;
-using df::global::world;
-using df::global::ui;
+DFHACK_PLUGIN("eventful");
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
 
 typedef df::reaction_product_itemst item_product;
-
-DFHACK_PLUGIN("eventful");
 
 struct ReagentSource {
     int idx;

--- a/plugins/fastdwarf.cpp
+++ b/plugins/fastdwarf.cpp
@@ -17,13 +17,10 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::debug_turbospeed;
-
-// dfhack interface
 DFHACK_PLUGIN("fastdwarf");
-
 DFHACK_PLUGIN_IS_ENABLED(active);
+REQUIRE_GLOBAL(world);
+using df::global::debug_turbospeed;  // not required
 
 static bool enable_fastdwarf = false;
 static bool enable_teledwarf = false;

--- a/plugins/feature.cpp
+++ b/plugins/feature.cpp
@@ -17,7 +17,8 @@ using std::endl;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("feature");
+REQUIRE_GLOBAL(world);
 
 
 static command_result feature(color_ostream &out, vector <string> &parameters)
@@ -91,8 +92,6 @@ static command_result feature(color_ostream &out, vector <string> &parameters)
 
     return CR_OK;
 }
-
-DFHACK_PLUGIN("feature");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/fixpositions.cpp
+++ b/plugins/fixpositions.cpp
@@ -18,7 +18,8 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("fixpositions");
+REQUIRE_GLOBAL(world);
 
 command_result df_fixdiplomats (color_ostream &out, vector<string> &parameters)
 {
@@ -225,8 +226,6 @@ command_result df_fixmerchants (color_ostream &out, vector<string> &parameters)
     out.print("Fixed %d of %d civilizations to enable merchant nobility.\n", fixed, checked);
     return CR_OK;
 }
-
-DFHACK_PLUGIN("fixpositions");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/fixveins.cpp
+++ b/plugins/fixveins.cpp
@@ -19,7 +19,8 @@ using std::string;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("fixveins");
+REQUIRE_GLOBAL(world);
 
 bool setTileMaterial(df::tiletype &tile, const df::tiletype_material mat)
 {
@@ -94,8 +95,6 @@ command_result df_fixveins (color_ostream &out, vector <string> & parameters)
         out.print("Restored missing references to %i mineral inclusion and %i map feature tiles.\n", mineral_added, feature_added);
     return CR_OK;
 }
-
-DFHACK_PLUGIN("fixveins");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/flows.cpp
+++ b/plugins/flows.cpp
@@ -15,7 +15,8 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("flows");
+REQUIRE_GLOBAL(world);
 
 command_result df_flows (color_ostream &out, vector <string> & parameters)
 {
@@ -55,8 +56,6 @@ command_result df_flows (color_ostream &out, vector <string> & parameters)
     out.print("Magma tiles:               %d\n", magma);
     return CR_OK;
 }
-
-DFHACK_PLUGIN("flows");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/follow.cpp
+++ b/plugins/follow.cpp
@@ -16,16 +16,15 @@
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("follow");
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+REQUIRE_GLOBAL(world);
 
 command_result follow (color_ostream &out, std::vector <std::string> & parameters);
 
 df::unit *followedUnit;
 int32_t prevX, prevY, prevZ;
 uint8_t prevMenuWidth;
-
-DFHACK_PLUGIN("follow");
-DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/forceequip.cpp
+++ b/plugins/forceequip.cpp
@@ -46,12 +46,12 @@ using namespace df::enums;
 
 using MapExtras::Block;
 using MapExtras::MapCache;
-using df::global::world;
+
+DFHACK_PLUGIN("forceequip");
+REQUIRE_GLOBAL(world);
 
 const int const_GloveRightHandedness = 1;
 const int const_GloveLeftHandedness = 2;
-
-DFHACK_PLUGIN("forceequip");
 
 command_result df_forceequip(color_ostream &out, vector <string> & parameters);
 

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -22,7 +22,8 @@ using std::set;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("getplants");
+REQUIRE_GLOBAL(world);
 
 command_result df_getplants (color_ostream &out, vector <string> & parameters)
 {
@@ -147,8 +148,6 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
         out.print("Updated %d plant designations.\n", count);
     return CR_OK;
 }
-
-DFHACK_PLUGIN("getplants");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands)
 {

--- a/plugins/infiniteSky.cpp
+++ b/plugins/infiniteSky.cpp
@@ -23,11 +23,10 @@ using namespace std;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("infiniteSky");
+REQUIRE_GLOBAL(world);
 
 command_result infiniteSky (color_ostream &out, std::vector <std::string> & parameters);
-
-DFHACK_PLUGIN("infiniteSky");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/initflags.cpp
+++ b/plugins/initflags.cpp
@@ -12,12 +12,11 @@ using std::endl;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::d_init;
+DFHACK_PLUGIN("initflags");
+REQUIRE_GLOBAL(d_init);
 
 command_result twaterlvl(color_ostream &out, vector <string> & parameters);
 command_result tidlers(color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("initflags");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/isoworldremote.cpp
+++ b/plugins/isoworldremote.cpp
@@ -31,10 +31,11 @@ using namespace DFHack;
 using namespace df::enums;
 using namespace isoworldremote;
 
-using df::global::gamemode;
-using df::global::world;
-using df::global::cur_year;
-using df::global::cur_season;
+DFHACK_PLUGIN("isoworldremote");
+REQUIRE_GLOBAL(gamemode);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cur_year);
+REQUIRE_GLOBAL(cur_season);
 
 // Here go all the command declarations...
 // mostly to allow having the mandatory stuff on top of the file and commands on the bottom
@@ -46,11 +47,6 @@ static command_result GetRawNames(color_ostream &stream, const MapRequest *in, R
 
 bool gather_embark_tile_layer(int EmbX, int EmbY, int EmbZ, EmbarkTileLayer * tile, MapExtras::MapCache * MP);
 bool gather_embark_tile(int EmbX, int EmbY, EmbarkTile * tile, MapExtras::MapCache * MP);
-
-
-// A plugin must be able to return its name and version.
-// The name string provided must correspond to the filename - skeleton.plug.so or skeleton.plug.dll in this case
-DFHACK_PLUGIN("isoworldremote");
 
 // Mandatory init function. If you have some global state, create it here.
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)

--- a/plugins/jobutils.cpp
+++ b/plugins/jobutils.cpp
@@ -31,11 +31,12 @@ using std::endl;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::ui;
-using df::global::ui_build_selector;
-using df::global::ui_workshop_job_cursor;
-using df::global::job_next_id;
+DFHACK_PLUGIN("jobutils");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
+REQUIRE_GLOBAL(ui_workshop_job_cursor);
+REQUIRE_GLOBAL(job_next_id);
 
 /* Plugin registration */
 
@@ -44,8 +45,6 @@ static bool job_material_hotkey(df::viewscreen *top);
 static command_result job_material(color_ostream &out, vector <string> & parameters);
 static command_result job_duplicate(color_ostream &out, vector <string> & parameters);
 static command_result job_cmd(color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("jobutils");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/lair.cpp
+++ b/plugins/lair.cpp
@@ -12,9 +12,9 @@
 #include "modules/Gui.h"
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
 
 DFHACK_PLUGIN("lair");
+REQUIRE_GLOBAL(world);
 
 enum state
 {

--- a/plugins/liquids.cpp
+++ b/plugins/liquids.cpp
@@ -46,14 +46,14 @@ using std::set;
 using namespace MapExtras;
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
+
+DFHACK_PLUGIN("liquids");
+REQUIRE_GLOBAL(world);
 
 CommandHistory liquids_hist;
 
 command_result df_liquids (color_ostream &out, vector <string> & parameters);
 command_result df_liquids_here (color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("liquids");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -36,10 +36,12 @@ using std::string;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::ui;
-using df::global::gps;
-using df::global::enabler;
+DFHACK_PLUGIN("manipulator");
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(enabler);
 
 struct SkillLevel
 {
@@ -1290,10 +1292,6 @@ struct unitlist_hook : df::viewscreen_unitlistst
 
 IMPLEMENT_VMETHOD_INTERPOSE(unitlist_hook, feed);
 IMPLEMENT_VMETHOD_INTERPOSE(unitlist_hook, render);
-
-DFHACK_PLUGIN("manipulator");
-
-DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 DFhackCExport command_result plugin_enable(color_ostream &out, bool enable)
 {

--- a/plugins/misery.cpp
+++ b/plugins/misery.cpp
@@ -15,10 +15,11 @@
 using namespace std;
 using namespace DFHack;
 
-using df::global::world;
-using df::global::ui;
-
+DFHACK_PLUGIN("misery");
 DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
 
 static int factor = 1;
 static map<int, int> processedThoughtCountTable;
@@ -27,8 +28,6 @@ static map<int, int> processedThoughtCountTable;
 static vector<std::pair<int,int> > fakeThoughts;
 static int count;
 const int maxCount = 1000;
-
-DFHACK_PLUGIN("misery");
 
 command_result misery(color_ostream& out, vector<string>& parameters);
 

--- a/plugins/mousequery.cpp
+++ b/plugins/mousequery.cpp
@@ -21,13 +21,12 @@
 #include "TileTypes.h"
 #include "DataFuncs.h"
 
-using df::global::world;
-using df::global::ui;
-using df::global::ui_build_selector;
+DFHACK_PLUGIN("mousequery");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
 
 using namespace df::enums::ui_sidebar_mode;
-
-DFHACK_PLUGIN("mousequery");
 
 #define PLUGIN_VERSION 0.18
 

--- a/plugins/petcapRemover.cpp
+++ b/plugins/petcapRemover.cpp
@@ -20,16 +20,16 @@
 using namespace DFHack;
 using namespace std;
 
-using df::global::world;
+DFHACK_PLUGIN("petcapRemover");
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+
+REQUIRE_GLOBAL(world);
 
 static int32_t howOften = 10000;
 static int32_t popcap = 100;
 static int32_t pregtime = 200000;
-DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 command_result petcapRemover (color_ostream &out, std::vector <std::string> & parameters);
-
-DFHACK_PLUGIN("petcapRemover");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/plants.cpp
+++ b/plugins/plants.cpp
@@ -18,11 +18,11 @@
 using std::vector;
 using std::string;
 using namespace DFHack;
-using df::global::world;
-
-const uint32_t sapling_to_tree_threshold = 120 * 28 * 12 * 3 - 1; // 3 years minus 1 - let the game handle the actual growing-up
 
 DFHACK_PLUGIN("plants");
+REQUIRE_GLOBAL(world);
+
+const uint32_t sapling_to_tree_threshold = 120 * 28 * 12 * 3 - 1; // 3 years minus 1 - let the game handle the actual growing-up
 
 /* Immolate/Extirpate no longer work in 0.40
 enum do_what

--- a/plugins/power-meter.cpp
+++ b/plugins/power-meter.cpp
@@ -38,12 +38,11 @@ using std::stack;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::gps;
-using df::global::world;
-using df::global::ui;
-using df::global::ui_build_selector;
-
 DFHACK_PLUGIN("power-meter");
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
 
 static const uint32_t METER_BIT = 0x80000000U;
 

--- a/plugins/probe.cpp
+++ b/plugins/probe.cpp
@@ -33,14 +33,14 @@ using std::vector;
 using std::string;
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
-using df::global::cursor;
+
+DFHACK_PLUGIN("probe");
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
 
 command_result df_probe (color_ostream &out, vector <string> & parameters);
 command_result df_cprobe (color_ostream &out, vector <string> & parameters);
 command_result df_bprobe (color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("probe");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/prospector.cpp
+++ b/plugins/prospector.cpp
@@ -38,8 +38,10 @@ using namespace std;
 
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
 using df::coord2d;
+
+DFHACK_PLUGIN("prospector");
+REQUIRE_GLOBAL(world);
 
 struct matdata
 {
@@ -197,8 +199,6 @@ void printVeins(color_ostream &con, MatMap &mat_map,
 }
 
 command_result prospector (color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("prospector");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/regrass.cpp
+++ b/plugins/regrass.cpp
@@ -22,9 +22,8 @@ using std::vector;
 using namespace std;
 using namespace DFHack;
 
-using df::global::world;
-
 DFHACK_PLUGIN("regrass");
+REQUIRE_GLOBAL(world);
 
 command_result df_regrass (color_ostream &out, vector <string> & parameters);
 

--- a/plugins/remotefortressreader.cpp
+++ b/plugins/remotefortressreader.cpp
@@ -56,6 +56,9 @@ using namespace df::enums;
 using namespace RemoteFortressReader;
 using namespace std;
 
+DFHACK_PLUGIN("RemoteFortressReader");
+REQUIRE_GLOBAL(world);
+
 // Here go all the command declarations...
 // mostly to allow having the mandatory stuff on top of the file and commands on the bottom
 
@@ -79,10 +82,6 @@ const char* growth_locations[] = {
     "SHRUB"
 };
 #define GROWTH_LOCATIONS_SIZE 8
-
-// A plugin must be able to return its name and version.
-// The name string provided must correspond to the filename - skeleton.plug.so or skeleton.plug.dll in this case
-DFHACK_PLUGIN("RemoteFortressReader");
 
 // Mandatory init function. If you have some global state, create it here.
 DFhackCExport command_result plugin_init(color_ostream &out, std::vector <PluginCommand> &commands)
@@ -387,9 +386,9 @@ RemoteFortressReader::TiletypeVariant TranslateVariant(df::tiletype_variant vari
 static command_result CheckHashes(color_ostream &stream, const EmptyMessage *in)
 {
     clock_t start = clock();
-    for (int i = 0; i < df::global::world->map.map_blocks.size(); i++)
+    for (int i = 0; i < world->map.map_blocks.size(); i++)
     {
-        df::map_block * block = df::global::world->map.map_blocks[i];
+        df::map_block * block = world->map.map_blocks[i];
         fletcher16((uint8_t*)(block->tiletype), 16 * 16 * sizeof(df::enums::tiletype::tiletype));
     }
     clock_t end = clock();
@@ -417,7 +416,7 @@ static command_result GetMaterialList(color_ostream &stream, const EmptyMessage 
 
 
 
-    df::world_raws *raws = &df::global::world->raws;
+    df::world_raws *raws = &world->raws;
     MaterialInfo mat;
     for (int i = 0; i < raws->inorganics.size(); i++)
     {
@@ -509,7 +508,7 @@ static command_result GetGrowthList(color_ostream &stream, const EmptyMessage *i
 
 
 
-    df::world_raws *raws = &df::global::world->raws;
+    df::world_raws *raws = &world->raws;
     if (!raws)
         return CR_OK;//'.
 
@@ -617,9 +616,9 @@ static command_result GetPlantList(color_ostream &stream, const BlockRequest *in
     for (int xx = min_x; xx < max_x; xx++)
     for (int yy = min_y; yy < max_y; yy++)
     {
-        if (xx < 0 || yy < 0 || xx >= df::global::world->map.x_count_block || yy >= df::global::world->map.y_count_block)
+        if (xx < 0 || yy < 0 || xx >= world->map.x_count_block || yy >= world->map.y_count_block)
             continue;
-        df::map_block_column * column = df::global::world->map.column_index[xx][yy];
+        df::map_block_column * column = world->map.column_index[xx][yy];
         for (int i = 0; i < column->plants.size(); i++)
         {
             df::plant * plant = column->plants[i];

--- a/plugins/rename.cpp
+++ b/plugins/rename.cpp
@@ -46,16 +46,16 @@ using namespace DFHack;
 using namespace df::enums;
 using namespace dfproto;
 
-using df::global::ui;
-using df::global::ui_sidebar_menus;
-using df::global::world;
+DFHACK_PLUGIN("rename");
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_sidebar_menus);
+REQUIRE_GLOBAL(world);
 
 DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_change_event event);
 
 static command_result rename(color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("rename");
-DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/rendermax/rendermax.cpp
+++ b/plugins/rendermax/rendermax.cpp
@@ -28,6 +28,21 @@ using df::viewscreen_dwarfmodest;
 using namespace DFHack;
 using std::vector;
 using std::string;
+
+DFHACK_PLUGIN("rendermax");
+REQUIRE_GLOBAL(cur_year_tick);
+REQUIRE_GLOBAL(cursor);
+REQUIRE_GLOBAL(enabler);
+REQUIRE_GLOBAL(gametype);
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_area_map_width);
+REQUIRE_GLOBAL(ui_menu_width);
+REQUIRE_GLOBAL(window_x);
+REQUIRE_GLOBAL(window_y);
+REQUIRE_GLOBAL(window_z);
+REQUIRE_GLOBAL(world);
+
 enum RENDERER_MODE
 {
     MODE_DEFAULT,MODE_TRIPPY,MODE_TRUECOLOR,MODE_LUA,MODE_LIGHT
@@ -36,9 +51,6 @@ RENDERER_MODE current_mode=MODE_DEFAULT;
 lightingEngine *engine=NULL;
 
 static command_result rendermax(color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("rendermax");
-
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {
@@ -93,34 +105,34 @@ void removeOld()
         engine=0;
     }
     if(current_mode!=MODE_DEFAULT)
-        delete df::global::enabler->renderer;
+        delete enabler->renderer;
     
     current_mode=MODE_DEFAULT;
 }
 void installNew(df::renderer* r,RENDERER_MODE newMode)
 {
-    df::global::enabler->renderer=r;
+    enabler->renderer=r;
     current_mode=newMode;
 }
 static void lockGrids()
 {
     if(current_mode!=MODE_LUA)
         return ;
-    renderer_lua* r=reinterpret_cast<renderer_lua*>(df::global::enabler->renderer);
+    renderer_lua* r=reinterpret_cast<renderer_lua*>(enabler->renderer);
     r->dataMutex.lock();
 }
 static void unlockGrids()
 {
     if(current_mode!=MODE_LUA)
         return ;
-    renderer_lua* r=reinterpret_cast<renderer_lua*>(df::global::enabler->renderer);
+    renderer_lua* r=reinterpret_cast<renderer_lua*>(enabler->renderer);
     r->dataMutex.unlock();
 }
 static void resetGrids()
 {
     if(current_mode!=MODE_LUA)
         return ;
-    renderer_lua* r=reinterpret_cast<renderer_lua*>(df::global::enabler->renderer);
+    renderer_lua* r=reinterpret_cast<renderer_lua*>(enabler->renderer);
     for(size_t i=0;i<r->foreMult.size();i++)
     {
         r->foreMult[i]=rgbf(1,1,1);
@@ -133,16 +145,16 @@ static int getGridsSize(lua_State* L)
 {
     if(current_mode!=MODE_LUA)
         return -1;
-    renderer_lua* r=reinterpret_cast<renderer_lua*>(df::global::enabler->renderer);
-    lua_pushnumber(L,df::global::gps->dimx);
-    lua_pushnumber(L,df::global::gps->dimy);
+    renderer_lua* r=reinterpret_cast<renderer_lua*>(enabler->renderer);
+    lua_pushnumber(L,gps->dimx);
+    lua_pushnumber(L,gps->dimy);
     return 2;
 }
 static int getCell(lua_State* L)
 {
     if(current_mode!=MODE_LUA)
         return 0;
-    renderer_lua* r=reinterpret_cast<renderer_lua*>(df::global::enabler->renderer);
+    renderer_lua* r=reinterpret_cast<renderer_lua*>(enabler->renderer);
     int x=luaL_checknumber(L,1);
     int y=luaL_checknumber(L,2);
     int id=r->xyToTile(x,y);
@@ -193,7 +205,7 @@ static int setCell(lua_State* L)
 {
     if(current_mode!=MODE_LUA)
         return 0;
-    renderer_lua* r=reinterpret_cast<renderer_lua*>(df::global::enabler->renderer);
+    renderer_lua* r=reinterpret_cast<renderer_lua*>(enabler->renderer);
     int x=luaL_checknumber(L,1);
     int y=luaL_checknumber(L,2);
 
@@ -242,7 +254,7 @@ static int invalidate(lua_State* L)
 {
     if(current_mode!=MODE_LUA)
         return 0;
-    renderer_lua* r=reinterpret_cast<renderer_lua*>(df::global::enabler->renderer);
+    renderer_lua* r=reinterpret_cast<renderer_lua*>(enabler->renderer);
     if(lua_gettop(L)==0)
     {
         r->invalidate();
@@ -324,7 +336,7 @@ static command_result rendermax(color_ostream &out, vector <string> & parameters
 {
     if(parameters.size()==0)
         return CR_WRONG_USAGE;
-    if(!df::global::enabler->renderer->uses_opengl())
+    if(!enabler->renderer->uses_opengl())
     {
         out.printerr("Sorry, this plugin needs open gl enabled printmode. Try STANDARD or other non-2D\n");
         return CR_FAILURE;
@@ -333,7 +345,7 @@ static command_result rendermax(color_ostream &out, vector <string> & parameters
     if(cmd=="trippy")
     {
         removeOld();
-        installNew(new renderer_trippy(df::global::enabler->renderer),MODE_TRIPPY);
+        installNew(new renderer_trippy(enabler->renderer),MODE_TRIPPY);
         return CR_OK;
     }
     else if(cmd=="truecolor")
@@ -341,7 +353,7 @@ static command_result rendermax(color_ostream &out, vector <string> & parameters
         if(current_mode!=MODE_TRUECOLOR)
         {
             removeOld();
-            installNew(new renderer_test(df::global::enabler->renderer),MODE_TRUECOLOR);
+            installNew(new renderer_test(enabler->renderer),MODE_TRUECOLOR);
         }
         if(current_mode==MODE_TRUECOLOR && parameters.size()==2)
         {
@@ -356,10 +368,10 @@ static command_result rendermax(color_ostream &out, vector <string> & parameters
             else if(col=="blue")
                 cur=blue;
 
-            renderer_test* r=reinterpret_cast<renderer_test*>(df::global::enabler->renderer);
+            renderer_test* r=reinterpret_cast<renderer_test*>(enabler->renderer);
             tthread::lock_guard<tthread::fast_mutex> guard(r->dataMutex);
-            int h=df::global::gps->dimy;
-            int w=df::global::gps->dimx;
+            int h=gps->dimy;
+            int w=gps->dimx;
             int cx=w/2;
             int cy=h/2;
             int rad=cx;
@@ -385,7 +397,7 @@ static command_result rendermax(color_ostream &out, vector <string> & parameters
     else if(cmd=="lua")
     {
         removeOld();
-        installNew(new renderer_lua(df::global::enabler->renderer),MODE_LUA);
+        installNew(new renderer_lua(enabler->renderer),MODE_LUA);
         lockGrids();
         resetGrids();
         unlockGrids();
@@ -396,7 +408,7 @@ static command_result rendermax(color_ostream &out, vector <string> & parameters
         if(current_mode!=MODE_LIGHT)
         {
             removeOld();
-            renderer_light *myRender=new renderer_light(df::global::enabler->renderer);
+            renderer_light *myRender=new renderer_light(enabler->renderer);
             installNew(myRender,MODE_LIGHT);
             engine=new lightingEngineViewscreen(myRender);
             
@@ -444,7 +456,7 @@ static command_result rendermax(color_ostream &out, vector <string> & parameters
         else
             removeOld();
         CoreSuspender guard;
-        df::global::gps->force_full_display_count++;
+        gps->force_full_display_count++;
         return CR_OK;
     }
     return CR_WRONG_USAGE;

--- a/plugins/resume.cpp
+++ b/plugins/resume.cpp
@@ -34,12 +34,12 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::gps;
-using df::global::ui;
-using df::global::world;
-
 DFHACK_PLUGIN("resume");
 #define PLUGIN_VERSION 0.2
+
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(world);
 
 #ifndef HAVE_NULLPTR
 #define nullptr 0L

--- a/plugins/reveal.cpp
+++ b/plugins/reveal.cpp
@@ -20,7 +20,10 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("reveal");
+DFHACK_PLUGIN_IS_ENABLED(is_active);
+
+REQUIRE_GLOBAL(world);
 
 /*
  * Anything that might reveal Hell is unsafe.
@@ -72,8 +75,6 @@ command_result revflood(color_ostream &out, vector<string> & params);
 command_result revforget(color_ostream &out, vector<string> & params);
 command_result nopause(color_ostream &out, vector<string> & params);
 
-DFHACK_PLUGIN("reveal");
-
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand("reveal","Reveal the map. 'reveal hell' will also reveal hell. 'reveal demon' won't pause.",reveal,false,
@@ -95,8 +96,6 @@ DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCom
         "Activate with 'nopause 1', deactivate with 'nopause 0'.\n"));
     return CR_OK;
 }
-
-DFHACK_PLUGIN_IS_ENABLED(is_active);
 
 DFhackCExport command_result plugin_onupdate ( color_ostream &out )
 {

--- a/plugins/search.cpp
+++ b/plugins/search.cpp
@@ -37,9 +37,12 @@ using std::string;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::gps;
-using df::global::gview;
-using df::global::ui;
+DFHACK_PLUGIN("search");
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(gview);
+REQUIRE_GLOBAL(ui);
 
 /*
 Search Plugin
@@ -1667,10 +1670,6 @@ IMPLEMENT_HOOKS(df::viewscreen_dwarfmodest, burrow_search);
 // END: Burrow assignment search
 //
 
-
-
-DFHACK_PLUGIN("search");
-DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 #define SEARCH_HOOKS \
     HOOK_ACTION(unitlist_search_hook) \

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -19,10 +19,13 @@
 using namespace std;
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
+
+DFHACK_PLUGIN("seedwatch");
+DFHACK_PLUGIN_IS_ENABLED(running); // whether seedwatch is counting the seeds or not
+
+REQUIRE_GLOBAL(world);
 
 const int buffer = 20; // seed number buffer - 20 is reasonable
-DFHACK_PLUGIN_IS_ENABLED(running); // whether seedwatch is counting the seeds or not
 
 // abbreviations for the standard plants
 map<string, string> abbreviations;
@@ -249,8 +252,6 @@ command_result df_seedwatch(color_ostream &out, vector<string>& parameters)
 
     return CR_OK;
 }
-
-DFHACK_PLUGIN("seedwatch");
 
 DFhackCExport command_result plugin_init(color_ostream &out, vector<PluginCommand>& commands)
 {

--- a/plugins/showmood.cpp
+++ b/plugins/showmood.cpp
@@ -25,7 +25,8 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("showmood");
+REQUIRE_GLOBAL(world);
 
 command_result df_showmood (color_ostream &out, vector <string> & parameters)
 {
@@ -290,8 +291,6 @@ command_result df_showmood (color_ostream &out, vector <string> & parameters)
 
     return CR_OK;
 }
-
-DFHACK_PLUGIN("showmood");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector<PluginCommand> &commands)
 {

--- a/plugins/siege-engine.cpp
+++ b/plugins/siege-engine.cpp
@@ -65,16 +65,15 @@ using std::stack;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::gamemode;
-using df::global::gps;
-using df::global::world;
-using df::global::ui;
-using df::global::ui_build_selector;
-using df::global::process_jobs;
-
 using Screen::Pen;
 
 DFHACK_PLUGIN("siege-engine");
+REQUIRE_GLOBAL(gamemode);
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
+REQUIRE_GLOBAL(process_jobs);
 
 /*
     Aiming is simulated by using a normal distribution to perturb X and Y.

--- a/plugins/skeleton/skeleton.cpp
+++ b/plugins/skeleton/skeleton.cpp
@@ -10,23 +10,29 @@
 #include "DataDefs.h"
 //#include "df/world.h"
 
-using namespace DFHack;
-using namespace df::enums;
-
 // our own, empty header.
 #include "skeleton.h"
 
+using namespace DFHack;
+using namespace df::enums;
+
+// A plugin must be able to return its name and version.
+// The name string provided must correspond to the filename -
+// skeleton.plug.so, skeleton.plug.dylib, or skeleton.plug.dll in this case
+DFHACK_PLUGIN("skeleton");
+
+// Any globals a plugin requires (e.g. world) should be listed here.
+// For example, this line expands to "using df::global::world" and prevents the
+// plugin from being loaded if df::global::world is null (i.e. missing from symbols.xml):
+//
+// REQUIRE_GLOBAL(world);
 
 // Here go all the command declarations...
 // mostly to allow having the mandatory stuff on top of the file and commands on the bottom
 command_result skeleton (color_ostream &out, std::vector <std::string> & parameters);
 
-// A plugin must be able to return its name and version.
-// The name string provided must correspond to the filename - skeleton.plug.so or skeleton.plug.dll in this case
-DFHACK_PLUGIN("skeleton");
-
 // Mandatory init function. If you have some global state, create it here.
-DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
+DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {
     // Fill the command list with your commands.
     commands.push_back(PluginCommand(
@@ -42,7 +48,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
 }
 
 // This is called right before the plugin library is removed from memory.
-DFhackCExport command_result plugin_shutdown ( color_ostream &out )
+DFhackCExport command_result plugin_shutdown (color_ostream &out)
 {
     // You *MUST* kill all threads you created before this returns.
     // If everything fails, just return CR_FAILURE. Your plugin will be

--- a/plugins/skeleton/skeletonShort.cpp
+++ b/plugins/skeleton/skeletonShort.cpp
@@ -8,11 +8,12 @@
 
 using namespace DFHack;
 
+DFHACK_PLUGIN("skeleton2");
+//REQUIRE_GLOBAL(world);
+
 command_result skeleton2 (color_ostream &out, std::vector <std::string> & parameters);
 
-DFHACK_PLUGIN("skeleton2");
-
-DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
+DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
         "skeleton2",
@@ -24,7 +25,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_shutdown ( color_ostream &out )
+DFhackCExport command_result plugin_shutdown (color_ostream &out)
 {
     return CR_OK;
 }

--- a/plugins/sort.cpp
+++ b/plugins/sort.cpp
@@ -37,22 +37,21 @@ using std::endl;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::ui;
-using df::global::world;
-using df::global::ui_building_in_assign;
-using df::global::ui_building_item_cursor;
-using df::global::ui_building_assign_type;
-using df::global::ui_building_assign_is_marked;
-using df::global::ui_building_assign_units;
-using df::global::ui_building_assign_items;
+DFHACK_PLUGIN("sort");
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui_building_in_assign);
+REQUIRE_GLOBAL(ui_building_item_cursor);
+REQUIRE_GLOBAL(ui_building_assign_type);
+REQUIRE_GLOBAL(ui_building_assign_is_marked);
+REQUIRE_GLOBAL(ui_building_assign_units);
+REQUIRE_GLOBAL(ui_building_assign_items);
 
 static bool unit_list_hotkey(df::viewscreen *top);
 static bool item_list_hotkey(df::viewscreen *top);
 
 static command_result sort_units(color_ostream &out, vector <string> & parameters);
 static command_result sort_items(color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("sort");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/steam-engine.cpp
+++ b/plugins/steam-engine.cpp
@@ -117,13 +117,13 @@ using std::set;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::gps;
-using df::global::world;
-using df::global::ui;
-using df::global::ui_build_selector;
-using df::global::cursor;
-
 DFHACK_PLUGIN("steam-engine");
+
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
+REQUIRE_GLOBAL(cursor);
 
 /*
  * List of known steam engine workshop raws.

--- a/plugins/stockflow.cpp
+++ b/plugins/stockflow.cpp
@@ -18,18 +18,18 @@
 using namespace DFHack;
 using namespace std;
 
-using df::global::world;
-using df::global::ui;
 using df::building_stockpilest;
 
 DFHACK_PLUGIN("stockflow");
-
 #define AUTOENABLE false
 #ifdef DFHACK_PLUGIN_IS_ENABLED
 DFHACK_PLUGIN_IS_ENABLED(enabled);
 #else
 bool enabled = false;
 #endif
+
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
 
 bool fast = false;
 const char *tagline = "Allows the fortress bookkeeper to queue jobs through the manager.";
@@ -72,7 +72,7 @@ public:
         } else {
             // Gather orders when the bookkeeper starts updating stockpile records,
             // and enqueue them when the job is done.
-            for (df::job_list_link* link = &df::global::world->job_list; link != NULL; link = link->next) {
+            for (df::job_list_link* link = &world->job_list; link != NULL; link = link->next) {
                 if (link->item == NULL) continue;
                 if (link->item->job_type == job_type::UpdateStockpileRecords) {
                     found = true;

--- a/plugins/stockpiles.cpp
+++ b/plugins/stockpiles.cpp
@@ -58,9 +58,10 @@ using namespace df::enums;
 using namespace google::protobuf;
 using namespace dfstockpiles;
 
-using df::global::world;
-using df::global::ui;
-using df::global::selection_rect;
+DFHACK_PLUGIN ( "stockpiles" );
+REQUIRE_GLOBAL ( world );
+REQUIRE_GLOBAL ( ui );
+REQUIRE_GLOBAL ( selection_rect );
 
 using df::building_stockpilest;
 using std::placeholders::_1;
@@ -73,8 +74,6 @@ static bool savestock_guard ( df::viewscreen *top );
 
 static command_result loadstock ( color_ostream &out, vector <string> & parameters );
 static bool loadstock_guard ( df::viewscreen *top );
-
-DFHACK_PLUGIN ( "stockpiles" );
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands )
 {

--- a/plugins/stocks.cpp
+++ b/plugins/stocks.cpp
@@ -28,10 +28,10 @@
 #include "df/building_cagest.h"
 #include "df/ui_advmode.h"
 
-using df::global::world;
-
 DFHACK_PLUGIN("stocks");
 #define PLUGIN_VERSION 0.12
+
+REQUIRE_GLOBAL(world);
 
 DFhackCExport command_result plugin_shutdown ( color_ostream &out )
 {

--- a/plugins/strangemood.cpp
+++ b/plugins/strangemood.cpp
@@ -32,15 +32,17 @@ using std::vector;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::ui;
-using df::global::d_init;
-using df::global::created_item_count;
-using df::global::created_item_type;
-using df::global::created_item_subtype;
-using df::global::created_item_mattype;
-using df::global::created_item_matindex;
-using df::global::debug_nomoods;
+DFHACK_PLUGIN("strangemood");
+
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(d_init);
+REQUIRE_GLOBAL(created_item_count);
+REQUIRE_GLOBAL(created_item_type);
+REQUIRE_GLOBAL(created_item_subtype);
+REQUIRE_GLOBAL(created_item_mattype);
+REQUIRE_GLOBAL(created_item_matindex);
+REQUIRE_GLOBAL(debug_nomoods);
 
 Random::MersenneRNG rng;
 
@@ -1301,8 +1303,6 @@ command_result df_strangemood (color_ostream &out, vector <string> & parameters)
     unit->unk_18e = 0;
     return CR_OK;
 }
-
-DFHACK_PLUGIN("strangemood");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector<PluginCommand> &commands)
 {

--- a/plugins/strangemood.cpp
+++ b/plugins/strangemood.cpp
@@ -42,7 +42,7 @@ REQUIRE_GLOBAL(created_item_type);
 REQUIRE_GLOBAL(created_item_subtype);
 REQUIRE_GLOBAL(created_item_mattype);
 REQUIRE_GLOBAL(created_item_matindex);
-REQUIRE_GLOBAL(debug_nomoods);
+using df::global::debug_nomoods;
 
 Random::MersenneRNG rng;
 
@@ -476,7 +476,7 @@ command_result df_strangemood (color_ostream &out, vector <string> & parameters)
         out.printerr("ARTIFACTS are not enabled!\n");
         return CR_FAILURE;
     }
-    if (*debug_nomoods)
+    if (debug_nomoods && *debug_nomoods)
     {
         out.printerr("Strange moods disabled via debug flag!\n");
         return CR_FAILURE;

--- a/plugins/tiletypes.cpp
+++ b/plugins/tiletypes.cpp
@@ -44,7 +44,8 @@ using namespace MapExtras;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
+DFHACK_PLUGIN("tiletypes");
+REQUIRE_GLOBAL(world);
 
 CommandHistory tiletypes_hist;
 
@@ -52,8 +53,6 @@ command_result df_tiletypes (color_ostream &out, vector <string> & parameters);
 command_result df_tiletypes_command (color_ostream &out, vector <string> & parameters);
 command_result df_tiletypes_here (color_ostream &out, vector <string> & parameters);
 command_result df_tiletypes_here_point (color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("tiletypes");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/trackstop.cpp
+++ b/plugins/trackstop.cpp
@@ -15,18 +15,18 @@
 using namespace DFHack;
 using namespace std;
 
-using df::global::world;
-using df::global::ui;
 using df::building_rollersst;
 using df::building_trapst;
 using df::enums::trap_type::trap_type;
 using df::enums::screw_pump_direction::screw_pump_direction;
 
 DFHACK_PLUGIN("trackstop");
-
 #define AUTOENABLE false
 DFHACK_PLUGIN_IS_ENABLED(enabled);
 
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(world);
 
 /*
  * Interface hooks
@@ -270,14 +270,6 @@ IMPLEMENT_VMETHOD_INTERPOSE(roller_hook, render);
 DFhackCExport command_result plugin_enable(color_ostream& out, bool enable) {
     // Accept the "enable trackstop" / "disable trackstop" commands.
     if (enable != enabled) {
-        // Check for global variables that, if missing, result in total failure.
-        // Missing enabler and ui_menu_width also produce visible effects, but not nearly as severe.
-        // This could be moved to the plugin_init step, but that's louder for no real benefit.
-        if (!(gps && ui && world)) {
-            out.printerr("trackstop: Missing required global variables.\n");
-            return CR_FAILURE;
-        }
-        
         if (!INTERPOSE_HOOK(trackstop_hook, feed).apply(enable) ||
                 !INTERPOSE_HOOK(trackstop_hook, render).apply(enable) ||
                 !INTERPOSE_HOOK(roller_hook, feed).apply(enable) ||

--- a/plugins/treefarm.cpp
+++ b/plugins/treefarm.cpp
@@ -21,17 +21,17 @@
 
 using namespace DFHack;
 
-using df::global::world;
-using df::global::ui;
+DFHACK_PLUGIN("treefarm");
+DFHACK_PLUGIN_IS_ENABLED(enabled);
+
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
 
 void checkFarms(color_ostream& out, void* ptr);
 command_result treefarm (color_ostream &out, std::vector <std::string> & parameters);
 
 EventManager::EventHandler handler(&checkFarms, -1);
 int32_t frequency = 1200*30;
-
-DFHACK_PLUGIN_IS_ENABLED(enabled);
-DFHACK_PLUGIN("treefarm");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/tubefill.cpp
+++ b/plugins/tubefill.cpp
@@ -17,7 +17,9 @@
 
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
+
+DFHACK_PLUGIN("tubefill");
+REQUIRE_GLOBAL(world);
 
 bool isDesignatedHollow(df::coord pos)
 {
@@ -32,8 +34,6 @@ bool isDesignatedHollow(df::coord pos)
 }
 
 command_result tubefill(color_ostream &out, std::vector<std::string> & params);
-
-DFHACK_PLUGIN("tubefill");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/tweak/tweak.cpp
+++ b/plugins/tweak/tweak.cpp
@@ -92,18 +92,19 @@ using std::endl;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::ui;
-using df::global::world;
-using df::global::ui_build_selector;
-using df::global::ui_menu_width;
-using df::global::ui_area_map_width;
+DFHACK_PLUGIN("tweak");
+
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
+REQUIRE_GLOBAL(ui_building_item_cursor);
+REQUIRE_GLOBAL(ui_menu_width);
+REQUIRE_GLOBAL(ui_area_map_width);
+REQUIRE_GLOBAL(world);
 
 using namespace DFHack::Gui;
 
 static command_result tweak(color_ostream &out, vector <string> & parameters);
 static std::multimap<std::string, VMethodInterposeLinkBase> tweak_hooks;
-
-DFHACK_PLUGIN("tweak");
 
 #define TWEAK_HOOK(tweak, cls, func) tweak_hooks.insert(std::pair<std::string, VMethodInterposeLinkBase>\
     (tweak, INTERPOSE_HOOK(cls, func)))

--- a/plugins/weather.cpp
+++ b/plugins/weather.cpp
@@ -13,14 +13,14 @@ using std::string;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::current_weather;
+DFHACK_PLUGIN("weather");
+
+REQUIRE_GLOBAL(current_weather);
 
 bool locked = false;
 unsigned char locked_data[25];
 
 command_result weather (color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("weather");
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/workNow.cpp
+++ b/plugins/workNow.cpp
@@ -14,10 +14,9 @@
 using namespace std;
 using namespace DFHack;
 
-using df::global::process_jobs;
-using df::global::process_dig;
-
 DFHACK_PLUGIN("workNow");
+REQUIRE_GLOBAL(process_jobs);
+REQUIRE_GLOBAL(process_dig);
 
 static int mode = 0;
 

--- a/plugins/workflow.cpp
+++ b/plugins/workflow.cpp
@@ -49,10 +49,12 @@ using std::flush;
 using namespace DFHack;
 using namespace df::enums;
 
-using df::global::world;
-using df::global::ui;
-using df::global::ui_workshop_job_cursor;
-using df::global::job_next_id;
+DFHACK_PLUGIN("workflow");
+
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_workshop_job_cursor);
+REQUIRE_GLOBAL(job_next_id);
 
 /* Plugin registration */
 
@@ -60,8 +62,6 @@ static command_result workflow_cmd(color_ostream &out, vector <string> & paramet
 
 static void init_state(color_ostream &out);
 static void cleanup_state(color_ostream &out);
-
-DFHACK_PLUGIN("workflow");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {

--- a/plugins/zone.cpp
+++ b/plugins/zone.cpp
@@ -74,33 +74,33 @@ using std::vector;
 using std::string;
 using namespace DFHack;
 using namespace df::enums;
-using df::global::world;
-using df::global::cursor;
-using df::global::ui;
-using df::global::ui_build_selector;
-using df::global::gps;
-using df::global::cur_year;
-using df::global::cur_year_tick;
 
-using df::global::ui_building_item_cursor;
-using df::global::ui_building_assign_type;
-using df::global::ui_building_assign_is_marked;
-using df::global::ui_building_assign_units;
-using df::global::ui_building_assign_items;
-using df::global::ui_building_in_assign;
+DFHACK_PLUGIN("zone");
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
-using df::global::ui_menu_width;
-using df::global::ui_area_map_width;
+REQUIRE_GLOBAL(world);
+REQUIRE_GLOBAL(cursor);
+REQUIRE_GLOBAL(ui);
+REQUIRE_GLOBAL(ui_build_selector);
+REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(cur_year);
+REQUIRE_GLOBAL(cur_year_tick);
+
+REQUIRE_GLOBAL(ui_building_item_cursor);
+REQUIRE_GLOBAL(ui_building_assign_type);
+REQUIRE_GLOBAL(ui_building_assign_is_marked);
+REQUIRE_GLOBAL(ui_building_assign_units);
+REQUIRE_GLOBAL(ui_building_assign_items);
+REQUIRE_GLOBAL(ui_building_in_assign);
+
+REQUIRE_GLOBAL(ui_menu_width);
+REQUIRE_GLOBAL(ui_area_map_width);
 
 using namespace DFHack::Gui;
 
 command_result df_zone (color_ostream &out, vector <string> & parameters);
 command_result df_autonestbox (color_ostream &out, vector <string> & parameters);
 command_result df_autobutcher(color_ostream &out, vector <string> & parameters);
-
-DFHACK_PLUGIN("zone");
-
-DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 DFhackCExport command_result plugin_enable ( color_ostream &out, bool enable);
 


### PR DESCRIPTION
This allows "`using df::global::*`"-type lines and checks for globals in plugin_init to be replaced by a single macro, REQUIRE_GLOBAL. DFHack will refuse to load a plugin if any of its required globals are null, before calling plugin_init. Many plugins currently fail to check for globals in plugin_init, leading to crashes (for example, burrows).
Note that REQUIRED_GLOBAL must be used after DFHACK_PLUGIN, as it appends to a vector defined there (I've updated the skeleton plugin accordingly). The technique it uses is similar to [static_add_to_map](https://github.com/DFHack/dfhack/blob/a273327c6a380d742a76657fa566ce34dc067919/library/include/MiscUtils.h#L300), but feel free to suggest a better way to do this.