### PR TITLE
Autocomplete built in commands (die, etc.)

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -429,14 +429,37 @@ command_result Core::runCommand(color_ostream &out, const std::string &command)
         return CR_NOT_IMPLEMENTED;
 }
 
+// List of built in commands
+static const std::set<std::string> built_in_commands = {
+    "ls" ,
+    "help" ,
+    "type" ,
+    "load" ,
+    "unload" ,
+    "reload" ,
+    "enable" ,
+    "disable" ,
+    "plug" ,
+    "keybinding" ,
+    "alias" ,
+    "fpause" ,
+    "cls" ,
+    "die" ,
+    "kill-lua" ,
+    "script" ,
+    "hide" ,
+    "show" ,
+    "sc-script"
+};
+
 static bool try_autocomplete(color_ostream &con, const std::string &first, std::string &completed)
 {
     std::vector<std::string> possible;
 
     // Check for possible built in commands to autocomplete first
-    for (auto iter = built_in_commands.begin(); iter != built_in_commands.end(); ++iter)
-        if (iter->substr(0, first.size()) == first)
-            possible.push_back(*iter);
+    for (auto const &command : built_in_commands)
+        if (command.substr(0, first.size()) == first)
+            possible.push_back(command);
 
     auto plug_mgr = Core::getInstance().getPluginManager();
     for (auto it = plug_mgr->begin(); it != plug_mgr->end(); ++it)

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -433,6 +433,11 @@ static bool try_autocomplete(color_ostream &con, const std::string &first, std::
 {
     std::vector<std::string> possible;
 
+    // Check for possible built in commands to autocomplete first
+    for (auto iter = built_in_commands.begin(); iter != built_in_commands.end(); ++iter)
+        if (iter->substr(0, first.size()) == first)
+            possible.push_back(*iter);
+
     auto plug_mgr = Core::getInstance().getPluginManager();
     for (auto it = plug_mgr->begin(); it != plug_mgr->end(); ++it)
     {
@@ -612,28 +617,12 @@ static std::string sc_event_name (state_change_event id) {
 string getBuiltinCommand(std::string cmd)
 {
     std::string builtin = "";
-    if (cmd == "ls" ||
-        cmd == "help" ||
-        cmd == "type" ||
-        cmd == "load" ||
-        cmd == "unload" ||
-        cmd == "reload" ||
-        cmd == "enable" ||
-        cmd == "disable" ||
-        cmd == "plug" ||
-        cmd == "keybinding" ||
-        cmd == "alias" ||
-        cmd == "fpause" ||
-        cmd == "cls" ||
-        cmd == "die" ||
-        cmd == "kill-lua" ||
-        cmd == "script" ||
-        cmd == "hide" ||
-        cmd == "show" ||
-        cmd == "sc-script"
-    )
+    
+    // Check our list of builtin commands from the header
+    if (built_in_commands.count(cmd))
         builtin = cmd;
 
+    // Check for some common aliases for built in commands
     else if (cmd == "?" || cmd == "man")
         builtin = "help";
 

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -30,7 +30,6 @@ distribution.
 #include <vector>
 #include <stack>
 #include <map>
-#include <set>
 #include <stdint.h>
 #include "Console.h"
 #include "modules/Graphic.h"
@@ -83,29 +82,6 @@ namespace DFHack
         SC_BEGIN_UNLOAD = 6,
         SC_PAUSED = 7,
         SC_UNPAUSED = 8
-    };
-
-    // List of built in commands
-    const std::set<std::string> built_in_commands = {
-        "ls" ,
-        "help" ,
-        "type" ,
-        "load" ,
-        "unload" ,
-        "reload" ,
-        "enable" ,
-        "disable" ,
-        "plug" ,
-        "keybinding" ,
-        "alias" ,
-        "fpause" ,
-        "cls" ,
-        "die" ,
-        "kill-lua" ,
-        "script" ,
-        "hide" ,
-        "show" ,
-        "sc-script"
     };
 
     class DFHACK_EXPORT StateChangeScript

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -30,6 +30,7 @@ distribution.
 #include <vector>
 #include <stack>
 #include <map>
+#include <set>
 #include <stdint.h>
 #include "Console.h"
 #include "modules/Graphic.h"
@@ -82,6 +83,29 @@ namespace DFHack
         SC_BEGIN_UNLOAD = 6,
         SC_PAUSED = 7,
         SC_UNPAUSED = 8
+    };
+
+    // List of built in commands
+    const std::set<std::string> built_in_commands = {
+        "ls" ,
+        "help" ,
+        "type" ,
+        "load" ,
+        "unload" ,
+        "reload" ,
+        "enable" ,
+        "disable" ,
+        "plug" ,
+        "keybinding" ,
+        "alias" ,
+        "fpause" ,
+        "cls" ,
+        "die" ,
+        "kill-lua" ,
+        "script" ,
+        "hide" ,
+        "show" ,
+        "sc-script"
     };
 
     class DFHACK_EXPORT StateChangeScript


### PR DESCRIPTION
Addresses https://github.com/DFHack/dfhack/issues/720

Output:
cl is not recognized. Possible completions: cls cleanconst clean cleanowned clear-smoke
di is not recognized. Possible completions: die disable digexp digcircle digFlood diggingInvaders digfort
he is not recognized. Did you mean help?
... etc.

Commands still work correctly. (Tested with cls, help, die, etc.)

Happy to take feedback!