### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/Readme.html
+++ b/Readme.html
@@ -1766,7 +1766,7 @@ If an argument is given, the designation of the selected tile is ignored, and al
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
-<tr class="field"><th class="field-name">X:</th><td class="field-body">Fill accross z-levels.</td>
+<tr class="field"><th class="field-name">X:</th><td class="field-body">Fill across z-levels.</td>
 </tr>
 <tr class="field"><th class="field-name">B:</th><td class="field-body">Include buildings and stockpiles.</td>
 </tr>

--- a/Readme.rst
+++ b/Readme.rst
@@ -1114,7 +1114,7 @@ Traffic Type Codes:
 
 Other Options:
 
-:X: Fill accross z-levels.
+:X: Fill across z-levels.
 :B: Include buildings and stockpiles.
 :P: Include empty space.
 


### PR DESCRIPTION
@DFHack, I've corrected a typographical error in the documentation of the [dfhack](https://github.com/DFHack/dfhack) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.