### PR TITLE
Make skill-change actually work with level

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 DFHack Future
     Internals
     Fixes
+        modtools/skill-change now properly works with level granularity.
     New Plugins
     New Scripts
     New Tweaks

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,25 @@
 DFHack Future
     Internals
+        Lua scripts will only be reloaded if necessary
+        Added support for onLoadMap/onUnloadMap.init scripts
+    New internal commands:
+        hide/show: hide and show the console on Windows
+        sc-script: Allows additional scripts to be run when certain events occur (similar to onLoad*.init scripts)
     Fixes
-        modtools/skill-change now properly works with level granularity.
+        Made PRELOAD_LIB more extensible on Linux
+        add-spatter/eventful: Fixed crash on world load
+        Gave add-thought a proper subthought arg.
+        fix-armory compiles and is available again (albeit with issues)
+        gui/gm-editor: Added search option (accessible with "s")
+        hack-wish: Made items stack properly.
+        modtools/skill-change: made level granularity work properly.
+        show-unit-syndromes should work
+        zone: Stopped crash when scrolling cage owner list
     New Plugins
     New Scripts
+        modtools/reaction-product-trigger: triggers callbacks when products are produced (contrast with when reactions complete)
     New Tweaks
+        tradereq-pet-gender: Displays pet genders on the trade request screen
     Removed
     Misc Improvements
 

--- a/scripts/modtools/skill-change.lua
+++ b/scripts/modtools/skill-change.lua
@@ -36,7 +36,7 @@ arguments
         set the skill that we're talking about
     -mode (add/set)
         are we adding experience/levels or setting them?
-    -granularity (experience/levels)
+    -granularity (experience/level)
         direct experience, or experience levels?
     -unit id
         id of the target unit
@@ -87,9 +87,9 @@ if args.granularity == granularity.experience then
  end
 elseif args.granularity == granularity.level then
  if args.mode == mode.set then
-  skill.rating = df.skill_rating[args.value]
+  skill.rating = args.value
  elseif args.mode == mode.add then
-  skill.rating = df.skill_rating[args.value + df.skill_rating[skill.rating]]
+  skill.rating = args.value + skill.rating
  else
   error 'bad mode'
  end


### PR DESCRIPTION
It was trying to set the level to the string "Proficient" instead of 5, same for every other skill level. There was no workaround, especially since it expected numbers for the value.