### PR TITLE
Update embark-profile-name tweak

### DIFF
--- a/plugins/tweak/tweaks/embark-profile-name.h
+++ b/plugins/tweak/tweaks/embark-profile-name.h
@@ -13,6 +13,9 @@ struct embark_profile_name_hook : df::viewscreen_setupdwarfgamest {
         if( in_save_profile && ch >= 33 && ch <= 126 ) {
             profile_name.push_back( ( char )ch );
         } else {
+            if( input->count( df::interface_key::LEAVESCREEN ) ) {
+                input->insert( df::interface_key::SETUPGAME_SAVE_PROFILE_ABORT );
+            }
             INTERPOSE_NEXT( feed )( input );
         }
     }

--- a/plugins/tweak/tweaks/embark-profile-name.h
+++ b/plugins/tweak/tweaks/embark-profile-name.h
@@ -1,22 +1,21 @@
 #include "df/viewscreen_setupdwarfgamest.h"
-using namespace DFHack;
+
 struct embark_profile_name_hook : df::viewscreen_setupdwarfgamest {
     typedef df::viewscreen_setupdwarfgamest interpose_base;
-    DEFINE_VMETHOD_INTERPOSE(void, feed, (std::set<df::interface_key> *input))
-    {
+
+    DEFINE_VMETHOD_INTERPOSE( void, feed, ( std::set<df::interface_key> *input ) ) {
         int ch = -1;
-        for (auto it = input->begin(); ch == -1 && it != input->end(); ++it)
-            ch = Screen::keyToChar(*it);
-        if (in_save_profile && ch >= 32 && ch <= 126)
-        {
-            profile_name.push_back((char)ch);
+        for( auto it = input->begin(); ch == -1 && it != input->end(); ++it ) {
+            ch = Screen::keyToChar( *it );
         }
-        else
-        {
-            if (input->count(df::interface_key::LEAVESCREEN))
-                input->insert(df::interface_key::SETUPGAME_SAVE_PROFILE_ABORT);
-            INTERPOSE_NEXT(feed)(input);
+        // Intercept all printable characters except space.
+        // If space is intercepted the shift-space abort key will not work.
+        if( in_save_profile && ch >= 33 && ch <= 126 ) {
+            profile_name.push_back( ( char )ch );
+        } else {
+            INTERPOSE_NEXT( feed )( input );
         }
     }
 };
-IMPLEMENT_VMETHOD_INTERPOSE(embark_profile_name_hook, feed);
+
+IMPLEMENT_VMETHOD_INTERPOSE( embark_profile_name_hook, feed );

--- a/plugins/tweak/tweaks/embark-profile-name.h
+++ b/plugins/tweak/tweaks/embark-profile-name.h
@@ -3,22 +3,22 @@
 struct embark_profile_name_hook : df::viewscreen_setupdwarfgamest {
     typedef df::viewscreen_setupdwarfgamest interpose_base;
 
-    DEFINE_VMETHOD_INTERPOSE( void, feed, ( std::set<df::interface_key> *input ) ) {
+    DEFINE_VMETHOD_INTERPOSE(void, feed, (std::set<df::interface_key> *input)) {
         int ch = -1;
-        for( auto it = input->begin(); ch == -1 && it != input->end(); ++it ) {
-            ch = Screen::keyToChar( *it );
+        for (auto it = input->begin(); ch == -1 && it != input->end(); ++it) {
+            ch = Screen::keyToChar(*it);
         }
         // Intercept all printable characters except space.
         // If space is intercepted the shift-space abort key will not work.
-        if( in_save_profile && ch >= 33 && ch <= 126 ) {
-            profile_name.push_back( ( char )ch );
+        if (in_save_profile && ch >= 33 && ch <= 126) {
+            profile_name.push_back((char)ch);
         } else {
-            if( input->count( df::interface_key::LEAVESCREEN ) ) {
-                input->insert( df::interface_key::SETUPGAME_SAVE_PROFILE_ABORT );
+            if (input->count(df::interface_key::LEAVESCREEN)) {
+                input->insert(df::interface_key::SETUPGAME_SAVE_PROFILE_ABORT);
             }
-            INTERPOSE_NEXT( feed )( input );
+            INTERPOSE_NEXT(feed)(input);
         }
     }
 };
 
-IMPLEMENT_VMETHOD_INTERPOSE( embark_profile_name_hook, feed );
+IMPLEMENT_VMETHOD_INTERPOSE(embark_profile_name_hook, feed);


### PR DESCRIPTION
This changes the embark-profile-name tweak to remove the undocumented abort key and reenable the abort key shown in game.

Fixes #1532 