### PR TITLE
Fix the un-quarantine behavior on OS X.

### DIFF
--- a/package/darwin/dfhack
+++ b/package/darwin/dfhack
@@ -13,7 +13,7 @@ fi
 
 # attempt to remove quarantine flag: https://github.com/DFHack/dfhack/issues/1465
 if ! test -f hack/quarantine-removed; then
-    find hack/ libs/ dwarfort.exe -name '*.dylib' -or -name '*.exe' -print0 | xargs -0 xattr -d com.apple.quarantine 2>&1 | grep -iv 'no such xattr'
+    find hack/ libs/ dwarfort.exe \( -name '*.dylib' -or -name '*.framework' -or -name '*.exe' \) -print0 | xargs -0 xattr -d com.apple.quarantine 2>&1 | grep -iv 'no such xattr'
     echo "quarantine flag removed on $(date); remove this file to re-run" > hack/quarantine-removed
 fi
 


### PR DESCRIPTION
This is a follow-up on #1465 . (I was pretty sure I tested the change after it made it into a release, but maybe it wasn't on a fresh install.)

The issue is that, when using find with an `-or`, the `-print0` is only applied to the last clause, so only the dwarfort.exe file is un-quarantined. Adding parentheses fixes that. (Example below.) FWIW, I also checked the version of find packaged with Ubuntu and the behavior is the same, so I'm assuming it's standard.

I also added the .framework files to the list of files to un-quarantine – these are included with DF and by default are blocked by OS X.

```bash
$ find hack/ libs/ dwarfort.exe -name '*.dylib' -or -name '*.exe' -print0
dwarfort.exe%

$ df 47.04 find hack/ libs/ dwarfort.exe \( -name '*.dylib' -or -name '*.framework' -or -name '*.exe' \) -print0
hack//libdfhack.dylibhack//libstdc++.6.dylibhack//libprotobuf-lite.dylibhack//plugins/eventful.plug.dylibhack//plugins/digFlood.plug.dylibhack//plugins/createitem.plug.dylibhack//plugins/prospector.plug.dylibhack//plugins/automaterial.plug.dylibhack//plugins/follow.plug.dylibhack//plugins/cleaners.plug.dylibhack//plugins/manipulator.plug.dylibhack//plugins/autogems.plug.dylibhack//plugins/petcapRemover.plug.dylibhack//plugins/mode.plug.dylibhack//plugins/resume.plug.dylibhack//plugins/dwarfvet.plug.dylibhack//plugins/rendermax.plug.dylibhack//plugins/fortplan.plug.dylibhack//plugins/autolabor.plug.dylibhack//plugins/add-spatter.plug.dylibhack//plugins/autofarm.plug.dylibhack//plugins/cleanowned.plug.dylibhack//plugins/stocks.plug.dylibhack//plugins/changeitem.plug.dylibhack//plugins/RemoteFortressReader.plug.dylibhack//plugins/embark-tools.plug.dylibhack//plugins/stockpiles.plug.dylibhack//plugins/autochop.plug.dylibhack//plugins/autodump.plug.dylibhack//plugins/changevein.plug.dylibhack//plugins/power-meter.plug.dylibhack//plugins/plants.plug.dylibhack//plugins/fix-unit-occupancy.plug.dylibhack//plugins/fixveins.plug.dylibhack//plugins/map-render.plug.dylibhack//plugins/misery.plug.dylibhack//plugins/debug.plug.dylibhack//plugins/3dveins.plug.dylibhack//plugins/getplants.plug.dylibhack//plugins/title-folder.plug.dylibhack//plugins/fix-armory.plug.dylibhack//plugins/dig.plug.dylibhack//plugins/lair.plug.dylibhack//plugins/stockflow.plug.dylibhack//plugins/workNow.plug.dylibhack//plugins/title-version.plug.dylibhack//plugins/liquids.plug.dylibhack//plugins/zone.plug.dylibhack//plugins/trackstop.plug.dylibhack//plugins/autohauler.plug.dylibhack//plugins/hotkeys.plug.dylibhack//plugins/search.plug.dylibhack//plugins/cxxrandom.plug.dylibhack//plugins/infiniteSky.plug.dylibhack//plugins/jobutils.plug.dylibhack//plugins/confirm.plug.dylibhack//plugins/cursecheck.plug.dylibhack//plugins/strangemood.plug.dylibhack//plugins/nestboxes.plug.dylibhack//plugins/automelt.plug.dylibhack//plugins/isoworldremote.plug.dylibhack//plugins/mousequery.plug.dylibhack//plugins/embark-assistant.plug.dylibhack//plugins/workflow.plug.dylibhack//plugins/labormanager.plug.dylibhack//plugins/steam-engine.plug.dylibhack//plugins/stonesense.plug.dylibhack//plugins/tweak.plug.dylibhack//plugins/luasocket.plug.dylibhack//plugins/changelayer.plug.dylibhack//plugins/ruby.plug.dylibhack//plugins/flows.plug.dylibhack//plugins/pathable.plug.dylibhack//plugins/seedwatch.plug.dylibhack//plugins/command-prompt.plug.dylibhack//plugins/buildingplan.plug.dylibhack//plugins/dwarfmonitor.plug.dylibhack//plugins/diggingInvaders.plug.dylibhack//plugins/autotrade.plug.dylibhack//plugins/tubefill.plug.dylibhack//plugins/tailor.plug.dylibhack//plugins/orders.plug.dylibhack//plugins/siege-engine.plug.dylibhack//plugins/cleanconst.plug.dylibhack//plugins/rename.plug.dylibhack//plugins/burrows.plug.dylibhack//plugins/showmood.plug.dylibhack//plugins/filltraffic.plug.dylibhack//plugins/sort.plug.dylibhack//plugins/blueprint.plug.dylibhack//plugins/generated-creature-renamer.plug.dylibhack//plugins/regrass.plug.dylibhack//plugins/reveal.plug.dylibhack//plugins/deramp.plug.dylibhack//plugins/autoclothing.plug.dylibhack//plugins/fastdwarf.plug.dylibhack//plugins/probe.plug.dylibhack//plugins/building-hacks.plug.dylibhack//plugins/tiletypes.plug.dylibhack//plugins/forceequip.plug.dylibhack//libdfhack-client.dylibhack//libdfhack.1.0.0.dylibhack//libs/liballegro_main.5.2.2.dylibhack//libs/liballegro_ttf.dylibhack//libs/liballegro_font.5.2.2.dylibhack//libs/liballegro_audio.5.2.dylibhack//libs/liballegro_image.5.2.dylibhack//libs/liballegro_image.dylibhack//libs/liballegro_ttf.5.2.2.dylibhack//libs/liballegro_dialog.dylibhack//libs/liballegro_dialog.5.2.dylibhack//libs/liballegro_font.5.2.dylibhack//libs/liballegro_memfile.dylibhack//libs/liballegro_primitives.5.2.2.dylibhack//libs/liballegro_main.dylibhack//libs/liballegro_font.dylibhack//libs/liballegro_dialog.5.2.2.dylibhack//libs/liballegro_primitives.dylibhack//libs/libfreetype.6.dylibhack//libs/liballegro_primitives.5.2.dylibhack//libs/liballegro_main.5.2.dylibhack//libs/liballegro_image.5.2.2.dylibhack//libs/liballegro_memfile.5.2.2.dylibhack//libs/liballegro.dylibhack//libs/liballegro_color.dylibhack//libs/liballegro_color.5.2.2.dylibhack//libs/liballegro_audio.dylibhack//libs/liballegro.5.2.2.dylibhack//libs/liballegro.5.2.dylibhack//libs/liballegro_color.5.2.dylibhack//libs/liballegro_acodec.5.2.2.dylibhack//libs/liballegro_ttf.5.2.dylibhack//libs/liballegro_audio.5.2.2.dylibhack//libs/liballegro_memfile.5.2.dylibhack//libs/liballegro_acodec.dylibhack//libs/liballegro_acodec.5.2.dylibhack//liblua.dyliblibs//SDL_image.frameworklibs//libstdc++.6.dyliblibs//SDL.frameworklibs//SDL_ttf.frameworklibs//SDL_ttf.framework/Versions/A/Frameworks/FreeType.frameworklibs//libfmodex.dyliblibs//libgcc_s.1.dylibdwarfort.exe%
```

