### PR TITLE
Reset dsgn_check_cooldown in Block::write

### DIFF
--- a/library/include/modules/MapCache.h
+++ b/library/include/modules/MapCache.h
@@ -55,7 +55,7 @@ class Block;
 
 struct BiomeInfo {
     // Determined by the 4-bit index in the designation bitfield
-    static const unsigned MAX_LAYERS = 16;
+    static constexpr unsigned MAX_LAYERS = 16;
 
     df::coord2d pos;
     int default_soil, default_stone, lava_stone;

--- a/library/modules/MapCache.cpp
+++ b/library/modules/MapCache.cpp
@@ -738,6 +738,7 @@ bool MapExtras::Block::Write ()
     {
         COPY(block->designation, designation);
         block->flags.bits.designated = true;
+        block->dsgn_check_cooldown = 0;
         dirty_designations = false;
     }
     if(dirty_tiles || dirty_veins)

--- a/library/modules/MapCache.cpp
+++ b/library/modules/MapCache.cpp
@@ -79,10 +79,6 @@ using df::global::world;
 
 extern bool GetLocalFeature(t_feature &feature, df::coord2d rgn_pos, int32_t index);
 
-#ifdef LINUX_BUILD
-const unsigned MapExtras::BiomeInfo::MAX_LAYERS;
-#endif
-
 const BiomeInfo MapCache::biome_stub = {
     df::coord2d(),
     -1, -1, -1, -1,


### PR DESCRIPTION
To make sure that DF generates jobjs from desgination as soon as
possible the dsgn_check_cooldown should be reset when designations
change.

Combined with a janitor change:
Use constexpr to prevent attempts of linking static variable