### PR TITLE
 allow custom filter in calls to `dfhack.printall_recurse`

### DIFF
--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -285,8 +285,8 @@ do_print_recurse = function(printfn, value, seen, indent)
     return recurse_type_map[t](printfn, value, seen, indent)
 end
 
-function printall_recurse(value)
-    local seen = {}
+function printall_recurse(value, seen)
+    local seen = seen or {}
     do_print_recurse(dfhack.println, value, seen, 0)
 end
 


### PR DESCRIPTION
Objects with links like `job` output way too much. With this change, it's possible to provide an optional filter and exclude the `list_link` (and other stuff).
```
[lua]# j = dfhack.gui.getSelectedJob()
[lua]# printall_recurse(j, {[tostring(j.list_link)]=true, [tostring(j.pos)]=true})
```