### PR TITLE
make labormanager know building instruments is furniture hauling

### DIFF
--- a/plugins/labormanager.cpp
+++ b/plugins/labormanager.cpp
@@ -842,6 +842,7 @@ private:
             case df::building_type::BarsVertical:
             case df::building_type::GrateWall:
             case df::building_type::Bookcase:
+            case df::building_type::Instrument:
                 return df::unit_labor::HAUL_FURNITURE;
             case df::building_type::Trap:
             case df::building_type::GearAssembly:


### PR DESCRIPTION
I did test that furniture hauling is responsible for building instruments