### PR TITLE
Fix "exportlegends maps"

### DIFF
--- a/scripts/exportlegends.lua
+++ b/scripts/exportlegends.lua
@@ -81,7 +81,7 @@ if dfhack.gui.getCurFocus() == "legends" then
         export_site_maps()
         wait_for_legends_vs()
     elseif args[1] == "info" then 
-        wait_for_legends_vs()
+        export_legends_info()
     elseif args[1] == "maps" then 
         wait_for_legends_vs()
     elseif args[1] == "sites" then 

--- a/scripts/exportlegends.lua
+++ b/scripts/exportlegends.lua
@@ -51,7 +51,7 @@ end
 function wait_for_export_maps_vs()
     local vs = dfhack.gui.getCurViewscreen()
     if dfhack.gui.getCurFocus() == "export_graphical_map" then
-        vs.sel_idx = i
+        vs.sel_idx = i-1
         print('    Exporting:  '..MAPS[i]..' map')
         gui.simulateInput(vs, 'SELECT')
         i = i + 1
@@ -88,6 +88,9 @@ if dfhack.gui.getCurFocus() == "legends" then
         export_site_maps()
     else dfhack.printerr('Valid arguments are "all", "info", "maps" or "sites"')
     end
+elseif args[1] == "maps" and
+        dfhack.gui.getCurFocus() == "export_graphical_map" then
+    wait_for_export_maps_vs()
 else
-    dfhack.printerr('Not in main legends view')
+    dfhack.printerr('Exportlegends must be run from the main legends view')
 end


### PR DESCRIPTION
Correct list index error which skipped export of detailed map.  Allow region-maps-only export to start from detailed maps viewscreen.  More informative error message.  Closes #445.

Also found a fixed a typo; the `info` option called the maps function instead of info export.