### PR TITLE
More cases for Gui::getSelectedUnit

### DIFF
--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -1065,7 +1065,7 @@ df::unit *Gui::getAnyUnit(df::viewscreen *top)
             {
                 // loo(k) at blood/ichor/.. spatter with a name
                 MaterialInfo mat;
-                if (mat.decode(item->spatter_mat_type, item->spatter_mat_index))
+                if (mat.decode(item->spatter_mat_type, item->spatter_mat_index) && mat.figure)
                     return df::unit::find(mat.figure->unit_id);
             }
         }


### PR DESCRIPTION
add new cases for Gui::getSelectedUnit: (these cases are mostly from gui/unit-info-viewer.lua)
- report list, 
- combat log list, 
- military screen, 
- unit health, 
- unit custumize, 
- assigning to cage, 
- viewing cage, 
- pitting, 
- penning, 
- burrows, 
- look at corpse, 
- look at named corpse piece, 
- look at named spatter.

This is a better implementation of a closed pull request https://github.com/DFHack/scripts/pull/44 that made the same change in lua for specific scripts.