### PR TITLE
autolabor-artisans.lua remove brewer skill

### DIFF
--- a/scripts/autolabor-artisans.lua
+++ b/scripts/autolabor-artisans.lua
@@ -14,7 +14,6 @@ local artisan_labors = {
     "ARCHITECT",
     "ANIMALTRAIN",
     "LEATHER",
-    "BREWER",
     "WEAVER",
     "CLOTHESMAKER",
     "COOK",


### PR DESCRIPTION
alcohol has no quality level, so brewer skill has no effect on output quality