### PR TITLE
full-heal Script: Fixed error with passing nil to unit.find

### DIFF
--- a/scripts/full-heal.lua
+++ b/scripts/full-heal.lua
@@ -29,7 +29,11 @@ if args.help then
   return
 end
 
-unit = df.unit.find(args.unit) or dfhack.gui.getSelectedUnit()
+if(args.unit) then
+	unit = df.unit.find(args.unit)
+else
+	unit = dfhack.gui.getSelectedUnit()
+end
 
 if not unit then
  qerror('Error: please select a unit or pass its id as an argument.')


### PR DESCRIPTION
full-heal only worked when passed unit id in command line. I fixed it so that it works again when selecting a unit in the GUI.

The Error was that args.unit contained nil without a id as parameter, so while the or shortcut would have worked unit.find didn't return nil but aborted instead.

Checking for a nil value beforehand fixes this so I added the check!
