### PR TITLE
Blocked errant line feed at full buffer

### DIFF
--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -62,7 +62,7 @@ using namespace DFHack;
 using namespace tthread;
 
 // FIXME: maybe make configurable with an ini option?
-#define MAX_CONSOLE_LINES 999;
+#define MAX_CONSOLE_LINES 999
 
 namespace DFHack
 {
@@ -165,7 +165,7 @@ namespace DFHack
             // Blank to EOL
             char* tmp = (char*)malloc(inf.dwSize.X);
             memset(tmp, ' ', inf.dwSize.X);
-            output(tmp, inf.dwSize.X, 0, inf.dwCursorPosition.Y);
+            blankout(tmp, inf.dwSize.X, 0, inf.dwCursorPosition.Y);
             free(tmp);
             COORD coord = {0, inf.dwCursorPosition.Y}; // Windows uses 0-based coordinates
             SetConsoleCursorPosition(GetStdHandle(STD_OUTPUT_HANDLE), coord);
@@ -210,6 +210,13 @@ namespace DFHack
             }
         }
 
+        void blankout(const char* str, size_t len, int x, int y)
+        {
+            COORD pos = { (SHORT)x, (SHORT)y };
+            DWORD count = 0;
+            WriteConsoleOutputCharacterA(console_out, str, len, pos, &count);
+        }
+
         void output(const char* str, size_t len, int x, int y)
         {
             COORD pos = { (SHORT)x, (SHORT)y };
@@ -248,7 +255,7 @@ namespace DFHack
                 // Blank to EOL
                 char* tmp = (char*)malloc(inf.dwSize.X - (plen + len));
                 memset(tmp, ' ', inf.dwSize.X - (plen + len));
-                output(tmp, inf.dwSize.X - (plen + len), len + plen, inf.dwCursorPosition.Y);
+                blankout(tmp, inf.dwSize.X - (plen + len), len + plen, inf.dwCursorPosition.Y);
                 free(tmp);
             }
             inf.dwCursorPosition.X = (SHORT)(cooked_cursor + plen);


### PR DESCRIPTION
Embarrassing!
It turned out that when the screen buffer gets full, the "new" console output command adds a line feed the "old" one didn't, so typing at the prompt caused a line feed for each letter, landing each one on a new line (without a carriage return, so the X position was the correct one).

I tried a fancier correction than the one here, but it didn't work out, possibly because I don't know what happens with line numbers as the buffer is full and starts to scroll.

The solution here essentially uses the original solution for blanking out the (remainder of) the line and the new one for the "business" output.

As can be seen, a semicolon has also been removed from a #define (there's a semicolon after its single use anyway).

The regressions of the previous attempt have been reperformed and work out as expected.
As an aside, if you then type "bkhjk" and "dfsf" (i.e. random non command strings) both are responded with by red error messages, while the second one also get a blue message. This happened with the original (before my previous attempt) version as well, though.

Edit: The alternative to accepting this pull request would be to roll back the previous one.