### PR TITLE
Twbt compatible plugins

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,11 +25,13 @@ DFHack Future
         tweak fps-min fixed
         workflow: Fixed some issues with stuck jobs
             - Note: Existing stuck jobs must be cancelled and re-added
+        automaterial, mousequery, and resume plugins are now compatible with TwbT by default
     Misc Improvements
         dwarfmonitor date format can be modified (see Readme)
         "keybinding list" accepts a context
         nyan: Can now be stopped with dfhack-run
         quicksave: Restricted to fortress mode
+        mousequery:  drag command enables dragging the map with configurable mouse buttons
     Removed
 
 DFHack 0.40.24-r3

--- a/Readme.rst
+++ b/Readme.rst
@@ -311,6 +311,31 @@ Controls speedydwarf and teledwarf. Speedydwarf makes dwarves move quickly and p
 Game interface
 ==============
 
+mousequery
+----------
+Adds mouse-based controls and information views.  
+
+Mousequery has a number of independently-controlled functions, including:
+
+* moving the cursor in build and designation mode
+* displaying the ``k`` text of the item under the cursor at the bottom of the main menu
+* cycling through information displays (``k, q, v``) when clicking on a tile from the main menu
+* moving the map by hovering at the edge of the display area
+* moving the map by click-and-dragging
+
+The commands are as follows::
+
+    mousequery [plugin|rbutton|track|edge|live] [enable|disable]
+        plugin: enable/disable the entire plugin
+        rbutton: enable/disable right mouse button
+        track: enable/disable moving cursor in build and designation mode
+        edge: enable/disable active edge scrolling (when on, will also enable tracking)
+        live: enable/disable query view when unpaused
+    mousequery drag [left|right|disable]
+        Enable map dragging with the specified mouse button, or disable it
+    mousequery delay [amount]
+        Show current delay when edge scrolling, or set to <amount> milliseconds
+
 follow
 ------
 Makes the game view follow the currently highlighted unit after you exit from

--- a/Readme.rst
+++ b/Readme.rst
@@ -313,7 +313,7 @@ Game interface
 
 mousequery
 ----------
-Adds mouse-based controls and information views.  
+Adds mouse-based controls and information views.
 
 Mousequery has a number of independently-controlled functions, including:
 

--- a/plugins/automaterial.cpp
+++ b/plugins/automaterial.cpp
@@ -36,6 +36,10 @@
 #include "TileTypes.h"
 #include "df/job_item.h"
 
+#include "df/enabler.h"
+#include "df/renderer.h"
+#include "renderer_twbt.h"
+
 using namespace std;
 using std::map;
 using std::string;
@@ -45,6 +49,7 @@ using namespace DFHack;
 using namespace df::enums;
 
 DFHACK_PLUGIN("automaterial");
+REQUIRE_GLOBAL(enabler);
 REQUIRE_GLOBAL(gps);
 REQUIRE_GLOBAL(ui);
 REQUIRE_GLOBAL(ui_build_selector);
@@ -677,7 +682,13 @@ struct jobutils_hook : public df::viewscreen_dwarfmodest
 
             x = x - vport.x + 1;
             y = y - vport.y + 1;
-            OutputString(COLOR_GREEN, x, y, "X");
+
+            renderer_cool *r = (renderer_cool*)enabler->renderer;
+            if (r->is_twbt())
+                r->output_char(COLOR_GREEN, x, y, 'X');
+            else
+                OutputString(COLOR_GREEN, x, y, "X");
+
         }
         else if (show_box_selection && box_select_mode == SELECT_SECOND)
         {
@@ -697,7 +708,12 @@ struct jobutils_hook : public df::viewscreen_dwarfmodest
 
                     int32_t x = xB - vport.x + 1;
                     int32_t y = yB - vport.y + 1;
-                    OutputString(color, x, y, "X");
+
+                    renderer_cool *r = (renderer_cool*)enabler->renderer;
+                    if (r->is_twbt())
+                        r->output_char(color, x, y, 'X');
+                    else
+                        OutputString(color, x, y, "X");
                 }
             }
         }
@@ -707,7 +723,13 @@ struct jobutils_hook : public df::viewscreen_dwarfmodest
             {
                 int32_t x = it->pos.x - vport.x + 1;
                 int32_t y = it->pos.y - vport.y + 1;
-                OutputString(COLOR_GREEN, x, y, "X");
+
+                renderer_cool *r = (renderer_cool*)enabler->renderer;
+                if (r->is_twbt())
+                    r->output_char(COLOR_GREEN, x, y, 'X');
+                else
+                    OutputString(COLOR_GREEN, x, y, "X");
+
             }
         }
     }
@@ -1172,9 +1194,18 @@ struct jobutils_hook : public df::viewscreen_dwarfmodest
                     label << "Selection: " << dX << "x" << dY;
                     OutputString(COLOR_WHITE, x, ++y, label.str(), true, left_margin);
 
-                    int cx = box_first.x;
-                    int cy = box_first.y;
-                    OutputString(COLOR_BROWN, cx, cy, "X");
+                    df::coord vport = Gui::getViewportPos();
+
+                    int cx = box_first.x - vport.x + 1;
+                    int cy = box_first.y - vport.y + 1;
+
+                    renderer_cool *r = (renderer_cool*)enabler->renderer;
+                    if (r->is_twbt())
+                        r->output_char(COLOR_BROWN, cx, cy, 'X');
+                    else
+
+
+                        OutputString(COLOR_BROWN, cx, cy, "X");
                 }
 
                 OutputString(COLOR_BROWN, x, ++y, "Ignore Building Restrictions", true, left_margin);
@@ -1188,7 +1219,7 @@ color_ostream_proxy console_out(Core::getInstance().getConsole());
 
 
 IMPLEMENT_VMETHOD_INTERPOSE(jobutils_hook, feed);
-IMPLEMENT_VMETHOD_INTERPOSE(jobutils_hook, render);
+IMPLEMENT_VMETHOD_INTERPOSE_PRIO(jobutils_hook, render, 300);
 
 DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 

--- a/plugins/mousequery.cpp
+++ b/plugins/mousequery.cpp
@@ -21,6 +21,9 @@
 #include "TileTypes.h"
 #include "DataFuncs.h"
 
+#include "df/renderer.h"
+#include "renderer_twbt.h"
+
 DFHACK_PLUGIN("mousequery");
 REQUIRE_GLOBAL(world);
 REQUIRE_GLOBAL(ui);
@@ -46,6 +49,9 @@ static bool mouse_moved = false;
 
 static int scroll_delay = 100;
 
+static bool awaiting_lbut_up, awaiting_rbut_up;
+static enum { None, Left, Right } drag_mode;
+color_ostream *out2;
 static df::coord get_mouse_pos(int32_t &mx, int32_t &my)
 {
     df::coord pos;
@@ -63,7 +69,12 @@ static df::coord get_mouse_pos(int32_t &mx, int32_t &my)
 
     pos.x = vx + mx - 1;
     pos.y = vy + my - 1;
-    pos.z = vz;
+
+    renderer_cool *r = (renderer_cool*)enabler->renderer;
+    if (r->is_twbt())
+        pos.z = vz - r->depth_at(mx, my);
+    else
+        pos.z = vz;
 
     return pos;
 }
@@ -181,6 +192,10 @@ static df::interface_key get_default_query_mode(const df::coord pos)
     return (fallback_to_building_query) ? df::interface_key::D_BUILDJOB : df::interface_key::D_LOOK;
 }
 
+extern "C" {
+    unsigned char *SDL_GetKeyState(int *numkeys);
+}
+
 struct mousequery_hook : public df::viewscreen_dwarfmodest
 {
     typedef df::viewscreen_dwarfmodest interpose_base;
@@ -290,6 +305,172 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
         return false;
     }
 
+    bool handleLeft(df::coord &mpos, int32_t mx, int32_t my)
+    {
+        static unsigned char *keystate = 0;
+        if (!keystate)
+            keystate = SDL_GetKeyState(NULL);
+
+        if (!(keystate[303] || keystate[304]))
+        {
+            renderer_cool *r = (renderer_cool*)enabler->renderer;
+            if (r->is_twbt())
+                mpos.z += r->depth_at(mx, my);
+        }
+
+        renderer_cool *r = (renderer_cool*)enabler->renderer;
+        auto mapdims = r->is_twbt() ? r->map_dims() : Gui::getDwarfmodeViewDims();
+
+        bool cursor_still_here = (last_clicked_x == mpos.x && last_clicked_y == mpos.y && last_clicked_z == mpos.z);
+        last_clicked_x = mpos.x;
+        last_clicked_y = mpos.y;
+        last_clicked_z = mpos.z;
+
+        df::interface_key key = interface_key::NONE;
+        bool designationMode = false;
+        bool skipRefresh = false;
+
+        if (isInTrackableMode())
+        {
+            designationMode = true;
+            key = df::interface_key::SELECT;
+        }
+        else
+        {
+            switch (ui->main.mode)
+            {
+            case QueryBuilding:
+                if (cursor_still_here)
+                    key = df::interface_key::D_BUILDITEM;
+                break;
+
+            case BuildingItems:
+                if (cursor_still_here)
+                    key = df::interface_key::D_VIEWUNIT;
+                break;
+
+            case ViewUnits:
+                if (cursor_still_here)
+                    key = df::interface_key::D_LOOK;
+                break;
+
+            case LookAround:
+                if (cursor_still_here)
+                    key = df::interface_key::D_BUILDJOB;
+                break;
+
+            case Build:
+                if (ui_build_selector)
+                {
+                    if (ui_build_selector->stage < 2)
+                    {
+                        designationMode = true;
+                        key = df::interface_key::SELECT;
+                    }
+                    else
+                    {
+                        designationMode = true;
+                        skipRefresh = true;
+                        key = df::interface_key::SELECT_ALL;
+                    }
+                }
+                break;
+
+            case Default:
+                break;
+
+            default:
+                return false;
+            }
+        }
+
+        enabler->mouse_lbut = 0;
+
+        // Can't check limits earlier as we must be sure we are in query or default mode
+        // (so we can clear the button down flag)
+        if (mx < 1 || mx > mapdims.map_x2 || my < 1 || my > mapdims.y2)
+            return false;
+
+        if (ui->main.mode == df::ui_sidebar_mode::Zones ||
+            ui->main.mode == df::ui_sidebar_mode::Stockpiles)
+        {
+            int32_t x, y, z;
+            if (Gui::getDesignationCoords(x, y, z))
+            {
+                auto dX = abs(x - mpos.x);
+                if (dX > 30)
+                    return false;
+
+                auto dY = abs(y - mpos.y);
+                if (dY > 30)
+                    return false;
+            }
+        }
+
+        if (!designationMode)
+        {
+            while (ui->main.mode != Default)
+            {
+                sendKey(df::interface_key::LEAVESCREEN);
+            }
+
+            if (key == interface_key::NONE)
+                key = get_default_query_mode(mpos);
+
+            sendKey(key);
+        }
+
+        if (!skipRefresh)
+        {
+            // Force UI refresh
+            moveCursor(mpos, true);
+        }
+
+        if (designationMode)
+            sendKey(key);
+
+        return true;
+    }
+
+    bool handleRight(df::coord &mpos, int32_t mx, int32_t my)
+    {
+        renderer_cool *r = (renderer_cool*)enabler->renderer;
+        auto dims = r->is_twbt() ? r->map_dims() : Gui::getDwarfmodeViewDims();
+
+        if (isInDesignationMenu() && !box_designation_enabled)
+            return false;
+
+        // Escape out of query mode
+        enabler->mouse_rbut_down = 0;
+        enabler->mouse_rbut = 0;
+
+        using namespace df::enums::ui_sidebar_mode;
+        if ((ui->main.mode == QueryBuilding || ui->main.mode == BuildingItems ||
+            ui->main.mode == ViewUnits || ui->main.mode == LookAround) ||
+            (isInTrackableMode() && tracking_enabled))
+        {
+            sendKey(df::interface_key::LEAVESCREEN);
+        }
+        else
+        {
+            int scroll_trigger_x = dims.map_x2 / 3;
+            int scroll_trigger_y = dims.y2 / 3;
+            if (mx < scroll_trigger_x)
+                sendKey(interface_key::CURSOR_LEFT_FAST);
+
+            if (mx > dims.map_x2 - scroll_trigger_x)
+                sendKey(interface_key::CURSOR_RIGHT_FAST);
+
+            if (my < scroll_trigger_y)
+                sendKey(interface_key::CURSOR_UP_FAST);
+
+            if (my > dims.y2 - scroll_trigger_y)
+                sendKey(interface_key::CURSOR_DOWN_FAST);
+        }
+
+        return false;
+    }
+
     bool handleMouse(const set<df::interface_key> *input)
     {
         int32_t mx, my;
@@ -297,152 +478,27 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
         if (mpos.x == -30000)
             return false;
 
-        auto dims = Gui::getDwarfmodeViewDims();
         if (enabler->mouse_lbut)
         {
-            bool cursor_still_here = (last_clicked_x == mpos.x && last_clicked_y == mpos.y && last_clicked_z == mpos.z);
-            last_clicked_x = mpos.x;
-            last_clicked_y = mpos.y;
-            last_clicked_z = mpos.z;
-
-            df::interface_key key = interface_key::NONE;
-            bool designationMode = false;
-            bool skipRefresh = false;
-
-            if (isInTrackableMode())
+            if (drag_mode == Left)
             {
-                designationMode = true;
-                key = df::interface_key::SELECT;
+                awaiting_lbut_up = true;
+                enabler->mouse_lbut = false;
+                last_move_pos = mpos;
             }
             else
-            {
-                switch (ui->main.mode)
-                {
-                case QueryBuilding:
-                    if (cursor_still_here)
-                        key = df::interface_key::D_BUILDITEM;
-                    break;
-
-                case BuildingItems:
-                    if (cursor_still_here)
-                        key = df::interface_key::D_VIEWUNIT;
-                    break;
-
-                case ViewUnits:
-                    if (cursor_still_here)
-                        key = df::interface_key::D_LOOK;
-                    break;
-
-                case LookAround:
-                    if (cursor_still_here)
-                        key = df::interface_key::D_BUILDJOB;
-                    break;
-
-                case Build:
-                    if (ui_build_selector)
-                    {
-                        if (ui_build_selector->stage < 2)
-                        {
-                            designationMode = true;
-                            key = df::interface_key::SELECT;
-                        }
-                        else
-                        {
-                            designationMode = true;
-                            skipRefresh = true;
-                            key = df::interface_key::SELECT_ALL;
-                        }
-                    }
-                    break;
-
-                case Default:
-                    break;
-
-                default:
-                    return false;
-                }
-            }
-
-            enabler->mouse_lbut = 0;
-
-            // Can't check limits earlier as we must be sure we are in query or default mode
-            // (so we can clear the button down flag)
-            int right_bound = (dims.menu_x1 > 0) ? dims.menu_x1 - 2 : gps->dimx - 2;
-            if (mx < 1 || mx > right_bound || my < 1 || my > gps->dimy - 2)
-                return false;
-
-            if (ui->main.mode == df::ui_sidebar_mode::Zones ||
-                ui->main.mode == df::ui_sidebar_mode::Stockpiles)
-            {
-                int32_t x, y, z;
-                if (Gui::getDesignationCoords(x, y, z))
-                {
-                    auto dX = abs(x - mpos.x);
-                    if (dX > 30)
-                        return false;
-
-                    auto dY = abs(y - mpos.y);
-                    if (dY > 30)
-                        return false;
-                }
-            }
-
-            if (!designationMode)
-            {
-                while (ui->main.mode != Default)
-                {
-                    sendKey(df::interface_key::LEAVESCREEN);
-                }
-
-                if (key == interface_key::NONE)
-                    key = get_default_query_mode(mpos);
-
-                sendKey(key);
-            }
-
-            if (!skipRefresh)
-            {
-                // Force UI refresh
-                moveCursor(mpos, true);
-            }
-
-            if (designationMode)
-                sendKey(key);
-
-            return true;
+                return handleLeft(mpos, mx, my);
         }
-        else if (rbutton_enabled && enabler->mouse_rbut)
+        else if (enabler->mouse_rbut)
         {
-            if (isInDesignationMenu() && !box_designation_enabled)
-                return false;
-
-            // Escape out of query mode
-            enabler->mouse_rbut_down = 0;
-            enabler->mouse_rbut = 0;
-
-            using namespace df::enums::ui_sidebar_mode;
-            if ((ui->main.mode == QueryBuilding || ui->main.mode == BuildingItems ||
-                ui->main.mode == ViewUnits || ui->main.mode == LookAround) ||
-                (isInTrackableMode() && tracking_enabled))
+            if (drag_mode == Right)
             {
-                sendKey(df::interface_key::LEAVESCREEN);
+                awaiting_rbut_up = true;
+                enabler->mouse_rbut = false;
+                last_move_pos = mpos;
             }
-            else
-            {
-                int scroll_trigger_x = dims.menu_x1 / 3;
-                int scroll_trigger_y = gps->dimy / 3;
-                if (mx < scroll_trigger_x)
-                    sendKey(interface_key::CURSOR_LEFT_FAST);
-
-                if (mx > ((dims.menu_x1 > 0) ? dims.menu_x1 : gps->dimx) - scroll_trigger_x)
-                    sendKey(interface_key::CURSOR_RIGHT_FAST);
-
-                if (my < scroll_trigger_y)
-                    sendKey(interface_key::CURSOR_UP_FAST);
-
-                if (my > gps->dimy - scroll_trigger_y)
-                    sendKey(interface_key::CURSOR_DOWN_FAST);
-            }
+            else if (rbutton_enabled)
+                return handleRight(mpos, mx, my);
         }
         else if (input->count(interface_key::CUSTOM_ALT_M) && isInDesignationMenu())
         {
@@ -547,13 +603,14 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
 
         static decltype(enabler->clock) last_t = 0;
 
-        auto dims = Gui::getDwarfmodeViewDims();
-        auto right_margin = (dims.menu_x1 > 0) ? dims.menu_x1 : gps->dimx;
+        renderer_cool *r = (renderer_cool*)enabler->renderer;
+        auto txtdims = Gui::getDwarfmodeViewDims();
+        auto mapdims = r->is_twbt() ? r->map_dims() : txtdims;
 
         int32_t mx, my;
         auto mpos = get_mouse_pos(mx, my);
         bool mpos_valid = mpos.x != -30000 && mpos.y != -30000 && mpos.z != -30000;
-        if (mx < 1 || mx > right_margin - 2 || my < 1 || my > gps->dimy - 2)
+        if (mx < 1 || mx > mapdims.map_x2 || my < 1 || my > mapdims.y2)
             mpos_valid = false;
 
         // Check if in lever binding mode
@@ -563,17 +620,55 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
             return;
         }
 
+        if (awaiting_lbut_up && !enabler->mouse_lbut_down)
+        {
+            awaiting_lbut_up = false;
+            handleLeft(mpos, mx, my);
+        }
+
+        if (awaiting_rbut_up && !enabler->mouse_rbut_down)
+        {
+            awaiting_rbut_up = false;
+            if (rbutton_enabled)
+                handleRight(mpos, mx, my);
+        }
+
         if (mpos_valid)
         {
             if (mpos.x != last_move_pos.x || mpos.y != last_move_pos.y || mpos.z != last_move_pos.z)
             {
+                awaiting_lbut_up = false;
+                awaiting_rbut_up = false;
+
+                if ((enabler->mouse_lbut_down && drag_mode == Left) || (enabler->mouse_rbut_down && drag_mode == Right))
+                {
+                    int newx = (*df::global::window_x) - (mpos.x - last_move_pos.x);
+                    int newy = (*df::global::window_y) - (mpos.y - last_move_pos.y);
+
+                    renderer_cool *r = (renderer_cool*)enabler->renderer;
+                    if (r->is_twbt())
+                    {
+                        newx = std::max(0, std::min(newx, world->map.x_count - r->gdimxfull));
+                        newy = std::max(0, std::min(newy, world->map.y_count - r->gdimyfull));
+                    }
+                    else
+                    {
+                        newx = std::max(0, std::min(newx, world->map.x_count - mapdims.map_x2));
+                        newy = std::max(0, std::min(newy, world->map.y_count - mapdims.y2));
+                    }
+
+                    (*df::global::window_x) = newx;
+                    (*df::global::window_y) = newy;
+                    return;
+                }
+
                 mouse_moved = true;
                 last_move_pos = mpos;
             }
         }
 
-        int left_margin = dims.menu_x1 + 1;
-        int look_width = dims.menu_x2 - dims.menu_x1 - 1;
+        int left_margin = txtdims.menu_x1 + 1;
+        int look_width = txtdims.menu_x2 - txtdims.menu_x1 - 1;
         int disp_x = left_margin;
 
         if (isInDesignationMenu())
@@ -630,7 +725,7 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
                 return;
             }
 
-            if (mx > right_margin - scroll_buffer)
+            if (mx > mapdims.map_x2 - scroll_buffer)
             {
                 sendKey(interface_key::CURSOR_RIGHT);
                 return;
@@ -642,7 +737,7 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
                 return;
             }
 
-            if (my > gps->dimy - scroll_buffer)
+            if (my > mapdims.y2 - scroll_buffer)
             {
                 sendKey(interface_key::CURSOR_DOWN);
                 return;
@@ -672,25 +767,33 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
                 }
             }
 
-            OutputString(color, mx, my, "X");
+            renderer_cool *r = (renderer_cool*)enabler->renderer;
+            if (r->is_twbt())
+                r->output_char(color, mx, my, 'X');
+            else
+                OutputString(color, mx, my, "X");
             return;
         }
 
         if (shouldTrack())
         {
             if (delta_t <= scroll_delay && (mx < scroll_buffer ||
-                mx > dims.menu_x1 - scroll_buffer ||
+                mx > mapdims.map_x2 - scroll_buffer ||
                 my < scroll_buffer ||
-                my > gps->dimy - scroll_buffer))
+                my > mapdims.y2 - scroll_buffer))
             {
                 return;
             }
+
+            // Don't change levels
+            if (mpos.z != *df::global::window_z)
+                return;
 
             last_t = enabler->clock;
             moveCursor(mpos, false);
         }
 
-        if (dims.menu_x1 <= 0)
+        if (txtdims.menu_x1 <= 0)
             return; // No menu displayed
 
         if (!is_valid_pos(mpos) || isInTrackableMode())
@@ -707,6 +810,14 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
         int look_list = ulist.size() + ((bld) ? 1 : 0) + ilist.size() + 1;
         set_to_limit(look_list, 8);
         int disp_y = gps->dimy - look_list - 2;
+
+        if (mpos.z != *df::global::window_z)
+        {
+            int y = gps->dimy - 2;
+            char buf[6];
+            sprintf(buf, "@%d", mpos.z - *df::global::window_z);
+            OutputString(COLOR_GREY, disp_x, y, buf, true, left_margin);
+        }
 
         int c = 0;
         for (auto it = ulist.begin(); it != ulist.end() && c < 8; it++, c++)
@@ -751,7 +862,7 @@ struct mousequery_hook : public df::viewscreen_dwarfmodest
 };
 
 IMPLEMENT_VMETHOD_INTERPOSE_PRIO(mousequery_hook, feed, 100);
-IMPLEMENT_VMETHOD_INTERPOSE_PRIO(mousequery_hook, render, 100);
+IMPLEMENT_VMETHOD_INTERPOSE_PRIO(mousequery_hook, render, 300);
 
 static command_result mousequery_cmd(color_ostream &out, vector <string> & parameters)
 {
@@ -791,6 +902,15 @@ static command_result mousequery_cmd(color_ostream &out, vector <string> & param
         else if (cmd[0] == 'l')
         {
             live_view = (state == "enable");
+        }
+        else if (cmd == "drag")
+        {
+            if (state == "left")
+                drag_mode = Left;
+            else if (state == "right")
+                drag_mode = Right;
+            else if (state == "disable")
+                drag_mode = None;
         }
         else if (cmd[0] == 'd')
         {
@@ -836,16 +956,19 @@ DFhackCExport command_result plugin_enable ( color_ostream &out, bool enable)
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
+    out2 = &out;
     commands.push_back(
         PluginCommand(
         "mousequery", "Add mouse functionality to Dwarf Fortress",
         mousequery_cmd, false,
-        "mousequery [plugin|rbutton|track|edge|live] [enabled|disabled]\n"
+        "mousequery [plugin|rbutton|track|edge|live] [enable|disable]\n"
         "  plugin: enable/disable the entire plugin\n"
         "  rbutton: enable/disable right mouse button\n"
         "  track: enable/disable moving cursor in build and designation mode\n"
         "  edge: enable/disable active edge scrolling (when on, will also enable tracking)\n"
         "  live: enable/disable query view when unpaused\n\n"
+        "mousequery drag [left|right|disable]\n"
+        "  Enable/disable map dragging with the specified mouse button\n\n"
         "mousequery delay <amount>\n"
         "  Set delay when edge scrolling in tracking mode. Omit amount to display current setting.\n"
         ));

--- a/plugins/resume.cpp
+++ b/plugins/resume.cpp
@@ -177,7 +177,7 @@ void show_suspended_buildings()
             renderer_cool *r = (renderer_cool*)enabler->renderer;
             if (r->dummy == 'TWBT')
                 r->output_char(color, x, y, 'X');
-            else            
+            else
                 OutputString(color, x, y, "X");
         }
 

--- a/plugins/resume.cpp
+++ b/plugins/resume.cpp
@@ -27,6 +27,10 @@
 
 #include "modules/World.h"
 
+#include "df/enabler.h"
+#include "df/renderer.h"
+#include "renderer_twbt.h"
+
 using std::map;
 using std::string;
 using std::vector;
@@ -37,6 +41,7 @@ using namespace df::enums;
 DFHACK_PLUGIN("resume");
 #define PLUGIN_VERSION 0.2
 
+REQUIRE_GLOBAL(enabler);
 REQUIRE_GLOBAL(gps);
 REQUIRE_GLOBAL(ui);
 REQUIRE_GLOBAL(world);
@@ -145,7 +150,8 @@ void show_suspended_buildings()
     if (!Gui::getViewCoords(vx, vy, vz))
         return;
 
-    auto dims = Gui::getDwarfmodeViewDims();
+    renderer_cool *r = (renderer_cool*)enabler->renderer;
+    auto dims = r->is_twbt() ? r->map_dims() : Gui::getDwarfmodeViewDims();
     int left_margin = vx + dims.map_x2;
     int bottom_margin = vy + dims.y2;
 
@@ -168,7 +174,11 @@ void show_suspended_buildings()
             else if (sb->was_resumed)
                 color = COLOR_RED;
 
-            OutputString(color, x, y, "X");
+            renderer_cool *r = (renderer_cool*)enabler->renderer;
+            if (r->dummy == 'TWBT')
+                r->output_char(color, x, y, 'X');
+            else            
+                OutputString(color, x, y, "X");
         }
 
         sb++;
@@ -234,7 +244,7 @@ struct resume_hook : public df::viewscreen_dwarfmodest
     }
 };
 
-IMPLEMENT_VMETHOD_INTERPOSE(resume_hook, render);
+IMPLEMENT_VMETHOD_INTERPOSE_PRIO(resume_hook, render, 300);
 
 DFhackCExport command_result plugin_enable ( color_ostream &out, bool enable)
 {


### PR DESCRIPTION
TwbT has for some time broken the standard versions of the `automaterial`, `mousequery`, and `resume` plugins.  It thus comes with replacement versions - which I've been using for some time.  Since they also work as normal when TwbT is not present, and don't need to be changed with TwbT versions, it seems crazy to maintain multiple copies of the same code.

For `automaterial` and `resume`, the TwbT-related changes are the only changes - I went through and fixed trailing whitespace, which was the only commit since they were last synchronized.  The TwbT version of `mousequery` additionally supports map dragging, which is a nice feature.