### PR TITLE
Re-enable GCC 5 compilation for OSX and Linux; updated build-osx.sh script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,13 @@ project(dfhack)
 macro(CHECK_GCC COMPILER_PATH)
   execute_process(COMMAND ${COMPILER_PATH} -dumpversion OUTPUT_VARIABLE GCC_VERSION_OUT)
   string(STRIP "${GCC_VERSION_OUT}" GCC_VERSION_OUT)
-  if (${GCC_VERSION_OUT} VERSION_LESS "4.5" OR ${GCC_VERSION_OUT} VERSION_GREATER "4.9.9")
-    message(SEND_ERROR "${COMPILER_PATH} version ${GCC_VERSION_OUT} cannot be used - use GCC 4.5 through 4.9")
+  if (${GCC_VERSION_OUT} VERSION_LESS "4.5")
+    message(SEND_ERROR "${COMPILER_PATH} version ${GCC_VERSION_OUT} cannot be used - use GCC 4.5 or later")
+  elseif (${GCC_VERSION_OUT} VERSION_GREATER "4.9.9")
+    # GCC 5 changes ABI name mangling to enable C++11 changes.
+    # This must be disabled to enable linking against DF.
+    # http://developerblog.redhat.com/2015/02/05/gcc5-and-the-c11-abi/
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
   endif()
 endmacro()
 

--- a/build/build-osx.sh
+++ b/build/build-osx.sh
@@ -3,112 +3,8 @@
 # This implements steps 7 and 8 of the OSX compilation procedure described in Compile.rst
 # If build-osx does not exist in the parent directory, it will be created.
 
-LUA_PATCH=1
-ME=$PWD/`basename $0`
-
-usage() {
-	echo "Usage: $0 [options] {DF_OSX_PATH}"
-	echo -e "\told\t- use on pre-Snow Leopard OSX installations"
-	echo -e "\tbrew\t- if GCC 4.5 was installed with homebrew"
-	echo -e "\tport\t- if GCC 4.5 was insalled with macports"
-	echo -e "\tclean\t- delete ../build-osx before compiling"
-	echo "Example:"
-	echo -e "\t$0 old brew ../../../personal/df_osx"
-	echo -e "\t$0 port clean /Users/dfplayer/df_osx"
-	exit $1
-}
-
-options() {
-	case $1 in
-		brew)
-			echo "Using homebrew gcc."
-			export CC=/usr/local/bin/gcc-4.5
-			export CXX=/usr/local/bin/g++-4.5
-			targetted=1
-			;;
-		port)
-			echo "Using macports gcc."
-			export CC=/opt/local/bin/gcc-mp-4.5
-			export CXX=/opt/local/bin/g++-mp-4.5
-			targetted=1
-			;;
-		old)
-			LUA_PATCH=0
-			;;
-		clean)
-			echo "Deleting ../build-osx"
-			rm -rf ../build-osx
-			;;
-		*)
-			;;
-	esac
-}
-
-# sanity checks
-if [[ $# -lt 1 ]]
-then
-	echo "Not enough arguments."
-	usage 0
-fi
-if [[ $# -gt 4 ]]
-then
-	echo "Too many arguments."
-	usage 1
-fi
-
-# run through the arguments
-for last
-do
-	options $last
-done
-# last keeps the last argument
-
-if [[ $targetted -eq 0 ]]
-then
-	echo "You did not specify whether you intalled GCC 4.5 from brew or ports."
-	echo "If you continue, your default compiler will be used."
-	read -p "Are you sure you want to continue? [y/N] " -n 1 -r
-	echo    # (optional) move to a new line
-	if [[ ! $REPLY =~ ^[Yy]$ ]]
-	then
-	    exit 0
-	fi
-fi
-
-# check for build folder and start working there
-if [[ ! -d ../build-osx ]]
-then
-	mkdir ../build-osx
-fi
-cd ../build-osx
-
-# patch if necessary
-if [[ $LUA_PATCH -ne 0 ]]
-then
-	cd ..
-	echo "$PWD"
-	sed -e '1,/'"PATCH""CODE"'/d' "$ME" | patch -p0
-	cd -
-fi
-
-echo "Generate"
-cmake .. -DCMAKE_BUILD_TYPE:string=Release -DCMAKE_INSTALL_PREFIX="$last"
-echo "Build"
-make
-echo "Install"
-make install
-
-# unpatch if /libarary/luaTypes.cpp was patched
-if [[ $LUA_PATCH -ne 0 ]]
-then
-	cd ..
-	echo -n "un"
-	sed -e '1,/'"PATCH""CODE"'/d' "$ME" | patch -p0 -R
-	cd -
-fi
-
-exit 0
-
+function lua_patch() { action="$1" LUA_PATCH="$2"
+  LUA_PATCH_CODE="
 # PATCHCODE - everything below this line is fed into patch
 --- library/LuaTypes.cpp	2014-08-20 00:13:17.000000000 -0700
 +++ library/LuaTypes.cpp	2014-08-31 23:31:00.000000000 -0700
@@ -120,4 +16,171 @@ exit 0
 +            int len = strlen((char*)ptr);
              lua_pushlstring(state, (char*)ptr, len);
              return;
-         }
+         }"
+
+  if [[ $LUA_PATCH -ne 0 ]]
+  then
+    (
+      cd ..
+      echo -n "Patch Lua code: "
+      if [[ "$action" == "remove" ]]
+      then
+        echo "removing patch."
+        patch -p0 <<< "$LUA_PATCH_CODE" -R
+      elif [[ "$action" == "apply" ]]
+      then
+        echo "applying patch."
+        patch -p0 <<< "$LUA_PATCH_CODE"
+      else
+        echo "Error in script: unknown lua_patch action"
+        exit 1
+      fi
+    )
+  fi
+}
+
+DEFAULT_GCC_VER=4.5
+GCC_VER="$DEFAULT_GCC_VER"
+PARALLEL_PROC=1
+LUA_PATCH=1
+
+targetted=0
+
+usage() {
+  echo "Usage: $0 [-gcc version] [-par #] [old] [brew|port] [clean] <DF_OSX_PATH>"
+  echo -e "\t-gcc <ver>\t-use GCC version <ver> instead of the default $DEFAULT_GCC_VER"
+  echo -e "\t-par #\t-build with # parallel processes (default = $PARALLEL_PROC)"
+  echo -e "\told\t- use on pre-Snow Leopard OSX installations"
+  echo -e "\tbrew\t- if GCC $GCC_VER was installed with homebrew"
+  echo -e "\tport\t- if GCC $GCC_VER was insalled with macports"
+  echo -e "\tclean\t- delete ../build-osx before compiling"
+  echo "Examples:"
+  echo -e "\t$0 old brew ../../../personal/df_osx"
+  echo -e "\t$0 port clean /Users/dfplayer/df_osx"
+  echo -e "\t$0 port -gcc 4.9 -par 4 /Users/dfplayer/df_osx"
+  echo -e "\t$0 -gcc 5 brew clean \~/games/df_osx"
+  exit $1
+}
+
+while (( $# > 1 )); do
+  case "$1" in
+    -gcc)
+      GCC_VER="$2"
+      [[ "$GCC_VER" == *[^0-9.]* ]] && { echo "Invalid GCC version specified: $GCC_VER" ; exit 1 ; }
+      echo "Changing GCC version from $DEFAULT_GCC_VER to $GCC_VER"
+      shift ; shift
+      ;;
+    -par)
+      PARALLEL_PROC="$2"
+      [[ "$PARALLEL_PROC" == *[^0-9]* ]] && { echo "Invalid parallel process specified: $PARALLEL_PROC" ; exit 1 ; }
+      echo "Changing parallel process count to $PARALLEL_PROC"
+      shift ; shift
+      ;;
+    brew)
+      echo "Using homebrew gcc."
+      export CC=/usr/local/bin/gcc-$GCC_VER
+      export CXX=/usr/local/bin/g++-$GCC_VER
+      targetted=1
+      shift
+      ;;
+      port)
+      echo "Using macports gcc."
+      export CC=/opt/local/bin/gcc-mp-$GCC_VER
+      export CXX=/opt/local/bin/g++-mp-$GCC_VER
+      targetted=1
+      shift
+      ;;
+      old)
+      LUA_PATCH=0
+      shift
+      ;;
+      clean)
+      echo "Deleting ../build-osx"
+      rm -rf ../build-osx
+      shift
+      ;;
+  esac
+done
+
+# sanity checks
+if (( $# < 1 ))
+then
+  echo "Not enough arguments."
+  usage 0
+fi
+if (( $# > 5 ))
+then
+  echo "Too many arguments."
+  usage 1
+fi
+
+if (( $targetted == 0 ))
+then
+  echo "You did not specify whether you intalled GCC $GCC_VER from brew or ports."
+  echo "If you continue, your default compiler will be used."
+  read -p "Are you sure you want to continue? [y/N] " -n 1 -r
+  echo    # (optional) move to a new line
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    exit 0
+  fi
+fi
+
+echo "Installing to: $1"
+
+if [[ ! -d "$1" ]]
+then
+  echo "ERROR: Specified installation directory $1 does not exist or is not a directory!"
+  exit 1
+fi
+
+# Only check that CC/CXX exist if $CC is non-empty, to allow for default compiler usage
+# when not specifying brew/port.
+if [[ ! -z "$CC" ]]
+then
+  echo "Compiler executables to be used:"
+  echo -e "\tCC: $CC"
+  echo -e "\tCXX: $CXX"
+
+  if [[ ! -x "$CC" || ! -x "$CXX" ]]
+  then
+    echo "ERROR: Cannot find compiler executable(s), or they are not executable!"
+    exit 1
+  fi
+fi
+
+# check for build folder and start working there
+if [[ ! -d ../build-osx ]]
+then
+  mkdir ../build-osx
+fi
+cd ../build-osx
+
+# patch if necessary
+lua_patch apply "$LUA_PATCH"
+
+# Run the build and time it.
+export TIMEFORMAT="%lR"
+# Bash redirection magic to capture the duration of the commands to a variable, without losing their stdout/err.
+{ build_time=$(
+  { time {
+      echo "Generate"
+      cmake .. -DCMAKE_BUILD_TYPE:string=Release -DCMAKE_INSTALL_PREFIX="$1"
+      echo "Build"
+      make -j"$PARALLEL_PROC"
+      echo "Install"
+      make install ; } 1>&3- 2>&4- ; } 2>&1 ); } 3>&1 4>&2
+
+echo "Build finished."
+echo "Build duration: $build_time"
+
+if [[ "$GCC_VER" != "$DEFAULT_GCC_VER" ]]
+then
+  echo "Reminder: you compiled with GCC $GCC_VER, which is not the default of GCC $DEFAULT_GCC_VER"
+  echo "You will need to copy or symlink your compiler's i386/32bit libstdc++.6.dylib into $1/hack/"
+fi
+
+# unpatch if /libarary/luaTypes.cpp was patched
+lua_patch remove "$LUA_PATCH"
+
+exit 0


### PR DESCRIPTION
Apologies that these are A) on Develop, and B) two unrelated commits in a single Pull.  I'm still having git issues - this time, it merged my local branches into origin/develop when I pushed, for no reason I can yet understand.

Commit 1:

Re-enable GCC 5 compilation for OSX and Linux, passing -D_GLIBCXX_USE_CXX11_ABI=0 to disable new C++11 name mangling and remain compatible with DF.

Commit 2:
OSX build script (build-osx.sh) - multiple improvements:
  Can specify -gcc X to change GCC version from default of 4.5.
  Can specify -par Y to give a -jY parallel build flag to make.
  Various error checks: existence of executables, output dir, etc.
  Improved Bash syntax, especially for Lua patching (now a valid .sh file).
  Times the overall build time and outputs this to stdout.
  If GCC version is not default, print reminder about installing libstdc++.
