### PR TITLE
Updated Windows compile docs

### DIFF
--- a/docs/Compile.rst
+++ b/docs/Compile.rst
@@ -363,7 +363,7 @@ To install Chocolatey and the required dependencies:
 * Close this ``cmd.exe`` window and open another Admin ``cmd.exe`` in the same way
 * Run the following command::
 
-    choco install git cmake strawberryperl -y
+    choco install git cmake.portable strawberryperl -y
 
 * Close the Admin ``cmd.exe`` window; you're done!
 


### PR DESCRIPTION
Needing cmake.portable instead of cmake