### PR TITLE
Manipulator update and fix

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1535,6 +1535,7 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, isHunter),
     WRAPM(Units, isAvailableForAdoption),
     WRAPM(Units, isOwnCiv),
+    WRAPM(Units, isOwnGroup),
     WRAPM(Units, isOwnRace),
     WRAPM(Units, getRaceName),
     WRAPM(Units, getRaceNamePlural),

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -240,6 +240,7 @@ DFHACK_EXPORT bool isWar(df::unit* unit);
 DFHACK_EXPORT bool isHunter(df::unit* unit);
 DFHACK_EXPORT bool isAvailableForAdoption(df::unit* unit);
 DFHACK_EXPORT bool isOwnCiv(df::unit* unit);
+DFHACK_EXPORT bool isOwnGroup(df::unit* unit);
 DFHACK_EXPORT bool isOwnRace(df::unit* unit);
 
 DFHACK_EXPORT std::string getRaceNameById(int32_t race_id);

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -888,6 +888,22 @@ bool Units::isOwnCiv(df::unit* unit)
     return unit->civ_id == ui->civ_id;
 }
 
+// check if creature belongs to the player's group
+bool Units::isOwnGroup(df::unit* unit)
+{
+    CHECK_NULL_POINTER(unit);
+    auto histfig = df::historical_figure::find(unit->hist_figure_id);
+    if (!histfig)
+        return false;
+    for (size_t i = 0; i < histfig->entity_links.size(); i++)
+    {
+        auto link = histfig->entity_links[i];
+        if (link->entity_id == ui->group_id && (*link).getType() == df::histfig_entity_link_type::MEMBER)
+            return true;
+    }
+    return false;
+}
+
 // check if creature belongs to the player's race
 // (in combination with check for civ helps to filter out own dwarves)
 bool Units::isOwnRace(df::unit* unit)

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -256,10 +256,26 @@ const SkillColumn columns[] = {
     {19, 6, profession::NONE, unit_labor::NONE, job_skill::POETRY, "Po"},
     {19, 6, profession::NONE, unit_labor::NONE, job_skill::READING, "Rd"},
     {19, 6, profession::NONE, unit_labor::NONE, job_skill::SPEAKING, "Sp"},
+    {19, 6, profession::NONE, unit_labor::NONE, job_skill::DANCE, "Dn"},
+    {19, 6, profession::NONE, unit_labor::NONE, job_skill::MAKE_MUSIC, "MM"},
+    {19, 6, profession::NONE, unit_labor::NONE, job_skill::SING_MUSIC, "SM"},
+    {19, 6, profession::NONE, unit_labor::NONE, job_skill::PLAY_KEYBOARD_INSTRUMENT, "PK"},
+    {19, 6, profession::NONE, unit_labor::NONE, job_skill::PLAY_STRINGED_INSTRUMENT, "PS"},
+    {19, 6, profession::NONE, unit_labor::NONE, job_skill::PLAY_WIND_INSTRUMENT, "PW"},
+    {19, 6, profession::NONE, unit_labor::NONE, job_skill::PLAY_PERCUSSION_INSTRUMENT, "PP"},
 
-    {20, 5, profession::NONE, unit_labor::NONE, job_skill::MILITARY_TACTICS, "MT"},
-    {20, 5, profession::NONE, unit_labor::NONE, job_skill::TRACKING, "Tr"},
-    {20, 5, profession::NONE, unit_labor::NONE, job_skill::MAGIC_NATURE, "Dr"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::CRITICAL_THINKING, "CT"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::LOGIC, "Lo"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::MATHEMATICS, "Ma"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::ASTRONOMY, "As"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::CHEMISTRY, "Ch"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::GEOGRAPHY, "Ge"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::OPTICS_ENGINEER, "OE"},
+    {20, 4, profession::NONE, unit_labor::NONE, job_skill::FLUID_ENGINEER, "FE"},
+
+    {21, 5, profession::NONE, unit_labor::NONE, job_skill::MILITARY_TACTICS, "MT"},
+    {21, 5, profession::NONE, unit_labor::NONE, job_skill::TRACKING, "Tr"},
+    {21, 5, profession::NONE, unit_labor::NONE, job_skill::MAGIC_NATURE, "Dr"},
 };
 
 struct UnitInfo

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -1143,9 +1143,6 @@ viewscreen_unitlaborsst::viewscreen_unitlaborsst(vector<df::unit*> &src, int cur
         cur->selected = false;
         cur->active_index = active_idx[unit];
 
-        if (!Units::isOwnRace(unit))
-            cur->allowEdit = false;
-
         if (!Units::isOwnCiv(unit))
             cur->allowEdit = false;
 

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -1146,6 +1146,9 @@ viewscreen_unitlaborsst::viewscreen_unitlaborsst(vector<df::unit*> &src, int cur
         if (!Units::isOwnCiv(unit))
             cur->allowEdit = false;
 
+        if (!Units::isOwnGroup(unit))
+            cur->allowEdit = false;
+
         if (unit->flags1.bits.dead)
             cur->allowEdit = false;
 

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -1155,6 +1155,9 @@ viewscreen_unitlaborsst::viewscreen_unitlaborsst(vector<df::unit*> &src, int cur
         if (unit->flags2.bits.visitor)
             cur->allowEdit = false;
 
+        if (unit->flags3.bits.ghostly)
+            cur->allowEdit = false;
+
         if (!ENUM_ATTR(profession, can_assign_labor, unit->profession))
             cur->allowEdit = false;
 

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -1149,6 +1149,9 @@ viewscreen_unitlaborsst::viewscreen_unitlaborsst(vector<df::unit*> &src, int cur
         if (unit->flags1.bits.dead)
             cur->allowEdit = false;
 
+        if (unit->flags2.bits.visitor)
+            cur->allowEdit = false;
+
         if (!ENUM_ATTR(profession, can_assign_labor, unit->profession))
             cur->allowEdit = false;
 


### PR DESCRIPTION
histfig.entity_links vector is one of things that determines ability to set unit's labors.
If it contains histfig_entity_link_memberst with entity_id equals to ui.group_id - player will be able to set labors in vanilla v-p-l menu otherwise menu shows "No labors available" text(assuming all other requirements are met).
histfig.entity_links vector also contains other types of entity links including histfig_entity_link_former_memberst. So type should be checked.
No more need in isOwnRace check since you can have not own race citizens.
flags2.bits.visitor and  antity links should be checked instead.
flags3.bits.ghostly should be checked - ghosts cant be edited in vanilla way, and they are not flags1.bits.dead.
Also added new 0.42.x skills to table.
Rebase fixupped one error, thanks warmist for pointing me out.