### PR TITLE
Fix build errors

### DIFF
--- a/library/include/df/custom/building_handler.methods.inc
+++ b/library/include/df/custom/building_handler.methods.inc
@@ -1,0 +1,1 @@
+friend struct df::world;

--- a/library/include/df/custom/machine_handler.methods.inc
+++ b/library/include/df/custom/machine_handler.methods.inc
@@ -1,0 +1,1 @@
+friend struct df::world;


### PR DESCRIPTION
These errors:

> 07:12 < _Q> G:\dwarfort\dfhack\library\include\df/static.ctors.inc(8103): error C2248: 
>             'df::building_handler::building_handler' : cannot access protected
> 07:12 < _Q> member declared in class 'df::building_handler' 
>             [G:\dwarfort\dfhack\build\VC2010\library\dfhack.vcxproj]
> 07:13 < _Q> same for machine_handler

Fixed by making world friend of machine and building handlers. (fix requires change in structures: https://github.com/DFHack/df-structures/pull/99)
