### PR TITLE
Activate autodump in default config

### DIFF
--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -245,6 +245,7 @@ enable \
  dwarfmonitor \
  mousequery \
  autogems \
+ autodump \
  automelt \
  autotrade \
  buildingplan \


### PR DESCRIPTION
Autodump is a useful plugin that most players would probably want so it should be active in the default config.