### PR TITLE
Fix EventManager building ID type

### DIFF
--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -1199,7 +1199,7 @@ void Buildings::clearBuildings(color_ostream& out) {
 
 void Buildings::updateBuildings(color_ostream& out, void* ptr)
 {
-    int32_t id = *((int32_t*)ptr);
+    int32_t id = (int32_t)(intptr_t)ptr;
     auto building = df::building::find(id);
 
     if (building)

--- a/library/modules/EventManager.cpp
+++ b/library/modules/EventManager.cpp
@@ -273,7 +273,7 @@ void DFHack::EventManager::onStateChange(color_ostream& out, state_change_event 
         }
         for ( size_t a = 0; a < df::global::world->buildings.all.size(); a++ ) {
             df::building* b = df::global::world->buildings.all[a];
-            Buildings::updateBuildings(out, (void*)&(b->id));
+            Buildings::updateBuildings(out, (void*)intptr_t(b->id));
             buildings.insert(b->id);
         }
         lastSyndromeTime = -1;
@@ -609,7 +609,7 @@ static void manageBuildingEvent(color_ostream& out) {
         buildings.insert(a);
         for ( auto b = copy.begin(); b != copy.end(); b++ ) {
             EventHandler bob = (*b).second;
-            bob.eventHandler(out, (void*)&a);
+            bob.eventHandler(out, (void*)intptr_t(a));
         }
     }
     nextBuilding = *df::global::building_next_id;
@@ -625,7 +625,7 @@ static void manageBuildingEvent(color_ostream& out) {
 
         for ( auto b = copy.begin(); b != copy.end(); b++ ) {
             EventHandler bob = (*b).second;
-            bob.eventHandler(out, (void*)&id);
+            bob.eventHandler(out, (void*)intptr_t(id));
         }
         a = buildings.erase(a);
     }

--- a/plugins/devel/eventExample.cpp
+++ b/plugins/devel/eventExample.cpp
@@ -175,8 +175,15 @@ void unitAttack(color_ostream& out, void* ptr) {
     EventManager::UnitAttackData* data = (EventManager::UnitAttackData*)ptr;
     out.print("unit %d attacks unit %d\n", data->attacker, data->defender);
     df::unit* defender = df::unit::find(data->defender);
+    if (!defender) {
+        out.printerr("defender %d does not exist\n", data->defender);
+        return;
+    }
     int32_t woundIndex = df::unit_wound::binsearch_index(defender->body.wounds, data->wound);
-    df::unit_wound* wound = defender->body.wounds[woundIndex];
+    df::unit_wound* wound = vector_get(defender->body.wounds, woundIndex);
+    if (!wound) {
+        return;
+    }
     set<int32_t> parts;
     for ( auto a = wound->parts.begin(); a != wound->parts.end(); a++ ) {
         parts.insert((*a)->body_part_id);


### PR DESCRIPTION
The pointer to the building ID was sometimes not dereferenced properly. Addressed by switching to an ID cast to a pointer type for consistency with other types of events.

(Note: not sure if this will reintroduce warnings that #1253 and 19695b4ee7e8b370c8ce53aa2dcd399e1e9ca94d fixed, hence the PR)

Fixes #1434
Ref #1003 (19695b4ee7e8b370c8ce53aa2dcd399e1e9ca94d)
Broken in #1253 (a7dfacd1c57490d08fc92a43eea963cff47c05eb)