### PR TITLE
Add gametype checks to World module

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1646,6 +1646,25 @@ static const luaL_Reg dfhack_maps_funcs[] = {
     { NULL, NULL }
 };
 
+/****** World module ******/
+
+static const LuaWrapper::FunctionReg dfhack_world_module[] = {
+    WRAPM(World, ReadPauseState),
+    WRAPM(World, SetPauseState),
+    WRAPM(World, ReadCurrentTick),
+    WRAPM(World, ReadCurrentYear),
+    WRAPM(World, ReadCurrentMonth),
+    WRAPM(World, ReadCurrentDay),
+    WRAPM(World, ReadCurrentWeather),
+    WRAPM(World, SetCurrentWeather),
+    WRAPM(World, ReadWorldFolder),
+    WRAPM(World, isFortressMode),
+    WRAPM(World, isAdventureMode),
+    WRAPM(World, isArena),
+    WRAPM(World, isLegends),
+    { NULL, NULL }
+};
+
 /***** Burrows module *****/
 
 static bool burrows_isAssignedBlockTile(df::burrow *burrow, df::map_block *block, int x, int y)
@@ -2483,6 +2502,7 @@ void OpenDFHackApi(lua_State *state)
     OpenModule(state, "units", dfhack_units_module, dfhack_units_funcs);
     OpenModule(state, "items", dfhack_items_module, dfhack_items_funcs);
     OpenModule(state, "maps", dfhack_maps_module, dfhack_maps_funcs);
+    OpenModule(state, "world", dfhack_world_module);
     OpenModule(state, "burrows", dfhack_burrows_module, dfhack_burrows_funcs);
     OpenModule(state, "buildings", dfhack_buildings_module, dfhack_buildings_funcs);
     OpenModule(state, "constructions", dfhack_constructions_module);

--- a/library/include/modules/World.h
+++ b/library/include/modules/World.h
@@ -157,6 +157,11 @@ namespace DFHack
         DFHACK_EXPORT bool WriteGameMode(const t_gamemodes & wr); // this is very dangerous
         DFHACK_EXPORT std::string ReadWorldFolder();
 
+        DFHACK_EXPORT bool isFortressMode(df::game_type t = (df::game_type)-1);
+        DFHACK_EXPORT bool isAdventureMode(df::game_type t = (df::game_type)-1);
+        DFHACK_EXPORT bool isArena(df::game_type t = (df::game_type)-1);
+        DFHACK_EXPORT bool isLegends(df::game_type t = (df::game_type)-1);
+
         // Store data in fake historical figure names.
         // This ensures that the values are stored in save games.
         DFHACK_EXPORT PersistentDataItem AddPersistentData(const std::string &key);

--- a/library/modules/World.cpp
+++ b/library/modules/World.cpp
@@ -152,6 +152,35 @@ string World::ReadWorldFolder()
     return world->cur_savegame.save_dir;
 }
 
+bool World::isFortressMode(df::game_type t)
+{
+    if (t == -1 && df::global::gametype)
+        t = *df::global::gametype;
+    return (t == game_type::DWARF_MAIN || t == game_type::DWARF_RECLAIM ||
+        t == game_type::DWARF_UNRETIRE);
+}
+
+bool World::isAdventureMode(df::game_type t)
+{
+    if (t == -1 && df::global::gametype)
+        t = *df::global::gametype;
+    return (t == game_type::ADVENTURE_MAIN);
+}
+
+bool World::isArena(df::game_type t)
+{
+    if (t == -1 && df::global::gametype)
+        t = *df::global::gametype;
+    return (t == game_type::DWARF_ARENA || t == game_type::ADVENTURE_ARENA);
+}
+
+bool World::isLegends(df::game_type t)
+{
+    if (t == -1 && df::global::gametype)
+        t = *df::global::gametype;
+    return (t == game_type::VIEW_LEGENDS);
+}
+
 static PersistentDataItem dataFromHFig(df::historical_figure *hfig)
 {
     return PersistentDataItem(hfig->id, hfig->name.first_name, &hfig->name.nickname, hfig->name.words);

--- a/plugins/3dveins.cpp
+++ b/plugins/3dveins.cpp
@@ -10,6 +10,7 @@
 #include "PluginManager.h"
 #include "modules/MapCache.h"
 #include "modules/Random.h"
+#include "modules/World.h"
 
 #include "MiscUtils.h"
 
@@ -1626,7 +1627,7 @@ command_result cmd_3dveins(color_ostream &con, std::vector<std::string> & parame
         return CR_FAILURE;
     }
 
-    if (*gametype != game_type::DWARF_MAIN && *gametype != game_type::DWARF_RECLAIM)
+    if (!World::isFortressMode())
     {
         con.printerr("Must be used in fortress mode!\n");
         return CR_FAILURE;

--- a/plugins/createitem.cpp
+++ b/plugins/createitem.cpp
@@ -11,6 +11,7 @@
 #include "modules/Gui.h"
 #include "modules/Items.h"
 #include "modules/Materials.h"
+#include "modules/World.h"
 
 #include "DataDefs.h"
 #include "df/game_type.h"
@@ -84,7 +85,7 @@ bool makeItem (df::reaction_product_itemst *prod, df::unit *unit, bool second_it
 
     prod->produce(unit, &out_items, &in_reag, &in_items, 1, job_skill::NONE,
         df::historical_entity::find(unit->civ_id),
-        ((*gametype == game_type::DWARF_MAIN) || (*gametype == game_type::DWARF_RECLAIM)) ? df::world_site::find(ui->site_id) : NULL);
+        (World::isFortressMode()) ? df::world_site::find(ui->site_id) : NULL);
     if (!out_items.size())
         return false;
     // if we asked to make shoes and we got twice as many as we asked, then we're okay
@@ -348,7 +349,7 @@ command_result df_createitem (color_ostream &out, vector <string> & parameters)
     df::unit *unit = Gui::getSelectedUnit(out, true);
     if (!unit)
     {
-        if (*gametype == game_type::ADVENTURE_ARENA || *gametype == game_type::ADVENTURE_MAIN)
+        if (*gametype == game_type::ADVENTURE_ARENA || World::isAdventureMode())
         {
             // Use the adventurer unit
             unit = world->units.active[0];

--- a/plugins/reveal.cpp
+++ b/plugins/reveal.cpp
@@ -346,7 +346,7 @@ command_result revflood(color_ostream &out, vector<string> & params)
     }
     t_gamemodes gm;
     World::ReadGameMode(gm);
-    if(gm.g_type != game_type::DWARF_MAIN && gm.g_mode != game_mode::DWARF )
+    if(!World::isFortressMode(gm.g_type) || gm.g_mode != game_mode::DWARF )
     {
         out.printerr("Only in proper dwarf mode.\n");
         return CR_FAILURE;

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -119,8 +119,7 @@ command_result df_seedwatch(color_ostream &out, vector<string>& parameters)
     World::ReadGameMode(gm);// FIXME: check return value
 
     // if game mode isn't fortress mode
-    if(gm.g_mode != game_mode::DWARF ||
-        !(gm.g_type == game_type::DWARF_MAIN || gm.g_type == game_type::DWARF_RECLAIM))
+    if(gm.g_mode != game_mode::DWARF || !World::isFortressMode(gm.g_type))
     {
         // just print the help
         printHelp(out);
@@ -310,8 +309,7 @@ DFhackCExport command_result plugin_onupdate(color_ostream &out)
         t_gamemodes gm;
         World::ReadGameMode(gm);// FIXME: check return value
         // if game mode isn't fortress mode
-        if(gm.g_mode != game_mode::DWARF ||
-            !(gm.g_type == game_type::DWARF_MAIN || gm.g_type == game_type::DWARF_RECLAIM))
+        if(gm.g_mode != game_mode::DWARF || !World::isFortressMode(gm.g_type))
         {
             // stop running.
             running = false;


### PR DESCRIPTION
This addresses issues in several plugins (possibly scripts as well) which do not recognize certain game types as valid game types in fortress mode (particularly DWARF_UNRETIRE, which is new in 0.40.xx).
See #532 