### PR TITLE
Add cmake configuration to select if stubs include symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ else(CMAKE_CONFIGURATION_TYPES)
 endif(CMAKE_CONFIGURATION_TYPES)
 
 OPTION(BUILD_DOCS "Choose whether to build the documentation (requires python and Sphinx)." OFF)
+OPTION(REMOVE_SYMBOLS_FROM_DF_STUBS "Remove debug symbols from DF stubs. (Reduces libdfhack size to about half but removes a few useful symbols)" ON)
 
 ## some generic CMake magic
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -267,14 +267,15 @@ ADD_CUSTOM_COMMAND(
 )
 
 ADD_CUSTOM_TARGET(generate_headers DEPENDS ${dfapi_SOURCE_DIR}/include/df/codegen.out.xml)
-
-IF(UNIX)
-  # Don't produce debug info for generated stubs
-  SET_SOURCE_FILES_PROPERTIES(DataStatics.cpp DataStaticsCtor.cpp DataStaticsFields.cpp ${STATIC_FIELDS_FILES}
-                              PROPERTIES COMPILE_FLAGS "-g0 -O1")
-ELSE(WIN32)
-  SET_SOURCE_FILES_PROPERTIES(DataStatics.cpp DataStaticsCtor.cpp DataStaticsFields.cpp ${STATIC_FIELDS_FILES}
-                              PROPERTIES COMPILE_FLAGS "/O1 /bigobj")
+IF(REMOVE_SYMBOLS_FROM_DF_STUBS)
+  IF(UNIX)
+    # Don't produce debug info for generated stubs
+    SET_SOURCE_FILES_PROPERTIES(DataStatics.cpp DataStaticsCtor.cpp DataStaticsFields.cpp ${STATIC_FIELDS_FILES}
+                                PROPERTIES COMPILE_FLAGS "-g0 -O1")
+  ELSE(WIN32)
+    SET_SOURCE_FILES_PROPERTIES(DataStatics.cpp DataStaticsCtor.cpp DataStaticsFields.cpp ${STATIC_FIELDS_FILES}
+                                PROPERTIES COMPILE_FLAGS "/O1 /bigobj")
+  ENDIF()
 ENDIF()
 
 # Compilation


### PR DESCRIPTION
G++ generates structure debug symbols for a few df namespace classes to
generated stub source files. I decided to test how much symbols from
those files would increase binary size. When the result was about double
size I decided to add cmake configuration option to let user easily
select if they prefer complete symbols or reduced size.