### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#DFHack Readme
+# DFHack Readme
 
 [![Build Status](https://travis-ci.org/DFHack/dfhack.svg?branch=develop)]
 (https://travis-ci.org/DFHack/dfhack)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
