### PR TITLE
Fix forum thread link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ If you're an end-user, modder, or interested in contributing to DFHack -
 go read those docs.
 
 If that's unclear or you need more help, try
-[the Bay12 forums thread](http://www.bay12forums.com/smf/index.php?topic=139553)
+[the Bay12 forums thread](http://www.bay12forums.com/smf/index.php?topic=164123)
 or the #dfhack IRC channel on freenode.


### PR DESCRIPTION
The README is pointing to the old thread, which in turn leads to an old download.