### PR TITLE
autolabor: Fix an array bounds overrun when assigning haulers while traders are active.

### DIFF
--- a/plugins/autolabor.cpp
+++ b/plugins/autolabor.cpp
@@ -1311,6 +1311,10 @@ DFhackCExport command_result plugin_onupdate ( color_ostream &out )
                     continue;
                 dwarfs[dwarf]->status.labors[labor] = false;
             }
+            if (dwarf_info[dwarf].state == IDLE || dwarf_info[dwarf].state == BUSY || dwarf_info[dwarf].state == EXCLUSIVE)
+            {
+                num_haulers--;
+            }
             continue;
         }
 


### PR DESCRIPTION
This reduces the number of haulers. Another solution would be limiting the number of haulers to the number of possible haulers.