### PR TITLE
Define MapExtras::BiomeInfo::MAX_LAYERS

### DIFF
--- a/library/modules/MapCache.cpp
+++ b/library/modules/MapCache.cpp
@@ -79,6 +79,8 @@ using df::global::world;
 
 extern bool GetLocalFeature(t_feature &feature, df::coord2d rgn_pos, int32_t index);
 
+constexpr unsigned MapExtras::BiomeInfo::MAX_LAYERS;
+
 const BiomeInfo MapCache::biome_stub = {
     df::coord2d(),
     -1, -1, -1, -1,


### PR DESCRIPTION
Definition is required even for constexpr variables in some compilation
setups (e.g. debug builds).

fix #1495