### PR TITLE
Add a framework for including 3rd-party script repos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "depends/clsocket"]
 	path = depends/clsocket
 	url = git://github.com/DFHack/clsocket.git
+[submodule "scripts/3rdparty/lethosor"]
+	path = scripts/3rdparty/lethosor
+	url = https://github.com/lethosor/dfhack-scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,8 @@ IF(BUILD_PLUGINS)
     add_subdirectory (plugins)
 endif()
 
+add_subdirectory(scripts)
+
 # Packaging with CPack!
 IF(UNIX)
     if(APPLE)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -377,6 +377,7 @@ install(DIRECTORY ${dfhack_SOURCE_DIR}/scripts
         DESTINATION ${DFHACK_DATA_DESTINATION}
         FILES_MATCHING PATTERN "*.lua"
                        PATTERN "*.rb"
+                       PATTERN "3rdparty" EXCLUDE
         )
 
 install(DIRECTORY ${dfhack_SOURCE_DIR}/patches

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,0 +1,2 @@
+include(Scripts.cmake)
+DFHACK_3RDPARTY_SCRIPT_REPO(lethosor)

--- a/scripts/Scripts.cmake
+++ b/scripts/Scripts.cmake
@@ -1,0 +1,19 @@
+include(../plugins/Plugins.cmake)
+
+MACRO(DFHACK_SCRIPTS)
+  PARSE_ARGUMENTS(SCRIPT
+    "SUBDIRECTORY"
+    "SOME_OPT"
+    ${ARGN}
+  )
+  CAR(SCRIPT_SUBDIRECTORY ${SCRIPT_SUBDIRECTORY})
+  install(FILES ${SCRIPT_DEFAULT_ARGS}
+    DESTINATION ${DFHACK_DATA_DESTINATION}/scripts/${SCRIPT_SUBDIRECTORY})
+ENDMACRO()
+
+MACRO(DFHACK_3RDPARTY_SCRIPT_REPO repo_path)
+  if(NOT EXISTS ${dfhack_SOURCE_DIR}/scripts/3rdparty/${repo_path}/CMakeLists.txt)
+    MESSAGE(FATAL_ERROR "Script submodule scripts/3rdparty/${repo_path} does not exist - run `git submodule update`.")
+  endif()
+  add_subdirectory(3rdparty/${repo_path})
+ENDMACRO()


### PR DESCRIPTION
Repos need to include a CMakeLists.txt file with calls to the DFHACK_SCRIPTS macro, which functions similarly to DFHACK_PLUGIN. The `open-legends` script from lethosor/dfhack-scripts is included as an example.

Examples:
```cmake
DFHACK_SCRIPTS(foo.lua)
DFHACK_SCRIPTS(gui/foo.lua SUBDIRECTORY gui)
```