### PR TITLE
Add dfhack.printall_recurse to quickly print df containers

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -2404,6 +2404,10 @@ environment by the mandatory init file dfhack.lua:
 
   If the argument is a lua table or DF object reference, prints all fields.
 
+* ``printall_recurse(obj)``
+
+  If the argument is a lua table or DF object reference, prints all fields recursively.
+
 * ``copyall(obj)``
 
   Returns a shallow copy of the table or reference as a lua table.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -44,6 +44,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - New functions:
     - ``Units::isDiplomat(unit)``
 
+## Lua
+- Add ``printall_recurse`` to print tables and DF references recursively. It can be also used with ``^`` from lua interpreter.
+
 ## Internals
 - jsoncpp: updated to version 1.8.4 and switched to using a git submodule
 


### PR DESCRIPTION
I often want to see multiple items quickly when trying to figure out
what states actually matter to an issue that I debug. I decided to make
it easier to quickly dump df structures with substructures and
containers. It will generate large amount of data which can be sometimes
slow to process manually. But processing can be automated using
dfhack-run lua ^<df data to inspect> and pipe to other tools (eg grep,
sed, perl, sort, uniq etc)

No changelog or documentation yet. I can add them when this looks acceptable. I still wonder if I should change some.

I'm not entirely happy how I formatted object keys.  I wanted to use format that is very close to printall(table) format. Basically only adding recursion to subjects and pointers. The original printing code used format that closely matched lua table definition where curly brackets helped key table printing. But as table keys is a very rare keys I decided not to try to improve it.