### PR TITLE
fix job-duplicate bug (ignoring cloned jobs with posting_index)

### DIFF
--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -71,6 +71,7 @@ df::job *DFHack::Job::cloneJobStruct(df::job *job, bool keepEverything)
         pnew->flags.bits.suspend = job->flags.bits.suspend;
 
         pnew->completion_timer = -1;
+        pnew->posting_index = -1;
     }
     pnew->list_link = NULL;
 


### PR DESCRIPTION
if job cannot be assigned right now, game puts it in `df.global.world.job_postings` vector
when job finally can be done, game removes job from postings and clears its `posting_index`
that index should not be cloned by job-duplicate(new jobs(added by vanilla way) have that value -1 always anyway)
invalid (because another job will have that index or no posting with that index will be  present in postings vector) `posting_index` causes the new job(and other jobs after it in the workshop's joblist) to be ignored(in the best case). 