### PR TITLE
Remove output from filetype()

### DIFF
--- a/library/modules/Filesystem.cpp
+++ b/library/modules/Filesystem.cpp
@@ -130,7 +130,6 @@ _filetype DFHack::Filesystem::filetype (std::string path)
 {
     STAT_STRUCT info;
     DFHack::Filesystem::stat(path, info);
-    std::cout << info.st_mode << std::endl;
     return mode2type(info.st_mode);
 }
 


### PR DESCRIPTION
Not sure how this made it in, but it's causing problems with PRINT_MODE:TEXT (not to mention filling up stdout.log)