### PR TITLE
Partial correction of issue 1479 and added verbose flag

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `embark-assistant`:
     - fixed bug causing crash on worlds without generated metals (as well as pruning vectors as originally intended).
     - fixed bug causing mineral matching to fail to cut off at the magma sea, reporting presence of things that aren't (like DF does currently).
+- `getplants`: fixed designation of plants out of season and added verbose flag, but failed to identify picked plants (which are still designated incorrectly)
 - `gui/autogems`: fixed error when no world is loaded
 - `gui/companion-order`:
     - fixed error when resetting group leaders

--- a/plugins/devel/CMakeLists.txt
+++ b/plugins/devel/CMakeLists.txt
@@ -1,6 +1,8 @@
 IF(UNIX)
 DFHACK_PLUGIN(vectors vectors.cpp)
-endif()
+ENDIF()
+
+INCLUDE(FindThreads)
 
 ADD_DEFINITIONS(-DDEV_PLUGIN)
 DFHACK_PLUGIN(buildprobe buildprobe.cpp)

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -84,7 +84,7 @@ selectability selectablePlant(const df::plant_raw *plant)
         return selectability::Selectable;
     }
 
-    for (auto i = 0; i < plant->growths.size(); i++)
+    for (size_t i = 0; i < plant->growths.size(); i++)
     {
         if (plant->growths[i]->item_type == df::item_type::SEEDS ||  //  Only trees have seed growths in vanilla, but raws can be modded...
             plant->growths[i]->item_type == df::item_type::PLANT_GROWTH)
@@ -146,7 +146,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
 {
     string plantMatStr = "";
     std::vector<selectability> plantSelections;
-    std::vector<uint16_t> collectionCount;
+    std::vector<size_t> collectionCount;
     set<string> plantNames;
     bool deselect = false, exclude = false, treesonly = false, shrubsonly = false, all = false, verbose = false;
 
@@ -155,7 +155,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
     plantSelections.resize(world->raws.plants.all.size());
     collectionCount.resize(world->raws.plants.all.size());
 
-    for (auto i = 0; i < plantSelections.size(); i++)
+    for (size_t i = 0; i < plantSelections.size(); i++)
     {
         plantSelections[i] = selectability::Unselected;
         collectionCount[i] = 0;
@@ -248,7 +248,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
         return CR_FAILURE;
     }
 
-    for (auto i = 0; i < plantSelections.size(); i++)
+    for (size_t i = 0; i < plantSelections.size(); i++)
     {
         if (plantSelections[i] == selectability::OutOfSeason ||
             plantSelections[i] == selectability::Selectable)
@@ -327,7 +327,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
         }
         if (!deselect && Designations::markPlant(plant))
         {
-//            out.print("Designated %s at (%i, %i, %i), %i\n", world->raws.plants.all[plant->material]->id.c_str(), plant->pos.x, plant->pos.y, plant->pos.z, i);
+//            out.print("Designated %s at (%i, %i, %i), %d\n", world->raws.plants.all[plant->material]->id.c_str(), plant->pos.x, plant->pos.y, plant->pos.z, i);
             collectionCount[plant->material]++;
             ++count;
         }
@@ -336,10 +336,10 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
     {
         if (verbose)
         {
-            for (auto i = 0; i < plantSelections.size(); i++)
+            for (size_t i = 0; i < plantSelections.size(); i++)
             {
                 if (collectionCount[i] > 0)
-                    out.print("Updated %i %s designations.\n", collectionCount[i], world->raws.plants.all[i]->id.c_str());
+                    out.print("Updated %d %s designations.\n", collectionCount[i], world->raws.plants.all[i]->id.c_str());
             }
             out.print("\n");
         }
@@ -357,11 +357,11 @@ DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCom
         "  Specify the types of trees to cut down and/or shrubs to gather by their\n"
         "  plant IDs, separated by spaces.\n"
         "Options:\n"
-        "  -t - Select trees only (exclude shrubs)\n"
-        "  -s - Select shrubs only (exclude trees)\n"
-        "  -c - Clear designations instead of setting them\n"
-        "  -x - Apply selected action to all plants except those specified\n"
-        "  -a - Select every type of plant (obeys -t/-s)\n"
+        "  -t - Tree: Select trees only (exclude shrubs)\n"
+        "  -s - Shrub: Select shrubs only (exclude trees)\n"
+        "  -c - Clear: Clear designations instead of setting them\n"
+        "  -x - eXept: Apply selected action to all plants except those specified\n"
+        "  -a - All: Select every type of plant (obeys -t/-s)\n"
         "  -v - Verbose: lists the number of (un)designations per plant\n"
         "Specifying both -t and -s will have no effect.\n"
         "If no plant IDs are specified, all valid plant IDs will be listed.\n"

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -127,7 +127,7 @@ selectability selectablePlant(const df::plant_raw *plant)
                         outOfSeason = true;
                     }
                 }
-            }  */          
+            }  */
     }
 
     if (outOfSeason)

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -327,7 +327,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
         }
         if (!deselect && Designations::markPlant(plant))
         {
-//            out.print("Designated %s at (%i, %i, %i), %d\n", world->raws.plants.all[plant->material]->id.c_str(), plant->pos.x, plant->pos.y, plant->pos.z, i);
+//            out.print("Designated %s at (%i, %i, %i), %d\n", world->raws.plants.all[plant->material]->id.c_str(), plant->pos.x, plant->pos.y, plant->pos.z, (int)i);
             collectionCount[plant->material]++;
             ++count;
         }
@@ -339,12 +339,12 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
             for (size_t i = 0; i < plantSelections.size(); i++)
             {
                 if (collectionCount[i] > 0)
-                    out.print("Updated %d %s designations.\n", collectionCount[i], world->raws.plants.all[i]->id.c_str());
+                    out.print("Updated %d %s designations.\n", (int)collectionCount[i], world->raws.plants.all[i]->id.c_str());
             }
             out.print("\n");
         }
     }
-    out.print("Updated %d plant designations.\n", count);
+    out.print("Updated %d plant designations.\n", (int)count);
 
     return CR_OK;
 }

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -94,7 +94,7 @@ selectability selectablePlant(const df::plant_raw *plant)
                  (growth_mat.material->flags.is_set(material_flags::EDIBLE_COOKED) ||
                   growth_mat.material->flags.is_set(material_flags::EDIBLE_RAW))) ||
                 (plant->growths[i]->item_type == df::item_type::PLANT_GROWTH &&
-                 growth_mat.material->flags.is_set(material_flags::STOCKPILE_PLANT_GROWTH)))
+                 growth_mat.material->flags.is_set(material_flags::LEAF_MAT)))  //  Will change name to STOCKPILE_PLANT_GROWTH any day now...
             {
                 if (*cur_year_tick >= plant->growths[i]->timing_1 &&
                     (plant->growths[i]->timing_2 == -1 ||
@@ -333,16 +333,17 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
         }
     }
     if (count)
+    {
         if (verbose)
         {
             for (auto i = 0; i < plantSelections.size(); i++)
             {
-                if (collectionCount [i] > 0)
-                    out.print("Updated %i %s designations.\n", collectionCount [i], world->raws.plants.all [i]->id.c_str());
+                if (collectionCount[i] > 0)
+                    out.print("Updated %i %s designations.\n", collectionCount[i], world->raws.plants.all[i]->id.c_str());
             }
             out.print("\n");
         }
-
+    }
     out.print("Updated %d plant designations.\n", count);
 
     return CR_OK;


### PR DESCRIPTION
I've been unable to identify where DF stores information about actual growths on plants, and so the correction only removes plants where growths are out of season, but not those already gathered.

(#1479)