### PR TITLE
Ls cleanup

### DIFF
--- a/docs/Contributing.rst
+++ b/docs/Contributing.rst
@@ -137,6 +137,11 @@ there are a few important standards for completeness and consistent style.  Trea
 this section as a guide rather than iron law, match the surrounding text, and you'll
 be fine.
 
+Each command should have a short (~54 character) help string, which is shown
+by the `ls` command.  For scripts, this is a comment on the first line
+(the comment marker and whitespace is stripped).  For plugins it's the second
+argument to ``PluginCommand``.  Please make this brief but descriptive!
+
 Everything should be documented!  If it's not clear *where* a particular
 thing should be documented, ask on IRC or in the DFHack thread on Bay12 -
 as well as getting help, you'll be providing valuable feedback that

--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -157,7 +157,7 @@ Usage and related commands:
 
 :reveal:        Reveal the whole map, except for HFS to avoid demons spawning
 :reveal hell:   Also show hell, but requires ``unreveal`` before unpausing
-:reveal demons: Reveals everything and allows unpausing - good luck!
+:reveal demon:  Reveals everything and allows unpausing - good luck!
 :unreveal:      Reverts the effects of ``reveal``
 :revtoggle:     Switches between ``reveal`` and ``unreveal``
 :revflood:      Hide everything, then reveal tiles with a path to the cursor

--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -275,7 +275,7 @@ One-shot subcommands:
 
 Subcommands that persist until disabled or DF quits:
 
-:adamantine-cloth-wear: Prevents adamantine clothing from wearing out while being worn (bug 6481).
+:adamantine-cloth-wear: Prevents adamantine clothing from wearing out while being worn (:bug:`6481`).
 :advmode-contained:     Works around :bug:`6202`, custom reactions with container inputs
                         in advmode. The issue is that the screen tries to force you to select
                         the contents separately from the container. This forcefully skips child
@@ -1083,7 +1083,7 @@ This plugin adds an option to the :kbd:`q` menu for stckpiles when `enabled <ena
 When autodump is enabled for a stockpile, any items placed in the stockpile will
 automatically be designated to be dumped.
 
-ALternatively, you can use it to quickly move all items designated to be dumped.
+Alternatively, you can use it to quickly move all items designated to be dumped.
 Items are instantly moved to the cursor position, the dump flag is unset,
 and the forbid flag is set, as if it had been dumped normally.
 Be aware that any active dump item tasks still point at the item.
@@ -1187,7 +1187,9 @@ Some widgets support additional options:
     * ``D``: The current day, zero-padded if necessary
     * ``d``: The current day, *not* zero-padded
 
-    The default date format is ``Y-M-D``, per the ISO8601 standard.
+    The default date format is ``Y-M-D``, per the ISO8601_ standard.
+
+    .. _ISO8601: https://en.wikipedia.org/wiki/ISO_8601
 
 * ``cursor`` widget:
 
@@ -1868,9 +1870,8 @@ is an optional description of where that is. You may also leave a description
 of the contents of the file itself following the closing parenthesis on the
 same line.
 
-The syntax of the file itself is similar to `digfort` or
-`quickfort <http://www.bay12forums.com/smf/index.php?topic=35931>`_. At present,
-only buildings constructed of an item with the same name as the building
+The syntax of the file itself is similar to `digfort` or :forums:`quickfort <35931>`.
+At present, only buildings constructed of an item with the same name as the building
 are supported. All other characters are ignored. For example::
 
     `,`,d,`,`
@@ -1881,7 +1882,7 @@ This section of a file would designate for construction a door and some
 furniture inside a bedroom: specifically, clockwise from top left, a cabinet,
 a table, a chair, a bed, and a statue.
 
-All of the building designation uses `Planning Mode <buildingplan>`, so you do not need to
+All of the building designation uses `buildingplan`, so you do not need to
 have the items available to construct all the buildings when you run
 fortplan with the .csv file.
 

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -791,7 +791,7 @@ DFhackCExport command_result plugin_enable(color_ostream &out, bool enable)
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "autochop", "Allows automatic harvesting of trees based on the number of stockpiled logs",
+        "autochop", "Auto-harvest trees when low on stockpiled logs",
         df_autochop, false,
         "Opens the automated chopping control screen. Specify 'debug' to forcibly save settings.\n"
     ));

--- a/plugins/automelt.cpp
+++ b/plugins/automelt.cpp
@@ -299,7 +299,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
 {
     commands.push_back(
         PluginCommand(
-        "automelt", "Automatically flag metal items in marked stockpiles for melting.",
+        "automelt", "Automatically melt metal items in marked stockpiles.",
         automelt_cmd, false, ""));
 
     return CR_OK;

--- a/plugins/cleaners.cpp
+++ b/plugins/cleaners.cpp
@@ -236,7 +236,7 @@ command_result clean (color_ostream &out, vector <string> & parameters)
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "clean","Removes contaminants from map tiles, items and creatures.",
+        "clean","Remove contaminants from tiles, items and creatures.",
         clean, false,
         "  Removes contaminants from map tiles, items and creatures.\n"
         "Options:\n"

--- a/plugins/cursecheck.cpp
+++ b/plugins/cursecheck.cpp
@@ -58,7 +58,7 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters);
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand("cursecheck",
-        "Checks for cursed creatures (vampires, necromancers, zombies, ...).",
+        "Check for cursed creatures (undead, necromancers...)",
         cursecheck, false ));
     return CR_OK;
 }

--- a/plugins/deramp.cpp
+++ b/plugins/deramp.cpp
@@ -83,7 +83,7 @@ command_result df_deramp (color_ostream &out, vector <string> & parameters)
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "deramp", "De-ramp. All ramps marked for removal are replaced with floors.",
+        "deramp", "Replace all ramps marked for removal with floors.",
         df_deramp, false,
         "  If there are any ramps designated for removal, they will be instantly\n"
         "  removed. Any ramps that don't have their counterpart will also be removed\n"

--- a/plugins/devel/kittens.cpp
+++ b/plugins/devel/kittens.cpp
@@ -42,7 +42,7 @@ DFHACK_PLUGIN("kittens");
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand("nyan","NYAN CAT INVASION!",kittens));
-    commands.push_back(PluginCommand("ktimer","Measure time between game updates and console lag (toggle).",ktimer));
+    commands.push_back(PluginCommand("ktimer","Measure time between game updates and console lag.",ktimer));
     commands.push_back(PluginCommand("trackmenu","Track menu ID changes (toggle).",trackmenu));
     commands.push_back(PluginCommand("trackpos","Track mouse and designation coords (toggle).",trackpos));
     commands.push_back(PluginCommand("trackstate","Track world and map state (toggle).",trackstate));

--- a/plugins/devel/memview.cpp
+++ b/plugins/devel/memview.cpp
@@ -36,7 +36,7 @@ DFHACK_PLUGIN("memview");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {
-    commands.push_back(PluginCommand("memview","Shows DF memory in real time.",memview));
+    commands.push_back(PluginCommand("memview","Shows DF memory in real time.",memview,false,"Shows memory in real time.\nParams: adrr length refresh_rate. If addr==0 then stop viewing."));
     memdata.state=STATE_OFF;
     mymutex=new tthread::mutex;
     return CR_OK;

--- a/plugins/devel/memview.cpp
+++ b/plugins/devel/memview.cpp
@@ -36,7 +36,7 @@ DFHACK_PLUGIN("memview");
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector <PluginCommand> &commands)
 {
-    commands.push_back(PluginCommand("memview","Shows memory in real time. Params: adrr length refresh_rate. If addr==0 then stop viewing",memview));
+    commands.push_back(PluginCommand("memview","Shows DF memory in real time.",memview));
     memdata.state=STATE_OFF;
     mymutex=new tthread::mutex;
     return CR_OK;

--- a/plugins/devel/rprobe.cpp
+++ b/plugins/devel/rprobe.cpp
@@ -45,7 +45,7 @@ DFHACK_PLUGIN("rprobe");
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "rprobe", "Display assorted region information from embark screen",
+        "rprobe", "Display region information from embark screen",
         rprobe, false,
         "Display assorted region information from embark screen\n"
     ));

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -55,8 +55,8 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
         "  Designates layerstone under the cursor for digging.\n"
         "  Also follows the stone between z-levels with stairs, like 'digl x' would.\n"
         ));
-    commands.push_back(PluginCommand("digexp","Select or designate an exploratory pattern. Use 'digexp ?' for help.",digexp));
-    commands.push_back(PluginCommand("digcircle","Dig designate a circle (filled or hollow) with given diameter.",digcircle));
+    commands.push_back(PluginCommand("digexp","Select or designate an exploratory pattern.",digexp));
+    commands.push_back(PluginCommand("digcircle","Dig designate a circle (filled or hollow)",digcircle));
     //commands.push_back(PluginCommand("digauto","Mark a tile for continuous digging.",autodig));
     commands.push_back(PluginCommand("digtype", "Dig all veins of a given type.", digtype,Gui::cursor_hotkey,
         "For every tile on the map of the same vein type as the selected tile, this command designates it to have the same designation as the selected tile. If the selected tile has no designation, they will be dig designated.\n"

--- a/plugins/fastdwarf.cpp
+++ b/plugins/fastdwarf.cpp
@@ -246,7 +246,7 @@ DFhackCExport command_result plugin_enable ( color_ostream &out, bool enable )
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand("fastdwarf",
-        "enable/disable fastdwarf and teledwarf (parameters=0/1)",
+        "let dwarves teleport and/or finish jobs instantly",
         fastdwarf, false,
         "fastdwarf: make dwarves faster.\n"
         "Usage:\n"

--- a/plugins/filltraffic.cpp
+++ b/plugins/filltraffic.cpp
@@ -44,7 +44,7 @@ DFHACK_PLUGIN("filltraffic");
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "filltraffic","Flood-fill with selected traffic designation from cursor",
+        "filltraffic","Flood-fill selected traffic designation from cursor",
         filltraffic, Gui::cursor_hotkey,
         "  Flood-fill selected traffic type from the cursor.\n"
         "Traffic Type Codes:\n"

--- a/plugins/follow.cpp
+++ b/plugins/follow.cpp
@@ -29,7 +29,7 @@ uint8_t prevMenuWidth;
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "follow", "Follow the selected unit until camera control is released",
+        "follow", "Make the screen follow the selected unit",
         follow, Gui::view_unit_hotkey,
         "  Select a unit and run this plugin to make the camera follow it.\n"
         "  Moving the camera yourself deactivates the plugin.\n"

--- a/plugins/forceequip.cpp
+++ b/plugins/forceequip.cpp
@@ -216,7 +216,7 @@ const string forceequip_help =
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "forceequip", "Moves local items from the ground into a unit's inventory",
+        "forceequip", "Move items from the ground into a unit's inventory",
         df_forceequip, false,
         forceequip_help.c_str()
     ));

--- a/plugins/fortplan.cpp
+++ b/plugins/fortplan.cpp
@@ -51,7 +51,7 @@ public:
 std::vector<BuildingInfo> buildings;
 
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands) {
-    commands.push_back(PluginCommand("fortplan","Lay out buildings in your fortress based on a Quickfort-style CSV input file.",fortplan,false,
+    commands.push_back(PluginCommand("fortplan","Lay out buildings from a Quickfort-style CSV file.",fortplan,false,
         "Lay out buildings in your fortress based on a Quickfort-style CSV input file.\n"
         "Usage: fortplan [filename]\n"));
 

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -152,7 +152,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "getplants", "Cut down all of the specified trees or gather specified shrubs",
+        "getplants", "Cut down trees or gather shrubs by ID",
         df_getplants, false,
         "  Specify the types of trees to cut down and/or shrubs to gather by their\n"
         "  plant IDs, separated by spaces.\n"

--- a/plugins/hotkeys.cpp
+++ b/plugins/hotkeys.cpp
@@ -354,7 +354,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
 
     commands.push_back(
         PluginCommand(
-        "hotkeys", "Shows ingame viewscreen with all dfhack keybindings active in current mode.",
+        "hotkeys", "Show all dfhack keybindings in current context.",
         hotkeys_cmd, false, ""));
 
     return CR_OK;

--- a/plugins/infiniteSky.cpp
+++ b/plugins/infiniteSky.cpp
@@ -32,7 +32,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
 {
     commands.push_back(PluginCommand(
         "infiniteSky",
-        "Creates new sky levels on request, or as you construct up.",
+        "Creates new sky levels on request, or as needed.",
         infiniteSky, false,
         "Usage:\n"
         "  infiniteSky\n"

--- a/plugins/lair.cpp
+++ b/plugins/lair.cpp
@@ -58,7 +58,7 @@ command_result lair(color_ostream &out, std::vector<std::string> & params)
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
 {
-    commands.push_back(PluginCommand("lair","Mark the map as a monster lair, preventing item scatter.",lair, false,
+    commands.push_back(PluginCommand("lair","Mark the map as a monster lair (avoids item scatter)",lair, false,
         "Usage: 'lair' to mark entire map as monster lair, 'lair reset' to undo the operation.\n"));
     return CR_OK;
 }

--- a/plugins/petcapRemover.cpp
+++ b/plugins/petcapRemover.cpp
@@ -36,7 +36,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
 {
     commands.push_back(PluginCommand(
         "petcapRemover",
-        "Removes the pet population cap by causing pregnancies.",
+        "Remove the pet population cap by causing pregnancies.",
         petcapRemover,
         false, //allow non-interactive use
         "petcapRemover\n"

--- a/plugins/resume.cpp
+++ b/plugins/resume.cpp
@@ -298,7 +298,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
 {
     commands.push_back(
         PluginCommand(
-        "resume", "A plugin to help display and resume suspended constructions conveniently",
+        "resume", "Display and easily resume suspended constructions",
         resume_cmd, false,
         "resume show\n"
         "  Show overlay when paused:\n"

--- a/plugins/reveal.cpp
+++ b/plugins/reveal.cpp
@@ -77,7 +77,7 @@ command_result nopause(color_ostream &out, vector<string> & params);
 
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands)
 {
-    commands.push_back(PluginCommand("reveal","Reveal the map. Args 'hell', 'demon' are risky.",reveal,false,
+    commands.push_back(PluginCommand("reveal","Reveal the map.",reveal,false,
         "Reveals the map, by default ignoring hell.\n"
         "Options:\n"
         "hell     - also reveal hell, while forcing the game to pause.\n"

--- a/plugins/reveal.cpp
+++ b/plugins/reveal.cpp
@@ -77,7 +77,7 @@ command_result nopause(color_ostream &out, vector<string> & params);
 
 DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCommand> &commands)
 {
-    commands.push_back(PluginCommand("reveal","Reveal the map. 'reveal hell' will also reveal hell. 'reveal demon' won't pause.",reveal,false,
+    commands.push_back(PluginCommand("reveal","Reveal the map. Args 'hell', 'demon' are risky.",reveal,false,
         "Reveals the map, by default ignoring hell.\n"
         "Options:\n"
         "hell     - also reveal hell, while forcing the game to pause.\n"
@@ -86,12 +86,12 @@ DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCom
         "Reverts the previous reveal operation, hiding the map again.\n"));
     commands.push_back(PluginCommand("revtoggle","Reveal/unreveal depending on state.",revtoggle,false,
         "Toggles between reveal and unreveal.\n"));
-    commands.push_back(PluginCommand("revflood","Hide all, reveal all tiles reachable from cursor position.",revflood,false,
+    commands.push_back(PluginCommand("revflood","Hide all, and reveal tiles reachable from the cursor.",revflood,false,
         "This command hides the whole map. Then, starting from the cursor,\n"
         "reveals all accessible tiles. Allows repairing parma-revealed maps.\n"));
-    commands.push_back(PluginCommand("revforget", "Forget the current reveal data, allowing to use reveal again.",revforget,false,
+    commands.push_back(PluginCommand("revforget", "Forget the current reveal data.",revforget,false,
         "Forget the current reveal data, allowing to use reveal again.\n"));
-    commands.push_back(PluginCommand("nopause","Disable pausing (doesn't affect pause forced by reveal).",nopause,false,
+    commands.push_back(PluginCommand("nopause","Disable manual and automatic pausing.",nopause,false,
         "Disable pausing (doesn't affect pause forced by reveal).\n"
         "Activate with 'nopause 1', deactivate with 'nopause 0'.\n"));
     return CR_OK;

--- a/plugins/ruby/ruby.cpp
+++ b/plugins/ruby/ruby.cpp
@@ -99,7 +99,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
                 df_rubyeval));
 
     commands.push_back(PluginCommand("rb",
-                "Ruby interpreter. Eval() a ruby string (alias for rb_eval).",
+                "Ruby interpreter. Eval() a ruby string.",
                 df_rubyeval));
 
     return CR_OK;

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -254,7 +254,7 @@ command_result df_seedwatch(color_ostream &out, vector<string>& parameters)
 
 DFhackCExport command_result plugin_init(color_ostream &out, vector<PluginCommand>& commands)
 {
-    commands.push_back(PluginCommand("seedwatch", "Switches cookery based on quantity of seeds, to keep reserves", df_seedwatch));
+    commands.push_back(PluginCommand("seedwatch", "Toggles seed cooking based on quantity available", df_seedwatch));
     // fill in the abbreviations map, with abbreviations for the standard plants
     abbreviations["bs"] = "SLIVER_BARB";
     abbreviations["bt"] = "TUBER_BLOATED";

--- a/plugins/stockflow.cpp
+++ b/plugins/stockflow.cpp
@@ -29,7 +29,7 @@ REQUIRE_GLOBAL(world);
 REQUIRE_GLOBAL(ui);
 
 bool fast = false;
-const char *tagline = "Allows the fortress bookkeeper to queue jobs through the manager.";
+const char *tagline = "Allow the bookkeeper to queue manager jobs.";
 const char *usage = (
     "  stockflow enable\n"
     "    Enable the plugin.\n"

--- a/plugins/stockpiles/stockpiles.cpp
+++ b/plugins/stockpiles/stockpiles.cpp
@@ -85,7 +85,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
         );
         commands.push_back (
             PluginCommand (
-                "loadstock", "Load settings from a file and apply them to the active stockpile.",
+                "loadstock", "Load and apply stockpile settings from a file.",
                 loadstock, loadstock_guard,
                 "Must be in 'q' mode and have a stockpile selected.\n"
                 "example: 'loadstock food.dfstock' will load the settings from 'food.dfstock'\n"

--- a/plugins/strangemood.cpp
+++ b/plugins/strangemood.cpp
@@ -1316,7 +1316,7 @@ command_result df_strangemood (color_ostream &out, vector <string> & parameters)
 
 DFhackCExport command_result plugin_init (color_ostream &out, std::vector<PluginCommand> &commands)
 {
-    commands.push_back(PluginCommand("strangemood", "Force a strange mood to happen.\n", df_strangemood, false,
+    commands.push_back(PluginCommand("strangemood", "Force a strange mood to happen.", df_strangemood, false,
         "Options:\n"
          "  -force         - Ignore standard mood preconditions.\n"
          "  -unit          - Use the selected unit instead of picking one randomly.\n"

--- a/plugins/tiletypes.cpp
+++ b/plugins/tiletypes.cpp
@@ -58,9 +58,9 @@ DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <Plug
 {
     tiletypes_hist.load("tiletypes.history");
     commands.push_back(PluginCommand("tiletypes", "Paint map tiles freely, similar to liquids.", df_tiletypes, true));
-    commands.push_back(PluginCommand("tiletypes-command", "Run the given commands (seperated by ' ; '; an empty command is the same as run).", df_tiletypes_command));
-    commands.push_back(PluginCommand("tiletypes-here", "Use the last settings from tiletypes, including brush, at cursor location.", df_tiletypes_here));
-    commands.push_back(PluginCommand("tiletypes-here-point", "Use the last settings from tiletypes, not including brush, at cursor location.", df_tiletypes_here_point));
+    commands.push_back(PluginCommand("tiletypes-command", "Run tiletypes commands (seperated by ' ; ')", df_tiletypes_command));
+    commands.push_back(PluginCommand("tiletypes-here", "Repeat tiletypes command at cursor (with brush)", df_tiletypes_here));
+    commands.push_back(PluginCommand("tiletypes-here-point", "Repeat tiletypes command at cursor (without brush)", df_tiletypes_here_point));
     return CR_OK;
 }
 

--- a/plugins/workNow.cpp
+++ b/plugins/workNow.cpp
@@ -29,7 +29,7 @@ DFhackCExport command_result plugin_init(color_ostream& out, std::vector<PluginC
     if (!process_jobs || !process_dig)
         return CR_FAILURE;
 
-    commands.push_back(PluginCommand("workNow", "makes dwarves look for jobs whever they finish one, or every time you pause", workNow, false, "When workNow is active, every time the game pauses, DF will make dwarves perform any appropriate available jobs. This includes when you one step through the game using the pause menu. When workNow is in mode 2, it will make dwarves look for jobs every time a job completes.\n"
+    commands.push_back(PluginCommand("workNow", "Don't allow dwarves to idle if any jobs are available", workNow, false, "When workNow is active, every time the game pauses, DF will make dwarves perform any appropriate available jobs. This includes when you one step through the game using the pause menu. When workNow is in mode 2, it will make dwarves look for jobs every time a job completes.\n"
                 "workNow\n"
                 "  print workNow status\n"
                 "workNow 0\n"

--- a/scripts/adaptation.rb
+++ b/scripts/adaptation.rb
@@ -1,4 +1,4 @@
-# View or set level of cavern adaptation for the selected unit or the whole fort
+# View or set cavern adaptation levels
 # based on removebadthoughts.rb
 =begin
 

--- a/scripts/armoks-blessing.lua
+++ b/scripts/armoks-blessing.lua
@@ -1,7 +1,4 @@
--- Adjust all attributes, personality, age and skills of all dwarves in play
--- without arguments, all attributes, age & personalities are adjusted
--- arguments allow for skills to be adjusted as well
--- WARNING: USING THIS SCRIPT WILL ADJUST ALL DWARVES IN PLAY!
+-- Adjust all attributes of all dwarves to an ideal
 -- by vjek
 --[[=begin
 
@@ -11,6 +8,9 @@ Runs the equivalent of `rejuvenate`, `elevate-physical`, `elevate-mental`, and
 `brainwash` on all dwarves currently on the map.  This is an extreme change,
 which sets every stat to an ideal - legendary skills, great traits, and
 easy-to-satisfy preferences.
+
+Without arguments, all attributes, age & personalities are adjusted.
+Arguments allow for skills to be adjusted as well.
 
 =end]]
 function rejuvenate(unit)

--- a/scripts/autofarm.rb
+++ b/scripts/autofarm.rb
@@ -1,4 +1,4 @@
-# Select cropt to plant based on current stocks
+# Select crops to plant based on current stocks
 =begin
 
 autofarm

--- a/scripts/autofarm.rb
+++ b/scripts/autofarm.rb
@@ -1,4 +1,4 @@
-
+# Select cropt to plant based on current stocks
 =begin
 
 autofarm

--- a/scripts/autolabor-artisans.lua
+++ b/scripts/autolabor-artisans.lua
@@ -1,10 +1,14 @@
--- Executes an autolabor command for each labor where skill level influences output quality.
+-- Run an autolabor command for skill-affected labors.
 
 --[[=begin
 
 autolabor-artisans
 ==================
-Runs `autolabor`, with settings tuned for small but highly skilled workforces.
+Runs an `autolabor` command, for all labors where skill level
+influences output quality.  Examples::
+
+    autolabor-artisans 0 2 3
+    autolabor-artisans disable
 
 =end]]
 local artisan_labors = {

--- a/scripts/brainwash.lua
+++ b/scripts/brainwash.lua
@@ -1,4 +1,4 @@
--- This script will brainwash a dwarf, modifying their personality
+-- Brainwash a dwarf, modifying their personality
 -- usage is:  target a unit in DF, and execute this script in dfhack
 -- by vjek
 --[[=begin

--- a/scripts/deterioratefood.rb
+++ b/scripts/deterioratefood.rb
@@ -1,4 +1,4 @@
-# Make food and plants decay, and vanish after a few months
+# Food and plants decay, and vanish after a few months
 =begin
 
 deterioratefood

--- a/scripts/devel/all-bob.lua
+++ b/scripts/devel/all-bob.lua
@@ -1,4 +1,4 @@
---all-bob.lua
+-- Changes the first name of all units to "Bob"
 --author expwnent
 --
 --[[=begin

--- a/scripts/devel/inject-raws.lua
+++ b/scripts/devel/inject-raws.lua
@@ -1,4 +1,4 @@
--- Injects new reaction, item and building defs into the world.
+-- Inject new raw definitions into the world
 --[[=begin
 
 devel/inject-raws
@@ -8,6 +8,8 @@ WARNING: THIS SCRIPT CAN PERMANENLY DAMAGE YOUR SAVE.
 This script attempts to inject new raw objects into your
 world. If the injected references do not match the actual
 edited raws, your save will refuse to load, or load but crash.
+
+This script can handle reaction, item and building definitions.
 
 The savegame contains a list of the relevant definition tokens in
 the right order, but all details are read from raws every time.

--- a/scripts/devel/inspect-screen.lua
+++ b/scripts/devel/inspect-screen.lua
@@ -1,4 +1,4 @@
--- Read the tiles from the screen and display info about them.
+-- Read from the screen and display info about the tiles
 --[[=begin
 
 devel/inspect-screen

--- a/scripts/devel/list-filters.lua
+++ b/scripts/devel/list-filters.lua
@@ -1,4 +1,4 @@
--- List input items for the building currently being built.
+-- List input items for the building being built.
 --[[=begin
 
 devel/list-filters

--- a/scripts/devel/nuke-items.lua
+++ b/scripts/devel/nuke-items.lua
@@ -1,4 +1,4 @@
--- Deletes ALL items not held by units, buildings or jobs.
+-- Delete ALL items not held by units, buildings or jobs
 --[[=begin
 
 devel/nuke-items

--- a/scripts/devel/prepare-save.lua
+++ b/scripts/devel/prepare-save.lua
@@ -1,4 +1,4 @@
--- Prepare the current save for use with devel/find-offsets.
+-- Prepare the current save for devel/find-offsets
 --[[=begin
 
 devel/prepare-save

--- a/scripts/devel/scanitemother.rb
+++ b/scripts/devel/scanitemother.rb
@@ -1,4 +1,4 @@
-# list indices in world.item.other[] where current selected item appears
+# list selected item's indices in world.item.other[]
 =begin
 
 devel/scanitemother

--- a/scripts/devel/spawn-unit-helper.rb
+++ b/scripts/devel/spawn-unit-helper.rb
@@ -1,4 +1,4 @@
-# setup stuff to allow arena creature spawn after a mode change
+# Allow arena creature spawn after a mode change
 
 df.world.arena_spawn.race.clear
 df.world.arena_spawn.caste.clear

--- a/scripts/devel/test-perlin.lua
+++ b/scripts/devel/test-perlin.lua
@@ -1,4 +1,4 @@
--- Generates an image using multiple octaves of perlin noise.
+-- Generates an image using perlin noise
 --[[=begin
 
 devel/test-perlin

--- a/scripts/digfort.rb
+++ b/scripts/digfort.rb
@@ -1,4 +1,4 @@
-# designate an area for digging according to a plan in csv format
+# designate an area based on a '.csv' plan
 =begin
 
 digfort

--- a/scripts/elevate-mental.lua
+++ b/scripts/elevate-mental.lua
@@ -1,4 +1,4 @@
--- This script will elevate all the mental attributes of a unit
+-- Elevate all the mental attributes of a unit
 -- by vjek
 --[[=begin
 

--- a/scripts/elevate-physical.lua
+++ b/scripts/elevate-physical.lua
@@ -1,4 +1,4 @@
--- This script will elevate all the physical attributes of a unit
+-- Elevate all the physical attributes of a unit
 -- by vjek
 --[[=begin
 

--- a/scripts/fix/blood-del.lua
+++ b/scripts/fix/blood-del.lua
@@ -1,6 +1,5 @@
---makes it so that civs won't come with barrels full of blood, ichor, or goo
---author Urist Da Vinci
---edited by expwnent, scamtank
+-- Stop traders bringing blood, ichor, or goo
+--author Urist Da Vinci; edited by expwnent, scamtank
 --[[=begin
 
 fix/blood-del

--- a/scripts/fix/loyaltycascade.rb
+++ b/scripts/fix/loyaltycascade.rb
@@ -1,4 +1,4 @@
-# script to fix loyalty cascade, when you order your militia to kill friendly units
+# Cancels a 'loyalty cascade' when citizens are killed
 =begin
 
 fix/loyaltycascade

--- a/scripts/fix/population-cap.lua
+++ b/scripts/fix/population-cap.lua
@@ -1,4 +1,4 @@
--- Communicates current population to mountainhomes to avoid cap overshooting.
+-- Tells mountainhomes your pop. to avoid overshoot
 
 --[[=begin
 

--- a/scripts/forum-dwarves.lua
+++ b/scripts/forum-dwarves.lua
@@ -1,7 +1,5 @@
--- scripts/forum-dwarves.lua
--- Save a copy of a text screen for the DF forums.  Use 'forumdwarves help' for more details.
--- original author: Caldfir
--- edited by expwnent, Mchl
+-- Save a copy of a text screen for the DF forums
+-- original author: Caldfir; edited by expwnent, Mchl
 --[[=begin
 
 forum-dwarves

--- a/scripts/full-heal.lua
+++ b/scripts/full-heal.lua
@@ -1,4 +1,4 @@
---full-heal.lua
+-- Attempts to fully heal the selected unit
 --author Kurik Amudnil, Urist DaVinci
 --edited by expwnent
 

--- a/scripts/gaydar.lua
+++ b/scripts/gaydar.lua
@@ -1,4 +1,4 @@
-local utils = require('utils')
+-- Shows the sexual orientation of units
 --[[=begin
 
 gaydar
@@ -8,6 +8,7 @@ the viability of livestock breeding programs.  Use ``gaydar -help`` for informat
 on available filters for orientation, citizenship, species, etc.
 
 =end]]
+local utils = require('utils')
 
 validArgs = utils.invert({
   'all',

--- a/scripts/growcrops.rb
+++ b/scripts/growcrops.rb
@@ -1,4 +1,4 @@
-# grow crops in farm plots. ex: growcrops helmet_plump 20
+# Instantly grow crops in farm plots
 =begin
 
 growcrops

--- a/scripts/gui/advfort_items.lua
+++ b/scripts/gui/advfort_items.lua
@@ -1,4 +1,4 @@
-
+--Does something with items in adventure mode jobs
 --[[=begin
 
 gui/advfort_items

--- a/scripts/gui/assign-rack.lua
+++ b/scripts/gui/assign-rack.lua
@@ -1,5 +1,4 @@
--- Assign weapon racks to squads. Requires the weaponrack-unassign patch.
-
+-- Assign weapon racks to squads (needs binpatch)
 --[[=begin
 
 gui/assign-rack

--- a/scripts/gui/choose-weapons.lua
+++ b/scripts/gui/choose-weapons.lua
@@ -1,4 +1,4 @@
--- Rewrite individual choice weapons into specific types.
+-- Rewrite individual choice weapons to specific types
 --[[=begin
 
 gui/choose-weapons

--- a/scripts/gui/clone-uniform.lua
+++ b/scripts/gui/clone-uniform.lua
@@ -1,4 +1,4 @@
--- Clone the current uniform template in the military screen.
+-- Clone a uniform template in the military screen
 --[[=begin
 
 gui/clone-uniform

--- a/scripts/gui/companion-order.lua
+++ b/scripts/gui/companion-order.lua
@@ -1,4 +1,4 @@
-
+-- Issue orders to companions in Adventure mode
 --[[=begin
 
 gui/companion-order

--- a/scripts/gui/gm-unit.lua
+++ b/scripts/gui/gm-unit.lua
@@ -1,4 +1,4 @@
--- Interface powered (somewhat user friendly) unit editor.
+-- Interface powered, user friendly, unit editor
 
 --[[=begin
 

--- a/scripts/gui/guide-path.lua
+++ b/scripts/gui/guide-path.lua
@@ -1,4 +1,4 @@
--- Show and manipulate the path used by Guide Cart orders.
+-- Show/change the path used by Guide Cart orders
 --[[=begin
 
 gui/guide-path

--- a/scripts/hfs-pit.lua
+++ b/scripts/hfs-pit.lua
@@ -1,4 +1,4 @@
--- Creates a pit under the target leading straight to the Underworld.  Type '?' for help.
+-- Creates a pit to the Underworld under the target
 -- Based on script by IndigoFenix, @ https://gist.github.com/IndigoFenix/8776696
 --[[=begin
 

--- a/scripts/make-legendary.lua
+++ b/scripts/make-legendary.lua
@@ -1,5 +1,4 @@
--- This script will modify a skill or the skills of a single unit
--- the skill will be increased to 20 (Legendary +5)
+-- Make a skill or skills of a unit Legendary +5
 -- by vjek
 --[[=begin
 

--- a/scripts/markdown.lua
+++ b/scripts/markdown.lua
@@ -1,4 +1,4 @@
--- Save a copy of a text screen in markdown (for reddit among others). Use 'markdown help' for more details.
+-- Save a text screen in markdown (eg for reddit)
 -- This is a derivatiwe work based upon scripts/forum-dwarves.lua by Caldfir and expwnent
 -- Adapted for markdown by Mchl https://github.com/Mchl
 --[[=begin

--- a/scripts/migrants-now.lua
+++ b/scripts/migrants-now.lua
@@ -1,4 +1,4 @@
--- Force a migrant wave (only works after hardcoded waves)
+-- Force a migrant wave (only after hardcoded waves)
 --[[=begin
 
 migrants-now

--- a/scripts/modtools/add-syndrome.lua
+++ b/scripts/modtools/add-syndrome.lua
@@ -1,4 +1,4 @@
---modtools/add-syndrome.lua
+-- Add or remove syndromes from units
 --author expwnent
 --[[=begin
 

--- a/scripts/modtools/anonymous-script.lua
+++ b/scripts/modtools/anonymous-script.lua
@@ -1,6 +1,5 @@
---scripts/modtools/anonymous-script.lua
+-- invoke simple lua scripts from strings
 --author expwnent
---a tool for invoking simple lua scripts without putting them in a file first
 --[[=begin
 
 modtools/anonymous-script

--- a/scripts/modtools/create-item.lua
+++ b/scripts/modtools/create-item.lua
@@ -1,6 +1,5 @@
---scripts/modtools/create-item.lua
+-- creates an item of a given type and material
 --author expwnent
---creates an item of a given type and material
 --[[=begin
 
 modtools/create-item

--- a/scripts/modtools/create-unit.lua
+++ b/scripts/modtools/create-unit.lua
@@ -1,4 +1,4 @@
--- create-unit.lua
+-- Creates a unit.  Beta; use at own risk.
 -- Originally created by warmist, edited by Putnam for the dragon ball mod to be used in reactions, modified by Dirst for use in The Earth Strikes Back mod, incorporating fixes discovered by Boltgun then Mifiki wrote the bit where it switches to arena mode briefly to do some of the messy work, then Expwnent combined that with the old script to make it function for histfigs
 -- version 0.51
 -- This is a beta version. Use at your own risk.

--- a/scripts/modtools/equip-item.lua
+++ b/scripts/modtools/equip-item.lua
@@ -1,4 +1,3 @@
--- modtools/equip-item.lua
 -- equip an item on a unit with a particular body part
 --[[=begin
 

--- a/scripts/modtools/force.lua
+++ b/scripts/modtools/force.lua
@@ -1,7 +1,6 @@
--- scripts/modtools/force.lua
+-- Forces an event (caravan, migrants, etc)
 -- author Putnam
 -- edited by expwnent
--- Forces an event.
 --[[=begin
 
 modtools/force

--- a/scripts/modtools/interaction-trigger.lua
+++ b/scripts/modtools/interaction-trigger.lua
@@ -1,6 +1,5 @@
---scripts/modtools/interaction-trigger.lua
+-- triggers scripts based on unit interactions
 --author expwnent
---triggers scripts when a unit does a unit interaction on another
 --[[=begin
 
 modtools/interaction-trigger

--- a/scripts/modtools/invader-item-destroyer.lua
+++ b/scripts/modtools/invader-item-destroyer.lua
@@ -1,6 +1,5 @@
---scripts/modtools/invader-item-destroyer.lua
+-- delete invader items when they die
 --author expwnent
---configurably deletes invader items when they die
 --[[=begin
 
 modtools/invader-item-destroyer

--- a/scripts/modtools/item-trigger.lua
+++ b/scripts/modtools/item-trigger.lua
@@ -1,4 +1,4 @@
---scripts/modtools/attack-trigger.lua
+-- trigger commands based on attacks with certain items
 --author expwnent
 --based on itemsyndrome by Putnam
 --triggers scripts when a unit attacks another with a weapon type, a weapon of a particular material, or a weapon contaminated with a particular material, or when a unit equips/unequips a particular item type, an item of a particular material, or an item contaminated with a particular material

--- a/scripts/modtools/moddable-gods.lua
+++ b/scripts/modtools/moddable-gods.lua
@@ -1,4 +1,4 @@
---scripts/modtools/moddable-gods.lua
+-- Create gods from the command-line
 --based on moddableGods by Putnam
 --edited by expwnent
 --[[=begin

--- a/scripts/modtools/outside-only.lua
+++ b/scripts/modtools/outside-only.lua
@@ -1,6 +1,5 @@
---scripts/modtools/outsideOnly.lua
+-- enables outside only and inside only buildings
 --author expwnent
---enables outside only and inside only buildings
 --[[=begin
 
 modtools/outside-only

--- a/scripts/modtools/projectile-trigger.lua
+++ b/scripts/modtools/projectile-trigger.lua
@@ -1,4 +1,4 @@
---scripts/modtools/projectile-trigger.lua
+-- trigger commands when projectiles hit targets
 --author expwnent
 --based on Putnam's projectileExpansion
 --TODO: trigger based on contaminants

--- a/scripts/modtools/random-trigger.lua
+++ b/scripts/modtools/random-trigger.lua
@@ -1,5 +1,4 @@
---scripts/modtools/random-trigger.lua
---triggers random scripts
+-- triggers random scripts
 --[[=begin
 
 modtools/random-trigger

--- a/scripts/modtools/reaction-product-trigger.lua
+++ b/scripts/modtools/reaction-product-trigger.lua
@@ -1,6 +1,5 @@
--- scripts/modtools/reaction-product-trigger.lua
+-- trigger commands before/after reactions produce items
 -- author expwnent
--- trigger commands just before and after custom reactions produce items
 --@ module = true
 --[[=begin
 

--- a/scripts/modtools/reaction-trigger-transition.lua
+++ b/scripts/modtools/reaction-trigger-transition.lua
@@ -1,4 +1,4 @@
--- scripts/modtools/reaction-trigger-transition.lua
+-- help transition from autoSyndrome
 -- author expwnent
 --[[=begin
 

--- a/scripts/modtools/reaction-trigger.lua
+++ b/scripts/modtools/reaction-trigger.lua
@@ -1,6 +1,6 @@
--- scripts/modtools/reaction-trigger.lua
+-- trigger commands when custom reactions complete
 -- author expwnent
--- replaces autoSyndrome: trigger commands when custom reactions are completed
+-- replaces autoSyndrome
 --@ module = true
 --[[=begin
 

--- a/scripts/modtools/skill-change.lua
+++ b/scripts/modtools/skill-change.lua
@@ -1,4 +1,4 @@
---scripts/modtools/skill-change.lua
+-- Sets or modifies a skill of a unit
 --author expwnent
 --based on skillChange.lua by Putnam
 --TODO: update skill level once experience increases/decreases

--- a/scripts/modtools/spawn-flow.lua
+++ b/scripts/modtools/spawn-flow.lua
@@ -1,6 +1,5 @@
---scripts/modtools/spawn-flow.lua
+-- spawns flows at locations
 --author expwnent
---spawns flows at locations
 --[[=begin
 
 modtools/spawn-flow

--- a/scripts/modtools/syndrome-trigger.lua
+++ b/scripts/modtools/syndrome-trigger.lua
@@ -1,6 +1,5 @@
---scripts/modtools/syndrome-trigger.lua
+-- triggers scripts when a syndrome is applied
 --author expwnent
---triggers scripts when units are infected with syndromes
 --[[=begin
 
 modtools/syndrome-trigger

--- a/scripts/modtools/transform-unit.lua
+++ b/scripts/modtools/transform-unit.lua
@@ -1,4 +1,4 @@
---scripts/modtools/transform-unit.lua
+-- Transforms a unit into another unit type
 --author expwnent
 --based on shapechange by Putnam
 --[[=begin

--- a/scripts/points.lua
+++ b/scripts/points.lua
@@ -1,4 +1,4 @@
--- by Meph
+-- Set available points at the embark screen
 -- http://www.bay12forums.com/smf/index.php?topic=135506.msg4925005#msg4925005
 --[[=begin
 

--- a/scripts/region-pops.lua
+++ b/scripts/region-pops.lua
@@ -1,4 +1,4 @@
--- Shows populations of animals in the region, and allows tweaking them.
+-- Show or edit regional plant and animal populations
 --[[=begin
 
 region-pops

--- a/scripts/remove-wear.lua
+++ b/scripts/remove-wear.lua
@@ -1,7 +1,5 @@
--- scripts/remove-wear.lua
 -- Resets all items in your fort to 0 wear
--- original author: Laggy
--- edited by expwnent
+-- original author: Laggy, edited by expwnent
 --[[=begin
 
 remove-wear

--- a/scripts/repeat.lua
+++ b/scripts/repeat.lua
@@ -1,5 +1,5 @@
--- scripts/repeat.lua
--- repeatedly calls a lua script, eg "repeat -time 1 months -command cleanowned"; to disable "repeat -cancel cleanowned"
+-- repeatedly call a lua script
+-- eg "repeat -time 1 months -command cleanowned"; to disable "repeat -cancel cleanowned"
 -- repeat -help for details
 -- author expwnent
 -- vaguely based on a script by Putnam

--- a/scripts/show-unit-syndromes.rb
+++ b/scripts/show-unit-syndromes.rb
@@ -1,6 +1,5 @@
-# Show syndromes affecting units and the remaining and maximum duration
-# original author: drayath
-# edited by expwnent
+# Show syndromes affecting units, including duration
+# original author: drayath, edited by expwnent
 =begin
 
 show-unit-syndromes

--- a/scripts/siren.lua
+++ b/scripts/siren.lua
@@ -1,4 +1,4 @@
--- Wakes up the sleeping, breaks up parties and stops breaks.
+-- Wakes up the sleeping, ends breaks and parties
 --[[=begin
 
 siren

--- a/scripts/source.rb
+++ b/scripts/source.rb
@@ -1,4 +1,4 @@
-# create an infinite magma/water source/drain at the cursor
+# create an infinite source/drain of magma/water
 =begin
 
 source

--- a/scripts/starvingdead.rb
+++ b/scripts/starvingdead.rb
@@ -1,4 +1,4 @@
-# Make undead units weaken after one month, and vanish after six
+# Weaken and eventually destroy undead over time
 =begin
 
 starvingdead

--- a/scripts/teleport.lua
+++ b/scripts/teleport.lua
@@ -1,4 +1,3 @@
--- teleport.lua
 -- teleports a unit to a location
 -- author Putnam
 -- edited by expwnent

--- a/scripts/warn-starving.lua
+++ b/scripts/warn-starving.lua
@@ -1,4 +1,4 @@
--- Pauses the game with a warning if a creature is starving, dehydrated, or very drowsy.
+-- Pause and warn if a unit is starving
 -- By Meneth32, PeridexisErrant, Lethosor
 --@ module = true
 --[[=begin

--- a/travis/script-in-readme.py
+++ b/travis/script-in-readme.py
@@ -42,7 +42,7 @@ def check_file(fname):
             else:
                 print('Error: no documentation in: ' + fname)
             return 1
-    title, underline = doclines[1], doclines[2]
+    title, underline = [d for d in doclines if d and '=begin' not in d][:2]
     if underline != '=' * len(title):
         print('Error: title/underline mismatch:', fname, title, underline)
         errors += 1

--- a/travis/script-in-readme.py
+++ b/travis/script-in-readme.py
@@ -13,12 +13,25 @@ def expected_cmd(path):
     return fname
 
 
+def check_ls(fname, line):
+    """Check length & existence of leading comment for "ls" builtin command."""
+    line = line.strip()
+    comment = '--' if fname.endswith('.lua') else '#'
+    if line.endswith('=begin') or not line.startswith(comment):
+        print('Error: no leading comment in ' + fname)
+        return 1
+    if len(line.replace(comment, '').strip()) > 53:
+        print('Error: leading comment too long in ' + fname)
+        return 1
+    return 0
+
+
 def check_file(fname):
     errors, doclines = 0, []
     with open(fname, errors='ignore') as f:
-        for l in f.readlines():
-            if not l.strip():
-                continue
+        lines = f.readlines()
+        errors += check_ls(fname, lines[0])
+        for l in lines:
             if doclines or l.strip().endswith('=begin'):
                 doclines.append(l.rstrip())
             if l.startswith('=end'):


### PR DESCRIPTION
Closes #739 

>At the moment, some are missing, others are too long (wrapping is pretty disruptive), and many are uninformative or verbose.

>We can fix all of these, and for scripts the first two can be added to the docs linter to ensure they stay fixed.  This requirement should also be noted in the Contributing doc.

Done.  It turns out that some existing help wasn't being picked up.  I fixed that, and also where I saw it added useful help instead of just the script name.