### PR TITLE
Trackstop bugfix: No longer prevents cancelling building removal.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 DFHack Future
     Internals
     Fixes
+        trackstop: No longer prevents cancelling the removal of a track stop or roller.
     New Plugins
     New Scripts
     Misc Improvements


### PR DESCRIPTION
Thanks to Ramblurr for pointing this out.