### PR TITLE
Fix windows crash when _exit calls static destructors in dll unload

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Fixed special characters in `command-prompt` and other non-console in-game outputs on Linux/macOS (in tools using ``df2console``)
 - `dwarfmonitor`, `manipulator`: fixed stress cutoffs
 - `startdwarf`: fixed on 64-bit Linux
+- `die`: Fixed windows crash in the exit handling
 
 ## API
 - Added to ``Units`` module:

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1163,7 +1163,7 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
         }
         else if (builtin == "die")
         {
-            _exit(666);
+            std::_Exit(666);
         }
         else if (builtin == "kill-lua")
         {

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -98,7 +98,8 @@ static bool parseKeySpec(std::string keyspec, int *psym, int *pmod, std::string 
 size_t loadScriptFiles(Core* core, color_ostream& out, const vector<std::string>& prefix, const std::string& folder);
 
 namespace DFHack {
-struct MainThread {
+class MainThread {
+public:
     //! MainThread::suspend keeps the main DF thread suspended from Core::Init to
     //! thread exit.
     static CoreSuspenderBase& suspend() {

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1479,17 +1479,7 @@ void fIOthread(void * iodata)
 
 Core::~Core()
 {
-    if (MainThread::suspend().owns_lock())
-        MainThread::suspend().unlock();
-
-    if (d->hotkeythread.joinable()) {
-        std::lock_guard<std::mutex> lock(HotkeyMutex);
-        hotkey_set = SHUTDOWN;
-        HotkeyCond.notify_one();
-    }
-    if (d->iothread.joinable())
-        con.shutdown();
-    delete d;
+    // we leak the memory in case ~Core is called after _exit
 }
 
 Core::Core() :
@@ -2299,6 +2289,8 @@ int Core::Shutdown ( void )
     }
     allModules.clear();
     memset(&(s_mods), 0, sizeof(s_mods));
+    delete d;
+    d = nullptr;
     return -1;
 }
 


### PR DESCRIPTION

Fixes #1356 