### PR TITLE
Change dwarfmonitor to use global lua state.

### DIFF
--- a/plugins/dwarfmonitor.cpp
+++ b/plugins/dwarfmonitor.cpp
@@ -1877,7 +1877,7 @@ static bool set_monitoring_mode(const string &mode, const bool &state)
         code running that uses these values. So this could use another mutex
         or just suspend the core while we edit our values.
     */
-    CoreSuspender guard; 
+    CoreSuspender guard;
 
     if (mode == "work" || mode == "all")
     {

--- a/plugins/dwarfmonitor.cpp
+++ b/plugins/dwarfmonitor.cpp
@@ -1872,12 +1872,12 @@ static bool set_monitoring_mode(const string &mode, const bool &state)
 
     if (!is_enabled)
         return false;
-	/*
-		NOTE: although we are not touching DF directly but there might be
-		code running that uses these values. So this could use another mutex
-		or just suspend the core while we edit our values.
-	*/
-	CoreSuspender guard; 
+    /*
+        NOTE: although we are not touching DF directly but there might be
+        code running that uses these values. So this could use another mutex
+        or just suspend the core while we edit our values.
+    */
+    CoreSuspender guard; 
 
     if (mode == "work" || mode == "all")
     {
@@ -1913,10 +1913,10 @@ static bool load_config()
 DFhackCExport command_result plugin_enable(color_ostream &out, bool enable)
 {
     if (enable)
-	{
-		CoreSuspender guard;
+    {
+        CoreSuspender guard;
         load_config();
-	}
+    }
     if (is_enabled != enable)
     {
         if (!INTERPOSE_HOOK(dwarf_monitor_hook, render).apply(enable))
@@ -1971,19 +1971,19 @@ static command_result dwarfmonitor_cmd(color_ostream &out, vector <string> & par
         }
         else if (cmd == 's' || cmd == 'S')
         {
-			CoreSuspender guard;
+            CoreSuspender guard;
             if(Maps::IsValid())
                 Screen::show(dts::make_unique<ViewscreenFortStats>(), plugin_self);
         }
         else if (cmd == 'p' || cmd == 'P')
         {
-			CoreSuspender guard;
+            CoreSuspender guard;
             if(Maps::IsValid())
                 Screen::show(dts::make_unique<ViewscreenPreferences>(), plugin_self);
         }
         else if (cmd == 'r' || cmd == 'R')
         {
-			CoreSuspender guard;
+            CoreSuspender guard;
             load_config();
         }
         else
@@ -2035,7 +2035,7 @@ DFhackCExport command_result plugin_init(color_ostream &out, std::vector <Plugin
         "  Reload configuration file (dfhack-config/dwarfmonitor.json)\n"
         ));
 
-	dm_lua::state=Lua::Core::State;
+    dm_lua::state=Lua::Core::State;
     if (dm_lua::state == NULL)
         return CR_FAILURE;
 


### PR DESCRIPTION
This needs more CoreSuspends but they are needed either way. This way
you can access other script environments and access this plugin enviroment
from lua.