### PR TITLE
 Add parameter type checks to printf style functions

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1339,7 +1339,7 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
                             con.printerr("that is not loaded - try \"load %s\" or check stderr.log\n",
                                 first.c_str());
                         else if (p->size())
-                            con.printerr("that implements %i commands - see \"ls %s\" for details\n",
+                            con.printerr("that implements %zi commands - see \"ls %s\" for details\n",
                                 p->size(), first.c_str());
                         else
                             con.printerr("but does not implement any commands\n");

--- a/library/Hooks-windows.cpp
+++ b/library/Hooks-windows.cpp
@@ -463,7 +463,7 @@ DFhackCExport char * SDL_GetError(void)
 }
 
 static void (*_SDL_SetError)(const char *fmt, ...) = 0;
-DFhackCExport void SDL_SetError(const char *fmt, ...)
+DFhackCExport void SDL_SetError(const char *fmt, ...) Wformat(printf,1,2)
 {
     char buf[1024];
     va_list args;

--- a/library/LuaWrapper.cpp
+++ b/library/LuaWrapper.cpp
@@ -27,6 +27,7 @@ distribution.
 #include <string>
 #include <vector>
 #include <map>
+#include <cinttypes>
 
 #include "MemAccess.h"
 #include "Core.h"
@@ -1008,7 +1009,7 @@ static int meta_ptr_tostring(lua_State *state)
     const char *cname = lua_tostring(state, -1);
 
     if (has_length)
-        lua_pushstring(state, stl_sprintf("<%s[%llu]: %p>", cname, length, (void*)ptr).c_str());
+        lua_pushstring(state, stl_sprintf("<%s[%" PRIu64 "]: %p>", cname, length, (void*)ptr).c_str());
     else
         lua_pushstring(state, stl_sprintf("<%s: %p>", cname, (void*)ptr).c_str());
     return 1;

--- a/library/include/ColorText.h
+++ b/library/include/ColorText.h
@@ -106,12 +106,12 @@ namespace  DFHack
         virtual ~color_ostream();
 
         /// Print a formatted string, like printf
-        void print(const char *format, ...);
-        void vprint(const char *format, va_list args);
+        void print(const char *format, ...) Wformat(printf,2,3);
+        void vprint(const char *format, va_list args) Wformat(printf,2,0);
 
         /// Print a formatted string, like printf, in red
-        void printerr(const char *format, ...);
-        void vprinterr(const char *format, va_list args);
+        void printerr(const char *format, ...) Wformat(printf,2,3);
+        void vprinterr(const char *format, va_list args) Wformat(printf,2,0);
 
         /// Get color
         color_value color() { return cur_color; }

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -191,8 +191,8 @@ namespace DFHack
         DFHack::VersionInfo * vinfo;
         DFHack::Windows::df_window * screen_window;
 
-        static void print(const char *format, ...);
-        static void printerr(const char *format, ...);
+        static void print(const char *format, ...) Wformat(printf,1,2);
+        static void printerr(const char *format, ...) Wformat(printf,1,2);
 
         PluginManager *getPluginManager() { return plug_mgr; }
 

--- a/library/include/Export.h
+++ b/library/include/Export.h
@@ -58,3 +58,14 @@ distribution.
     #define DFhackCExport extern "C" __declspec(dllexport)
     #define DFhackDataExport extern "C" __declspec(dllexport)
 #endif
+
+// Make gcc warn if types and format string don't match for printf
+#ifdef __GNUC__
+    //! Tell GCC about format functions to allow parameter strict type checks
+    //! \param type The type of function can be printf, scanf, strftime or strfmon
+    //! \param fmtstr One based position index for format parameter
+    //! \param vararg One based position index for the first checked parameter
+    #define Wformat(type, fmtstr, vararg) __attribute__ ((format (type, fmtstr, vararg)))
+#else
+    #define Wformat(type, fmtstr, vararg)
+#endif

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -354,8 +354,8 @@ DFHACK_EXPORT int random_int(int max);
  */
 DFHACK_EXPORT uint64_t GetTimeMs64();
 
-DFHACK_EXPORT std::string stl_sprintf(const char *fmt, ...);
-DFHACK_EXPORT std::string stl_vsprintf(const char *fmt, va_list args);
+DFHACK_EXPORT std::string stl_sprintf(const char *fmt, ...) Wformat(printf,1,2);
+DFHACK_EXPORT std::string stl_vsprintf(const char *fmt, va_list args) Wformat(printf,1,0);
 
 // Conversion between CP437 and UTF-8
 DFHACK_EXPORT std::string UTF2DF(const std::string &in);

--- a/library/modules/Kitchen.cpp
+++ b/library/modules/Kitchen.cpp
@@ -33,7 +33,7 @@ void Kitchen::debug_print(color_ostream &out)
     out.print("Kitchen Exclusions\n");
     for(std::size_t i = 0; i < size(); ++i)
     {
-        out.print("%2u: IT:%2i IS:%i MT:%3i MI:%2i ET:%i %s\n",
+        out.print("%2zu: IT:%2i IS:%i MT:%3i MI:%2i ET:%i %s\n",
                        i,
                        ui->kitchen.item_types[i],
                        ui->kitchen.item_subtypes[i],

--- a/plugins/3dveins.cpp
+++ b/plugins/3dveins.cpp
@@ -589,7 +589,7 @@ bool VeinGenerator::init_biomes()
 
         if (info.geo_index < 0 || !info.geobiome)
         {
-            out.printerr("Biome %d is not defined.\n", i);
+            out.printerr("Biome %zd is not defined.\n", i);
             return false;
         }
 
@@ -1567,7 +1567,7 @@ bool VeinGenerator::place_veins(bool verbose)
     sort(queue.begin(), queue.end(), vein_cmp);
 
     // Place tiles
-    out.print("Processing... ", queue.size());
+    out.print("Processing... (%zu)", queue.size());
 
     for (size_t j = 0; j < queue.size(); j++)
     {
@@ -1588,7 +1588,7 @@ bool VeinGenerator::place_veins(bool verbose)
                 out.print("done.");
 
             out.print(
-                "\nVein layer %d of %d: %s %s (%.2f%%)... ",
+                "\nVein layer %zu of %zu: %s %s (%.2f%%)... ",
                 j+1, queue.size(),
                 MaterialInfo(0,queue[j]->vein.first).getToken().c_str(),
                 ENUM_KEY_STR(inclusion_type, queue[j]->vein.second).c_str(),
@@ -1597,7 +1597,7 @@ bool VeinGenerator::place_veins(bool verbose)
         }
         else
         {
-            out.print("\rVein layer %d of %d... ", j+1, queue.size());
+            out.print("\rVein layer %zu of %zu... ", j+1, queue.size());
             out.flush();
         }
 

--- a/plugins/autolabor.cpp
+++ b/plugins/autolabor.cpp
@@ -1497,7 +1497,7 @@ command_result autolabor (color_ostream &out, std::vector <std::string> & parame
 
         if (maximum < minimum || maximum < 0 || minimum < 0)
         {
-            out.printerr("Syntax: autolabor <labor> <minimum> [<maximum>] [<talent pool>]\n", maximum, minimum);
+            out.printerr("Syntax: autolabor <labor> <minimum> [<maximum>] [<talent pool>], %d > %d\n", maximum, minimum);
             return CR_WRONG_USAGE;
         }
 

--- a/plugins/burrows.cpp
+++ b/plugins/burrows.cpp
@@ -295,7 +295,7 @@ static void init_map(color_ostream &out)
     active = true;
 
     if (auto_grow && !grow_burrows.empty())
-        out.print("Auto-growing %d burrows.\n", grow_burrows.size());
+        out.print("Auto-growing %zu burrows.\n", grow_burrows.size());
 }
 
 static void deinit_map(color_ostream &out)

--- a/plugins/changelayer.cpp
+++ b/plugins/changelayer.cpp
@@ -120,12 +120,12 @@ command_result changelayer (color_ostream &out, std::vector <std::string> & para
     {
         if(parameters[i] == "help" || parameters[i] == "?")
         {
-            out.print(changelayer_help.c_str());
+            out.print("%s",changelayer_help.c_str());
             return CR_OK;
         }
         if(parameters[i] == "trouble")
         {
-            out.print(changelayer_trouble.c_str());
+            out.print("%s",changelayer_trouble.c_str());
             return CR_OK;
         }
         if(parameters[i] == "force")

--- a/plugins/cleanowned.cpp
+++ b/plugins/cleanowned.cpp
@@ -87,7 +87,7 @@ command_result df_cleanowned (color_ostream &out, vector <string> & parameters)
         return CR_FAILURE;
     }
 
-    out.print("Found total %d items.\n", world->items.all.size());
+    out.print("Found total %zd items.\n", world->items.all.size());
 
     for (std::size_t i=0; i < world->items.all.size(); i++)
     {
@@ -160,7 +160,7 @@ command_result df_cleanowned (color_ostream &out, vector <string> & parameters)
             std::string description;
             item->getItemDescription(&description, 0);
             out.print(
-                "0x%x %s (wear %d)",
+                "0x%p %s (wear %d)",
                 item,
                 description.c_str(),
                 item->getWear()

--- a/plugins/cursecheck.cpp
+++ b/plugins/cursecheck.cpp
@@ -239,9 +239,9 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
     }
 
     if (checkWholeMap)
-        out.print("Number of cursed creatures on map: %d \n", cursecount);
+        out.print("Number of cursed creatures on map: %zd \n", cursecount);
     else
-        out.print("Number of cursed creatures on tile: %d \n", cursecount);
+        out.print("Number of cursed creatures on tile: %zd \n", cursecount);
 
     return CR_OK;
 }

--- a/plugins/diggingInvaders/assignJob.cpp
+++ b/plugins/diggingInvaders/assignJob.cpp
@@ -260,7 +260,7 @@ int32_t assignJob(color_ostream& out, Edge firstImportantEdge, unordered_map<df:
                 df::world_site::find(df::global::ui->site_id), 0);
 
             if ( out_items.size() != 1 ) {
-                out.print("%s, %d: wrong size: %d.\n", __FILE__, __LINE__, out_items.size());
+                out.print("%s, %d: wrong size: %zu.\n", __FILE__, __LINE__, out_items.size());
                 return -1;
             }
             out_items[0]->moveToGround(firstInvader->pos.x, firstInvader->pos.y, firstInvader->pos.z);

--- a/plugins/diggingInvaders/diggingInvaders.cpp
+++ b/plugins/diggingInvaders/diggingInvaders.cpp
@@ -62,6 +62,7 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
+#include <cinttypes>
 
 using namespace std;
 
@@ -301,7 +302,7 @@ command_result diggingInvadersCommand(color_ostream& out, std::vector<std::strin
             DigAbilities& abilities = digAbilities[raceString];
 
             df::coord bob = Gui::getCursorPos();
-            out.print("(%d,%d,%d), (%d,%d,%d): cost = %lld\n", lastDebugEdgeCostPoint.x, lastDebugEdgeCostPoint.y, lastDebugEdgeCostPoint.z, bob.x, bob.y, bob.z, getEdgeCost(out, lastDebugEdgeCostPoint, bob, abilities));
+            out.print("(%d,%d,%d), (%d,%d,%d): cost = %" PRId64 "\n", lastDebugEdgeCostPoint.x, lastDebugEdgeCostPoint.y, lastDebugEdgeCostPoint.z, bob.x, bob.y, bob.z, getEdgeCost(out, lastDebugEdgeCostPoint, bob, abilities));
             lastDebugEdgeCostPoint = bob;
             a++;
         } else if ( parameters[a] == "now" ) {

--- a/plugins/dwarfvet.cpp
+++ b/plugins/dwarfvet.cpp
@@ -582,7 +582,7 @@ void tickHandler(color_ostream& out, void* data) {
     /* Now add it to the scratch AHZ */
     for (vector<df::building*>::iterator current_hospital = to_be_added.begin(); current_hospital != to_be_added.end(); current_hospital++) {
         // Add it to the vector
-        out.print("Adding new hospital #id at x1 %d y1: %d z: %d\n",
+        out.print("Adding new hospital #id: %d at x1 %d y1: %d z: %d\n",
                 (*current_hospital)->id,
                 (*current_hospital)->x1,
                 (*current_hospital)->y1,

--- a/plugins/follow.cpp
+++ b/plugins/follow.cpp
@@ -156,7 +156,7 @@ command_result follow (color_ostream &out, std::vector <std::string> & parameter
         ss << "Unpause to begin following " << world->raws.creatures.all[followedUnit->race]->name[0];
         if (followedUnit->name.has_name) ss << " " << followedUnit->name.first_name;
         ss << ". Simply manually move the view to break the following.\n";
-        out.print(ss.str().c_str());
+        out.print("%s", ss.str().c_str());
     }
     else followedUnit = 0;
     is_enabled = (followedUnit != NULL);

--- a/plugins/forceequip.cpp
+++ b/plugins/forceequip.cpp
@@ -298,7 +298,7 @@ static bool moveToInventory(MapExtras::MapCache &mc, df::item *item, df::unit *u
         else
         {
             // The specified body part has not been found, and we've reached the end of the list.  Report failure.
-            if (verbose) { Core::printerr("The specified body part (%s) does not belong to the chosen unit.  Please double-check to ensure that your spelling is correct, and that you have not chosen a dismembered bodypart.\n"); }
+            if (verbose) { Core::printerr("The specified body part (%s) does not belong to the chosen unit.  Please double-check to ensure that your spelling is correct, and that you have not chosen a dismembered bodypart.\n",targetBodyPart->token.c_str()); }
             return false;
         }
 

--- a/plugins/fortplan.cpp
+++ b/plugins/fortplan.cpp
@@ -270,7 +270,7 @@ command_result fortplan(color_ostream &out, vector<string> & params) {
                                             checkCode = layout[checkY][checkX];
                                         }
 
-                                        con.print(" - Code at (%d,%d) is '%s': ",checkX,checkY,checkCode.c_str());
+                                        con.print(" - Code at (%zu,%zu) is '%s': ",checkX,checkY,checkCode.c_str());
                                         auto checkIndex = std::find_if(buildings.begin(), buildings.end(), MatchesCode(checkCode.c_str()));
                                         //if (checkIndex == buildings.end()) {
                                         //    con.print("this is not a valid code, so we keep going.\n");
@@ -331,16 +331,16 @@ command_result fortplan(color_ostream &out, vector<string> & params) {
                                     offsetCursor.y -= yOffset;
                                     DFHack::Gui::setCursorCoords(offsetCursor.x, offsetCursor.y, offsetCursor.z);
                                     if (!buildingInfo.allocate()) {
-                                        con.print("*** There was an error placing building with code '%s' centered at (%d,%d).\n",curCode.c_str(),x,y);
+                                        con.print("*** There was an error placing building with code '%s' centered at (%zu,%zu).\n",curCode.c_str(),x,y);
                                     }
                                     DFHack::Gui::setCursorCoords(cursor.x, cursor.y, cursor.z);
                                 } else if (block) {
                                     //con.print("Placing a building with code '%s' with corner at (%d,%d) and default size %dx%d.\n",curCode.c_str(),x,y,buildingInfo.defaultWidth,buildingInfo.defaultHeight);
                                     if (!buildingInfo.allocate()) {
-                                        con.print("*** There was an error placing building with code '%s' with corner at (%d,%d).\n",curCode.c_str(),x,y);
+                                        con.print("*** There was an error placing building with code '%s' with corner at (%zu,%zu).\n",curCode.c_str(),x,y);
                                     }
                                 } else {
-                                    con.print("*** Found a code '%s' at (%d,%d) for a building with default size %dx%d with an invalid size designation.\n",curCode.c_str(),x,y,buildingInfo.defaultWidth,buildingInfo.defaultHeight);
+                                    con.print("*** Found a code '%s' at (%zu,%zu) for a building with default size %dx%d with an invalid size designation.\n",curCode.c_str(),x,y,buildingInfo.defaultWidth,buildingInfo.defaultHeight);
                                 }
                             } else {
                                 //buildingSize = findBuildingExtent(layout, x, y, -1, -1, out);
@@ -350,7 +350,7 @@ command_result fortplan(color_ostream &out, vector<string> & params) {
                         } else {
                             //con.print("Building a(n) %s.\n",buildingInfo.name.c_str());
                             if (!buildingInfo.allocate()) {
-                                con.print("*** There was an error placing the %s at (%d,%d).\n",buildingInfo.name.c_str(),x,y);
+                                con.print("*** There was an error placing the %s at (%zu,%zu).\n",buildingInfo.name.c_str(),x,y);
                             }
                         }
                     }

--- a/plugins/generated-creature-renamer.cpp
+++ b/plugins/generated-creature-renamer.cpp
@@ -199,11 +199,10 @@ command_result list_creatures(color_ostream &out, std::vector <std::string> & pa
         auto creatureRaw = world->raws.creatures.all[i];
         if (!creatureRaw->flags.is_set(df::enums::creature_raw_flags::GENERATED))
             continue;
-        out.print(creatureRaw->creature_id.c_str());
+        out.print("%s",creatureRaw->creature_id.c_str());
         if (detailed)
         {
-            out.print("\t");
-            out.print(creatureRaw->caste[0]->description.c_str());
+            out.print("\t%s",creatureRaw->caste[0]->description.c_str());
         }
         out.print("\n");
     }

--- a/plugins/jobutils.cpp
+++ b/plugins/jobutils.cpp
@@ -156,14 +156,14 @@ static command_result job_material_in_job(color_ostream &out, MaterialInfo &new_
 
         if (item_mat != cur_mat)
         {
-            out.printerr("Job item %d has different material: %s\n",
+            out.printerr("Job item %zu has different material: %s\n",
                          i, item_mat.toString().c_str());
             return CR_FAILURE;
         }
 
         if (!new_mat.matches(*item))
         {
-            out.printerr("Job item %d requirements not satisfied by %s.\n",
+            out.printerr("Job item %zu requirements not satisfied by %s.\n",
                          i, new_mat.toString().c_str());
             return CR_FAILURE;
         }

--- a/plugins/labormanager/labormanager.cpp
+++ b/plugins/labormanager/labormanager.cpp
@@ -1757,7 +1757,7 @@ public:
         }
 
         if (print_debug)
-            out.print("available count = %d, distinct labors needed = %d\n", available_dwarfs.size(), pq.size());
+            out.print("available count = %zu, distinct labors needed = %zu\n", available_dwarfs.size(), pq.size());
 
         std::map<df::unit_labor, int> to_assign;
 
@@ -1958,7 +1958,7 @@ public:
         /* Assign any leftover dwarfs to "standard" labors */
 
         if (print_debug)
-            out.print("After assignment, %d dwarfs left over\n", available_dwarfs.size());
+            out.print("After assignment, %zu dwarfs left over\n", available_dwarfs.size());
 
         for (auto d = available_dwarfs.begin(); d != available_dwarfs.end(); d++)
         {

--- a/plugins/probe.cpp
+++ b/plugins/probe.cpp
@@ -191,7 +191,7 @@ command_result df_probe (color_ostream &out, vector <string> & parameters)
     }
 
     auto &block = *b->getRaw();
-    out.print("block addr: 0x%x\n\n", &block);
+    out.print("block addr: 0x%p\n\n", &block);
 /*
     if (showBlock)
     {
@@ -333,7 +333,7 @@ command_result df_probe (color_ostream &out, vector <string> & parameters)
         out.print("%-16s", "");
         out.print("  %4d", block.local_feature);
         out.print(" (%2d)", local.type);
-        out.print(" addr 0x%X ", local.origin);
+        out.print(" addr 0x%p ", local.origin);
         out.print(" %s\n", sa_feature(local.type));
     }
     PRINT_FLAG( des, feature_global );
@@ -461,7 +461,7 @@ command_result df_bprobe (color_ostream &out, vector <string> & parameters)
         case building_type::NestBox:
             {
                 df::building_nest_boxst* nestbox = (df::building_nest_boxst*) building.origin;
-                out.print(", claimed:(%i), items:%i", nestbox->claimed_by, nestbox->contained_items.size());
+                out.print(", claimed:(%i), items:%zu", nestbox->claimed_by, nestbox->contained_items.size());
                 break;
             }
         default:

--- a/plugins/rendermax/renderer_light.cpp
+++ b/plugins/rendermax/renderer_light.cpp
@@ -1207,31 +1207,31 @@ void lightingEngineViewscreen::loadSettings()
                 lua_pushlightuserdata(s, this);
                 lua_pushvalue(s,env);
                 Lua::SafeCall(out,s,2,0);
-                out.print("%d materials loaded\n",matDefs.size());
+                out.print("%zu materials loaded\n",matDefs.size());
 
                 lua_pushcfunction(s, parseSpecial);
                 lua_pushlightuserdata(s, this);
                 lua_pushvalue(s,env);
                 Lua::SafeCall(out,s,2,0);
-                out.print("%d day light colors loaded\n",dayColors.size());
+                out.print("%zu day light colors loaded\n",dayColors.size());
 
                 lua_pushcfunction(s, parseBuildings);
                 lua_pushlightuserdata(s, this);
                 lua_pushvalue(s,env);
                 Lua::SafeCall(out,s,2,0);
-                out.print("%d buildings loaded\n",buildingDefs.size());
+                out.print("%zu buildings loaded\n",buildingDefs.size());
 
                 lua_pushcfunction(s, parseCreatures);
                 lua_pushlightuserdata(s, this);
                 lua_pushvalue(s,env);
                 Lua::SafeCall(out,s,2,0);
-                out.print("%d creatures loaded\n",creatureDefs.size());
+                out.print("%zu creatures loaded\n",creatureDefs.size());
 
                 lua_pushcfunction(s, parseItems);
                 lua_pushlightuserdata(s, this);
                 lua_pushvalue(s,env);
                 Lua::SafeCall(out,s,2,0);
-                out.print("%d items loaded\n",itemDefs.size());
+                out.print("%zu items loaded\n",itemDefs.size());
             }
 
         }

--- a/plugins/ruby/ruby.cpp
+++ b/plugins/ruby/ruby.cpp
@@ -814,7 +814,7 @@ static VALUE rb_dfmemory_pageprotect(VALUE self, VALUE ptr, VALUE len, VALUE pro
         ++prot_p;
     }
 
-    Core::printerr("pageprot %x %x %x\n", rb_num2ulong(ptr), rb_num2ulong(len), prot);
+    Core::printerr("pageprot %zx %zx %x\n", rb_num2ulong(ptr), rb_num2ulong(len), prot);
     ret = Core::getInstance().p->memProtect((void*)rb_num2ulong(ptr), rb_num2ulong(len), prot);
 
     return ret ? Qfalse : Qtrue;

--- a/plugins/showmood.cpp
+++ b/plugins/showmood.cpp
@@ -173,7 +173,7 @@ command_result df_showmood (color_ostream &out, vector <string> & parameters)
         for (size_t i = 0; i < job->job_items.size(); i++)
         {
             df::job_item *item = job->job_items[i];
-            out.print("Item %i: ", i + 1);
+            out.print("Item %zu: ", i + 1);
 
             MaterialInfo matinfo(item->mat_type, item->mat_index);
 

--- a/plugins/sort.cpp
+++ b/plugins/sort.cpp
@@ -147,7 +147,7 @@ bool read_order(color_ostream &out, lua_State *L, std::vector<unsigned> *order, 
 
     if (lua_rawlen(L, -1) != size)
     {
-        out.printerr("Invalid ordering size: expected %d, actual %d\n", size, lua_rawlen(L, -1));
+        out.printerr("Invalid ordering size: expected %zu, actual %zu\n", size, lua_rawlen(L, -1));
         return false;
     }
 

--- a/plugins/tiletypes.cpp
+++ b/plugins/tiletypes.cpp
@@ -876,9 +876,9 @@ command_result executePaintJob(color_ostream &out)
     }
 
     if (failures > 0)
-        out.printerr("Could not update %d tiles of %d.\n", failures, all_tiles.size());
+        out.printerr("Could not update %d tiles of %zu.\n", failures, all_tiles.size());
     else
-        out.print("Processed %d tiles.\n", all_tiles.size());
+        out.print("Processed %zu tiles.\n", all_tiles.size());
 
     if (map.WriteAll())
     {

--- a/plugins/tubefill.cpp
+++ b/plugins/tubefill.cpp
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <iostream>
 #include <map>
+#include <cinttypes>
 #include <vector>
 #include "Core.h"
 #include "Console.h"
@@ -117,6 +118,6 @@ command_result tubefill(color_ostream &out, std::vector<std::string> & params)
             }
         }
     }
-    out.print("Found and changed %d tiles.\n", count);
+    out.print("Found and changed %" PRId64 " tiles.\n", count);
     return CR_OK;
 }

--- a/plugins/workflow.cpp
+++ b/plugins/workflow.cpp
@@ -525,7 +525,7 @@ static void stop_protect(color_ostream &out)
     pending_recover.clear();
 
     if (!known_jobs.empty())
-        out.print("Unprotecting %d jobs.\n", known_jobs.size());
+        out.print("Unprotecting %zd jobs.\n", known_jobs.size());
 
     for (TKnownJobs::iterator it = known_jobs.begin(); it != known_jobs.end(); ++it)
         delete it->second;
@@ -557,7 +557,7 @@ static void start_protect(color_ostream &out)
     check_lost_jobs(out, 0);
 
     if (!known_jobs.empty())
-        out.print("Protecting %d jobs.\n", known_jobs.size());
+        out.print("Protecting %zd jobs.\n", known_jobs.size());
 }
 
 static void init_state(color_ostream &out)


### PR DESCRIPTION
gcc supports type checks for printf parameters which can catch some hard
to reproduce bugs. Possible bugs happen when the parameter value is
intepreted differently to the variable value.

Example warnings follow
../library/LuaWrapper.cpp:1011:86: warning: format ‘%llu’ expects argument
    of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t
    {aka long unsigned int}’ [-Wformat=]
../plugins/follow.cpp:159:35: warning: format not a string literal and no
    format arguments [-Wformat-security]

I make errors with printf formats often enough. Even tough bugs caused by them are very rare those are often very hard to reproduce and debug. It is much easier to let compiler do type checks and fix any warnings compiler gives.

I don't know if msvc has similar function attribute to enforce format checks.  It has been many years when I last compiled anything with ms compiler.