### PR TITLE
knowledge category flag

### DIFF
--- a/library/include/df/custom/knowledge_scholar_category_flag.methods.inc
+++ b/library/include/df/custom/knowledge_scholar_category_flag.methods.inc
@@ -1,0 +1,13 @@
+df::enums::dfhack_knowledge_scholar_flag::dfhack_knowledge_scholar_flag value() const
+{
+    int32_t value = category * 32;
+    for (int32_t i = 0; i < 32; i++)
+    {
+        if (flags & (1 << i))
+        {
+            value += i;
+            break;
+        }
+    }
+    return df::enums::dfhack_knowledge_scholar_flag::dfhack_knowledge_scholar_flag(value);
+}


### PR DESCRIPTION
Instead of having to go through a bunch of one-bit tests, this means the knowledge type can be used as an enum with switch statements and all the extra compiler stuff that comes with that.

Requires DFHack/df-structures#126