### PR TITLE
exit if a fatal startup error is encountered while in headless mode

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1579,6 +1579,12 @@ void Core::fatal (std::string output)
 #else
     cout << "DFHack fatal error: " << out.str() << std::endl;
 #endif
+
+    bool is_headless = bool(getenv("DFHACK_HEADLESS"));
+    if (is_headless)
+    {
+        exit('f');
+    }
 }
 
 std::string Core::getHackPath()


### PR DESCRIPTION
exit code `'f'` (102) is so the test script can detect it.