### PR TITLE
README.md: Fix broken markdown links and header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
-#DFHack Readme
+# DFHack Readme
 
-[![Build Status](https://travis-ci.org/DFHack/dfhack.svg?branch=develop)]
-(https://travis-ci.org/DFHack/dfhack)
-[![Documentation Status](https://readthedocs.org/projects/dfhack/badge)]
-(https://dfhack.readthedocs.org)
-[![License](https://img.shields.io/badge/license-ZLib-blue.svg)]
-(https://en.wikipedia.org/wiki/Zlib_License)
-[![Github Issues](http://githubbadges.herokuapp.com/DFHack/dfhack/issues)]
-(https://github.com/DFHack/dfhack/issues)
-[![Open Pulls](http://githubbadges.herokuapp.com/DFHack/dfhack/pulls)]
-(https://github.com/DFHack/dfhack/pulls)
+[![Build Status](https://travis-ci.org/DFHack/dfhack.svg?branch=develop)](https://travis-ci.org/DFHack/dfhack)
+[![Documentation Status](https://readthedocs.org/projects/dfhack/badge)](https://dfhack.readthedocs.org)
+[![License](https://img.shields.io/badge/license-ZLib-blue.svg)](https://en.wikipedia.org/wiki/Zlib_License)
+[![Github Issues](http://githubbadges.herokuapp.com/DFHack/dfhack/issues)](https://github.com/DFHack/dfhack/issues)
+[![Open Pulls](http://githubbadges.herokuapp.com/DFHack/dfhack/pulls)](https://github.com/DFHack/dfhack/pulls)
 
 DFHack is a Dwarf Fortress memory access library, distributed with scripts
 and plugins implementing a wide variety of useful functions and tools.
@@ -19,6 +14,6 @@ from the README.html page in the DFHack distribution, or as raw text in the `./d
 If you're an end-user, modder, or interested in contributing to DFHack - 
 go read those docs.
 
-If that's unclear or you need more help, try [the Bay12 forums thread]
-(http://www.bay12forums.com/smf/index.php?topic=139553) or the #dfhack IRC
-channel on freenode.
+If that's unclear or you need more help, try
+[the Bay12 forums thread](http://www.bay12forums.com/smf/index.php?topic=139553)
+or the #dfhack IRC channel on freenode.


### PR DESCRIPTION
Github's markdown parser does not permit newlines between link titles
and link text. This change removes the newlines, resulting in a less
pleasing source, but one which renders when viewed on github.

Github also requires a space between the '#' and text of headings, so
we fix that, too.