### PR TITLE
blueprint: fix compilation (i.e. undefined find)

### DIFF
--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -2,6 +2,8 @@
 //By cdombroski
 //Translates a region of tiles specified by the cursor and arguments/prompts into a series of blueprint files suitable for digfort/buildingplan/quickfort
 
+#include <algorithm>
+
 #include <Console.h>
 #include <PluginManager.h>
 


### PR DESCRIPTION
Without this, `std::find` is not found, leading to the same problem as in https://stackoverflow.com/questions/27996423/how-do-i-pass-a-constant-string-vector-to-a-function-for-string-matching .