### PR TITLE
fix teledwarf bug (leaves babies lying on ground)

### DIFF
--- a/plugins/fastdwarf.cpp
+++ b/plugins/fastdwarf.cpp
@@ -10,6 +10,7 @@
 #include "df/unit.h"
 #include "df/unit_action.h"
 #include "df/map_block.h"
+#include "df/units_other_id.h"
 
 using std::string;
 using std::vector;
@@ -97,6 +98,17 @@ DFhackCExport command_result plugin_onupdate ( color_ostream &out )
             // move unit to destination
             unit->pos = unit->path.dest;
             unit->path.path.clear();
+
+            //move unit's riders(including babies) to destination
+            if (unit->flags1.bits.ridden)
+            {
+                for (size_t j = 0; j < world->units.other[units_other_id::ANY_RIDER].size(); j++)
+                {
+                    df::unit *rider = world->units.other[units_other_id::ANY_RIDER][j];
+                    if (rider->relations.rider_mount_id == unit->id)
+                        rider->pos = unit->pos;
+                }
+            }
         } while (0);
 
         if (enable_fastdwarf)


### PR DESCRIPTION
fix https://github.com/DFHack/dfhack/issues/835
Mother has `flags1.bits.ridden` 
Baby has `flags1.bits.rider` and `relations.rider_mount_id`
And it looks like all riders are stored in `world->units.other[units_other_id::ANY_RIDER]`

So I propose check unit's `flags1.bits.ridden` and teleport units from `world->units.other[units_other_id::ANY_RIDER]` with matching `relations.rider_mount_id` to its pos.
