### PR TITLE
Implementation for df-other-vectors-type

### DIFF
--- a/library/LuaTypes.cpp
+++ b/library/LuaTypes.cpp
@@ -1422,6 +1422,28 @@ void struct_identity::build_metatable(lua_State *state)
     SetPtrMethods(state, base+1, base+2);
 }
 
+void other_vectors_identity::build_metatable(lua_State *state)
+{
+    int base = lua_gettop(state);
+    MakeFieldMetatable(state, this, meta_struct_index, meta_struct_newindex);
+
+    EnableMetaField(state, base+2, "_enum");
+
+    LookupInTable(state, index_enum, &DFHACK_TYPEID_TABLE_TOKEN);
+    lua_setfield(state, base+1, "_enum");
+
+    auto keys = &index_enum->getKeys()[-index_enum->getFirstItem()];
+
+    for (int64_t i = 0; i < index_enum->getLastItem(); i++)
+    {
+        lua_getfield(state, base+2, keys[i]);
+        lua_rawseti(state, base+2, int(i));
+    }
+
+    SetStructMethod(state, base+1, base+2, meta_struct_field_reference, "_field");
+    SetPtrMethods(state, base+1, base+2);
+}
+
 void global_identity::build_metatable(lua_State *state)
 {
     int base = lua_gettop(state);

--- a/library/include/BitArray.h
+++ b/library/include/BitArray.h
@@ -574,6 +574,8 @@ namespace DFHack
     {
         std::vector<I *> & operator[](O other_id)
         {
+            CHECK_INVALID_ARGUMENT(size_t(other_id) < sizeof(*this) / sizeof(std::vector<I *>));
+
             auto vectors = reinterpret_cast<std::vector<I *> *>(this);
             return vectors[other_id];
         }

--- a/library/include/BitArray.h
+++ b/library/include/BitArray.h
@@ -568,4 +568,14 @@ namespace DFHack
             root->next = link;
         }
     };
+
+    template<typename T, typename O, typename I>
+    struct DfOtherVectors
+    {
+        std::vector<I *> & operator[](O other_id)
+        {
+            auto vectors = reinterpret_cast<std::vector<I *> *>(this);
+            return vectors[other_id];
+        }
+    };
 }

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -334,6 +334,23 @@ namespace DFHack
         virtual identity_type type() { return IDTYPE_UNION; }
     };
 
+    class DFHACK_EXPORT other_vectors_identity : public struct_identity {
+        enum_identity *index_enum;
+
+    public:
+        other_vectors_identity(size_t size, TAllocateFn alloc,
+                compound_identity *scope_parent, const char *dfhack_name,
+                struct_identity *parent, const struct_field_info *fields,
+                enum_identity *index_enum) :
+            struct_identity(size, alloc, scope_parent, dfhack_name, parent, fields),
+            index_enum(index_enum)
+        {}
+
+        enum_identity *getIndexEnum() { return index_enum; }
+
+        virtual void build_metatable(lua_State *state);
+    };
+
 #ifdef _MSC_VER
     typedef void *virtual_ptr;
 #else
@@ -465,6 +482,7 @@ namespace df
     using DFHack::global_identity;
     using DFHack::struct_identity;
     using DFHack::union_identity;
+    using DFHack::other_vectors_identity;
     using DFHack::struct_field_info;
     using DFHack::struct_field_info_extra;
     using DFHack::bitfield_item_info;

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -474,6 +474,7 @@ namespace df
     using DFHack::BitArray;
     using DFHack::DfArray;
     using DFHack::DfLinkedList;
+    using DFHack::DfOtherVectors;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"

--- a/plugins/ruby/codegen.pl
+++ b/plugins/ruby/codegen.pl
@@ -240,6 +240,12 @@ sub render_global_class {
     }
 
     my $rbparent = ($parent ? rb_ucase($parent) : 'MemHack::Compound');
+    my $ienum;
+    if (($type->getAttribute('ld:subtype') or '') eq 'df-other-vectors-type')
+    {
+        $rbparent = 'MemHack::OtherVectors';
+        $ienum = rb_ucase($type->getAttribute('index-enum'));
+    }
     push @lines_rb, "class $rbname < $rbparent";
     indent_rb {
         my $sz = sizeof($type);
@@ -248,6 +254,8 @@ sub render_global_class {
         push @lines_rb, "sizeof $sz\n";
 
         push @lines_rb, "rtti_classname :$rtti_name\n" if $rtti_name;
+
+        push @lines_rb, "ienum $ienum\n" if $ienum;
 
         render_struct_fields($type);
 

--- a/plugins/ruby/ruby-autogen-defs.rb
+++ b/plugins/ruby/ruby-autogen-defs.rb
@@ -205,6 +205,22 @@ module DFHack
             end
         end
 
+        class OtherVectors < Compound
+            class << self
+                attr_accessor :_enum
+                def ienum(enum)
+                    @_enum = enum
+                end
+            end
+
+            def [](i)
+                self.send(self.class._enum.sym(i))
+            end
+            def []=(i, v)
+                self.send((self.class._enum.sym(i).to_s + "=").to_sym, v)
+            end
+        end
+
         class Enum
             # number -> symbol
             def self.enum


### PR DESCRIPTION
In C++. Still needs Lua and Ruby support.

See DFHack/df-structures#402.