### PR TITLE
Add intrigue skill to manipulator

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,6 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `tweak` embark-profile-name: fixed handling of the native shift+space key
 
 ## Misc Improvements
+- `manipulator`: added intrigue to displayed skills
 - `search`: added support for the fortress mode justice screen
 
 ## Lua

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -242,6 +242,7 @@ const SkillColumn columns[] = {
     {16, 3, profession::NONE, unit_labor::NONE, job_skill::FLATTERY, "Fl"},
     {16, 3, profession::NONE, unit_labor::NONE, job_skill::CONSOLE, "Cs"},
     {16, 3, profession::NONE, unit_labor::NONE, job_skill::PACIFY, "Pc"},
+    {16, 3, profession::NONE, unit_labor::NONE, job_skill::INTRIGUE, "Sc"},
 // Noble
     {17, 5, profession::TRADER, unit_labor::NONE, job_skill::APPRAISAL, "Ap"},
     {17, 5, profession::ADMINISTRATOR, unit_labor::NONE, job_skill::ORGANIZATION, "Or"},


### PR DESCRIPTION
Display the intrigue skill of units in manipulator. I put it in the social category for now, because I though that's where it would fit best, but that can be easily changed. 

Depends on DFHack/df-structures#394 (skill needs to have a caption_noun attribute for manipulator to display it properly)