### PR TITLE
Start script additions strace, gdbserver and df arguments to gdb

### DIFF
--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -68,11 +68,8 @@ setarch_arch=$(cat hack/dfhack_setarch.txt || printf i386)
 case "$1" in
   -g | --gdb)
     shift
-    echo "set environment LD_LIBRARY_PATH $LD_LIBRARY_PATH" > gdbcmd.tmp
-    echo "set environment LD_PRELOAD $PRELOAD_LIB" >> gdbcmd.tmp
-    echo "set environment MALLOC_PERTURB_ 45" >> gdbcmd.tmp
-    echo "set startup-with-shell off" >> gdbcmd.tmp
-    gdb $DF_GDB_OPTS -x gdbcmd.tmp ./libs/Dwarf_Fortress "$@"
+    echo "set exec-wrapper env LD_LIBRARY_PATH='$LD_LIBRARY_PATH' LD_PRELOAD='$PRELOAD_LIB' MALLOC_PERTURB_=45" > gdbcmd.tmp
+    gdb $DF_GDB_OPTS -x gdbcmd.tmp --args ./libs/Dwarf_Fortress "$@"
     rm gdbcmd.tmp
     ret=$?
     ;;

--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -91,6 +91,11 @@ case "$1" in
     LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_CALLGRIND_OPTS --tool=callgrind --separate-threads=yes --dump-instr=yes --instr-atstart=no --log-file=callgrind.log ./libs/Dwarf_Fortress "$@"
     ret=$?
     ;;
+  --strace)
+    shift
+    strace -f setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@" 2> strace.log
+    ret=$?
+    ;;
   *)
     setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@"
     ret=$?

--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -73,6 +73,34 @@ case "$1" in
     rm gdbcmd.tmp
     ret=$?
     ;;
+  -r | --remotegdb)
+    shift
+    if [ "$#" -gt 0 ]; then
+      echo "****"
+      echo "gdbserver doesn't support spaces in arguments."
+      echo "If your world gen name has spaces you need to remove spaces from the name in data/init/world_gen.txt"
+      echo "****"
+    fi
+    echo "set environment LD_LIBRARY_PATH $LD_LIBRARY_PATH" > gdbcmd.tmp
+    echo "set environment LD_PRELOAD $PRELOAD_LIB" >> gdbcmd.tmp
+    echo "set environment MALLOC_PERTURB_ 45" >> gdbcmd.tmp
+    echo "set startup-with-shell off" >> gdbcmd.tmp
+    echo "target extended-remote localhost:12345" >> gdbcmd.tmp
+    echo "set remote exec-file ./libs/Dwarf_Fortress" >> gdbcmd.tmp
+    # For some reason gdb ignores sysroot setting if it is from same file as
+    # target extended-remote command
+    echo "set sysroot /" > gdbcmd_sysroot.tmp
+    gdb $DF_GDB_OPTS -x gdbcmd.tmp -x gdbcmd_sysroot.tmp --args ./libs/Dwarf_Fortress "$@"
+    rm gdbcmd.tmp gdbcmd_sysroot.tmp
+    ret=$?
+    ;;
+  -s | --gdbserver) # -s for server
+    shift
+    echo "Starting gdbserver in multi mode."
+    echo "To exit the gdbserver you can enter 'monitor exit' command to gdb or use kill signal"
+    gdbserver --multi localhost:12345
+    ret=$?
+    ;;
   -h | --helgrind)
     shift
     LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_HELGRIND_OPTS --tool=helgrind --log-file=helgrind.log ./libs/Dwarf_Fortress "$@"


### PR DESCRIPTION
I have made a few modifications to my dfhack script. Here are modifications if they look like something that would help others too.

I didn't include ltrace change because I don't know setup that would feel like useable. I either get very slow execution or not enough information. A compromise could be allowing the -x argument of ltrace to be passed for dfhack. But I don't know if it can be done with a simply change.