### PR TITLE
Add current job as a view mode in manipulator

### DIFF
--- a/Contributors.rst
+++ b/Contributors.rst
@@ -75,6 +75,7 @@ Ben Lubar               BenLubar
 miffedmap               miffedmap
 scamtank                scamtank
 Mason11987              Mason11987
+James Logsdon           jlogsdon
 ======================= ====================    ===========================
 
 And these are the cool people who made **Stonesense**.

--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ DFHack Future
     Misc Improvements
         catsplosion: Can now trigger pregnancies in (most) other creatures
         exportlegends: 'info' and 'all' exports legends_plus xml with more data for legends utilities
+        manipulator: Add "Job" as a View Type, in addition to "Profession" and "Squad"
         remotefortressreader: Exposes more information
 
 DFHack 0.40.24-r2


### PR DESCRIPTION
This replaces the Profession/Squad toggle with an enum of 3 different modes: Profession, Squad or Job. Sorting and the like works with it properly (Idle has the lowest "priority" when sorting, not sure if that will be desired or not but its easy enough to rip out). Eventually it may be nice to set the color of the job to the profession it belongs to, but I'm not currently sure of the best way to handle that.

This is my first time writing any C++ code ever, so there may be better ways to do the mode switching that I am unaware of.