### PR TITLE
Allow canceling lineedit with ctrl+c

### DIFF
--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -287,7 +287,7 @@ namespace DFHack
                 lock->unlock();
                 if (ReadConsoleInputA(console_in, &rec, 1, &count) != 0) {
                     lock->lock();
-                    return -2;
+                    return Console::SHUTDOWN;
                 }
                 lock->lock();
                 if (rec.EventType != KEY_EVENT || !rec.Event.KeyEvent.bKeyDown)
@@ -382,7 +382,7 @@ namespace DFHack
             state = con_lineedit;
             this->prompt = prompt;
             count = prompt_loop(lock, ch);
-            if(count != -1)
+            if(count > Console::FAILURE)
                 output = raw_buffer;
             state = con_unclaimed;
             print("\n");
@@ -591,7 +591,7 @@ void Console::cursor(bool enable)
 int Console::lineedit(const std::string & prompt, std::string & output, CommandHistory & ch)
 {
     wlock->lock();
-    int ret = -2;
+    int ret = Console::SHUTDOWN;
     if(inited)
         ret = d->lineedit(prompt,output,wlock,ch);
     wlock->unlock();

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1421,13 +1421,15 @@ void fIOthread(void * iodata)
     while (true)
     {
         string command = "";
-        int ret = con.lineedit("[DFHack]# ",command, main_history);
-        if(ret == -2)
+        int ret;
+        while ((ret = con.lineedit("[DFHack]# ",command, main_history))
+                == Console::RETRY);
+        if(ret == Console::SHUTDOWN)
         {
             cerr << "Console is shutting down properly." << endl;
             return;
         }
-        else if(ret == -1)
+        else if(ret == Console::FAILURE)
         {
             cerr << "Console caught an unspecified error." << endl;
             continue;

--- a/library/include/Console.h
+++ b/library/include/Console.h
@@ -153,6 +153,12 @@ namespace  DFHack
         int  get_rows(void);
         /// beep. maybe?
         //void beep (void);
+        //! \defgroup lineedit_return_values Possible errors from lineedit
+        //! \{
+        static constexpr int FAILURE = -1;
+        static constexpr int SHUTDOWN = -2;
+        static constexpr int RETRY = -3;
+        //! \}
         /// A simple line edit (raw mode)
         int lineedit(const std::string& prompt, std::string& output, CommandHistory & history );
         bool isInited (void) { return inited; };

--- a/plugins/Brushes.h
+++ b/plugins/Brushes.h
@@ -237,8 +237,10 @@ DFHack::command_result parseRectangle(DFHack::color_ostream & out,
 
             str.str("");
             str << "Set range width <" << width << "> ";
-            if ((rv = con.lineedit(str.str(), command, hist)) < 0)
-                return rv == -2 ? CR_OK : CR_FAILURE;
+            while ((rv = con.lineedit(str.str(), command, hist))
+                    == Console::RETRY);
+            if (rv <= Console::FAILURE)
+                return rv == Console::FAILURE ? CR_FAILURE : CR_FAILURE;
             hist.add(command);
             newWidth = command.empty() ? width : atoi(command.c_str());
         } else {
@@ -252,8 +254,10 @@ DFHack::command_result parseRectangle(DFHack::color_ostream & out,
 
             str.str("");
             str << "Set range height <" << height << "> ";
-            if ((rv = con.lineedit(str.str(), command, hist)) < 0)
-                return rv == -2 ? CR_OK : CR_FAILURE;
+            while ((rv = con.lineedit(str.str(), command, hist))
+                    == Console::RETRY);
+            if (rv <= Console::FAILURE)
+                return rv == Console::FAILURE ? CR_FAILURE : CR_OK;
             hist.add(command);
             newHeight = command.empty() ? height : atoi(command.c_str());
         } else {
@@ -267,8 +271,10 @@ DFHack::command_result parseRectangle(DFHack::color_ostream & out,
 
             str.str("");
             str << "Set range z-levels <" << zLevels << "> ";
-            if ((rv = con.lineedit(str.str(), command, hist)) < 0)
-                return rv == -2 ? CR_OK : CR_FAILURE;
+            while ((rv = con.lineedit(str.str(), command, hist))
+                    == Console::RETRY);
+            if (rv <= Console::FAILURE)
+                return rv == Console::FAILURE ? CR_FAILURE :  CR_OK;
             hist.add(command);
             newZLevels = command.empty() ? zLevels : atoi(command.c_str());
         } else {

--- a/plugins/liquids.cpp
+++ b/plugins/liquids.cpp
@@ -189,8 +189,10 @@ command_result df_liquids (color_ostream &out_, vector <string> & parameters)
         print_prompt(str, cur_mode);
         str << "# ";
         int rv;
-        if((rv = out.lineedit(str.str(),input,liquids_hist)) < 0)
-            return rv == -2 ? CR_OK : CR_FAILURE;
+        while ((rv = out.lineedit(str.str(),input,liquids_hist))
+                == Console::RETRY);
+        if (rv <= Console::FAILURE)
+            return rv == Console::FAILURE ? CR_FAILURE : CR_OK;
         liquids_hist.add(input);
 
         commands.clear();

--- a/plugins/mode.cpp
+++ b/plugins/mode.cpp
@@ -140,9 +140,10 @@ command_result mode (color_ostream &out_, vector <string> & parameters)
             string selected;
             input_again:
             CommandHistory hist;
-            rv = out.lineedit("Enter new mode: ",selected, hist);
-            if(rv < 0 || selected == "c")
-                return rv == -2 ? CR_OK : CR_FAILURE;
+            while((rv = out.lineedit("Enter new mode: ",selected, hist))
+                    == Console::RETRY);
+            if(rv <= Console::FAILURE || selected == "c")
+                return rv == Console::FAILURE ? CR_FAILURE : CR_OK;
             const char * start = selected.c_str();
             char * end = 0;
             select = strtol(start, &end, 10);
@@ -179,14 +180,16 @@ command_result mode (color_ostream &out_, vector <string> & parameters)
         {
             CommandHistory hist;
             string selected;
-            rv = out.lineedit("Enter new game mode number (c for exit): ",selected, hist);
-            if(rv < 0 || selected == "c")
-                return rv == -2 ? CR_OK : CR_FAILURE;
+            while ((rv = out.lineedit("Enter new game mode number (c for exit): ",selected, hist))
+                    == Console::RETRY);
+            if(rv <= Console::FAILURE || selected == "c")
+                return rv == Console::FAILURE ? CR_FAILURE : CR_OK;
             const char * start = selected.c_str();
             gm.g_mode = (GameMode) strtol(start, 0, 10);
-            rv = out.lineedit("Enter new game type number (c for exit): ",selected, hist);
-            if(rv < 0 || selected == "c")
-                return rv == -2 ? CR_OK : CR_FAILURE;
+            while((rv = out.lineedit("Enter new game type number (c for exit): ",selected, hist))
+                    == Console::RETRY);
+            if(rv <= Console::FAILURE || selected == "c")
+                return rv == Console::FAILURE ? CR_FAILURE : CR_OK;
             start = selected.c_str();
             gm.g_type = (GameType) strtol(start, 0, 10);
         }

--- a/plugins/tiletypes.cpp
+++ b/plugins/tiletypes.cpp
@@ -986,8 +986,10 @@ command_result df_tiletypes (color_ostream &out_, vector <string> & parameters)
         std::string input = "";
         int rv = 0;
 
-        if ((rv = out.lineedit("tiletypes> ",input,tiletypes_hist)) < 0)
-            return rv == -2 ? CR_OK : CR_FAILURE;
+        while ((rv = out.lineedit("tiletypes> ",input,tiletypes_hist))
+                == Console::RETRY);
+        if (rv <= Console::FAILURE)
+            return rv == Console::FAILURE ? CR_FAILURE : CR_OK;
         tiletypes_hist.add(input);
 
         commands.clear();


### PR DESCRIPTION
@lethosor Is this closer to behavior you expect from lineedit?

Windows seems to not to support ctrl+c at the moment.