### PR TITLE
Add astyle config and check style in CI

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,50 @@
+# "One True Brace Style"
+--style=1tbs
+
+# 4 spaces per indentation level and per tab stop
+--indent=spaces=4
+
+# replaces tabs with spaces in non-indent sections, except in strings
+--convert-tabs
+
+# force LF line endings
+--lineend=linux
+
+# attach brackets to class and struct inline function definitions.
+--attach-inlines
+
+# 'char *foo' instead of 'char* foo'
+--align-pointer=name
+
+# maximum length for a single unbroken line
+--max-code-length=100
+
+# 'foo ||\nbar' instead of 'foo\n|| bar'
+--break-after-logical
+
+# indent 'public:' 'protected:' 'private:' deeper than 'class' or 'struct'
+--indent-classes
+
+# indent 'case' lines deeper than 'switch'
+--indent-switches
+
+# indent later lines of multi-line preprocessor directives
+--indent-preproc-define
+
+# indent comments on column 1 to match the code block they are in
+--indent-col1-comments
+
+# indent multi-line control block headers like 'if (foo\nbar)'
+--min-conditional-indent=0
+
+# add space around operators with two operands
+--pad-oper
+
+# add brackets to unbracketed one line conditional statements
+--add-brackets
+
+# remove extra space padding around parentheses
+--unpad-paren
+
+# insert space padding around parentheses on the inside only
+--pad-paren-in

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
 - sh travis/git-info.sh
 - sphinx-build -qW -j3 . docs/html
 - python travis/pr-check-base.py
+- travis/astyle-check.sh
 - python travis/lint.py
 - python travis/authors-rst.py
 - python travis/script-docs.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
       - libxml-libxslt-perl
       - ninja-build
       - zlib1g-dev
+      - astyle
 matrix:
   include:
     - env: GCC_VERSION=4.8

--- a/travis/astyle-check.sh
+++ b/travis/astyle-check.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+sources=$(find plugins library -type f -regextype posix-awk -regex ".*\.(h|cpp)")
+
+output=$(astyle --options=.astylerc --dry-run -Q $sources)
+
+if [ -n "$output" ]
+then
+    printf "Files modified by astyle\n$output"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Adds a standard astyle config and a CI check for code style. The first 4 points of the config here will enforce current style requirements as specified in Contributing.rst. The rest of it is some things to consider standardizing that have worked well for us on the CDDA team. Anyone who's regularly developing here should check out how it fits their preferences.

Closes #1535

To do:
- [ ] Decide on any additions to standard project style for the config
- [ ] If any changes are made that current code doesn't meet add a file blacklist so CI doesn't always fail until standard style is met by all files
- [ ] Update any relevant documentation