### PR TITLE
Fix stockpile inventory not to include inventory items

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `remove-stress`: fixed an error when running on soul-less units (e.g. with ``-all``)
 - `revflood`: stopped revealing tiles adjacent to tiles above open space inappropriately
 - `stockpiles`: ``loadstock`` sets usable and unusable weapon and armor settings
+- `stocks`: Remove carried items from stockpile where they were picked up
 
 ## Misc Improvements
 - Added script name to messages produced by ``qerror()`` in Lua scripts

--- a/plugins/uicommon.h
+++ b/plugins/uicommon.h
@@ -348,10 +348,22 @@ public:
 
     bool inStockpile(df::item *i)
     {
-        df::item *container = Items::getContainer(i);
+        // Check if the item is assigned to a stockpile
+        if (i->isAssignedToStockpile())
+            return i->isAssignedToThisStockpile(sp->id);
+
+        // If this is in a container check where the container item is
+        df::item* container = Items::getContainer(i);
         if (container)
             return inStockpile(container);
 
+        // Inventory items seems to have stale position information. We can
+        // assume that they are not in the stockpile.
+        if (i->flags.bits.in_inventory)
+            return false;
+
+        // Only containers are assigned to a stockpile. We need a coordinate
+        // check for free items.
         if (i->pos.z != z) return false;
         if (i->pos.x < x1 || i->pos.x >= x2 ||
             i->pos.y < y1 || i->pos.y >= y2) return false;


### PR DESCRIPTION
Inventory items have stale position information. The coordinates can be
very old if item is owned and continuesly carried for long time. The fix
checks if item is carried. To avoid filtering carried items that are
assigned (containers) to the stockpile the assignment needs to be
checked.

Fixes #1288