### PR TITLE
Allow user to set additional entries in LD_PRELOAD on linux

### DIFF
--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -38,12 +38,12 @@ old_tty_settings=$(stty -g)
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"./hack/libs":"./hack"
 
-PRELOAD_LIB=./hack/libdfhack.so
+PRELOAD_LIB="$PRELOAD_LIB ./hack/libdfhack.so"
 
 case "$1" in
   -g | --gdb)
     shift
-    echo "set environment LD_PRELOAD=$PRELOAD_LIB" > gdbcmd.tmp
+    echo "set environment LD_PRELOAD=\"$PRELOAD_LIB\"" > gdbcmd.tmp
     echo "set environment MALLOC_PERTURB_=45" >> gdbcmd.tmp
     gdb $DF_GDB_OPTS -x gdbcmd.tmp ./libs/Dwarf_Fortress "$@"
     rm gdbcmd.tmp
@@ -51,21 +51,21 @@ case "$1" in
     ;;
   -h | --helgrind)
     shift
-    LD_PRELOAD=$PRELOAD_LIB setarch i386 -R valgrind $DF_HELGRIND_OPTS --tool=helgrind --log-file=helgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch i386 -R valgrind $DF_HELGRIND_OPTS --tool=helgrind --log-file=helgrind.log ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
   -v | --valgrind)
     shift
-    LD_PRELOAD=$PRELOAD_LIB setarch i386 -R valgrind $DF_VALGRIND_OPTS --log-file=valgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch i386 -R valgrind $DF_VALGRIND_OPTS --log-file=valgrind.log ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
   -c | --callgrind)
     shift
-    LD_PRELOAD=$PRELOAD_LIB setarch i386 -R valgrind $DF_CALLGRIND_OPTS --tool=callgrind --separate-threads=yes --dump-instr=yes --instr-atstart=no --log-file=callgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch i386 -R valgrind $DF_CALLGRIND_OPTS --tool=callgrind --separate-threads=yes --dump-instr=yes --instr-atstart=no --log-file=callgrind.log ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
   *)
-    setarch i386 -R env LD_PRELOAD=$PRELOAD_LIB ./libs/Dwarf_Fortress "$@"
+    setarch i386 -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
 esac


### PR DESCRIPTION
Some 64bit distros fail with errors about libpng when running df becaue of multilib issues. This
can be fixed by setting LD_PRELOAD properly, but dfhack doesn't let you dod that without manually
editing the script. 

This patch includes the user specified PRELOAD_LIB if it exists in the final LD_PRELOAD value used.