### PR TITLE
Autobutcher: prioritize non-breeders

### DIFF
--- a/plugins/zone.cpp
+++ b/plugins/zone.cpp
@@ -709,7 +709,7 @@ int getUnitIndexFromId(df::unit* unit_)
 
 bool isGay(df::unit* unit)
 {
-	return isFemale(unit) && unit->status.current_soul->orientation_flags.bits.romance_female || unit->status.current_soul->orientation_flags.bits.romance_male;
+    return isFemale(unit) && unit->status.current_soul->orientation_flags.bits.romance_female || unit->status.current_soul->orientation_flags.bits.romance_male;
 }
 
 // dump some unit info
@@ -2803,8 +2803,7 @@ public:
     int mk_prot;
     int ma_prot;
 
-    // bah, this should better be an array of 4 vectors
-    // that way there's no need for the 4 ugly process methods
+    // butcherable units
     vector <df::unit*> fk_ptr;
     vector <df::unit*> mk_ptr;
     vector <df::unit*> fa_ptr;
@@ -2910,53 +2909,14 @@ public:
         ma_ptr.clear();
     }
 
-    int ProcessUnits_fk()
+    int ProcessUnits(vector<df::unit*>& unit_ptr, int prot, int goal)
     {
         int subcount = 0;
-        while(fk_ptr.size() && (fk_ptr.size() + fk_prot > fk) )
+        while(unit_ptr.size() && (unit_ptr.size() + prot > goal) )
         {
-            df::unit* unit = fk_ptr.back();
+            df::unit* unit = unit_ptr.back();
             doMarkForSlaughter(unit);
-            fk_ptr.pop_back();
-            subcount++;
-        }
-        return subcount;
-    }
-
-    int ProcessUnits_mk()
-    {
-        int subcount = 0;
-        while(mk_ptr.size() && (mk_ptr.size() + mk_prot > mk) )
-        {
-            df::unit* unit = mk_ptr.back();
-            doMarkForSlaughter(unit);
-            mk_ptr.pop_back();
-            subcount++;
-        }
-        return subcount;
-    }
-
-    int ProcessUnits_fa()
-    {
-        int subcount = 0;
-        while(fa_ptr.size() && (fa_ptr.size() + fa_prot > fa) )
-        {
-            df::unit* unit = fa_ptr.back();
-            doMarkForSlaughter(unit);
-            fa_ptr.pop_back();
-            subcount++;
-        }
-        return subcount;
-    }
-
-    int ProcessUnits_ma()
-    {
-        int subcount = 0;
-        while(ma_ptr.size() && (ma_ptr.size() + ma_prot > ma) )
-        {
-            df::unit* unit = ma_ptr.back();
-            doMarkForSlaughter(unit);
-            ma_ptr.pop_back();
+            unit_ptr.pop_back();
             subcount++;
         }
         return subcount;
@@ -2966,10 +2926,10 @@ public:
     {
         SortUnitsByAge();
         int slaughter_count = 0;
-        slaughter_count += ProcessUnits_fk();
-        slaughter_count += ProcessUnits_mk();
-        slaughter_count += ProcessUnits_fa();
-        slaughter_count += ProcessUnits_ma();
+        slaughter_count += ProcessUnits(fk_ptr, fk_prot, fk);
+        slaughter_count += ProcessUnits(mk_ptr, mk_prot, mk);
+        slaughter_count += ProcessUnits(fa_ptr, fa_prot, fa);
+        slaughter_count += ProcessUnits(ma_ptr, ma_prot, ma);
         ClearUnits();
         return slaughter_count;
     }

--- a/plugins/zone.cpp
+++ b/plugins/zone.cpp
@@ -67,6 +67,7 @@ using namespace std;
 #include "df/general_ref_building_civzone_assignedst.h"
 #include <df/creature_raw.h>
 #include <df/caste_raw.h>
+#include "df/unit_soul.h"
 #include "df/viewscreen_dwarfmodest.h"
 #include "modules/Translation.h"
 
@@ -345,6 +346,7 @@ bool isHunter(df::unit* unit);
 bool isOwnCiv(df::unit* unit);
 bool isMerchant(df::unit* unit);
 bool isForest(df::unit* unit);
+bool isGay(df::unit* unit);
 
 bool isActivityZone(df::building * building);
 bool isPenPasture(df::building * building);
@@ -703,6 +705,11 @@ int getUnitIndexFromId(df::unit* unit_)
             return i;
     }
     return -1;
+}
+
+bool isGay(df::unit* unit)
+{
+	return isFemale(unit) && unit->status.current_soul->orientation_flags.bits.romance_female || unit->status.current_soul->orientation_flags.bits.romance_male;
 }
 
 // dump some unit info

--- a/plugins/zone.cpp
+++ b/plugins/zone.cpp
@@ -2870,10 +2870,10 @@ public:
         sort(mk_ptr.begin(), mk_ptr.end(), compareUnitAgesOlder);
         sort(fa_ptr.begin(), fa_ptr.end(), compareUnitAgesYounger);
         sort(ma_ptr.begin(), ma_ptr.end(), compareUnitAgesYounger);
-        sort(fk_pri_ptr.begin(), fk_ptr.end(), compareUnitAgesOlder);
-        sort(mk_pri_ptr.begin(), mk_ptr.end(), compareUnitAgesOlder);
-        sort(fa_pri_ptr.begin(), fa_ptr.end(), compareUnitAgesYounger);
-        sort(ma_pri_ptr.begin(), ma_ptr.end(), compareUnitAgesYounger);
+        sort(fk_pri_ptr.begin(), fk_pri_ptr.end(), compareUnitAgesOlder);
+        sort(mk_pri_ptr.begin(), mk_pri_ptr.end(), compareUnitAgesOlder);
+        sort(fa_pri_ptr.begin(), fa_pri_ptr.end(), compareUnitAgesYounger);
+        sort(ma_pri_ptr.begin(), ma_pri_ptr.end(), compareUnitAgesYounger);
     }
 
     void PushUnit(df::unit * unit)


### PR DESCRIPTION
When processing units(animals) for autobutchering, checks to see if the unit will not breed due to orientation issues. If the unit will not breed, it is placed into a separate list that will be processed first when creating butchering requests.

Should fix #357