### PR TITLE
Revert "Log output of "dfhack" script to dfhack.log"

### DIFF
--- a/package/darwin/dfhack
+++ b/package/darwin/dfhack
@@ -12,6 +12,6 @@ fi
 
 old_tty_settings=$(stty -g)
 cd "${PWD}"
-DYLD_INSERT_LIBRARIES=./hack/libdfhack.dylib ./dwarfort.exe "$@" 2>&1 | tee dfhack.log
+DYLD_INSERT_LIBRARIES=./hack/libdfhack.dylib ./dwarfort.exe "$@"
 stty "$old_tty_settings"
 echo ""

--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -65,7 +65,7 @@ case "$1" in
     ret=$?
     ;;
   *)
-    setarch i386 -R env LD_PRELOAD=$PRELOAD_LIB ./libs/Dwarf_Fortress "$@" 2>&1 | tee dfhack.log
+    setarch i386 -R env LD_PRELOAD=$PRELOAD_LIB ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
 esac


### PR DESCRIPTION
This appears to be the cause of recent problems with PRINT_MODE:TEXT on Linux.