### PR TITLE
(labormanager) add support for craft item from pearl jobs (fixes #1162)

### DIFF
--- a/plugins/labormanager/joblabormapper.cpp
+++ b/plugins/labormanager/joblabormapper.cpp
@@ -516,7 +516,8 @@ public:
                     if (j->material_category.bits.bone ||
                         j->material_category.bits.horn ||
                         j->material_category.bits.tooth ||
-                        j->material_category.bits.shell)
+                        j->material_category.bits.shell ||
+                        j->material_category.bits.pearl)
                         return df::unit_labor::BONE_CARVE;
                     else
                     {


### PR DESCRIPTION
This adds job labor inference support for craft item from pearl jobs, and will close issue #1162.