### PR TITLE
Labormanager trap components and constructions with multiple materials

### DIFF
--- a/plugins/labormanager.cpp
+++ b/plugins/labormanager.cpp
@@ -673,8 +673,15 @@ static df::building* get_building_from_job(df::job* j)
     return 0;
 }
 
-static df::unit_labor construction_build_labor (df::item* i)
+static df::unit_labor construction_build_labor (df::building_actual* b)
 {
+    if (b->getType() == df::building_type::RoadPaved)
+        return df::unit_labor::BUILD_ROAD;
+    auto a = (df::building_actual *) b;
+    // For screw pumps contained_items[0] = pipe, 1 corkscrew, 2 block
+    // For wells 0 mechanism, 1 rope, 2 bucket, 3 block
+    // Trade depots and bridges use the last one too
+    df::item* i = a->contained_items.back()->item;
     MaterialInfo matinfo;
     if (i && matinfo.decode(i))
     {
@@ -813,7 +820,7 @@ private:
                     df::building_actual* b = (df::building_actual*) bld;
                     if (b->design && !b->design->flags.bits.designed)
                         return df::unit_labor::ARCHITECT;
-                    return construction_build_labor(j->items[0]->item);
+                    return construction_build_labor(b);
                 }
                 break;
             case df::building_type::FarmPlot:
@@ -911,8 +918,8 @@ private:
             case df::building_type::Well:
             case df::building_type::Windmill:
                 {
-                    df::building_actual* b = (df::building_actual*) bld;
-                    return construction_build_labor(b->contained_items[0]->item);
+                    auto b = (df::building_actual*) bld;
+                    return construction_build_labor(b);
                 }
                 break;
             case df::building_type::FarmPlot:

--- a/plugins/labormanager.cpp
+++ b/plugins/labormanager.cpp
@@ -1273,7 +1273,7 @@ public:
         job_to_labor_table[df::job_type::FireCatapult]            = jlf_const(df::unit_labor::SIEGEOPERATE);
         job_to_labor_table[df::job_type::FireBallista]            = jlf_const(df::unit_labor::SIEGEOPERATE);
         job_to_labor_table[df::job_type::ConstructMechanisms]    = jlf_const(df::unit_labor::MECHANIC);
-        job_to_labor_table[df::job_type::MakeTrapComponent]        = jlf_const(df::unit_labor::MECHANIC) ;
+        job_to_labor_table[df::job_type::MakeTrapComponent]        = jlf_make_weapon;
         job_to_labor_table[df::job_type::LoadCageTrap]            = jlf_const(df::unit_labor::MECHANIC) ;
         job_to_labor_table[df::job_type::LoadStoneTrap]            = jlf_const(df::unit_labor::MECHANIC) ;
         job_to_labor_table[df::job_type::LoadWeaponTrap]        = jlf_const(df::unit_labor::MECHANIC) ;


### PR DESCRIPTION
Trap components were left to mechanic labor, which stalled my only carpenter's workshop when trying to craft a wooden corkscrew. Screw pumps would not get built unless the pipe section's material's labor matched the block's, and other multi-material constructions had similar problems. This fixes these issues.