### PR TITLE
Request c++11 support from compilers (through cmake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(WIN32)
 endif()
 
 # Ask for C++14 standard from compilers
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 # Require the standard support from compilers.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Use only standard c++ to keep code portable
@@ -58,7 +58,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(MSVC)
   # cmake 3.10 is first version that support msvc standard settings
   if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++14")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++11")
   endif()
 # disable C4819 code-page warning
 add_definitions( "/wd4819" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,18 @@ if(WIN32)
   endif()
 endif()
 
+# Ask for C++14 standard from compilers
+set(CMAKE_CXX_STANDARD 14)
+# Require the standard support from compilers.
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Use only standard c++ to keep code portable
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if(MSVC)
+  # cmake 3.10 is first version that support msvc standard settings
+  if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++14")
+  endif()
 # disable C4819 code-page warning
 add_definitions( "/wd4819" )
 
@@ -191,7 +202,7 @@ IF(UNIX)
   add_definitions(-DLINUX_BUILD)
   add_definitions(-D_GLIBCXX_USE_C99)
   SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g -Wall -Wno-unused-variable")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -mtune=generic -std=c++0x")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -mtune=generic")
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -mtune=generic")
   IF(DFHACK_BUILD_64)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -mno-avx")

--- a/depends/protobuf/CMakeLists.txt
+++ b/depends/protobuf/CMakeLists.txt
@@ -1,10 +1,5 @@
 PROJECT(protobuf)
 
-#Protocol buffers use C++0x hash maps, so we need to look for those. This is a rewrite of stl_hash.m4 in CMake.
-IF(CMAKE_COMPILER_IS_GNUCC)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-ENDIF()
-
 SET(HASH_MAP_H <unordered_map>)
 SET(HASH_SET_H <unordered_map>)
 SET(HASH_NAMESPACE std)

--- a/plugins/Plugins.cmake
+++ b/plugins/Plugins.cmake
@@ -1,7 +1,7 @@
 IF(UNIX)
   add_definitions(-DLINUX_BUILD)
   SET(CMAKE_CXX_FLAGS_DEBUG "-g -Wall")
-  SET(CMAKE_CXX_FLAGS "-fvisibility=hidden -std=c++0x")
+  SET(CMAKE_CXX_FLAGS "-fvisibility=hidden")
   SET(CMAKE_C_FLAGS "-fvisibility=hidden")
   IF(DFHACK_BUILD_64)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -mno-avx")


### PR DESCRIPTION
All platforms seems to either have compiler supporting c++14. Windows
already requires msvc2015 that supports c++14 which should make it
minimal issue to require c++14 support from all compilers because gcc
is pretty easy to upgrade.

I decided to make the change and submit the pull request to raise discussion if there is any setup blocking the change. I tested it quickly by creating a new pocket world and making a very short embark to there. I didn't notice any issues which at least shows most common features work with c++14 selected for gcc.