### PR TITLE
Change MOD_* to DFH_MOD_*

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1591,11 +1591,11 @@ int Core::DFH_SDL_Event(SDL::Event* ev)
         auto ke = (SDL::KeyboardEvent *)ev;
 
         if (ke->ksym.sym == SDL::K_LSHIFT || ke->ksym.sym == SDL::K_RSHIFT)
-            modstate = (ev->type == SDL::ET_KEYDOWN) ? modstate | MOD_SHIFT : modstate & ~MOD_SHIFT;
+            modstate = (ev->type == SDL::ET_KEYDOWN) ? modstate | DFH_MOD_SHIFT : modstate & ~DFH_MOD_SHIFT;
         else if (ke->ksym.sym == SDL::K_LCTRL || ke->ksym.sym == SDL::K_RCTRL)
-            modstate = (ev->type == SDL::ET_KEYDOWN) ? modstate | MOD_CTRL : modstate & ~MOD_CTRL;
+            modstate = (ev->type == SDL::ET_KEYDOWN) ? modstate | DFH_MOD_CTRL : modstate & ~DFH_MOD_CTRL;
         else if (ke->ksym.sym == SDL::K_LALT || ke->ksym.sym == SDL::K_RALT)
-            modstate = (ev->type == SDL::ET_KEYDOWN) ? modstate | MOD_ALT : modstate & ~MOD_ALT;
+            modstate = (ev->type == SDL::ET_KEYDOWN) ? modstate | DFH_MOD_ALT : modstate & ~DFH_MOD_ALT;
         else if(ke->state == SDL::BTN_PRESSED && !hotkey_states[ke->ksym.sym])
         {
             hotkey_states[ke->ksym.sym] = true;

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2358,13 +2358,13 @@ static int internal_getModifiers(lua_State *L)
     int8_t modstate = Core::getInstance().getModstate();
     lua_newtable(L);
     lua_pushstring(L, "shift");
-    lua_pushboolean(L, modstate & MOD_SHIFT);
+    lua_pushboolean(L, modstate & DFH_MOD_SHIFT);
     lua_settable(L, -3);
     lua_pushstring(L, "ctrl");
-    lua_pushboolean(L, modstate & MOD_CTRL);
+    lua_pushboolean(L, modstate & DFH_MOD_CTRL);
     lua_settable(L, -3);
     lua_pushstring(L, "alt");
-    lua_pushboolean(L, modstate & MOD_ALT);
+    lua_pushboolean(L, modstate & DFH_MOD_ALT);
     lua_settable(L, -3);
     return 1;
 }

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -36,9 +36,9 @@ distribution.
 
 #include "RemoteClient.h"
 
-#define MOD_SHIFT 1
-#define MOD_CTRL 2
-#define MOD_ALT 4
+#define DFH_MOD_SHIFT 1
+#define DFH_MOD_CTRL 2
+#define DFH_MOD_ALT 4
 
 struct WINDOW;
 


### PR DESCRIPTION
MOD_* constants are defined in Winuser.h on Windows, which causes problems with DFHack's modifier handling (Alt and Shift are reversed)