### PR TITLE
Add git commit information to libdfhack-version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,10 @@ include_directories(${ZLIB_INCLUDE_DIRS})
 include_directories(depends/clsocket/src)
 add_subdirectory(depends)
 
+find_package(Git)
+if(NOT GIT_FOUND)
+    message(FATAL_ERROR "could not find git")
+endif()
 
 #find_package(Docutils)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -257,6 +257,14 @@ SET_PROPERTY(TARGET dfhack-version APPEND PROPERTY COMPILE_DEFINITIONS
     DFHACK_RELEASE="${DFHACK_RELEASE}"
 )
 
+ADD_CUSTOM_TARGET(git-describe
+    COMMAND ${CMAKE_COMMAND}
+        -D dfhack_SOURCE_DIR:STRING=${dfhack_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/git-describe.cmake
+    COMMENT "Obtaining git commit information"
+)
+ADD_DEPENDENCIES(dfhack-version git-describe)
+
 ADD_LIBRARY(dfhack SHARED ${PROJECT_SOURCES})
 ADD_DEPENDENCIES(dfhack generate_headers)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -260,6 +260,7 @@ SET_PROPERTY(TARGET dfhack-version APPEND PROPERTY COMPILE_DEFINITIONS
 ADD_CUSTOM_TARGET(git-describe
     COMMAND ${CMAKE_COMMAND}
         -D dfhack_SOURCE_DIR:STRING=${dfhack_SOURCE_DIR}
+        -D GIT_EXECUTABLE:STRING=${GIT_EXECUTABLE}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/git-describe.cmake
     COMMENT "Obtaining git commit information"
 )

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1229,6 +1229,8 @@ bool Core::Init()
     if(errorstate)
         return false;
 
+    fprintf(stderr, "DFHack build: %s\n", Version::git_description());
+
     // find out what we are...
     #ifdef LINUX_BUILD
         const char * path = "hack/symbols.xml";

--- a/library/DFHackVersion.cpp
+++ b/library/DFHackVersion.cpp
@@ -1,8 +1,23 @@
 #include "DFHackVersion.h"
+#include "git-describe.h"
+#include "Export.h"
 namespace DFHack {
     namespace Version {
-        const char *dfhack_version() { return DFHACK_VERSION; }
-        const char *df_version()     { return DF_VERSION; }
-        const char *dfhack_release() { return DFHACK_RELEASE; }
+        const char *dfhack_version()
+        {
+            return DFHACK_VERSION;
+        }
+        const char *df_version()
+        {
+            return DF_VERSION;
+        }
+        const char *dfhack_release()
+        {
+            return DFHACK_RELEASE;
+        }
+        const char *git_description()
+        {
+            return DFHACK_GIT_DESCRIPTION;
+        }
     }
 }

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -230,10 +230,13 @@ bool Plugin::load(color_ostream &con)
     plugin_check_symbol("plugin_self")
     plugin_check_symbol("plugin_init")
     plugin_check_symbol("plugin_globals")
+    plugin_check_symbol("git_description")
     const char ** plug_name =(const char ** ) LookupPlugin(plug, "name");
     const char ** plug_version =(const char ** ) LookupPlugin(plug, "version");
+    const char ** plug_git_description = (const char**) LookupPlugin(plug, "git_description");
     Plugin **plug_self = (Plugin**)LookupPlugin(plug, "plugin_self");
     const char *dfhack_version = Version::dfhack_version();
+    const char *dfhack_git_desc = Version::git_description();
     if (strcmp(dfhack_version, *plug_version) != 0)
     {
         con.printerr("Plugin %s was not built for this version of DFHack.\n"
@@ -241,6 +244,9 @@ bool Plugin::load(color_ostream &con)
         plugin_abort_load;
         return false;
     }
+    if (strcmp(dfhack_git_desc, *plug_git_description) != 0)
+        con.printerr("Warning: Plugin %s compiled for DFHack %s, running DFHack %s\n",
+            *plug_name, *plug_git_description, dfhack_git_desc);
     bool *plug_dev = (bool*)LookupPlugin(plug, "plugin_dev");
     if (plug_dev && *plug_dev && getenv("DFHACK_NO_DEV_PLUGINS"))
     {

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -208,6 +208,7 @@ bool Plugin::load(color_ostream &con)
     // enter suspend
     CoreSuspender suspend;
     // open the library, etc
+    fprintf(stderr, "loading plugin %s\n", filename.c_str());
     DFLibrary * plug = OpenPlugin(filename.c_str());
     if(!plug)
     {
@@ -232,10 +233,11 @@ bool Plugin::load(color_ostream &con)
     plugin_check_symbol("plugin_globals")
     const char ** plug_name =(const char ** ) LookupPlugin(plug, "name");
     const char ** plug_version =(const char ** ) LookupPlugin(plug, "version");
-    const char ** plug_git_description = (const char**) LookupPlugin(plug, "git_description");
+    const char ** plug_git_desc_ptr = (const char**) LookupPlugin(plug, "git_description");
     Plugin **plug_self = (Plugin**)LookupPlugin(plug, "plugin_self");
     const char *dfhack_version = Version::dfhack_version();
     const char *dfhack_git_desc = Version::git_description();
+    const char *plug_git_desc = plug_git_desc_ptr ? *plug_git_desc_ptr : "unknown";
     if (strcmp(dfhack_version, *plug_version) != 0)
     {
         con.printerr("Plugin %s was not built for this version of DFHack.\n"
@@ -243,14 +245,17 @@ bool Plugin::load(color_ostream &con)
         plugin_abort_load;
         return false;
     }
-    if (plug_git_description)
+    if (plug_git_desc_ptr)
     {
-        if (strcmp(dfhack_git_desc, *plug_git_description) != 0)
+        if (strcmp(dfhack_git_desc, plug_git_desc) != 0)
             con.printerr("Warning: Plugin %s compiled for DFHack %s, running DFHack %s\n",
-                *plug_name, *plug_git_description, dfhack_git_desc);
+                *plug_name, plug_git_desc, dfhack_git_desc);
     }
     else
+    {
         con.printerr("Warning: Plugin %s missing git information\n", *plug_name);
+        plug_git_desc = "unknown";
+    }
     bool *plug_dev = (bool*)LookupPlugin(plug, "plugin_dev");
     if (plug_dev && *plug_dev && getenv("DFHACK_NO_DEV_PLUGINS"))
     {
@@ -297,6 +302,7 @@ bool Plugin::load(color_ostream &con)
         parent->registerCommands(this);
         if ((plugin_onupdate || plugin_enable) && !plugin_is_enabled)
             con.printerr("Plugin %s has no enabled var!\n", name.c_str());
+        fprintf(stderr, "loaded plugin %s; DFHack build %s\n", name.c_str(), plug_git_desc);
         return true;
     }
     else

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -230,7 +230,6 @@ bool Plugin::load(color_ostream &con)
     plugin_check_symbol("plugin_self")
     plugin_check_symbol("plugin_init")
     plugin_check_symbol("plugin_globals")
-    plugin_check_symbol("git_description")
     const char ** plug_name =(const char ** ) LookupPlugin(plug, "name");
     const char ** plug_version =(const char ** ) LookupPlugin(plug, "version");
     const char ** plug_git_description = (const char**) LookupPlugin(plug, "git_description");
@@ -244,9 +243,14 @@ bool Plugin::load(color_ostream &con)
         plugin_abort_load;
         return false;
     }
-    if (strcmp(dfhack_git_desc, *plug_git_description) != 0)
-        con.printerr("Warning: Plugin %s compiled for DFHack %s, running DFHack %s\n",
-            *plug_name, *plug_git_description, dfhack_git_desc);
+    if (plug_git_description)
+    {
+        if (strcmp(dfhack_git_desc, *plug_git_description) != 0)
+            con.printerr("Warning: Plugin %s compiled for DFHack %s, running DFHack %s\n",
+                *plug_name, *plug_git_description, dfhack_git_desc);
+    }
+    else
+        con.printerr("Warning: Plugin %s missing git information\n", *plug_name);
     bool *plug_dev = (bool*)LookupPlugin(plug, "plugin_dev");
     if (plug_dev && *plug_dev && getenv("DFHACK_NO_DEV_PLUGINS"))
     {

--- a/library/git-describe.cmake
+++ b/library/git-describe.cmake
@@ -1,0 +1,9 @@
+execute_process(COMMAND git describe --tags
+    WORKING_DIRECTORY "${dfhack_SOURCE_DIR}"
+    OUTPUT_VARIABLE DFHACK_GIT_DESCRIPTION)
+string(STRIP ${DFHACK_GIT_DESCRIPTION} DFHACK_GIT_DESCRIPTION)
+file(WRITE ${dfhack_SOURCE_DIR}/library/include/git-describe.tmp.h
+    "#define DFHACK_GIT_DESCRIPTION \"${DFHACK_GIT_DESCRIPTION}\"")
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${dfhack_SOURCE_DIR}/library/include/git-describe.tmp.h
+    ${dfhack_SOURCE_DIR}/library/include/git-describe.h)

--- a/library/git-describe.cmake
+++ b/library/git-describe.cmake
@@ -1,4 +1,4 @@
-execute_process(COMMAND git describe --tags
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags
     WORKING_DIRECTORY "${dfhack_SOURCE_DIR}"
     OUTPUT_VARIABLE DFHACK_GIT_DESCRIPTION)
 string(STRIP ${DFHACK_GIT_DESCRIPTION} DFHACK_GIT_DESCRIPTION)

--- a/library/include/.gitignore
+++ b/library/include/.gitignore
@@ -1,0 +1,1 @@
+git-describe.*

--- a/library/include/DFHackVersion.h
+++ b/library/include/DFHackVersion.h
@@ -4,5 +4,6 @@ namespace DFHack {
         const char *dfhack_version();
         const char *df_version();
         const char *dfhack_release();
+        const char *git_description();
     }
 }

--- a/library/include/PluginManager.h
+++ b/library/include/PluginManager.h
@@ -61,6 +61,7 @@ namespace DFHack
 
     namespace Version {
         const char *dfhack_version();
+        const char *git_description();
     }
 
     // anon type, pretty much
@@ -289,6 +290,7 @@ namespace DFHack
 #define DFHACK_PLUGIN_AUX(plugin_name, is_dev) \
     DFhackDataExport const char * name = plugin_name;\
     DFhackDataExport const char * version = DFHack::Version::dfhack_version();\
+    DFhackDataExport const char * git_description = DFHack::Version::git_description();\
     DFhackDataExport Plugin *plugin_self = NULL;\
     std::vector<std::string> _plugin_globals;\
     DFhackDataExport std::vector<std::string>* plugin_globals = &_plugin_globals; \


### PR DESCRIPTION
This runs `git describe --tags` to produce a more descriptive version identifier, like `0.40.24-r3-155-g0fa5570` (commit 0fa5570, 155 commits after 0.40.24-r3). Currently, plugins can be loaded as long as their DFHack version matches core's, but a warning will be displayed if their commits don't match.