### PR TITLE
Add brew, mill, thread, and milk to ban-cooking. See #796 and #795.

### DIFF
--- a/scripts/ban-cooking.rb
+++ b/scripts/ban-cooking.rb
@@ -6,7 +6,7 @@ ban-cooking
 A more convenient way to ban cooking various categories of foods than the
 kitchen interface.  Usage:  ``ban-cooking <type>``.  Valid types are ``booze``,
 ``honey``, ``tallow``, ``oil``, ``seeds`` (non-tree plants with seeds),
-``brew``, ``mill``, and ``thread``.
+``brew``, ``mill``, ``thread``, and ``milk``.
 
 =end
 
@@ -109,6 +109,15 @@ $script_args.each do |arg|
             ban_cooking[p.material_defs.type_basic_mat, p.material_defs.idx_basic_mat, :PLANT] if m.flags[:THREAD]
         end
 
+    when 'milk'
+        df.world.raws.creatures.all.each_with_index do |c, i|
+            c.material.each_with_index do |m, j|
+                if m.reaction_product and m.reaction_product.id and m.reaction_product.id.include?('CHEESE_MAT')
+                    ban_cooking[j + DFHack::MaterialInfo::CREATURE_BASE, i, :LIQUID_MISC]
+                end
+            end
+        end
+
     else
         puts "ban-cooking booze  - bans cooking of drinks"
         puts "ban-cooking honey  - bans cooking of honey bee honey"
@@ -118,5 +127,6 @@ $script_args.each do |arg|
         puts "ban-cooking brew   - bans cooking of plants that can be brewed into alcohol"
         puts "ban-cooking mill   - bans cooking of plants that can be milled into powder"
         puts "ban-cooking thread - bans cooking of plants that can be turned into thread"
+        puts "ban-cooking milk   - bans cooking of creature liquids that can be turned into cheese"
     end
 end

--- a/scripts/ban-cooking.rb
+++ b/scripts/ban-cooking.rb
@@ -5,7 +5,8 @@ ban-cooking
 ===========
 A more convenient way to ban cooking various categories of foods than the
 kitchen interface.  Usage:  ``ban-cooking <type>``.  Valid types are ``booze``,
-``honey``, ``tallow``, ``oil``, and ``seeds`` (non-tree plants with seeds).
+``honey``, ``tallow``, ``oil``, ``seeds`` (non-tree plants with seeds),
+``brew``, ``mill``, and ``thread``.
 
 =end
 
@@ -87,11 +88,35 @@ $script_args.each do |arg|
             end
         end
 
+    when 'brew'
+        df.world.raws.plants.all.each do |p|
+            m = df.decode_mat(p.material_defs.type_basic_mat, p.material_defs.idx_basic_mat).material
+            ban_cooking[p.material_defs.type_basic_mat, p.material_defs.idx_basic_mat, :PLANT] if m.reaction_product and m.reaction_product.id and m.reaction_product.id.include?('DRINK_MAT')
+
+            p.growths.each do |g|
+                m = df.decode_mat(g).material
+                ban_cooking[g.mat_type, g.mat_index, :PLANT_GROWTH] if m.reaction_product and m.reaction_product.id and m.reaction_product.id.include?('DRINK_MAT')
+            end
+        end
+
+    when 'mill'
+        df.world.raws.plants.all.each do |p|
+            ban_cooking[p.material_defs.type_basic_mat, p.material_defs.idx_basic_mat, :PLANT] if m.flags[:MILL]
+        end
+
+    when 'thread'
+        df.world.raws.plants.all.each do |p|
+            ban_cooking[p.material_defs.type_basic_mat, p.material_defs.idx_basic_mat, :PLANT] if m.flags[:THREAD]
+        end
+
     else
         puts "ban-cooking booze  - bans cooking of drinks"
         puts "ban-cooking honey  - bans cooking of honey bee honey"
         puts "ban-cooking tallow - bans cooking of tallow"
         puts "ban-cooking oil    - bans cooking of oil"
         puts "ban-cooking seeds  - bans cooking of plants that have seeds (tree seeds don't count)"
+        puts "ban-cooking brew   - bans cooking of plants that can be brewed into alcohol"
+        puts "ban-cooking mill   - bans cooking of plants that can be milled into powder"
+        puts "ban-cooking thread - bans cooking of plants that can be turned into thread"
     end
 end


### PR DESCRIPTION
brew: bans cooking of plants and fruits that can be made into alcohol
(assuming default brewing reaction)
mill: bans cooking of plants that can be milled.
thread: bans cooking of plants that can be turned into thread.
milk: bans cooking of animal liquids that can be turned into cheese
(assuming default cheesemaking reaction)