### PR TITLE
Multibyte console support for posix and fix potential data races in console shutdown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,12 @@ ${CMAKE_MODULE_PATH}
 # generates compile_commands.json, used for autocompletion by some editors
 SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(CheckIncludeFileCXX)
+CHECK_INCLUDE_FILE_CXX("cuchar" HAVE_CUCHAR)
+if(HAVE_CUCHAR)
+	add_definitions("-DHAVE_CUCHAR")
+endif()
+
 # mixing the build system with the source code is ugly and stupid. enforce the opposite :)
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
    message(FATAL_ERROR "In-source builds are not allowed.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,10 +137,19 @@ ${CMAKE_MODULE_PATH}
 # generates compile_commands.json, used for autocompletion by some editors
 SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(CheckIncludeFileCXX)
-CHECK_INCLUDE_FILE_CXX("cuchar" HAVE_CUCHAR)
-if(HAVE_CUCHAR)
-	add_definitions("-DHAVE_CUCHAR")
+include(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdlib>
+#include <cuchar>
+int main(void) {
+    char32_t in = 0;
+    char out[MB_CUR_MAX];
+    std::mbstate_t state{};
+    std::c32rtomb(out, in, &state);
+    return 0;
+}" HAVE_CUCHAR2)
+if(HAVE_CUCHAR2)
+    add_definitions("-DHAVE_CUCHAR")
 endif()
 
 # mixing the build system with the source code is ugly and stupid. enforce the opposite :)

--- a/library/Console-posix.cpp
+++ b/library/Console-posix.cpp
@@ -157,7 +157,7 @@ namespace DFHack
             FD_SET(STDIN_FILENO, &descriptor_set);
             FD_SET(exit_pipe[0], &descriptor_set);
             int ret = TMP_FAILURE_RETRY(
-                select (FD_SETSIZE,&descriptor_set, NULL, NULL, NULL)
+                select (std::max(STDIN_FILENO,exit_pipe[0])+1,&descriptor_set, NULL, NULL, NULL)
             );
             if(ret == -1)
                 return false;

--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -285,7 +285,10 @@ namespace DFHack
                 INPUT_RECORD rec;
                 DWORD count;
                 lock->unlock();
-                ReadConsoleInputA(console_in, &rec, 1, &count);
+                if (ReadConsoleInputA(console_in, &rec, 1, &count) != 0) {
+                    lock->lock();
+                    return -2;
+                }
                 lock->lock();
                 if (rec.EventType != KEY_EVENT || !rec.Event.KeyEvent.bKeyDown)
                     continue;

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -49,7 +49,6 @@ using namespace DFHack;
 using namespace std;
 
 #include "tinythread.h"
-using namespace tthread;
 
 #include <assert.h>
 
@@ -83,8 +82,8 @@ struct Plugin::RefLock
     RefLock()
     {
         refcount = 0;
-        wakeup = new condition_variable();
-        mut = new mutex();
+        wakeup = new tthread::condition_variable();
+        mut = new tthread::mutex();
     }
     ~RefLock()
     {
@@ -119,8 +118,8 @@ struct Plugin::RefLock
             wakeup->wait(*mut);
         }
     }
-    condition_variable * wakeup;
-    mutex * mut;
+    tthread::condition_variable * wakeup;
+    tthread::mutex * mut;
     int refcount;
 };
 
@@ -786,8 +785,8 @@ void Plugin::push_function(lua_State *state, LuaFunction *fn)
 
 PluginManager::PluginManager(Core * core) : core(core)
 {
-    plugin_mutex = new recursive_mutex();
-    cmdlist_mutex = new mutex();
+    plugin_mutex = new tthread::recursive_mutex();
+    cmdlist_mutex = new tthread::mutex();
     ruby = NULL;
 }
 

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -198,6 +198,7 @@ namespace DFHack
         DFHack::Console con;
 
         Core();
+        ~Core();
 
         struct Private;
         Private *d;

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -145,7 +145,7 @@ namespace DFHack
         /// sets the current hotkey command
         bool setHotkeyCmd( std::string cmd );
         /// removes the hotkey command and gives it to the caller thread
-        std::string getHotkeyCmd( void );
+        std::string getHotkeyCmd( bool &keep_going );
 
         /// adds a named pointer (for later or between plugins)
         void RegisterData(void *p,std::string key);
@@ -257,7 +257,12 @@ namespace DFHack
         std::map<int, std::vector<KeyBinding> > key_bindings;
         std::map<int, bool> hotkey_states;
         std::string hotkey_cmd;
-        bool hotkey_set;
+        enum hotkey_set_t {
+            NO,
+            SET,
+            SHUTDOWN,
+        };
+        hotkey_set_t hotkey_set;
         std::mutex HotkeyMutex;
         std::condition_variable HotkeyCond;
 

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -34,6 +34,9 @@ distribution.
 #include "Console.h"
 #include "modules/Graphic.h"
 
+#include <mutex>
+#include <condition_variable>
+
 #include "RemoteClient.h"
 
 #define DFH_MOD_SHIFT 1
@@ -41,13 +44,6 @@ distribution.
 #define DFH_MOD_ALT 4
 
 struct WINDOW;
-
-namespace tthread
-{
-    class mutex;
-    class condition_variable;
-    class thread;
-}
 
 namespace df
 {
@@ -246,7 +242,7 @@ namespace DFHack
         DFHack::PluginManager * plug_mgr;
 
         std::vector<std::string> script_paths[2];
-        tthread::mutex *script_path_mutex;
+        std::mutex script_path_mutex;
 
         // hotkey-related stuff
         struct KeyBinding {
@@ -261,11 +257,11 @@ namespace DFHack
         std::map<int, bool> hotkey_states;
         std::string hotkey_cmd;
         bool hotkey_set;
-        tthread::mutex * HotkeyMutex;
-        tthread::condition_variable * HotkeyCond;
+        std::mutex HotkeyMutex;
+        std::condition_variable HotkeyCond;
 
         std::map<std::string, std::vector<std::string>> aliases;
-        tthread::recursive_mutex * alias_mutex;
+        std::recursive_mutex alias_mutex;
 
         bool SelectHotkey(int key, int modifiers);
 
@@ -280,7 +276,7 @@ namespace DFHack
         // Additional state change scripts
         std::vector<StateChangeScript> state_change_scripts;
 
-        tthread::mutex * misc_data_mutex;
+        std::mutex misc_data_mutex;
         std::map<std::string,void*> misc_data_map;
 
         friend class CoreService;

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -395,7 +395,7 @@ namespace DFHack {namespace Lua {
 
         // Not exported; for use by the Core class
         bool Init(color_ostream &out);
-        void Reset(color_ostream &out, const char *where);
+        DFHACK_EXPORT void Reset(color_ostream &out, const char *where);
 
         // Events signalled by the core
         void onStateChange(color_ostream &out, int code);

--- a/library/include/RemoteTools.h
+++ b/library/include/RemoteTools.h
@@ -133,6 +133,7 @@ namespace DFHack
 
     class CoreService : public RPCService {
         int suspend_depth;
+        CoreSuspender* coreSuspender;
 
         static int doRunLuaFunction(lua_State *L);
     public:

--- a/library/lua/utils.lua
+++ b/library/lua/utils.lua
@@ -505,17 +505,17 @@ function prompt_yes_no(msg,default)
         prompt = prompt..' (y/n)[n]: '
     end
     while true do
-        local rv = dfhack.lineedit(prompt)
-        if rv then
-            if string.match(rv,'^[Yy]') then
-                return true
-            elseif string.match(rv,'^[Nn]') then
-                return false
-            elseif rv == 'abort' then
-                qerror('User abort')
-            elseif rv == '' and default ~= nil then
-                return default
-            end
+        local rv,err = dfhack.lineedit(prompt)
+        if not rv then
+            qerror(err);
+        elseif string.match(rv,'^[Yy]') then
+            return true
+        elseif string.match(rv,'^[Nn]') then
+            return false
+        elseif rv == 'abort' then
+            qerror('User abort')
+        elseif rv == '' and default ~= nil then
+            return default
         end
     end
 end
@@ -524,7 +524,10 @@ end
 function prompt_input(prompt,check,quit_str)
     quit_str = quit_str or '~~~'
     while true do
-        local rv = dfhack.lineedit(prompt)
+        local rv,err = dfhack.lineedit(prompt)
+        if not rv then
+            qerror(err);
+        end
         if rv == quit_str then
             qerror('User abort')
         end

--- a/plugins/Brushes.h
+++ b/plugins/Brushes.h
@@ -214,7 +214,7 @@ DFHack::command_result parseRectangle(DFHack::color_ostream & out,
                               bool hasConsole = true)
 {
     using namespace DFHack;
-    int newWidth = 0, newHeight = 0, newZLevels = 0;
+    int newWidth = 0, newHeight = 0, newZLevels = 0, rv = 0;
 
     if (end > start + 1)
     {
@@ -237,7 +237,8 @@ DFHack::command_result parseRectangle(DFHack::color_ostream & out,
 
             str.str("");
             str << "Set range width <" << width << "> ";
-            con.lineedit(str.str(), command, hist);
+            if ((rv = con.lineedit(str.str(), command, hist)) < 0)
+                return rv == -2 ? CR_OK : CR_FAILURE;
             hist.add(command);
             newWidth = command.empty() ? width : atoi(command.c_str());
         } else {
@@ -251,7 +252,8 @@ DFHack::command_result parseRectangle(DFHack::color_ostream & out,
 
             str.str("");
             str << "Set range height <" << height << "> ";
-            con.lineedit(str.str(), command, hist);
+            if ((rv = con.lineedit(str.str(), command, hist)) < 0)
+                return rv == -2 ? CR_OK : CR_FAILURE;
             hist.add(command);
             newHeight = command.empty() ? height : atoi(command.c_str());
         } else {
@@ -265,7 +267,8 @@ DFHack::command_result parseRectangle(DFHack::color_ostream & out,
 
             str.str("");
             str << "Set range z-levels <" << zLevels << "> ";
-            con.lineedit(str.str(), command, hist);
+            if ((rv = con.lineedit(str.str(), command, hist)) < 0)
+                return rv == -2 ? CR_OK : CR_FAILURE;
             hist.add(command);
             newZLevels = command.empty() ? zLevels : atoi(command.c_str());
         } else {

--- a/plugins/liquids.cpp
+++ b/plugins/liquids.cpp
@@ -188,8 +188,9 @@ command_result df_liquids (color_ostream &out_, vector <string> & parameters)
         std::stringstream str;
         print_prompt(str, cur_mode);
         str << "# ";
-        if(out.lineedit(str.str(),input,liquids_hist) == -1)
-            return CR_FAILURE;
+        int rv;
+        if((rv = out.lineedit(str.str(),input,liquids_hist)) < 0)
+            return rv == -2 ? CR_OK : CR_FAILURE;
         liquids_hist.add(input);
 
         commands.clear();

--- a/plugins/mode.cpp
+++ b/plugins/mode.cpp
@@ -96,6 +96,7 @@ command_result mode (color_ostream &out_, vector <string> & parameters)
     string command = "";
     bool set = false;
     bool abuse = false;
+    int rv = 0;
     t_gamemodes gm;
     for(auto iter = parameters.begin(); iter != parameters.end(); iter++)
     {
@@ -139,9 +140,9 @@ command_result mode (color_ostream &out_, vector <string> & parameters)
             string selected;
             input_again:
             CommandHistory hist;
-            out.lineedit("Enter new mode: ",selected, hist);
-            if(selected == "c")
-                return CR_OK;
+            rv = out.lineedit("Enter new mode: ",selected, hist);
+            if(rv < 0 || selected == "c")
+                return rv == -2 ? CR_OK : CR_FAILURE;
             const char * start = selected.c_str();
             char * end = 0;
             select = strtol(start, &end, 10);
@@ -178,14 +179,14 @@ command_result mode (color_ostream &out_, vector <string> & parameters)
         {
             CommandHistory hist;
             string selected;
-            out.lineedit("Enter new game mode number (c for exit): ",selected, hist);
-            if(selected == "c")
-                return CR_OK;
+            rv = out.lineedit("Enter new game mode number (c for exit): ",selected, hist);
+            if(rv < 0 || selected == "c")
+                return rv == -2 ? CR_OK : CR_FAILURE;
             const char * start = selected.c_str();
             gm.g_mode = (GameMode) strtol(start, 0, 10);
-            out.lineedit("Enter new game type number (c for exit): ",selected, hist);
-            if(selected == "c")
-                return CR_OK;
+            rv = out.lineedit("Enter new game type number (c for exit): ",selected, hist);
+            if(rv < 0 || selected == "c")
+                return rv == -2 ? CR_OK : CR_FAILURE;
             start = selected.c_str();
             gm.g_type = (GameType) strtol(start, 0, 10);
         }

--- a/plugins/tiletypes.cpp
+++ b/plugins/tiletypes.cpp
@@ -984,9 +984,10 @@ command_result df_tiletypes (color_ostream &out_, vector <string> & parameters)
         printState(out);
 
         std::string input = "";
+        int rv = 0;
 
-        if (out.lineedit("tiletypes> ",input,tiletypes_hist) == -1)
-            return CR_FAILURE;
+        if ((rv = out.lineedit("tiletypes> ",input,tiletypes_hist)) < 0)
+            return rv == -2 ? CR_OK : CR_FAILURE;
         tiletypes_hist.add(input);
 
         commands.clear();


### PR DESCRIPTION
I noticed that console code doesn't support multibyte characters at all. This may lead messed up console state and invalid multibyte sequence passed into command handlers. I decided to fix the input handling to keep console state match printed characters and prevent any partial multibyte characters passed into command handlers.

While I was implementing the multibyte support I noticed select was getting a suboptimal nfds parameters (first).  The large nfs parameter doesn't affect anything but it is minor performance issue because kernel has to scan up to nfds -1 FD bits in the fdset.

Then I also noticed the data race potential in the shutdown code. I decided to implement a simple fix by joining the thread before Core frees or cleanups any state.

Windows change is untested. Can someone test if it works correctly?
My assumption is that FreeConsole closes the console which makes ReadConsoleInputA return non-zero value that indicates an error.