### PR TITLE
getFullName of the container AND the item, also exclude container of char

### DIFF
--- a/library/DataDefs.cpp
+++ b/library/DataDefs.cpp
@@ -540,7 +540,8 @@ const struct_field_info *DFHack::find_union_tag(const struct_field_info *fields,
     }
 
     auto union_fields = ((struct_identity*)union_field->type)->getFields();
-    if (tag_container_type->getFullName(nullptr) != "vector<bool>" &&
+    if (tag_container_type->getFullName() != "vector<bool>" &&
+            tag_container_type->getFullName() != "vector<char>" &&
             union_fields[0].mode != struct_field_info::END &&
             union_fields[1].mode != struct_field_info::END &&
             union_fields[2].mode == struct_field_info::END)

--- a/library/DataDefs.cpp
+++ b/library/DataDefs.cpp
@@ -540,8 +540,7 @@ const struct_field_info *DFHack::find_union_tag(const struct_field_info *fields,
     }
 
     auto union_fields = ((struct_identity*)union_field->type)->getFields();
-    if (tag_container_type->getFullName() != "vector<bool>" &&
-            tag_container_type->getFullName() != "vector<char>" &&
+    if (tag_container_type->getFullName() == "vector<bool>" &&
             union_fields[0].mode != struct_field_info::END &&
             union_fields[1].mode != struct_field_info::END &&
             union_fields[2].mode == struct_field_info::END)


### PR DESCRIPTION
While debugging further (see debugging session bellow), I found that calling `tag_container_type->getFullName(nullptr)` will always returns only the container name with `void` as its item, so I change this to call `tag_container_type->getFullName()`.

Also, it seems in this particular case that the container is a `vector<char>`, so I excluded this one also from the if (where we assume the container contains a struct ?).

Anyway, I may not really know what I am doing, but it fixes #1514 , so it works now and I had fun doing it :)

```
(gdb) info locals
__PRETTY_FUNCTION__ = "const DFHack::struct_field_info* DFHack::find_union_tag(const DFHack::struct_field_info*, const DFHack::struct_field_info*)"
tag_candidate = 0x7ffff7f3f780 <df::viewscreen_petst_fields+96>
container_type = <optimized out>
tag_container_type = 0x7ffff7f77c00 <df::identity_traits<std::vector<char, std::allocator<char> > >::get()::identity>
union_fields = 0x1

(gdb) ptype tag_candidate
type = const struct DFHack::struct_field_info {
    DFHack::struct_field_info::Mode mode;
    const char *name;
    size_t offset;
    DFHack::type_identity *type;
    size_t count;
    DFHack::enum_identity *eid;
} *

(gdb) p tag_candidate.name
$29 = 0x7ffff7cf8881 "is_vermin"

(gdb) ptype tag_container_type
type = class DFHack::container_identity : public DFHack::constructed_identity {
  private:
    DFHack::type_identity *item;
    DFHack::enum_identity *ienum;

  public:
    container_identity(size_t, DFHack::TAllocateFn, DFHack::type_identity *, DFHack::enum_identity *);
    virtual DFHack::identity_type type(void);
    virtual std::string getFullName(void);
    virtual std::string getFullName(DFHack::type_identity *);
    virtual void build_metatable(lua_State *);
    virtual bool isContainer(void);
    DFHack::type_identity * getItemType(void);
    DFHack::type_identity * getIndexEnumType(void);
    int lua_item_count(lua_State *, void *, DFHack::container_identity::CountMode);
    virtual void lua_item_reference(lua_State *, int, void *, int);
    virtual void lua_item_read(lua_State *, int, void *, int);
    virtual void lua_item_write(lua_State *, int, void *, int, int);
    virtual bool is_readonly(void);
    virtual bool resize(void *, int);
    virtual bool erase(void *, int);
    virtual bool insert(void *, int, void *);
    virtual bool lua_insert2(lua_State *, int, void *, int, int);
  protected:
    virtual int item_count(void *, DFHack::container_identity::CountMode);
    virtual void * item_pointer(DFHack::type_identity *, void *, int);
} *

(gdb) p tag_container_type->getFullName()
warning: RTTI symbol not found for class 'df::stl_container_identity<std::vector<char, std::allocator<char> > >'
warning: RTTI symbol not found for class 'df::stl_container_identity<std::vector<char, std::allocator<char> > >'
warning: RTTI symbol not found for class 'df::stl_container_identity<std::vector<char, std::allocator<char> > >'
$7 = "vector<char>"
```