### PR TITLE
Fix luasocket receive with byte count

### DIFF
--- a/plugins/lua/luasocket.lua
+++ b/plugins/lua/luasocket.lua
@@ -47,7 +47,7 @@ function client:receive( pattern )
     local pattern=pattern or "*l"
     local bytes=-1
     
-    if type(pattern)== number then
+    if type(pattern)== 'number' then
         bytes=pattern
     end
 


### PR DESCRIPTION
Did not correctly detect when you typed in a number instead of pattern.