### PR TITLE
Fix unlikely GUI::getAnyUnit segfault

### DIFF
--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -955,7 +955,7 @@ df::unit *Gui::getAnyUnit(df::viewscreen *top)
 
     if (VIRTUAL_CAST_VAR(screen, df::viewscreen_announcelistst, top))
     {
-        if (screen->unit) {
+        if (world && screen->unit) {
             // in (r)eports -> enter
             auto *report = vector_get(screen->reports, screen->sel_idx);
             if (report)


### PR DESCRIPTION
It seems unlikely we will end up on an `df::viewscreen_announcelistst` without a `world`. But we perform the same check elsewhere, and segfaults are bad.

I also verified that most cases in Gui::getAnyUnit still work in 44.10 (could not figure out what `df::viewscreen_dungeon_monsterstatusst` is).
