### PR TITLE
Tsan race warning fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ if(WIN32)
   endif()
 endif()
 
+option(EXTERNAL_LIBSTDCXX "macOS only: Avoid installing the DFHack-provided libstdc++." OFF)
 if(APPLE)
   # libstdc++ (GCC 4.8.5 for OS X 10.6)
   # fixes crash-on-unwind bug in DF's libstdc++
@@ -346,9 +347,10 @@ if(APPLE)
     endif()
   endif()
 
-  install(PROGRAMS ${LIBSTDCXX_DOWNLOAD_DIR}/libstdc++.6.dylib
-    DESTINATION ./hack/)
-
+  if(NOT EXTERNAL_LIBSTDCXX)
+    install(PROGRAMS ${LIBSTDCXX_DOWNLOAD_DIR}/libstdc++.6.dylib
+      DESTINATION ./hack/)
+  endif()
 endif()
 
 #### expose depends ####

--- a/depends/lua/CMakeLists.txt
+++ b/depends/lua/CMakeLists.txt
@@ -95,6 +95,13 @@ LIST(APPEND SRC_LIBLUA ${HDR_LIBLUA})
 ADD_LIBRARY ( lua SHARED ${SRC_LIBLUA} )
 TARGET_LINK_LIBRARIES ( lua ${LIBS})
 
+target_include_directories(lua PRIVATE ../)
+if (MSVC)
+    target_compile_options(lua PRIVATE /FI lualimit.h)
+else ()
+    target_compile_options(lua PRIVATE -include lualimit.h)
+endif ()
+
 install(TARGETS lua
         LIBRARY DESTINATION ${DFHACK_LIBRARY_DESTINATION}
         RUNTIME DESTINATION ${DFHACK_LIBRARY_DESTINATION})

--- a/depends/lua/CMakeLists.txt
+++ b/depends/lua/CMakeLists.txt
@@ -95,11 +95,10 @@ LIST(APPEND SRC_LIBLUA ${HDR_LIBLUA})
 ADD_LIBRARY ( lua SHARED ${SRC_LIBLUA} )
 TARGET_LINK_LIBRARIES ( lua ${LIBS})
 
-target_include_directories(lua PRIVATE ../)
 if (MSVC)
-    target_compile_options(lua PRIVATE /FI lualimit.h)
+    target_compile_options(lua PRIVATE /FI dfhack_llimits.h)
 else ()
-    target_compile_options(lua PRIVATE -include lualimit.h)
+    target_compile_options(lua PRIVATE -include dfhack_llimits.h)
 endif ()
 
 install(TARGETS lua

--- a/depends/lua/include/dfhack_llimits.h
+++ b/depends/lua/include/dfhack_llimits.h
@@ -31,7 +31,7 @@ redistribute it freely, subject to the following restrictions:
 
 #include <stdlib.h>
 
-/*! \file lualimit.h
+/*! \file dfhack_llimits.h
  * dfhack specific lua porting header that overrides lua defaults for thread
  * safety.
  */

--- a/depends/lualimit.h
+++ b/depends/lualimit.h
@@ -1,0 +1,61 @@
+/**
+Copyright © 2018 Pauli <suokkos@gmail.com>
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+   not claim that you wrote the original software. If you use this
+   software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+   must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+   distribution.
+ */
+
+#pragma once
+
+#ifdef _MSC_VER
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+#include <stdlib.h>
+
+/*! \file lualimit.h
+ * dfhack specific lua porting header that overrides lua defaults for thread
+ * safety.
+ */
+
+#ifdef _MSC_VER
+typedef CRITICAL_SECTION mutex_t;
+#else
+typedef pthread_mutex_t mutex_t;
+#endif
+
+struct lua_extra_state {
+    mutex_t* mutex;
+};
+
+#define luai_mutex(L) ((lua_extra_state*)lua_getextraspace(L))->mutex
+
+#ifdef _MSC_VER
+#define luai_userstateopen(L) luai_mutex(L) = (mutex_t*)malloc(sizeof(mutex_t)); InitializeCriticalSection(luai_mutex(L))
+#define luai_userstateclose(L) lua_unlock(L); DeleteCriticalSection(luai_mutex(L)); free(luai_mutex(L))
+#define lua_lock(L) EnterCriticalSection(luai_mutex(L))
+#define lua_unlock(L) LeaveCriticalSection(luai_mutex(L))
+#else
+#define luai_userstateopen(L) luai_mutex(L) = (mutex_t*)malloc(sizeof(mutex_t)); *luai_mutex(L) = PTHREAD_MUTEX_INITIALIZER
+#define luai_userstateclose(L) lua_unlock(L); pthread_mutex_destroy(luai_mutex(L)); free(luai_mutex(L))
+#define lua_lock(L) pthread_mutex_lock(luai_mutex(L))
+#define lua_unlock(L) pthread_mutex_unlock(luai_mutex(L))
+#endif

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1529,6 +1529,7 @@ Core::Core() :
     HotkeyMutex{},
     HotkeyCond{},
     alias_mutex{},
+    started{false},
     misc_data_mutex{},
     CoreSuspendMutex{},
     CoreWakeup{},
@@ -1538,7 +1539,7 @@ Core::Core() :
     // init the console. This must be always the first step!
     plug_mgr = 0;
     errorstate = false;
-    started = false;
+    vinfo = 0;
     memset(&(s_mods), 0, sizeof(s_mods));
 
     // set up hotkey capture

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1427,6 +1427,7 @@ bool Core::loadScriptFile(color_ostream &out, string fname, bool silent)
 
 static void run_dfhack_init(color_ostream &out, Core *core)
 {
+    CoreSuspender lock;
     if (!df::global::world || !df::global::ui || !df::global::gview)
     {
         out.printerr("Key globals are missing, skipping loading dfhack.init.\n");

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -283,7 +283,7 @@ namespace DFHack
         df::viewscreen *top_viewscreen;
         bool last_pause_state;
         // Very important!
-        bool started;
+        std::atomic<bool> started;
         // Additional state change scripts
         std::vector<StateChangeScript> state_change_scripts;
 

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -308,7 +308,6 @@ namespace DFHack
         friend class CoreSuspenderBase;
         friend struct CoreSuspendClaimMain;
         friend struct CoreSuspendReleaseMain;
-        ServerMain *server;
     };
 
     class CoreSuspenderBase  : protected std::unique_lock<std::recursive_mutex> {

--- a/library/include/RemoteServer.h
+++ b/library/include/RemoteServer.h
@@ -28,6 +28,8 @@ distribution.
 #include "RemoteClient.h"
 #include "Core.h"
 
+#include <future>
+
 class CPassiveSocket;
 class CActiveSocket;
 class CSimpleSocket;
@@ -233,26 +235,25 @@ namespace  DFHack
         CoreService *core_service;
         std::map<std::string, RPCService*> plugin_services;
 
-        tthread::thread *thread;
-        static void threadFn(void *);
         void threadFn();
+        ServerConnection(CActiveSocket* socket);
+        ~ServerConnection();
 
     public:
-        ServerConnection(CActiveSocket *socket);
-        ~ServerConnection();
+
+        static void Accepted(CActiveSocket* socket);
 
         ServerFunctionBase *findFunction(color_ostream &out, const std::string &plugin, const std::string &name);
     };
 
     class ServerMain {
-        CPassiveSocket *socket;
+        static std::mutex access_;
+        static bool blocked_;
+        friend struct BlockGuard;
 
-        tthread::thread *thread;
-        static void threadFn(void *);
     public:
-        ServerMain();
-        ~ServerMain();
 
-        bool listen(int port);
+        static std::future<bool> listen(int port);
+        static void block();
     };
 }


### PR DESCRIPTION
Make lua data race free 

Fixes tsan trace report between lua viewscreen and other threads running
lua without CoreSuspender lock. But I would assume similar races exists
when using lua from console thread, remote thread and vmethods same time.


Fix data race between threaded init and EventManager

The initial run_dfhack_init loads shared state information that is used
by EventManager when state changes. There is a small risk that
EventManager can handle events while run_dfhack_init is still running.

Make ServerMain and ServerConnection data race free

RemoteServer and PluginManager side would need complete redesign to be
data race free and concurrent. But as that would be unlikely to be
required from DFHack I decided simpler solution that is fixing data
ownership to a thread and all ServerConnection share a single lock which
allows access to PluginManager and Core.