### PR TITLE
Allow Lua scripts to implement enable/disable commands and specify other behavior (e.g. "module mode") that they implement

### DIFF
--- a/Lua API.rst
+++ b/Lua API.rst
@@ -3457,6 +3457,30 @@ Note that this function lets errors propagate to the caller.
   This will not be an issue in most cases.
   This function also permits circular dependencies of scripts.
 
+* ``dfhack.reqscript(name)`` or ``reqscript(name)``
+
+  Nearly identical to script_environment() but requires scripts being loaded to
+  include a line similar to::
+
+      --@ module = true
+
+  This is intended to only allow scripts that take appropriate action when used
+  as a module to be loaded.
+
+Enabling and disabling scripts
+==============================
+
+Scripts can choose to recognize the built-in ``enable`` and ``disable`` commands
+by including the following line anywhere in their file::
+
+    --@ enable = true
+
+When the ``enable`` and ``disable`` commands are invoked, a ``dfhack_flags``
+table will be passed to the script with the following fields set:
+
+* ``enable``: Always true if the script is being enabled *or* disabled
+* ``enable_state``: True if the script is being enabled, false otherwise
+
 Save init script
 ================
 

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ DFHack Future
         Developer plugins can be ignored on startup by setting the DFHACK_NO_DEV_PLUGINS environment variable
         The console on Linux and OS X now recognizes keyboard input between prompts
     Lua
+        Scripts can be enabled with the built-in enable/disable commands
+        A new function, reqscript(), is available as a safer alternative to script_environment()
     New internal commands
     New plugins
     New scripts

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -288,6 +288,10 @@ namespace {
         const string *pcmd;
         vector<string> *pargs;
     };
+    struct ScriptEnableState {
+        const string *pcmd;
+        bool pstate;
+    };
 }
 
 static bool init_run_script(color_ostream &out, lua_State *state, void *info)
@@ -311,6 +315,30 @@ static command_result runLuaScript(color_ostream &out, std::string name, vector<
     data.pargs = &args;
 
     bool ok = Lua::RunCoreQueryLoop(out, Lua::Core::State, init_run_script, &data);
+
+    return ok ? CR_OK : CR_FAILURE;
+}
+
+static bool init_enable_script(color_ostream &out, lua_State *state, void *info)
+{
+    auto args = (ScriptEnableState*)info;
+    if (!lua_checkstack(state, 4))
+        return false;
+    Lua::PushDFHack(state);
+    lua_getfield(state, -1, "enable_script");
+    lua_remove(state, -2);
+    lua_pushstring(state, args->pcmd->c_str());
+    lua_pushboolean(state, args->pstate);
+    return true;
+}
+
+static command_result enableLuaScript(color_ostream &out, std::string name, bool state)
+{
+    ScriptEnableState data;
+    data.pcmd = &name;
+    data.pstate = state;
+
+    bool ok = Lua::RunCoreQueryLoop(out, Lua::Core::State, init_enable_script, &data);
 
     return ok ? CR_OK : CR_FAILURE;
 }
@@ -637,8 +665,16 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
 
                     if(!plug)
                     {
-                        res = CR_NOT_FOUND;
-                        con.printerr("No such plugin: %s\n", parts[i].c_str());
+                        std::string lua = findScript(this->p->getPath(), parts[i] + ".lua");
+                        if (lua.size())
+                        {
+                            res = enableLuaScript(con, parts[i], enable);
+                        }
+                        else
+                        {
+                            res = CR_NOT_FOUND;
+                            con.printerr("No such plugin or Lua script: %s\n", parts[i].c_str());
+                        }
                     }
                     else if (!plug->can_set_enabled())
                     {

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -661,32 +661,43 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
 
                 for (size_t i = 0; i < parts.size(); i++)
                 {
-                    Plugin * plug = plug_mgr->getPluginByName(parts[i]);
+                    std::string part = parts[i];
+                    if (part.find('\\') != std::string::npos)
+                    {
+                        con.printerr("Replacing backslashes with forward slashes in \"%s\"\n", part.c_str());
+                        for (size_t j = 0; j < part.size(); j++)
+                        {
+                            if (part[j] == '\\')
+                                part[j] = '/';
+                        }
+                    }
+
+                    Plugin * plug = plug_mgr->getPluginByName(part);
 
                     if(!plug)
                     {
-                        std::string lua = findScript(this->p->getPath(), parts[i] + ".lua");
+                        std::string lua = findScript(this->p->getPath(), part + ".lua");
                         if (lua.size())
                         {
-                            res = enableLuaScript(con, parts[i], enable);
+                            res = enableLuaScript(con, part, enable);
                         }
                         else
                         {
                             res = CR_NOT_FOUND;
-                            con.printerr("No such plugin or Lua script: %s\n", parts[i].c_str());
+                            con.printerr("No such plugin or Lua script: %s\n", part.c_str());
                         }
                     }
                     else if (!plug->can_set_enabled())
                     {
                         res = CR_NOT_IMPLEMENTED;
-                        con.printerr("Cannot %s plugin: %s\n", first.c_str(), parts[i].c_str());
+                        con.printerr("Cannot %s plugin: %s\n", first.c_str(), part.c_str());
                     }
                     else
                     {
                         res = plug->set_enabled(con, enable);
 
                         if (res != CR_OK || plug->is_enabled() != enable)
-                            con.printerr("Could not %s plugin: %s\n", first.c_str(), parts[i].c_str());
+                            con.printerr("Could not %s plugin: %s\n", first.c_str(), part.c_str());
                     }
                 }
 

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -443,6 +443,13 @@ function dfhack.run_script(name,...)
     return dfhack.run_script_with_env(nil, name, nil, ...)
 end
 
+function dfhack.enable_script(name, state)
+    local res = dfhack.pcall(dfhack.run_script_with_env, nil, name, {enable=true, enable_state=state})
+    if not res then
+        qerror('Cannot ' .. (state and 'enable' or 'disable') .. ' Lua script: ' .. name)
+    end
+end
+
 function dfhack.script_environment(name)
     _, env = dfhack.run_script_with_env(nil, name, {module=true})
     return env

--- a/scripts/add-thought.lua
+++ b/scripts/add-thought.lua
@@ -1,4 +1,5 @@
 -- Adds emotions to creatures.
+--@ module = true
 
 local utils=require('utils')
 

--- a/scripts/modtools/reaction-product-trigger.lua
+++ b/scripts/modtools/reaction-product-trigger.lua
@@ -1,6 +1,7 @@
 -- scripts/modtools/reaction-product-trigger.lua
 -- author expwnent
 -- trigger commands just before and after custom reactions produce items
+--@ module = true
 
 local eventful = require 'plugins.eventful'
 local utils = require 'utils'

--- a/scripts/modtools/reaction-trigger.lua
+++ b/scripts/modtools/reaction-trigger.lua
@@ -1,6 +1,7 @@
 -- scripts/modtools/reaction-trigger.lua
 -- author expwnent
 -- replaces autoSyndrome: trigger commands when custom reactions are completed
+--@ module = true
 
 local eventful = require 'plugins.eventful'
 local syndromeUtil = require 'syndrome-util'


### PR DESCRIPTION
See #548
This currently works by scanning comments for lines of the form `--@ enable = true`, for example (`--@ enable = false`  also works, if script authors want to be explicit). Feel free to suggest a better way of retrieving data from a script without actually executing it.