### PR TITLE
labormanager: fix deconstruction of buildings containing items

### DIFF
--- a/plugins/labormanager.cpp
+++ b/plugins/labormanager.cpp
@@ -842,6 +842,7 @@ private:
             case df::building_type::BarsVertical:
             case df::building_type::GrateWall:
             case df::building_type::Bookcase:
+            case df::building_type::Instrument:
                 return df::unit_labor::HAUL_FURNITURE;
             case df::building_type::Trap:
             case df::building_type::GearAssembly:


### PR DESCRIPTION
This corrects an error introduced in #1025.