### PR TITLE
Include math.h in 3dveins.cpp

### DIFF
--- a/plugins/3dveins.cpp
+++ b/plugins/3dveins.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <algorithm>
 #include <vector>
+#include <math.h>
 
 #include "Core.h"
 #include "Console.h"


### PR DESCRIPTION
3dveins.cpp won't build for me without math.h as a dependency - errors about 'fabsf' and other math functions

arch linux, gcc-multilib 6.1.1-1