### PR TITLE
Add scripts: burial and fix-ster

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ DFHack Future
     New plugins
     New scripts
         view-item-info: adds information and customisable descriptions to item viewscreens
+        fix-ster:  changes fertility/sterility of animals or dwarves
     New tweaks
     New features
         dwarfmonitor date format can be modified (see Readme)

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ DFHack Future
     New scripts
         view-item-info: adds information and customisable descriptions to item viewscreens
         fix-ster:  changes fertility/sterility of animals or dwarves
+        burial:  sets all unowned coffins to allow burial ("-pets" to allow pets too)
     New tweaks
     New features
         dwarfmonitor date format can be modified (see Readme)

--- a/Readme.rst
+++ b/Readme.rst
@@ -2247,6 +2247,11 @@ If the name of the patch has no extension or directory separators, the
 script uses ``hack/patches/<df-version>/<name>.dif``, thus auto-selecting
 the version appropriate for the currently loaded executable.
 
+burial
+======
+Sets all unowned coffins to allow burial.  ``burial -pets`` also allows burial
+of pets.
+
 create-items
 ============
 Spawn arbitrary items under the cursor.

--- a/Readme.rst
+++ b/Readme.rst
@@ -2353,6 +2353,18 @@ To purify all elves on the map with fire (may have side-effects)::
 
     exterminate elve magma
 
+fix-ster
+========
+Utilizes the orientation tag to either fix infertile creatures or inflict
+infertility on creatures that you do not want to breed.  Usage::
+
+    fix-ster [fert|ster] [all|animals|only:<creature>]
+
+``fert`` or ``ster`` is a required argument; whether to make the target fertile
+or sterile.  Optional arguments specify the target: no argument for the
+selected unit, ``all`` for all units on the map, ``animals`` for all non-dwarf
+creatures, or ``only:<creature>`` to only process matching creatures.
+
 fortplan
 ========
 Usage: fortplan [filename]

--- a/scripts/burial.lua
+++ b/scripts/burial.lua
@@ -1,0 +1,19 @@
+-- allows burial in unowned coffins
+-- by Putnam https://gist.github.com/Putnam3145/e7031588f4d9b24b9dda
+
+local utils=require('utils')
+
+validArgs = validArgs or utils.invert({
+ 'pets'
+})
+
+local args = utils.processArgs({...}, validArgs)
+
+for k,v in ipairs(df.global.world.buildings.other.COFFIN) do
+    if v.owner_id==-1 then
+        v.burial_mode.allow_burial=true
+        if not args.pets then
+            v.burial_mode.no_pets=true
+        end
+    end
+end

--- a/scripts/fix-ster.lua
+++ b/scripts/fix-ster.lua
@@ -1,0 +1,130 @@
+-- makes creatures [in]fertile, by modifying orientation
+-- usage:  fix-ster [fert|ster] [all|animals|only:<creature>]
+-- by Tacomagic (minor fixes by PeridexisErrant)
+
+--[[
+This script utilizes the orientation tag to either fix infertile creatures
+or inflict infertility on creatures that you do not want to breed
+
+Required arg:
+   fert: sets the flag to assure creature(s) are fertile
+   ster: sets the flag to assure creature(s) are sterile
+Optional args:
+   <no arg>         the script will only process the currently selected creature
+   all:             process all creatures currently on the map
+   animals:         processes everything but dwarves on the map
+   only:<creature>: processes all of the creatures matching the specified creature on the map
+]]--
+
+function getunit()
+    local unit
+    unit=dfhack.gui.getSelectedUnit()
+    if unit==nil then
+        print("No unit under cursor.")
+        return
+    end
+    return unit
+end
+
+function changeorient(unit,ori)
+    --Sets the fertility flag based on gender.
+    if unit.sex == 0 then
+        unit.status.current_soul.orientation_flags.marry_male=ori
+    else
+        unit.status.current_soul.orientation_flags.marry_female=ori
+    end
+    return
+end
+
+function changelots(creatures,ori)
+    local v
+    local unit
+    local c = 0
+    --loops through indexes in creatures table and changes orientation flags
+    for _,v in ipairs(creatures) do
+        unit = df.global.world.units.active[v]
+        changeorient(unit,ori)
+        c = c + 1
+    end
+    print("Changed "..c.. " creatures.")
+    return
+end
+
+function process_args(arg)
+    local n,v
+    local ori
+    local creatures = {}
+    local crenum
+    --Checks for any arguments at all.
+    if arg==nil then
+        print("No arguments.  Usage is: fixster <fert|ster> [all|animals|only:<creature>]")
+        return
+    end
+    if string.lower(arg[1])=="ster" then
+        ori = false
+    elseif string.lower(arg[1])=="fert" then
+        ori = true
+    else
+        print("Unrecognised first argument.  Aborting.")
+        return
+    end
+
+    --Checks for the existence of the second argument.  If it's missing, uses selected unit (if any)
+    if arg[2]==nil then
+        unit = getunit()
+        if unit == nil then return end
+        changeorient(unit,ori)
+        print('Changed selected creature.')
+
+    --ALL arg processing
+    elseif string.lower(arg[2])=="all" then
+        --Create table of all current unit indexes
+        for n,v in ipairs(df.global.world.units.active) do
+            table.insert(creatures,n)
+        end
+        changelots(creatures,ori)
+
+    --ANIMALS arg processing
+    elseif string.lower(arg[2])=="animals" then
+        --Create a table of all creature indexes except dwarves on the current map
+        for n,v in ipairs(df.global.world.units.active) do
+            if v.race~=df.global.ui.race_id then
+                table.insert(creatures,n)
+            end
+        end
+        changelots(creatures,ori)
+
+    -- ONLY:<creature> arg processing
+    elseif string.lower(string.sub(arg[2],1,4))=="only" then
+        creidx = string.upper(string.sub(arg[2],6))
+
+        print(string.upper(string.sub(arg[2],6)))
+
+        --Search raws for creature
+        for k,v in pairs(df.global.world.raws.creatures.all) do
+            if v.creature_id==creidx then
+                crenum = k
+            end
+        end
+        --If no match, abort
+        if crenum == nil then
+            print("Creature not found.  Check spelling.")
+            return
+        end
+
+        --create a table of all the matching creature indexes on the map for processing
+        for n,v in ipairs(df.global.world.units.active) do
+            if v.race == crenum then
+                table.insert(creatures,n)
+            end
+        end
+        changelots(creatures,ori)
+    else
+        print("Unrecognised optional argument.  Aborting")
+        return
+    end
+    return
+end
+
+local arg = table.pack(...)
+process_args(arg)


### PR DESCRIPTION
Adds two scripts which have been useful to many people through my pack.

`burial.lua` is very simple; it just allows burial for dwarves (and optionally pets) in unowned coffins.  @Putnam3145 is presumably fine with this.

`fix-ster.lua` was written by Tacomagic on DFFD, and allows control of animal (and dwarven) fertility.  Very useful for livestock, or if there's some other breeding issue.  The code style might not be great, but it works and is again useful to a fair few people.