### PR TITLE
makes dfhack -g work correctly

### DIFF
--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -68,8 +68,10 @@ setarch_arch=$(cat hack/dfhack_setarch.txt || printf i386)
 case "$1" in
   -g | --gdb)
     shift
-    echo "set environment LD_PRELOAD=\"$PRELOAD_LIB\"" > gdbcmd.tmp
-    echo "set environment MALLOC_PERTURB_=45" >> gdbcmd.tmp
+    echo "set environment LD_LIBRARY_PATH $LD_LIBRARY_PATH" > gdbcmd.tmp
+    echo "set environment LD_PRELOAD $PRELOAD_LIB" >> gdbcmd.tmp
+    echo "set environment MALLOC_PERTURB_ 45" >> gdbcmd.tmp
+    echo "set startup-with-shell off" >> gdbcmd.tmp
     gdb $DF_GDB_OPTS -x gdbcmd.tmp ./libs/Dwarf_Fortress "$@"
     rm gdbcmd.tmp
     ret=$?


### PR DESCRIPTION
First, simplifies the quoting of the environment variables. Then sets
startup-with-shell to off so that gdb does not start bash first; if it
starts bash ld will see the LD_PRELOAD and try to load libdfhack.so
into the bash process, which is not what we want.

We could instead use an exec-wrapper, but that would be a slightly
larger change and we don't need any of the convenience features that
using a shell gives us (argument expansion and redirects, basically).