### PR TITLE
Fix widgets.FilteredList widget search on plain string choices

### DIFF
--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -736,9 +736,9 @@ end
 
 function FilteredList:setChoices(choices, pos)
     choices = choices or {}
-    self.choices = choices
     self.edit.text = ''
     self.list:setChoices(choices, pos)
+    self.choices = self.list.choices
     self.not_found.visible = (#choices == 0)
 end
 


### PR DESCRIPTION
Using search feature of `FilteredList` with plain string choices was throwing errors :

 ```lua
widgets.FilteredList { choices =  { "foo", "bar" } }
```

> ./hack/lua/gui/widgets.lua:795: bad argument #1 to 'match' (string expected, got nil)

Inside `FilteredList:setChoices`, choices list is correctly given to `self.list:setChoices` but `self.choices` isn't updated afterward and thus not correctly formatted. (_e.g._ `"foo"` isn't formatted to `{text = "foo" ...}` )
