### PR TITLE
Allow loading (external) plugins compiled against r3

### DIFF
--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -280,14 +280,14 @@ bool Plugin::load(color_ostream &con)
             return false; \
         }
 
-    plugin_check_symbols("plugin_name", "name")					// allow r3 plugins		
-    plugin_check_symbols("plugin_version", "version")			// allow r3 plugins	
+    plugin_check_symbols("plugin_name", "name")                 // allow r3 plugins		
+    plugin_check_symbols("plugin_version", "version")           // allow r3 plugins	
     plugin_check_symbol("plugin_self")
     plugin_check_symbol("plugin_init")
     plugin_check_symbol("plugin_globals")
     const char ** plug_name =(const char ** ) LookupPlugin(plug, "plugin_name");
-	if (!plug_name)												// allow r3 plugin naming	
-		plug_name = (const char ** )LookupPlugin(plug, "name");
+    if (!plug_name)                                            // allow r3 plugin naming	
+        plug_name = (const char ** )LookupPlugin(plug, "name");
 
     if (name != *plug_name)
     {
@@ -296,8 +296,8 @@ bool Plugin::load(color_ostream &con)
         return false;
     }
     const char ** plug_version =(const char ** ) LookupPlugin(plug, "plugin_version");
-	if (!plug_version)											// allow r3 plugin version
-		plug_version =(const char ** ) LookupPlugin(plug, "version");
+    if (!plug_version)                                         // allow r3 plugin version
+        plug_version =(const char ** ) LookupPlugin(plug, "version");
 
     const char ** plug_git_desc_ptr = (const char**) LookupPlugin(plug, "plugin_git_description");
     Plugin **plug_self = (Plugin**)LookupPlugin(plug, "plugin_self");

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -272,13 +272,23 @@ bool Plugin::load(color_ostream &con)
             plugin_abort_load; \
             return false; \
         }
+    #define plugin_check_symbols(sym1,sym2) \
+        if (!LookupPlugin(plug, sym1) && !LookupPlugin(plug, sym2)) \
+        { \
+            con.printerr("Plugin %s: missing symbols: %s & %s\n", name.c_str(), sym1, sym2); \
+            plugin_abort_load; \
+            return false; \
+        }
 
-    plugin_check_symbol("plugin_name")
-    plugin_check_symbol("plugin_version")
+    plugin_check_symbols("plugin_name", "name")					// allow r3 plugins		
+    plugin_check_symbols("plugin_version", "version")			// allow r3 plugins	
     plugin_check_symbol("plugin_self")
     plugin_check_symbol("plugin_init")
     plugin_check_symbol("plugin_globals")
     const char ** plug_name =(const char ** ) LookupPlugin(plug, "plugin_name");
+	if (!plug_name)												// allow r3 plugin naming	
+		plug_name = (const char ** )LookupPlugin(plug, "name");
+
     if (name != *plug_name)
     {
         con.printerr("Plugin %s: name mismatch, claims to be %s\n", name.c_str(), *plug_name);
@@ -286,6 +296,9 @@ bool Plugin::load(color_ostream &con)
         return false;
     }
     const char ** plug_version =(const char ** ) LookupPlugin(plug, "plugin_version");
+	if (!plug_version)											// allow r3 plugin version
+		plug_version =(const char ** ) LookupPlugin(plug, "version");
+
     const char ** plug_git_desc_ptr = (const char**) LookupPlugin(plug, "plugin_git_description");
     Plugin **plug_self = (Plugin**)LookupPlugin(plug, "plugin_self");
     const char *dfhack_version = Version::dfhack_version();

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -280,13 +280,13 @@ bool Plugin::load(color_ostream &con)
             return false; \
         }
 
-    plugin_check_symbols("plugin_name", "name")                 // allow r3 plugins		
-    plugin_check_symbols("plugin_version", "version")           // allow r3 plugins	
+    plugin_check_symbols("plugin_name", "name")                 // allow r3 plugins
+    plugin_check_symbols("plugin_version", "version")           // allow r3 plugins
     plugin_check_symbol("plugin_self")
     plugin_check_symbol("plugin_init")
     plugin_check_symbol("plugin_globals")
     const char ** plug_name =(const char ** ) LookupPlugin(plug, "plugin_name");
-    if (!plug_name)                                            // allow r3 plugin naming	
+    if (!plug_name)                                            // allow r3 plugin naming
         plug_name = (const char ** )LookupPlugin(plug, "name");
 
     if (name != *plug_name)


### PR DESCRIPTION
Commit 4fc6cb6f175aebc96bf7ec4629a90cd05b71e8ee broke binary compatibility with (third party) plugins compiled against r3 (or any develoment build from before this commit).

Specifically the renaming of `pluginmanager.h`'s `DFHACK_PLUGIN_AUX` fields `name` and `version` to `plugin_name` & `plugin_version` in https://github.com/DFHack/dfhack/commit/4fc6cb6f175aebc96bf7ec4629a90cd05b71e8ee#diff-bd71300c004474c4053e54ada7483b31L290 and corresponding changes to  `pluginmanager.cpp`'s `Plugin::load`at https://github.com/DFHack/dfhack/commit/4fc6cb6f175aebc96bf7ec4629a90cd05b71e8ee#diff-bcb993821b53968bc228a308c6193963L229 cause errors on load for 'old' plugins. 

One **popular** example would be *twbt* from LNP ;). Last available version is compiled against r3, which means it only has fields _without_ the new `plugin_` prefix, which means it won't load on anything compiled after 4fc6cb6f175aebc96bf7ec4629a90cd05b71e8ee :(

My change would allow a (silent) fallback to the old field names to allow using those plugins. I've been running this for serveral days and have not seen any adverse effects.

A _good_ implementation would probably put the whole 'allow r3 plugins' switch inside some compilation (symbol) check, a _great_ one would put it inside some configuration setting. I don't trust my C++ enough to write the corresponding macros for the first, and I don't know the config system well enough - i.e. at all -  for the second. And since you might even intentionally force people to only use 'matching' binaries, I'm not going to try this myself.

But in case you want to keep backwards compatibility, this should do it.