### PR TITLE
Add 'Max Quality' setting to buildingplan

### DIFF
--- a/docs/Authors.rst
+++ b/docs/Authors.rst
@@ -131,6 +131,7 @@ Tim Walberg             twalberg
 Timothy Collett         danaris
 Tom Jobbins             TheBloke
 Tom Prince
+TotallyGatsby           TotallyGatsby
 Travis Hoppe            thoppe                  orthographic-pedant
 txtsd                   txtsd
 U-glouglou\\simon

--- a/plugins/buildingplan-lib.cpp
+++ b/plugins/buildingplan-lib.cpp
@@ -39,7 +39,7 @@ bool ItemFilter::matches(DFHack::MaterialInfo &material) const
 
 bool ItemFilter::matches(df::item *item)
 {
-    if (item->getQuality() < min_quality)
+    if (item->getQuality() < min_quality || item->getQuality() > max_quality)
         return false;
 
     if (decorated_only && !item->hasImprovements())
@@ -118,6 +118,11 @@ bool ItemFilter::parseSerializedMaterialTokens(std::string str)
 std::string ItemFilter::getMinQuality()
 {
     return ENUM_KEY_STR(item_quality, min_quality);
+}
+
+std::string ItemFilter::getMaxQuality()
+{
+    return ENUM_KEY_STR(item_quality, max_quality);
 }
 
 bool ItemFilter::isValid()
@@ -400,6 +405,7 @@ PlannedBuilding::PlannedBuilding(df::building *building, ItemFilter *filter)
     config.ival(1) = building->id;
     config.ival(2) = filter->min_quality + 1;
     config.ival(3) = static_cast<int>(filter->decorated_only) + 1;
+    config.ival(4) = filter->max_quality + 1;
 }
 
 PlannedBuilding::PlannedBuilding(PersistentDataItem &config, color_ostream &out)
@@ -418,6 +424,7 @@ PlannedBuilding::PlannedBuilding(PersistentDataItem &config, color_ostream &out)
 
     pos = df::coord(building->centerx, building->centery, building->z);
     filter.min_quality = static_cast<df::item_quality>(config.ival(2) - 1);
+    filter.max_quality = static_cast<df::item_quality>(config.ival(4) - 1);
     filter.decorated_only = config.ival(3) - 1;
 }
 
@@ -647,11 +654,20 @@ PlannedBuilding *Planner::getSelectedPlannedBuilding()
     return nullptr;
 }
 
-void Planner::cycleDefaultQuality(df::building_type type)
+void Planner::cycleMinQuality(df::building_type type)
 {
-    auto quality = &getDefaultItemFilterForType(type)->min_quality;
+    cycleItemQuality(&getDefaultItemFilterForType(type)->min_quality);
+}
+
+void Planner::cycleMaxQuality(df::building_type type)
+{
+    cycleItemQuality(&getDefaultItemFilterForType(type)->max_quality);
+}
+
+
+void Planner::cycleItemQuality(item_quality::item_quality *quality) {
     *quality = static_cast<df::item_quality>(*quality + 1);
-    if (*quality == item_quality::Artifact)
+    if (*quality > item_quality::Artifact)
         (*quality) = item_quality::Ordinary;
 }
 

--- a/plugins/buildingplan-lib.cpp
+++ b/plugins/buildingplan-lib.cpp
@@ -654,20 +654,35 @@ PlannedBuilding *Planner::getSelectedPlannedBuilding()
     return nullptr;
 }
 
-void Planner::cycleMinQuality(df::building_type type)
+void Planner::adjustMinQuality(df::building_type type, int amount)
 {
-    cycleItemQuality(&getDefaultItemFilterForType(type)->min_quality);
+    auto min_quality = &getDefaultItemFilterForType(type)->min_quality;
+    *min_quality = static_cast<df::item_quality>(*min_quality + amount);
+
+    boundsCheckItemQuality(min_quality);
+    auto max_quality = &getDefaultItemFilterForType(type)->max_quality;
+    if (*min_quality > *max_quality)
+        (*max_quality) = *min_quality;
+
 }
 
-void Planner::cycleMaxQuality(df::building_type type)
+void Planner::adjustMaxQuality(df::building_type type, int amount)
 {
-    cycleItemQuality(&getDefaultItemFilterForType(type)->max_quality);
+    auto max_quality = &getDefaultItemFilterForType(type)->max_quality;
+    *max_quality = static_cast<df::item_quality>(*max_quality + amount);
+
+    boundsCheckItemQuality(max_quality);
+    auto min_quality = &getDefaultItemFilterForType(type)->min_quality;
+    if (*max_quality < *min_quality)
+        (*min_quality) = *max_quality;
 }
 
-
-void Planner::cycleItemQuality(item_quality::item_quality *quality) {
-    *quality = static_cast<df::item_quality>(*quality + 1);
+void Planner::boundsCheckItemQuality(item_quality::item_quality *quality)
+{
+    *quality = static_cast<df::item_quality>(*quality);
     if (*quality > item_quality::Artifact)
+        (*quality) = item_quality::Artifact;
+    if (*quality < item_quality::Ordinary)
         (*quality) = item_quality::Ordinary;
 }
 

--- a/plugins/buildingplan-lib.h
+++ b/plugins/buildingplan-lib.h
@@ -417,8 +417,8 @@ public:
 
     ItemFilter *getDefaultItemFilterForType(df::building_type type) { return &default_item_filters[type]; }
 
-    void cycleMinQuality(df::building_type type);
-    void cycleMaxQuality(df::building_type type);
+    void adjustMinQuality(df::building_type type, int amount);
+    void adjustMaxQuality(df::building_type type, int amount);
 
     void enableQuickfortMode()
     {
@@ -445,7 +445,7 @@ private:
 
     std::vector<PlannedBuilding> planned_buildings;
 
-    void cycleItemQuality(item_quality::item_quality *quality);
+    void boundsCheckItemQuality(item_quality::item_quality *quality);
 
     void gather_available_items()
     {

--- a/plugins/buildingplan-lib.h
+++ b/plugins/buildingplan-lib.h
@@ -111,9 +111,11 @@ struct ItemFilter
     df::dfhack_material_category mat_mask;
     std::vector<DFHack::MaterialInfo> materials;
     df::item_quality min_quality;
+    df::item_quality max_quality;
+
     bool decorated_only;
 
-    ItemFilter() : min_quality(df::item_quality::Ordinary), decorated_only(false), valid(true)
+    ItemFilter() : min_quality(df::item_quality::Ordinary), max_quality(df::item_quality::Artifact), decorated_only(false), valid(true)
     {
         clear(); // mat_mask is not cleared by default (see issue #1047)
     }
@@ -133,6 +135,7 @@ struct ItemFilter
     bool parseSerializedMaterialTokens(std::string str);
 
     std::string getMinQuality();
+    std::string getMaxQuality();
 
     bool isValid();
 
@@ -414,7 +417,8 @@ public:
 
     ItemFilter *getDefaultItemFilterForType(df::building_type type) { return &default_item_filters[type]; }
 
-    void cycleDefaultQuality(df::building_type type);
+    void cycleMinQuality(df::building_type type);
+    void cycleMaxQuality(df::building_type type);
 
     void enableQuickfortMode()
     {
@@ -440,6 +444,8 @@ private:
     bool quickfort_mode;
 
     std::vector<PlannedBuilding> planned_buildings;
+
+    void cycleItemQuality(item_quality::item_quality *quality);
 
     void gather_available_items()
     {

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -163,7 +163,11 @@ struct buildingplan_hook : public df::viewscreen_dwarfmodest
                 }
                 else if (input->count(interface_key::CUSTOM_SHIFT_Q))
                 {
-                    planner.cycleDefaultQuality(type);
+                    planner.cycleMinQuality(type);
+                }
+                else if (input->count(interface_key::CUSTOM_SHIFT_W))
+                {
+                    planner.cycleMaxQuality(type);
                 }
                 else if (input->count(interface_key::CUSTOM_SHIFT_D))
                 {
@@ -274,6 +278,9 @@ struct buildingplan_hook : public df::viewscreen_dwarfmodest
                     OutputHotkeyString(x, y, "Min Quality: ", "Q");
                     OutputString(COLOR_BROWN, x, y, filter->getMinQuality(), true, left_margin);
 
+                    OutputHotkeyString(x, y, "Max Quality: ", "W");
+                    OutputString(COLOR_BROWN, x, y, filter->getMaxQuality(), true, left_margin);
+
                     OutputToggleString(x, y, "Decorated Only: ", "D", filter->decorated_only, true, left_margin);
 
                     OutputHotkeyString(x, y, "Material Filter:", "M", true, left_margin);
@@ -299,7 +306,10 @@ struct buildingplan_hook : public df::viewscreen_dwarfmodest
             auto filter = planner.getSelectedPlannedBuilding()->getFilter();
             y = 24;
             OutputString(COLOR_BROWN, x, y, "Planned Building Filter:", true, left_margin);
+            OutputString(COLOR_BROWN, x, y, "Min Quality: ", false, left_margin);
             OutputString(COLOR_BLUE, x, y, filter->getMinQuality(), true, left_margin);
+            OutputString(COLOR_BROWN, x, y, "Max Quality: ", false, left_margin);
+            OutputString(COLOR_BLUE, x, y, filter->getMaxQuality(), true, left_margin);
 
             if (filter->decorated_only)
                 OutputString(COLOR_BLUE, x, y, "Decorated Only", true, left_margin);

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -112,7 +112,6 @@ struct buildingplan_hook : public df::viewscreen_dwarfmodest
             }
             else if (input->count(interface_key::CUSTOM_P) ||
                      input->count(interface_key::CUSTOM_F) ||
-                     input->count(interface_key::CUSTOM_Q) ||
                      input->count(interface_key::CUSTOM_D) ||
                      input->count(interface_key::CUSTOM_N))
             {
@@ -163,11 +162,19 @@ struct buildingplan_hook : public df::viewscreen_dwarfmodest
                 }
                 else if (input->count(interface_key::CUSTOM_SHIFT_Q))
                 {
-                    planner.cycleMinQuality(type);
+                    planner.adjustMinQuality(type, 1);
                 }
                 else if (input->count(interface_key::CUSTOM_SHIFT_W))
                 {
-                    planner.cycleMaxQuality(type);
+                    planner.adjustMaxQuality(type, 1);
+                }
+                else if (input->count(interface_key::CUSTOM_Q))
+                {
+                    planner.adjustMinQuality(type, -1);
+                }
+                else if (input->count(interface_key::CUSTOM_W))
+                {
+                    planner.adjustMaxQuality(type, -1);
                 }
                 else if (input->count(interface_key::CUSTOM_SHIFT_D))
                 {
@@ -275,10 +282,10 @@ struct buildingplan_hook : public df::viewscreen_dwarfmodest
 
                     auto filter = planner.getDefaultItemFilterForType(type);
 
-                    OutputHotkeyString(x, y, "Min Quality: ", "Q");
+                    OutputHotkeyString(x, y, "Min Quality: ", "qQ");
                     OutputString(COLOR_BROWN, x, y, filter->getMinQuality(), true, left_margin);
 
-                    OutputHotkeyString(x, y, "Max Quality: ", "W");
+                    OutputHotkeyString(x, y, "Max Quality: ", "wW");
                     OutputString(COLOR_BROWN, x, y, filter->getMaxQuality(), true, left_margin);
 
                     OutputToggleString(x, y, "Decorated Only: ", "D", filter->decorated_only, true, left_margin);


### PR DESCRIPTION
Fulfills feature request #1274

Additionally, made it so one can set the minimum quality to Artifact (if it was intentional that buildingplan did not allow for placement of Artifact furniture, I can quickly fix that up.)

Only built/tested on Windows, but the scope of the changes is pretty small.

(Not sure where to drop the notice in the changelog.)