### PR TITLE
Make stl_vsprintf return if there is an vsnprintf error

### DIFF
--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -27,6 +27,8 @@ distribution.
 #include "MiscUtils.h"
 
 #ifndef LINUX_BUILD
+// We don't want min and max macros
+#define NOMINMAX
     #include <Windows.h>
 #else
     #include <sys/time.h>
@@ -67,6 +69,8 @@ std::string stl_vsprintf(const char *fmt, va_list args) {
     // Allocate enough memory for the output and null termination
     rv.resize(rsz+1);
     rsz = vsnprintf(&rv[0], rv.size(), fmt, args);
+    if (rsz + 1 < static_cast<int>(rv.size()))
+      rv.resize(std::max(rsz+1,0));
     return rv;
 }
 


### PR DESCRIPTION
vsnprintf man page claims:
"If an output error is encountered, a negative value is returned."

That means we has to call vsnprintf twice at most to have whole output
written to a string. But in case of error we return an empty string.

The code also optimizes an expected common case of outputting single
line with a small stack allocated buffer. If the stack buffer is too
small then it uses std::string::resize to allocate exactly enough memory
and writes directly to std::string.

Second call could use vsprintf because memory is known to be large
enough. But I think that difference isn't detectable outside micro
benchmarks.