### PR TITLE
Temporary lower command-prompt when executing the command

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `remove-stress`: fixed an error when running on soul-less units (e.g. with ``-all``)
 - `revflood`: stopped revealing tiles adjacent to tiles above open space inappropriately
 - `stockpiles`: ``loadstock`` sets usable and unusable weapon and armor settings
+- `command-prompt`: Allow executing commands that require specific screen to be visible
 
 ## Misc Improvements
 - Added script name to messages produced by ``qerror()`` in Lua scripts

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -70,6 +70,11 @@ namespace DFHack
         class df_window;
     }
 
+    namespace Screen
+    {
+        struct Hide;
+    }
+
     enum state_change_event
     {
         SC_UNKNOWN = -1,
@@ -273,6 +278,7 @@ namespace DFHack
         void *last_world_data_ptr;
         // for state change tracking
         void *last_local_map_ptr;
+        friend struct Screen::Hide;
         df::viewscreen *top_viewscreen;
         bool last_pause_state;
         // Very important!

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -301,6 +301,15 @@ namespace DFHack
             GUI_HOOK_DECLARE(set_tile, bool, (const Pen &pen, int x, int y, bool map));
         }
 
+        //! Temporary hide a screen until destructor is called
+        struct DFHACK_EXPORT Hide {
+            Hide(df::viewscreen* screen);
+            ~Hide();
+        private:
+            void extract(df::viewscreen*);
+            void merge(df::viewscreen*);
+            df::viewscreen* screen_;
+        };
     }
 
     class DFHACK_EXPORT dfhack_viewscreen : public df::viewscreen {
@@ -374,4 +383,5 @@ namespace DFHack
         virtual df::building *getSelectedBuilding();
         virtual df::plant *getSelectedPlant();
     };
+
 }

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -371,6 +371,42 @@ bool Screen::hasActiveScreens(Plugin *plugin)
     return false;
 }
 
+namespace DFHack { namespace Screen {
+
+Hide::Hide(df::viewscreen* screen) :
+    screen_{screen}
+{
+    extract(screen_);
+}
+
+Hide::~Hide()
+{
+    if (screen_)
+        merge(screen_);
+}
+
+void Hide::extract(df::viewscreen* a)
+{
+    df::viewscreen* ap = a->parent;
+    df::viewscreen* ac = a->child;
+
+    ap->child = ac;
+    if (ac) ac->parent = ap;
+    else Core::getInstance().top_viewscreen = ap;
+}
+
+void Hide::merge(df::viewscreen* a)
+{
+    df::viewscreen* ap = a->parent;
+    df::viewscreen* ac = a->parent->child;
+
+    ap->child = a;
+    a->child = ac;
+    if (ac) ac->parent = a;
+    else Core::getInstance().top_viewscreen = a;
+}
+} }
+
 #ifdef _LINUX
 class DFHACK_EXPORT renderer {
     unsigned char *screen;

--- a/plugins/command-prompt.cpp
+++ b/plugins/command-prompt.cpp
@@ -200,7 +200,10 @@ void viewscreen_commandpromptst::submit()
         return;
     submitted = true;
     prompt_ostream out(this);
-    Core::getInstance().runCommand(out, get_entry());
+    {
+        Screen::Hide hide_guard(this);
+        Core::getInstance().runCommand(out, get_entry());
+    }
     if(out.empty() && responses.empty())
         Screen::dismiss(this);
     else

--- a/plugins/command-prompt.cpp
+++ b/plugins/command-prompt.cpp
@@ -315,7 +315,7 @@ void viewscreen_commandpromptst::feed(std::set<df::interface_key> *events)
 
 command_result show_prompt(color_ostream &out, std::vector <std::string> & parameters)
 {
-    if (Gui::getCurFocus() == "dfhack/commandprompt")
+    if (Gui::getCurFocus(true) == "dfhack/commandprompt")
     {
         Screen::dismiss(Gui::getCurViewscreen(true));
         return CR_OK;


### PR DESCRIPTION
command-prompt viewscreen may affect command execution if they are
looking for UI state. To make commands execute simillary to hotkeys or
console commands the viewscreen needs to removed from the top position.

Fixes #1194

I'm unsure if LowerScreen should be part of Core or module/Screen. I first put it to the Core but I can moved it to Screen if it sounds like a better place for this functionality.

What about lowering position? I only lower it a level but it might be better to lower to bottom (gview->view.child = screen_)