### PR TITLE
syndrome-util: added function to remove syndrome wound data

### DIFF
--- a/library/lua/syndrome-util.lua
+++ b/library/lua/syndrome-util.lua
@@ -22,6 +22,15 @@ ResetPolicy = ResetPolicy or utils.invert({
  "NewInstance"
 })
 
+function eraseSyndromeData(unit,syndromeId,oldestFirst)
+ for i = (oldestFirst and 0) or #unit.body.wounds-1,(oldestFirst and #unit.body.wounds-1) or 0,(oldestFirst and 1) or -1 do
+  if unit.body.wounds[i].syndrome_id == syndromeId then
+   unit.body.wounds:erase(i)
+   break
+  end
+ end
+end
+
 function eraseSyndrome(unit,syndromeId,oldestFirst)
  local i1
  local iN
@@ -38,6 +47,7 @@ function eraseSyndrome(unit,syndromeId,oldestFirst)
  local syndromes = unit.syndromes.active
  for i=i1,iN,d do
   if syndromes[i]['type'] == syndromeId then
+   eraseSyndromeData(unit,syndromeId,oldestFirst)
    syndromes:erase(i)
    return true
   end
@@ -50,6 +60,7 @@ local function eraseSyndromeClassHelper(unit,synclass)
   local syndrome = df.syndrome.find(unitSyndrome.type)
   for _,class in ipairs(syndrome.syn_class) do
    if class.value == synclass then
+    eraseSyndromeData(unit,syndrome.id)
     unit.syndromes.active:erase(i)
     return true
    end
@@ -172,4 +183,3 @@ function infectWithSyndromeIfValidTarget(target,syndrome,resetPolicy)
 end
 
 return _ENV
-


### PR DESCRIPTION
The presence of syndrome data in unit.syndromes.active generates corresponding wound data in unit.body.wounds. This wound data acts to produce all of the syndrome's actual effects, including but not limited to flag changes, interaction abilities, body transformation and display name alterations. Wound data persists when syndrome data is cleared from unit.syndromes.active. Since syndrome-util did not touch wound data at all, the erase function was completely ineffective at actually removing syndromes.

Note that syndromes also generate a bunch of data in the historical figure information of units. I have observed that this historical data is sufficient to restore the syndrome in a unit following map reload (at least in adventure mode), so its clearance (which needs to also include removal of any corresponding interaction effects) will have to be addressed in a future update. As is, syndrome erasure remains incomplete.