### PR TITLE
Plugin exports

### DIFF
--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -268,6 +268,7 @@ bool Plugin::load(color_ostream &con)
     plugin_enable = (command_result (*)(color_ostream &,bool)) LookupPlugin(plug, "plugin_enable");
     plugin_is_enabled = (bool*) LookupPlugin(plug, "plugin_is_enabled");
     plugin_eval_ruby = (command_result (*)(color_ostream &, const char*)) LookupPlugin(plug, "plugin_eval_ruby");
+    plugin_get_exports = (void* (*)(void)) LookupPlugin(plug, "plugin_get_exports");
     index_lua(plug);
     this->name = *plug_name;
     plugin_lib = plug;
@@ -755,6 +756,16 @@ Plugin *PluginManager::getPluginByCommand(const std::string &command)
         return iter->second;
     else
         return NULL;
+}
+
+void *PluginManager::getPluginExports(const std::string &name)
+{
+    Plugin *plug = getPluginByName(name);
+    if (!plug)
+        return NULL;
+    if (plug->getState() != Plugin::plugin_state::PS_LOADED)
+        return NULL;
+    return plug->getExports();
 }
 
 // FIXME: handle name collisions...

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -268,7 +268,7 @@ bool Plugin::load(color_ostream &con)
     plugin_enable = (command_result (*)(color_ostream &,bool)) LookupPlugin(plug, "plugin_enable");
     plugin_is_enabled = (bool*) LookupPlugin(plug, "plugin_is_enabled");
     plugin_eval_ruby = (command_result (*)(color_ostream &, const char*)) LookupPlugin(plug, "plugin_eval_ruby");
-    plugin_get_exports = (void* (*)(void)) LookupPlugin(plug, "plugin_get_exports");
+    plugin_get_exports = (PluginExports* (*)(void)) LookupPlugin(plug, "plugin_get_exports");
     index_lua(plug);
     this->name = *plug_name;
     plugin_lib = plug;
@@ -523,6 +523,16 @@ Plugin::plugin_state Plugin::getState() const
     return state;
 }
 
+PluginExports *Plugin::getExports()
+{
+    if (!plugin_get_exports)
+        return NULL;
+    PluginExports *exports = plugin_get_exports();
+    if (!exports->bind(plugin_lib))
+        return NULL;
+    return exports;
+};
+
 void Plugin::index_lua(DFLibrary *lib)
 {
     if (auto cmdlist = (CommandReg*)LookupPlugin(lib, "plugin_lua_commands"))
@@ -693,6 +703,19 @@ void Plugin::push_function(lua_State *state, LuaFunction *fn)
     lua_pushfstring(state, "%s.%s()", name.c_str(), fn->name.c_str());
     lua_pushlightuserdata(state, fn);
     lua_pushcclosure(state, lua_fun_wrapper, 4);
+}
+
+bool PluginExports::bind(DFLibrary *lib)
+{
+    for (auto it = bindings.begin(); it != bindings.end(); ++it)
+    {
+        std::string name = it->first;
+        void** dest = it->second;
+        *dest = LookupPlugin(lib, name.c_str());
+        if (!*dest)
+            return false;
+    }
+    return true;
 }
 
 PluginManager::PluginManager(Core * core)

--- a/library/include/PluginManager.h
+++ b/library/include/PluginManager.h
@@ -162,6 +162,12 @@ namespace DFHack
         command_result invoke(color_ostream &out, const std::string & command, std::vector <std::string> & parameters);
         bool can_invoke_hotkey(const std::string & command, df::viewscreen *top );
         plugin_state getState () const;
+        void *getExports()
+        {
+            if (plugin_get_exports)
+                return plugin_get_exports();
+            return NULL;
+        };
 
         RPCService *rpc_connect(color_ostream &out);
 
@@ -224,6 +230,7 @@ namespace DFHack
         command_result (*plugin_enable)(color_ostream &, bool);
         RPCService* (*plugin_rpcconnect)(color_ostream &);
         command_result (*plugin_eval_ruby)(color_ostream &, const char*);
+        void* (*plugin_get_exports)(void);
     };
     class DFHACK_EXPORT PluginManager
     {
@@ -241,6 +248,7 @@ namespace DFHack
     public:
         Plugin *getPluginByName (const std::string & name);
         Plugin *getPluginByCommand (const std::string &command);
+        void *getPluginExports(const std::string &name);
         command_result InvokeCommand(color_ostream &out, const std::string & command, std::vector <std::string> & parameters);
         bool CanInvokeHotkey(const std::string &command, df::viewscreen *top);
         Plugin* operator[] (std::size_t index)
@@ -282,6 +290,17 @@ namespace DFHack
 #define DFHACK_PLUGIN_IS_ENABLED(varname) \
     DFhackDataExport bool plugin_is_enabled = false; \
     bool &varname = plugin_is_enabled;
+
+#define DFHACK_PLUGIN_EXPORTS(clsname) \
+    DFhackCExport void* plugin_get_exports() \
+    { \
+        static clsname* instance = NULL; \
+        if (!instance) \
+            instance = new clsname; \
+        return (void*)instance; \
+    }
+#define GET_PLUGIN_EXPORTS(plugname, clsname) \
+    (clsname*)DFHack::Core::getInstance().getPluginManager()->getPluginExports(plugname)
 
 #define DFHACK_PLUGIN_LUA_COMMANDS \
     DFhackCExport const DFHack::CommandReg plugin_lua_commands[] =


### PR DESCRIPTION
This allows plugins to make certain functions available to an object. It currently works much like the Lua side by returning a single object with all functions that a plugin exports available as methods.