### PR TITLE
Add CMakeSettings.json for MSVC 2017.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ tags
 #VS is annoying about this one.
 /build/win64/DF_PATH.txt
 /build/win32/DF_PATH.txt
+/.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ if(UNIX)
 endif()
 
 if(WIN32)
-  if((NOT MSVC) OR (NOT MSVC_VERSION STREQUAL 1900))
-    message(SEND_ERROR "MSVC 2015 is required")
+  if((NOT MSVC) OR (MSVC_VERSION LESS 1900) OR (MSVC_VERSION GREATER 1919))
+    message(SEND_ERROR "MSVC 2015 or 2017 is required")
   endif()
 endif()
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,305 @@
+{
+  // See https://go.microsoft.com//fwlink/?linkid=834763 for more information about this file.
+  "configurations": [
+    {
+      "name": "MSVC 32 Debug",
+      "generator": "Visual Studio 14 2015",
+      "configurationType": "RelWithDebInfo",
+      "intelliSenseMode": "windows-msvc-x86",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "32"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        },
+        {
+          "name": "REMOVE_SYMBOLS_FROM_DF_STUBS",
+          "value": "0"
+        }
+      ],
+      "installRoot": "${thisFileDir}/build/win32/DF"
+    },
+    {
+      "name": "MSVC 32 Release",
+      "generator": "Visual Studio 14 2015",
+      "configurationType": "Release",
+      "intelliSenseMode": "windows-msvc-x86",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "32"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        }
+      ],
+      "installRoot": "${thisFileDir}/build/win32/DF"
+    },
+    {
+      "name": "MSVC 64 Debug",
+      "generator": "Visual Studio 14 2015 Win64",
+      "configurationType": "RelWithDebInfo",
+      "intelliSenseMode": "windows-msvc-x64",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "64"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        },
+        {
+          "name": "REMOVE_SYMBOLS_FROM_DF_STUBS",
+          "value": "0"
+        }
+      ],
+      "installRoot": "${thisFileDir}/build/win64/DF"
+    },
+    {
+      "name": "MSVC 64 Release",
+      "generator": "Visual Studio 14 2015 Win64",
+      "configurationType": "Release",
+      "intelliSenseMode": "windows-msvc-x64",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "64"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        }
+      ],
+      "installRoot": "${thisFileDir}/build/win64/DF"
+    },
+    {
+      "name": "GCC 32 Debug",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/debug-32",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "RelWithDebInfo",
+      "intelliSenseMode": "linux-gcc-x86",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "32"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        },
+        {
+          "name": "REMOVE_SYMBOLS_FROM_DF_STUBS",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "name": "GCC 32 Release",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/release-32",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "Release",
+      "intelliSenseMode": "linux-gcc-x86",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "32"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "name": "GCC 64 Debug",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/debug-64",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "RelWithDebInfo",
+      "intelliSenseMode": "linux-gcc-x64",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "64"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        },
+        {
+          "name": "REMOVE_SYMBOLS_FROM_DF_STUBS",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "name": "GCC 64 Release",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/release-64",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "Release",
+      "intelliSenseMode": "linux-gcc-x64",
+      "variables": [
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "64"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "name": "GCC 4.8 32 Debug",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/debug-32-48",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "RelWithDebInfo",
+      "intelliSenseMode": "linux-gcc-x86",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "gcc-4.8"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "g++-4.8"
+        },
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "32"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        },
+        {
+          "name": "REMOVE_SYMBOLS_FROM_DF_STUBS",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "name": "GCC 4.8 32 Release",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/release-32-48",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "Release",
+      "intelliSenseMode": "linux-gcc-x86",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "gcc-4.8"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "g++-4.8"
+        },
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "32"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "name": "GCC 4.8 64 Debug",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/debug-64-48",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "RelWithDebInfo",
+      "intelliSenseMode": "linux-gcc-x64",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "gcc-4.8"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "g++-4.8"
+        },
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "64"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        },
+        {
+          "name": "REMOVE_SYMBOLS_FROM_DF_STUBS",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "name": "GCC 4.8 64 Release",
+      "remoteMachineName": "${defaultRemoteMachineName}",
+      "remoteCMakeListsRoot": "/tmp/dfhack-${workspaceHash}/src",
+      "remoteBuildRoot": "/tmp/dfhack-${workspaceHash}/release-64-48",
+      "rsyncCommandArgs": "--exclude=build --include=.git",
+      "remoteCopySources": true,
+      "cmakeExecutable": "$(which cmake)/..",
+      "generator": "Unix Makefiles",
+      "configurationType": "Release",
+      "intelliSenseMode": "linux-gcc-x64",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "gcc-4.8"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "g++-4.8"
+        },
+        {
+          "name": "DFHACK_BUILD_ARCH",
+          "value": "64"
+        },
+        {
+          "name": "BUILD_STONESENSE",
+          "value": "1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I tried to make the GCC settings as generic as possible, so anyone with SSH credentials configured in Visual Studio should be able to use this without modification.

I didn't add anything to help with starting the debugger, but that would be a good future addition. Microsoft's documentation, as always, is confusing and contradictory.

<!-- buildmaster:skip-pr -->