### PR TITLE
Add 'undisturbed' flag to job item checks

### DIFF
--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -307,7 +307,7 @@ bool ItemTypeInfo::matches(const df::job_item &item, MaterialInfo *mat, bool ski
     RQ(1,extract_bearing_plant); RQ(1,extract_bearing_fish); RQ(1,extract_bearing_vermin);
     RQ(1,processable_to_vial); RQ(1,processable_to_bag); RQ(1,processable_to_barrel);
     RQ(1,solid); RQ(1,tameable_vermin); RQ(1,sand_bearing); RQ(1,milk); RQ(1,milkable);
-    RQ(1,not_bin); RQ(1,lye_bearing);
+    RQ(1,not_bin); RQ(1,lye_bearing); RQ(1, undisturbed);
 
     RQ(2,dye); RQ(2,dyeable); RQ(2,dyed); RQ(2,glass_making); RQ(2,screw);
     RQ(2,building_material); RQ(2,fire_safe); RQ(2,magma_safe);
@@ -423,6 +423,7 @@ bool ItemTypeInfo::matches(const df::job_item &item, MaterialInfo *mat, bool ski
         break;
 
     case THREAD:
+        OK(1,undisturbed);
     case CLOTH:
         OK(2,dyeable); OK(2,dyed);
         break;

--- a/library/modules/Materials.cpp
+++ b/library/modules/Materials.cpp
@@ -493,6 +493,7 @@ void MaterialInfo::getMatchBits(df::job_item_flags1 &ok, df::job_item_flags1 &ma
     TEST(tameable_vermin, false);
     TEST(sharpenable, MAT_FLAG(IS_STONE));
     TEST(milk, linear_index(material->reaction_product.id, std::string("CHEESE_MAT")) >= 0);
+    TEST(undisturbed, MAT_FLAG(SILK));
     //04000000 - "milkable" - vtable[107],1,1
 }
 


### PR DESCRIPTION
This change allows a _somewhat_ more manageable filtering for 'Collect Web' material selections. Without it, every body part of every creature is available, with this addition in place it's a manageable three pages, all of actually valid items.

