### PR TITLE
Moving a search option to the bottom of the screen.

### DIFF
--- a/plugins/search.cpp
+++ b/plugins/search.cpp
@@ -1671,7 +1671,7 @@ public:
 
     void render() const
     {
-        print_search_option(2, 23);
+        print_search_option(2, gps->dimy - 5);
     }
 
     vector<df::unit *> *get_primary_list()


### PR DESCRIPTION
The list of workers in the workshop profile page can take nearly the full height of the screen.