### PR TITLE
Use Windows code page when processing console.

### DIFF
--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -387,5 +387,7 @@ DFHACK_EXPORT std::string stl_vsprintf(const char *fmt, va_list args) Wformat(pr
 // Conversion between CP437 and UTF-8
 DFHACK_EXPORT std::string UTF2DF(const std::string &in);
 DFHACK_EXPORT std::string DF2UTF(const std::string &in);
+DFHACK_EXPORT std::string UTF2CONSOLE(const std::string &in);
+DFHACK_EXPORT std::string UTF2CONSOLE(DFHack::color_ostream &out, const std::string &in);
 DFHACK_EXPORT std::string DF2CONSOLE(const std::string &in);
 DFHACK_EXPORT std::string DF2CONSOLE(DFHack::color_ostream &out, const std::string &in);


### PR DESCRIPTION
- Read input as UTF-16.
- Store history as UTF-8.
- Write output as current code page.
- Add helper functions for converting UTF-8 strings to console encoding.

Fixes #1474.

*Untested; submitting as a pull request because it's easier to compile this way.*