### PR TITLE
Improved issue with workflow job being resumed but never being worked

### DIFF
--- a/plugins/workflow.cpp
+++ b/plugins/workflow.cpp
@@ -254,7 +254,7 @@ public:
             if (!resume_time)
                 want_resumed = false;
             else if (world->frame_counter >= resume_time)
-                actual_job->flags.bits.suspend = false;
+                set_resumed(true);
         }
     }
 
@@ -262,7 +262,7 @@ public:
     {
         actual_job = job;
         job->flags.bits.repeat = true;
-        job->flags.bits.suspend = true;
+        set_resumed(false);
 
         resume_delay = std::min(DAY_TICKS*MONTH_DAYS, 5*resume_delay/3);
         resume_time = world->frame_counter + resume_delay;
@@ -272,8 +272,11 @@ public:
     {
         if (resume)
         {
-            if (world->frame_counter >= resume_time)
+            if (world->frame_counter >= resume_time && actual_job->flags.bits.suspend)
+            {
+                actual_job->unk_v4020_1 = -1;
                 actual_job->flags.bits.suspend = false;
+            }
         }
         else
         {
@@ -281,7 +284,11 @@ public:
             if (isActuallyResumed())
                 resume_delay = DAY_TICKS;
 
-            actual_job->flags.bits.suspend = true;
+            if (!actual_job->flags.bits.suspend)
+            {
+                actual_job->flags.bits.suspend = true;
+                actual_job->unk_v4020_1 = -1;
+            }
         }
 
         want_resumed = resume;


### PR DESCRIPTION
Fixes #487

* This doesn't fix existing stuck jobs, in order to fix, remove repeat, cancel, add, repeat
* Most workshops worked great after this, however, I noticed my bone bolts and wood bolts still got stuck, not sure if it is the same issue

* The unk_v4020_1 field was not being reset to -1 when resuming the job.
* Updated to be reset only when the job is being resumed
  * Setting it to -1 without checking sets this field on all workflow jobs, which causes a crash
* Made other calls to suspend call set_resumed rather than setting the suspend field

This is the behavior I saw for the unk_v4020_1 field:
Suspended jobs: -1
Jobs not in the top of the list but not suspended: -1
Jobs at the top of the list to work next, not suspended: A positive integer (priority of job?)