### PR TITLE
Add search to justice screen

### DIFF
--- a/plugins/search.cpp
+++ b/plugins/search.cpp
@@ -25,6 +25,7 @@
 #include "df/viewscreen_buildinglistst.h"
 #include "df/viewscreen_dwarfmodest.h"
 #include "df/viewscreen_joblistst.h"
+#include "df/viewscreen_justicest.h"
 #include "df/viewscreen_kitchenprefst.h"
 #include "df/viewscreen_layer_militaryst.h"
 #include "df/viewscreen_layer_noblelistst.h"
@@ -2327,6 +2328,85 @@ IMPLEMENT_HOOKS(df::viewscreen_layer_stone_restrictionst, stone_search);
 // END: Stone status screen search
 //
 
+//
+// START: Justice screen conviction search
+//
+
+typedef search_generic<df::viewscreen_justicest, df::unit*> justice_conviction_search_base;
+class justice_conviction_search : public justice_conviction_search_base
+{
+public:
+    bool can_init (df::viewscreen_justicest *screen)
+    {
+        return screen->cur_column == df::viewscreen_justicest::ConvictChoices;
+    }
+
+    string get_element_description (df::unit *unit) const
+    {
+        return get_unit_description(unit);
+    }
+
+    void render() const
+    {
+        print_search_option(37);
+    }
+
+    vector<df::unit*> *get_primary_list()
+    {
+        return &viewscreen->convict_choices;
+    }
+
+    virtual int32_t *get_viewscreen_cursor()
+    {
+        return &viewscreen->cursor_right;
+    }
+};
+
+IMPLEMENT_HOOKS(df::viewscreen_justicest, justice_conviction_search);
+
+//
+// END: Justice screen conviction search
+//
+
+//
+// START: Justice screen interrogation search
+//
+
+typedef search_generic<df::viewscreen_justicest, df::unit*> justice_interrogation_search_base;
+class justice_interrogation_search : public justice_interrogation_search_base
+{
+public:
+    bool can_init (df::viewscreen_justicest *screen)
+    {
+        return screen->cur_column == df::viewscreen_justicest::InterrogateChoices;
+    }
+
+    string get_element_description (df::unit *unit) const
+    {
+        return get_unit_description(unit);
+    }
+
+    void render() const
+    {
+        print_search_option(37);
+    }
+
+    vector<df::unit*> *get_primary_list()
+    {
+        return &viewscreen->interrogate_choices;
+    }
+
+    virtual int32_t *get_viewscreen_cursor()
+    {
+        return &viewscreen->cursor_right;
+    }
+};
+
+IMPLEMENT_HOOKS(df::viewscreen_justicest, justice_interrogation_search);
+
+//
+// END: Justice screen conviction search
+//
 
 #define SEARCH_HOOKS \
     HOOK_ACTION(unitlist_search_hook) \
@@ -2350,6 +2430,8 @@ IMPLEMENT_HOOKS(df::viewscreen_layer_stone_restrictionst, stone_search);
     HOOK_ACTION(location_assign_occupation_search_hook) \
     HOOK_ACTION(kitchen_pref_search_hook) \
     HOOK_ACTION(stone_search_hook) \
+    HOOK_ACTION(justice_conviction_search_hook) \
+    HOOK_ACTION(justice_interrogation_search_hook) \
 
 
 DFhackCExport command_result plugin_enable ( color_ostream &out, bool enable)


### PR DESCRIPTION
This PR adds search to both the conviction and interrogation selection pages on the justice screen. 

Compiled and tested on Linux64.

Depends on DFHack/df-structures#391