### PR TITLE
jsoncpp: Fix (U)Int64 to long int on 64bit linux

### DIFF
--- a/depends/jsoncpp/jsoncpp.h
+++ b/depends/jsoncpp/jsoncpp.h
@@ -195,6 +195,8 @@ license you like.
 #define JSONCPP_DEPRECATED(message)
 #endif // if !defined(JSONCPP_DEPRECATED)
 
+#include <cstdint>
+
 namespace Json {
 typedef int Int;
 typedef unsigned int UInt;
@@ -208,8 +210,8 @@ typedef unsigned int LargestUInt;
 typedef __int64 Int64;
 typedef unsigned __int64 UInt64;
 #else                 // if defined(_MSC_VER) // Other platforms, use long long
-typedef long long int Int64;
-typedef unsigned long long int UInt64;
+typedef int64_t Int64;
+typedef uint64_t UInt64;
 #endif // if defined(_MSC_VER)
 typedef Int64 LargestInt;
 typedef UInt64 LargestUInt;


### PR DESCRIPTION
Passing a 64bit integer to Json::Value fails to find matching. Even
tough long long int is also 64bits gcc considres long long int different
to long int. But fix can't be as simple as removing an long from type
because that would reduce 32bit builds to have only 32bit maximum int
size. But standard offers fixed width integer types that can be used to
get correct underlying type depending on platform.