### PR TITLE
listcolumn tweak for GCC

### DIFF
--- a/plugins/listcolumn.h
+++ b/plugins/listcolumn.h
@@ -70,7 +70,7 @@ public:
         display_max_rows = gps->dimy - 4 - bottom_margin;
     }
 
-    void add(ListEntry<T> &entry)
+    void add(const ListEntry<T> &entry)
     {
         list.push_back(entry);
         if (entry.text.length() > max_item_width)


### PR DESCRIPTION
This was preventing my TwitchName plugin from compiling on Linux - `list.add(ListEntry<T>(x,y))` would error out with `invalid initialization of non-const reference of type 'ListEntry<T>&' from an rvalue of type 'ListEntry<T>'` (though curiously it worked just fine on Windows).