### PR TITLE
Fix windows ReadConsoleInput return value check

### DIFF
--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -285,7 +285,7 @@ namespace DFHack
                 INPUT_RECORD rec;
                 DWORD count;
                 lock->unlock();
-                if (ReadConsoleInputA(console_in, &rec, 1, &count) != 0) {
+                if (ReadConsoleInputA(console_in, &rec, 1, &count) == 0) {
                     lock->lock();
                     return Console::SHUTDOWN;
                 }


### PR DESCRIPTION
I messed up the check. I forgot that windows commonly has opposite
return values to posix and failed to check it from documentation.

Fixes #1345

Still untested as I don't have windows machine.