### PR TITLE
Point Homebrew users to homebrew/versions

### DIFF
--- a/Compile.rst
+++ b/Compile.rst
@@ -106,10 +106,10 @@ If you are building on 10.6, please read the subsection below titled "Snow Leopa
     Option 2: Using Homebrew:
     
         * `Install Homebrew <http://brew.sh/>`_ and run:
-        * ``brew tap lethosor/gcc``
+        * ``brew tap homebrew/versions``
         * ``brew install git``
         * ``brew install cmake``
-        * ``brew install lethosor/gcc/gcc45 --enable-multilib``
+        * ``brew install gcc45 --enable-multilib``
 
 5. Install perl dependencies
 


### PR DESCRIPTION
The GCC 4.5 changes required to build on OS X Yosemite have been merged upstream