### PR TITLE
Add job remove method

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1469,6 +1469,8 @@ static const LuaWrapper::FunctionReg dfhack_job_module[] = {
     WRAPM(Job,getName),
     WRAPM(Job,linkIntoWorld),
     WRAPM(Job,removePostings),
+    WRAPM(Job,disconnectJobItem),
+    WRAPM(Job,disconnectJobGeneralRef),
     WRAPM(Job,removeJob),
     WRAPN(is_equal, jobEqual),
     WRAPN(is_item_equal, jobItemEqual),

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1469,6 +1469,7 @@ static const LuaWrapper::FunctionReg dfhack_job_module[] = {
     WRAPM(Job,getName),
     WRAPM(Job,linkIntoWorld),
     WRAPM(Job,removePostings),
+    WRAPM(Job,removeJob),
     WRAPN(is_equal, jobEqual),
     WRAPN(is_item_equal, jobItemEqual),
     { NULL, NULL }

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -68,16 +68,16 @@ namespace DFHack
 
         // This helpful method only removes the backref from the item to the job, but it doesn't
         // remove the item ref from the job's vector, or delete it or anything.  Think of it as a method
-        // that does all the needful to make an item ref ready to delete. 
+        // that does all the needful to make an item ref ready to delete.
         DFHACK_EXPORT void disconnectJobItem(df::job_item_ref *item, df::job *job);
         // This helpful method only removes the backref from whatever the general_ref points to,
         // it doesn't remove the general_ref from the job's vector, or delete it or anything.
-        // Think of it as a method that does all the needful to make a ref ready to delete. 
+        // Think of it as a method that does all the needful to make a ref ready to delete.
         // If it returns false, you've found a ref that the method doesn't know how to handle.  Congratulations!
         // You should report that and/or check in a fix.
         DFHACK_EXPORT bool disconnectJobGeneralRef(df::general_ref *ref, df::job *job);
         // Delete a job & remove all refs from everywhere.
-        // This method DELETES the job object!  Everything related to it will be wiped 
+        // This method DELETES the job object!  Everything related to it will be wiped
         // clean from the earth, so make sure you pull what you need out before calling this!
         DFHACK_EXPORT bool removeJob(df::job *job);
 

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -66,6 +66,11 @@ namespace DFHack
         DFHACK_EXPORT void setJobCooldown(df::building *workshop, df::unit *worker, int cooldown = 100);
         DFHACK_EXPORT bool removeWorker(df::job *job, int cooldown = 100);
 
+        // Delete a job & remove all refs from everywhere.
+        // This method DELETES the job object!  Everything related to it will be wiped 
+        // clean from the earth, so make sure you pull what you need out before calling this!
+        DFHACK_EXPORT void removeJob(df::job *job);
+
         // Instruct the game to check and assign workers
         DFHACK_EXPORT void checkBuildingsNow();
         DFHACK_EXPORT void checkDesignationsNow();

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -66,10 +66,20 @@ namespace DFHack
         DFHACK_EXPORT void setJobCooldown(df::building *workshop, df::unit *worker, int cooldown = 100);
         DFHACK_EXPORT bool removeWorker(df::job *job, int cooldown = 100);
 
+        // This helpful method only removes the backref from the item to the job, but it doesn't
+        // remove the item ref from the job's vector, or delete it or anything.  Think of it as a method
+        // that does all the needful to make an item ref ready to delete. 
+        DFHACK_EXPORT void disconnectJobItem(df::job_item_ref *item, df::job *job);
+        // This helpful method only removes the backref from whatever the general_ref points to,
+        // it doesn't remove the general_ref from the job's vector, or delete it or anything.
+        // Think of it as a method that does all the needful to make a ref ready to delete. 
+        // If it returns false, you've found a ref that the method doesn't know how to handle.  Congratulations!
+        // You should report that and/or check in a fix.
+        DFHACK_EXPORT bool disconnectJobGeneralRef(df::general_ref *ref, df::job *job);
         // Delete a job & remove all refs from everywhere.
         // This method DELETES the job object!  Everything related to it will be wiped 
         // clean from the earth, so make sure you pull what you need out before calling this!
-        DFHACK_EXPORT void removeJob(df::job *job);
+        DFHACK_EXPORT bool removeJob(df::job *job);
 
         // Instruct the game to check and assign workers
         DFHACK_EXPORT void checkBuildingsNow();

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -69,13 +69,13 @@ namespace DFHack
         // This helpful method only removes the backref from the item to the job, but it doesn't
         // remove the item ref from the job's vector, or delete it or anything.  Think of it as a method
         // that does all the needful to make an item ref ready to delete.
-        DFHACK_EXPORT void disconnectJobItem(df::job_item_ref *item, df::job *job);
+        DFHACK_EXPORT void disconnectJobItem(df::job *job, df::job_item_ref *item);
         // This helpful method only removes the backref from whatever the general_ref points to,
         // it doesn't remove the general_ref from the job's vector, or delete it or anything.
         // Think of it as a method that does all the needful to make a ref ready to delete.
         // If it returns false, you've found a ref that the method doesn't know how to handle.  Congratulations!
         // You should report that and/or check in a fix.
-        DFHACK_EXPORT bool disconnectJobGeneralRef(df::general_ref *ref, df::job *job);
+        DFHACK_EXPORT bool disconnectJobGeneralRef(df::job *job, df::general_ref *ref);
         // Delete a job & remove all refs from everywhere.
         // This method DELETES the job object!  Everything related to it will be wiped
         // clean from the earth, so make sure you pull what you need out before calling this!

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -304,7 +304,7 @@ void DFHack::Job::setJobCooldown(df::building *workshop, df::unit *worker, int c
     }
 }
 
-void DFHack::Job::disconnectJobItem(df::job_item_ref *ref, df::job *job) {
+void DFHack::Job::disconnectJobItem(df::job *job, df::job_item_ref *ref) {
     if (!ref) return;
 
     auto item = ref->item;
@@ -329,7 +329,7 @@ void DFHack::Job::disconnectJobItem(df::job_item_ref *ref, df::job *job) {
     if (!stillHasJobs) item->flags.bits.in_job = false;
 }
 
-bool DFHack::Job::disconnectJobGeneralRef(df::general_ref *ref, df::job *job) {
+bool DFHack::Job::disconnectJobGeneralRef(df::job *job, df::general_ref *ref) {
     if (ref == NULL) return true;
 
     df::building *building = NULL;
@@ -388,7 +388,7 @@ bool DFHack::Job::removeJob(df::job *job) {
         //Our code above should have ensured that this won't return false- if it does, there's not
         //a great way of recovering since we can't properly destroy the job & we can't leave it
         //around.  Better to know the moment that becomes a problem.
-        bool success = disconnectJobGeneralRef(ref, job);
+        bool success = disconnectJobGeneralRef(job, ref);
         assert(success);
 
         vector_erase_at(job->general_refs, 0);
@@ -398,7 +398,7 @@ bool DFHack::Job::removeJob(df::job *job) {
     //Detach all items from the job
     while (job->items.size() > 0) {
         auto itemRef = job->items[0];
-        disconnectJobItem(itemRef, job);
+        disconnectJobItem(job, itemRef);
         vector_erase_at(job->items, 0);
         if (itemRef != NULL) delete itemRef;
     }

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -376,6 +376,15 @@ void DFHack::Job::removeJob(df::job *job) {
     //Remove job from job board
     Job::removePostings(job, true);
 
+    //Clean up job_items
+    while (job->job_items.size() > 0) {
+        auto jobItem = job->job_items[0];
+        vector_erase_at(job->job_items, 0);
+        if (jobItem) {
+            delete jobItem;
+        }
+    }
+
     //Remove job from global list
     if (job->list_link) {
         auto prev = job->list_link->prev;

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -346,6 +346,33 @@ void DFHack::Job::removeJob(df::job *job) {
         delete ref;
     }
 
+    //Detach all items from the job
+    while (job->items.size() > 0) {
+        auto itemRef = job->items[0];
+        df::item *item = NULL;
+
+        if (itemRef) {
+            item = itemRef->item;
+        
+            if (item) {
+                item->flags.bits.in_job = false;
+
+                //Work backward through the specific refs & remove/delete all specific refs to this job
+                int refCount = item->specific_refs.size();
+                for(int refIndex = refCount-1; refIndex >= 0; refIndex--) {
+                    auto ref = item->specific_refs[refIndex];
+                    if (ref->type == df::specific_ref_type::JOB && ref->job == job) {
+                        vector_erase_at(item->specific_refs, refIndex);
+                        delete ref;
+                    }
+                }
+            }
+
+            delete itemRef;
+        }
+        vector_erase_at(job->items, 0);
+    }
+
     //Remove job from job board
     Job::removePostings(job, true);
 

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -332,9 +332,12 @@ void DFHack::Job::disconnectJobItem(df::job_item_ref *ref, df::job *job) {
 bool DFHack::Job::disconnectJobGeneralRef(df::general_ref *ref, df::job *job) {
     if (ref == NULL) return true;
 
+    df::building *building = NULL;
+    df::unit *unit = NULL;
+
     switch (ref->getType()) {
     case general_ref_type::BUILDING_HOLDER:
-        auto building = ref->getBuilding();
+        building = ref->getBuilding();
 
         if (building != NULL) {
             int jobIndex = linear_index(building->jobs, job);
@@ -344,7 +347,7 @@ bool DFHack::Job::disconnectJobGeneralRef(df::general_ref *ref, df::job *job) {
         }
         break;
     case general_ref_type::UNIT_WORKER:
-        auto unit = ref->getUnit();
+        unit = ref->getUnit();
 
         if (unit != NULL) {
             if (unit->job.current_job == job) {
@@ -385,7 +388,9 @@ bool DFHack::Job::removeJob(df::job *job) {
         //Our code above should have ensured that this won't return false- if it does, there's not
         //a great way of recovering since we can't properly destroy the job & we can't leave it
         //around.  Better to know the moment that becomes a problem.
-        assert(disconnectJobGeneralRef(ref, job));
+        bool success = disconnectJobGeneralRef(ref, job);
+        assert(success);
+
         vector_erase_at(job->general_refs, 0);
         if (ref != NULL) delete ref;
     }


### PR DESCRIPTION
Job remove eliminates a job's worker & holder references, if any, puts
the worker on cd, if appropriate, removes the job's postings, eliminates
the job from the global linked list, and then finally deletes it.  This
code was tested by incorporating it into autochop and it does make the
plugin work.  However, chop jobs don't have holder building references,
and anyway, with DF being 90% edge case by volume, this could use a heck
of a lot more testing.

I saw elsewhere code that prevented worker removal if the job was a
special job, and that made me feel funny so I made the job remove method
not work if the job is a special job.