### PR TITLE
add Units::getPhysicalDescription

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1611,6 +1611,7 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, isOwnCiv),
     WRAPM(Units, isOwnGroup),
     WRAPM(Units, isOwnRace),
+    WRAPM(Units, getDescription),
     WRAPM(Units, getRaceName),
     WRAPM(Units, getRaceNamePlural),
     WRAPM(Units, getRaceBabyName),

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1611,7 +1611,7 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, isOwnCiv),
     WRAPM(Units, isOwnGroup),
     WRAPM(Units, isOwnRace),
-    WRAPM(Units, getDescription),
+    WRAPM(Units, getPhysicalDescription),
     WRAPM(Units, getRaceName),
     WRAPM(Units, getRaceNamePlural),
     WRAPM(Units, getRaceBabyName),

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -45,6 +45,17 @@ using std::endl;
     #define DFHACK_FUNCTION_SIG __func__
 #endif
 
+#ifdef _WIN32
+// On x86 MSVC, __thiscall passes |this| in ECX. On x86_64, __thiscall is the
+// same as the standard calling convention.
+// See https://docs.microsoft.com/en-us/cpp/cpp/thiscall for more info.
+#define THISCALL __thiscall
+#else
+// On other platforms, there's no special calling convention for calling member
+// functions.
+#define THISCALL
+#endif
+
 namespace DFHack {
     class color_ostream;
 }

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -120,7 +120,7 @@ DFHACK_EXPORT bool isVisible(df::unit* unit);
 
 DFHACK_EXPORT std::string getRaceNameById(int32_t race_id);
 DFHACK_EXPORT std::string getRaceName(df::unit* unit);
-DFHACK_EXPORT std::string getDescription(df::unit* unit);
+DFHACK_EXPORT std::string getPhysicalDescription(df::unit* unit);
 DFHACK_EXPORT std::string getRaceNamePluralById(int32_t race_id);
 DFHACK_EXPORT std::string getRaceNamePlural(df::unit* unit);
 DFHACK_EXPORT std::string getRaceBabyNameById(int32_t race_id);

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -120,6 +120,7 @@ DFHACK_EXPORT bool isVisible(df::unit* unit);
 
 DFHACK_EXPORT std::string getRaceNameById(int32_t race_id);
 DFHACK_EXPORT std::string getRaceName(df::unit* unit);
+DFHACK_EXPORT std::string getDescription(df::unit* unit);
 DFHACK_EXPORT std::string getRaceNamePluralById(int32_t race_id);
 DFHACK_EXPORT std::string getRaceNamePlural(df::unit* unit);
 DFHACK_EXPORT std::string getRaceBabyNameById(int32_t race_id);

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -541,20 +541,13 @@ string Units::getRaceName(df::unit* unit)
     return getRaceNameById(unit->race);
 }
 
-#ifdef _WIN32
-#define THISCALL __thiscall
-#else
-#define THISCALL
-#endif
-
-typedef void (THISCALL *df_unit_physical_description_fn)(df::unit*, string*);
 void df_unit_physical_description(df::unit* unit, string* out_str)
 {
-    static df_unit_physical_description_fn fn =
-        reinterpret_cast<df_unit_physical_description_fn>(
+    static auto* const fn =
+        reinterpret_cast<void(THISCALL *)(df::unit*, string*)>(
             Core::getInstance().vinfo->getAddress("unit_physical_description"));
-    if (fn)
-        fn(unit, out_str);
+    CHECK_NULL_POINTER(fn);
+    fn(unit, out_str);
 }
 
 string Units::getDescription(df::unit* unit)

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -541,7 +541,13 @@ string Units::getRaceName(df::unit* unit)
     return getRaceNameById(unit->race);
 }
 
-typedef void (*df_unit_physical_description_fn)(df::unit*, string*);
+#ifdef _WIN32
+#define THISCALL __thiscall
+#else
+#define THISCALL
+#endif
+
+typedef void (THISCALL *df_unit_physical_description_fn)(df::unit*, string*);
 void df_unit_physical_description(df::unit* unit, string* out_str)
 {
     static df_unit_physical_description_fn fn =

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -541,13 +541,21 @@ string Units::getRaceName(df::unit* unit)
     return getRaceNameById(unit->race);
 }
 
-typedef void (*df_unit_desc_fn)(df::unit*, std::string*);
-static df_unit_desc_fn df_unit_desc = reinterpret_cast<df_unit_desc_fn>(0x100cbb890);
+typedef void (*df_unit_physical_description_fn)(df::unit*, string*);
+void df_unit_physical_description(df::unit* unit, string* out_str)
+{
+    static df_unit_physical_description_fn fn =
+        reinterpret_cast<df_unit_physical_description_fn>(
+            Core::getInstance().vinfo->getAddress("unit_physical_description"));
+    if (fn)
+        fn(unit, out_str);
+}
+
 string Units::getDescription(df::unit* unit)
 {
     CHECK_NULL_POINTER(unit);
-    std::string str;
-    df_unit_desc(unit, &str);
+    string str;
+    df_unit_physical_description(unit, &str);
     return str;
 }
 

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -541,11 +541,11 @@ string Units::getRaceName(df::unit* unit)
     return getRaceNameById(unit->race);
 }
 
-void df_unit_physical_description(df::unit* unit, string* out_str)
+void df_unit_get_physical_description(df::unit* unit, string* out_str)
 {
     static auto* const fn =
         reinterpret_cast<void(THISCALL *)(df::unit*, string*)>(
-            Core::getInstance().vinfo->getAddress("unit_physical_description"));
+            Core::getInstance().vinfo->getAddress("unit_get_physical_description"));
     if (fn)
         fn(unit, out_str);
     else
@@ -556,7 +556,7 @@ string Units::getPhysicalDescription(df::unit* unit)
 {
     CHECK_NULL_POINTER(unit);
     string str;
-    df_unit_physical_description(unit, &str);
+    df_unit_get_physical_description(unit, &str);
     return str;
 }
 

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -546,8 +546,10 @@ void df_unit_physical_description(df::unit* unit, string* out_str)
     static auto* const fn =
         reinterpret_cast<void(THISCALL *)(df::unit*, string*)>(
             Core::getInstance().vinfo->getAddress("unit_physical_description"));
-    CHECK_NULL_POINTER(fn);
-    fn(unit, out_str);
+    if (fn)
+        fn(unit, out_str);
+    else
+        *out_str = "";
 }
 
 string Units::getPhysicalDescription(df::unit* unit)

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -550,7 +550,7 @@ void df_unit_physical_description(df::unit* unit, string* out_str)
     fn(unit, out_str);
 }
 
-string Units::getDescription(df::unit* unit)
+string Units::getPhysicalDescription(df::unit* unit)
 {
     CHECK_NULL_POINTER(unit);
     string str;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -541,6 +541,16 @@ string Units::getRaceName(df::unit* unit)
     return getRaceNameById(unit->race);
 }
 
+typedef void (*df_unit_desc_fn)(df::unit*, std::string*);
+static df_unit_desc_fn df_unit_desc = reinterpret_cast<df_unit_desc_fn>(0x100cbb890);
+string Units::getDescription(df::unit* unit)
+{
+    CHECK_NULL_POINTER(unit);
+    std::string str;
+    df_unit_desc(unit, &str);
+    return str;
+}
+
 // get plural of race name (used for display in autobutcher UI and for sorting the watchlist)
 string Units::getRaceNamePluralById(int32_t id)
 {

--- a/plugins/proto/RemoteFortressReader.proto
+++ b/plugins/proto/RemoteFortressReader.proto
@@ -420,7 +420,7 @@ message UnitAppearance
     optional Hair beard = 6;
     optional Hair moustache = 7;
     optional Hair sideburns = 8;
-    optional string description = 9;
+    optional string physical_description = 9;
 }
 
 message InventoryItem

--- a/plugins/proto/RemoteFortressReader.proto
+++ b/plugins/proto/RemoteFortressReader.proto
@@ -420,6 +420,7 @@ message UnitAppearance
     optional Hair beard = 6;
     optional Hair moustache = 7;
     optional Hair sideburns = 8;
+    optional string description = 9;
 }
 
 message InventoryItem

--- a/plugins/remotefortressreader/remotefortressreader.cpp
+++ b/plugins/remotefortressreader/remotefortressreader.cpp
@@ -1750,7 +1750,7 @@ static command_result GetUnitListInside(color_ostream &stream, const BlockReques
             appearance->add_colors(unit->appearance.colors[j]);
         appearance->set_size_modifier(unit->appearance.size_modifier);
 
-        appearance->set_description(Units::getDescription(unit));
+        appearance->set_physical_description(Units::getPhysicalDescription(unit));
 
         send_unit->set_profession_id(unit->profession);
 

--- a/plugins/remotefortressreader/remotefortressreader.cpp
+++ b/plugins/remotefortressreader/remotefortressreader.cpp
@@ -1750,6 +1750,8 @@ static command_result GetUnitListInside(color_ostream &stream, const BlockReques
             appearance->add_colors(unit->appearance.colors[j]);
         appearance->set_size_modifier(unit->appearance.size_modifier);
 
+        appearance->set_description(Units::getDescription(unit));
+
         send_unit->set_profession_id(unit->profession);
 
         std::vector<Units::NoblePosition> pvec;


### PR DESCRIPTION
This returns the physical unit description seen on the unit screen, e.g.

> His very long sideburns are braided.  His very long moustache is arranged in double braids.  His very long beard is arranged in double braids.  His hair is clean-shaven.  He has a scratchy voice.  His free-lobed ears are splayed out.  His nose is narrow.  His lips are very thin.  His nose bridge is slightly convex.  His dark peach skin is slightly wrinkled.  His emerald eyes have slightly thin irises.  His hair is ecru with a touch of gray.

There's no easy way to reproduce this string directly from the body information, as there's a substantial amount of logic that goes into deciding what appears in this string and in what order.

Requires a new symbol in symbols.txt, which I've currently only found for macos x64 (0x100cbb890), but I'll find it on other platforms if this is plausibly mergeable! I found it by setting a memory-read breakpoint on a constant string that appears in that description (e.g. "incredibly short"), then jumping up the stack trace until I found this function.