### PR TITLE
labormanager: add deconstruct labor for constructed instruments

### DIFF
--- a/plugins/labormanager.cpp
+++ b/plugins/labormanager.cpp
@@ -961,6 +961,7 @@ private:
             case df::building_type::GrateFloor:
             case df::building_type::GrateWall:
             case df::building_type::Bookcase:
+            case df::building_type::Instrument:
                 return df::unit_labor::HAUL_FURNITURE;
             case df::building_type::AnimalTrap:
                 return df::unit_labor::TRAPPER;


### PR DESCRIPTION
This patch adds the deconstruct labor for constructed instruments (missed in #1020)