### PR TITLE
Work around GCC enum bound checking bug

### DIFF
--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -700,7 +700,7 @@ namespace DFHack {
 #define ENUM_NEXT_ITEM(enum,val) \
     (DFHack::next_enum_item<df::enum>(val))
 #define FOR_ENUM_ITEMS(enum,iter) \
-    for(df::enum iter = ENUM_FIRST_ITEM(enum); iter <= ENUM_LAST_ITEM(enum); iter = df::enum(1+int(iter)))
+    for(df::enum iter = ENUM_FIRST_ITEM(enum); is_valid_enum_item(iter); iter = df::enum(1+int(iter)))
 
 /*
  * Include mandatory generated headers.


### PR DESCRIPTION
This addresses #654. I think it should work in MSVC, but it should be tested before merging.
