### PR TITLE
Rebuilt missing half of plant product descriptions

### DIFF
--- a/scripts/view-item-info.lua
+++ b/scripts/view-item-info.lua
@@ -249,7 +249,6 @@ end
 
 function get_plant_reaction_products (mat)
     local list = {}
---  add_react_prod (list, mat, "DRINK_MAT", "Used to brew ") -- redundant with the jury-rig in the next function
     add_react_prod (list, mat, "GROWTH_JUICE_PROD", "Pressed into ")
     add_react_prod (list, mat, "PRESS_LIQUID_MAT", "Pressed into ")
     add_react_prod (list, mat, "LIQUID_EXTRACTABLE", "Extractable product: ")

--- a/scripts/view-item-info.lua
+++ b/scripts/view-item-info.lua
@@ -249,7 +249,7 @@ end
 
 function get_plant_reaction_products (mat)
     local list = {}
-    add_react_prod (list, mat, "DRINK_MAT", "Used to brew ")
+--  add_react_prod (list, mat, "DRINK_MAT", "Used to brew ") -- redundant with the jury-rig in the next function
     add_react_prod (list, mat, "GROWTH_JUICE_PROD", "Pressed into ")
     add_react_prod (list, mat, "PRESS_LIQUID_MAT", "Pressed into ")
     add_react_prod (list, mat, "LIQUID_EXTRACTABLE", "Extractable product: ")
@@ -290,15 +290,26 @@ function GetFoodPropertiesStringList (item)
     if item._type == df.item_plantst and GetMatPlant (item) then
         local plant = GetMatPlant (item)
         for k,v in pairs (plant.material_defs) do
-            if v ~= -1 and string.find (k,"type_") and not string.find (k,"type_basic")
-                    or string.find (k,"type_seed") or string.find (k,"type_tree") then
+            if v ~= -1 and string.find (k,"type_") and not (string.find (k,"type_basic")
+                    or string.find (k,"type_seed") or string.find (k,"type_tree")) then
                 local targetmat = dfhack.matinfo.decode (v,
                     plant.material_defs["idx_"..string.match (k,"type_(.+)")])
                 local state = "Liquid"
-                if string.find (k,"type_mill") then state = "Powder"
-                elseif string.find (k,"type_thread") then state = "Solid" end
+                local describe = "Made into "
+                if string.find (k,"type_mill")
+                    then state = "Powder" describe = "Ground into "
+                elseif string.find (k,"type_thread")
+                    then state = "Solid" describe = "Woven into "
+                elseif string.find (k,"type_drink")
+                    then describe = "Brewed into "
+                elseif string.find (k,"type_extract_barrel")
+                    then describe = "Cask-aged into "
+                elseif string.find (k,"type_extract_vial")
+                    then describe = "Refined into vials of "
+                elseif string.find (k,"type_extract_still_vial")
+                    then describe = "Distilled into vials of " end
                 local st_name = targetmat.material.state_name[state]
-                append(list,"Used to make "..targetmat.material.prefix..''..st_name)
+                append(list,describe..targetmat.material.prefix..''..st_name)
             end
         end
     end

--- a/scripts/view-item-info.lua
+++ b/scripts/view-item-info.lua
@@ -289,23 +289,23 @@ function GetFoodPropertiesStringList (item)
     if item._type == df.item_plantst and GetMatPlant (item) then
         local plant = GetMatPlant (item)
         for k,v in pairs (plant.material_defs) do
-            if v ~= -1 and string.find (k,"type_") and not (string.find (k,"type_basic")
-                    or string.find (k,"type_seed") or string.find (k,"type_tree")) then
+            if v ~= -1 and k:find("type_") and not (k:find("type_basic")
+                    or k:find("type_seed") or k:find("type_tree")) then
                 local targetmat = dfhack.matinfo.decode (v,
-                    plant.material_defs["idx_"..string.match (k,"type_(.+)")])
+                    plant.material_defs["idx_"..k:match("type_(.+)")])
                 local state = "Liquid"
                 local describe = "Made into "
-                if string.find (k,"type_mill")
+                if k:find("type_mill")
                     then state = "Powder" describe = "Ground into "
-                elseif string.find (k,"type_thread")
+                elseif k:find("type_thread")
                     then state = "Solid" describe = "Woven into "
-                elseif string.find (k,"type_drink")
+                elseif k:find("type_drink")
                     then describe = "Brewed into "
-                elseif string.find (k,"type_extract_barrel")
+                elseif k:find("type_extract_barrel")
                     then describe = "Cask-aged into "
-                elseif string.find (k,"type_extract_vial")
+                elseif k:find("type_extract_vial")
                     then describe = "Refined into vials of "
-                elseif string.find (k,"type_extract_still_vial")
+                elseif k:find("type_extract_still_vial")
                     then describe = "Distilled into vials of " end
                 local st_name = targetmat.material.state_name[state]
                 append(list,describe..targetmat.material.prefix..''..st_name)


### PR DESCRIPTION
Turns out that *get_plant_reaction_products* is tuned to look for the specific material reaction products in the Natural Balance mod that this was originally designed around instead of looking at the basic item types.
 
The calls for liquid pressing, rendering, soapmaking and cheesemaking work as intended (being handled with MRPs by default), but the brewing stuff overlapped with the similar set of instructions in the next function and the milling/threshing/sugaring(?)/extracting/plastermaking were looking for tokens that just aren't there.
So what I did was comment out the addition of any DRINK_MAT material reaction products into the description and extended the mechanism at the ass-end of *GetFoodPropertiesStringList* to handle basic products other than the present booze, thread and powder, using verbal descriptions with more flair than the same "made into" for everything.

Seeds still need to have their product yields looked up and stuff like quarry bushes don't mention they can be threshed for growths at all, but at least it works without coming up blank or barfing on the user's lap most of the time. It's a start.