### PR TITLE
max_barrels was serialized on max_bins position

### DIFF
--- a/plugins/stockpiles/StockpileSerializer.cpp
+++ b/plugins/stockpiles/StockpileSerializer.cpp
@@ -465,8 +465,9 @@ int StockpileSerializer::other_mats_token ( const std::map<int, std::string> oth
 
 void StockpileSerializer::write_general()
 {
-    mBuffer.set_max_bins ( mPile->max_barrels );
+    mBuffer.set_max_bins ( mPile->max_bins );
     mBuffer.set_max_wheelbarrows ( mPile->max_wheelbarrows );
+    mBuffer.set_max_barrels ( mPile->max_barrels );
     mBuffer.set_use_links_only ( mPile->use_links_only );
     mBuffer.set_unknown1 ( mPile->settings.unk1 );
     mBuffer.set_allow_inorganic ( mPile->settings.allow_inorganic );


### PR DESCRIPTION
When I save and load stockpile settings with stockpile management plugin, then saved barrels count will be loaded in bins and barrels are zero. So I think this change should correct it.