### PR TITLE
Fix crash when editing lines that are exactly console width

### DIFF
--- a/library/Console-posix.cpp
+++ b/library/Console-posix.cpp
@@ -486,9 +486,10 @@ namespace DFHack
             int cooked_cursor = raw_cursor;
             if ((plen+cooked_cursor) >= cols)
             {
-                begin = plen+cooked_cursor-cols-1;
-                len -= plen+cooked_cursor-cols-1;
-                cooked_cursor -= plen+cooked_cursor-cols-1;
+                const int text_over = plen + cooked_cursor + 1 - cols;
+                begin = text_over;
+                len -= text_over;
+                cooked_cursor -= text_over;
             }
             if (plen+len > cols)
                 len -= plen+len - cols;


### PR DESCRIPTION
plen+cooked_cursor==cols => begin = -1 which is passed to substr. The
sign is incorrect as code should be removing a character from begin
instead of trying to add a character.