### PR TITLE
Change autobutcher export format a little

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -1899,8 +1899,8 @@ Options:
                default target count.
 :noautowatch:  Stop auto-adding new races to the watchlist.
 :list:         Print the current status and watchlist.
-:list_export:  Print status and watchlist in a format which can be used
-               to import them to another savegame (see notes).
+:list_export:  Print the commands needed to set up status and watchlist,
+               which can be used to import them to another save (see notes).
 :target fk mk fa ma R: Set target count for specified race(s).
                  fk = number of female kids,
                  mk = number of male kids,
@@ -1949,11 +1949,11 @@ add some new races with 'watch'. If you simply want to stop it completely use
 
 Settings and watchlist are stored in the savegame, so that you can have
 different settings for each world. If you want to copy your watchlist to
-another savegame you can export and then import them with ``list_export``:
+another savegame you can export the commands with ``list_export``:
 
-To export them, open a terminal in the DF directory, and run
-``dfhack-run autobutcher list_export > autobutcher.bat`` (or ``.sh`` on OSX or
-Linux).  To import, load your new save and run the script you created.
+To export, open an external terminal in the DF directory, and run
+``dfhack-run autobutcher list_export > filename.txt``.  To import, load your
+new save and run ``script filename.txt`` in the DFHack terminal.
 
 autochop
 ---------

--- a/plugins/zone.cpp
+++ b/plugins/zone.cpp
@@ -2806,21 +2806,17 @@ command_result df_autobutcher(color_ostream &out, vector <string> & parameters)
 
     if(list_export)
     {
-        string run = "dfhack-run autobutcher ";
-#ifdef LINUX_BUILD
-        run = "./dfhack-run autobutcher ";
-#endif
         // force creation of config
-        out << run << "start" << endl;
+        out << "autobutcher start" << endl;
 
         if(!enable_autobutcher)
-            out << run << "stop" << endl;
+            out << "autobutcher stop" << endl;
 
         if (enable_autobutcher_autowatch)
-            out << run << "autowatch" << endl;
+            out << "autobutcher autowatch" << endl;
 
-        out << run << "sleep " << sleep_autobutcher << endl;
-        out << run << "target"
+        out << "autobutcher sleep " << sleep_autobutcher << endl;
+        out << "autobutcher target"
             << " " << default_fk
             << " " << default_mk
             << " " << default_fa
@@ -2833,7 +2829,7 @@ command_result df_autobutcher(color_ostream &out, vector <string> & parameters)
             df::creature_raw * raw = world->raws.creatures.all[w->raceId];
             string name = raw->creature_id;
 
-            out << run << "target"
+            out << "autobutcher target"
                 << " " << w->fk
                 << " " << w->mk
                 << " " << w->fa
@@ -2841,7 +2837,7 @@ command_result df_autobutcher(color_ostream &out, vector <string> & parameters)
                 << " " << name << endl;
 
             if(w->isWatched)
-                out << run << "watch " << name << endl;
+                out << "autobutcher watch " << name << endl;
         }
         return CR_OK;
     }


### PR DESCRIPTION
Closes #554.  This changes the result of `autobutcher list-export` to be platform-independent, and match `workflow list-commands`.