### PR TITLE
Support internal scripts that don't show up in #DFHack ls

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,7 +56,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - Added a ``ref_target`` field to primitive field references, corresponding to the ``ref-target`` XML attribute
-- Support for splitting scripts into multiple files without polluting the output of '#DFHack ls'. Scripts that end in '-internal.lua' will not be listed, but but they can still be 'require'd from other scripts.
+- Support for splitting scripts into multiple files without polluting the output of ``#DFHack ls``. Scripts can now add internal files to an ``scripts/internal`` folder.
 
 ## Ruby
 - Updated ``item_find`` and ``building_find`` to use centralized logic that works on more screens

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - Added a ``ref_target`` field to primitive field references, corresponding to the ``ref-target`` XML attribute
+- Support for splitting scripts into multiple files without polluting the output of '#DFHack ls'. Scripts that end in '-internal.lua' will not be listed, but but they can still be 'require'd from other scripts.
 
 ## Ruby
 - Updated ``item_find`` and ``building_find`` to use centralized logic that works on more screens

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -51,7 +51,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `confirm`: added a confirmation dialog for convicting dwarves of crimes
 
 ## API
-- Added ``Filesystem::mkdir_recursive``
+- Added ``Filesystem::mkdir_recursive`` (returns true if directories to create already exist)
+- Extended ``Filesystem::listdir_recursive`` to optionally make returned filenames relative to the start directory
 
 ## Lua
 - Added a ``ref_target`` field to primitive field references, corresponding to the ``ref-target`` XML attribute

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -301,7 +301,7 @@ static void listScripts(PluginManager *plug_mgr, std::map<string,string> &pset, 
     path += '/';
     for (size_t i = 0; i < files.size(); i++)
     {
-        if (hasEnding(files[i], ".lua") && !hasEnding(files[i], "-internal.lua"))
+        if (hasEnding(files[i], ".lua"))
         {
             string help = getScriptHelp(path + files[i], "--");
             string key = prefix + files[i].substr(0, files[i].size()-4);
@@ -317,7 +317,7 @@ static void listScripts(PluginManager *plug_mgr, std::map<string,string> &pset, 
                 pset[key] = help;
             }
         }
-        else if (all && !files[i].empty() && files[i][0] != '.')
+        else if (all && !files[i].empty() && files[i][0] != '.' && files[i] != "internal")
         {
             listScripts(plug_mgr, pset, path+files[i]+"/", all, prefix+files[i]+"/");
         }

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -301,7 +301,7 @@ static void listScripts(PluginManager *plug_mgr, std::map<string,string> &pset, 
     path += '/';
     for (size_t i = 0; i < files.size(); i++)
     {
-        if (hasEnding(files[i], ".lua"))
+        if (hasEnding(files[i], ".lua") && !hasEnding(files[i], "-internal.lua"))
         {
             string help = getScriptHelp(path + files[i], "--");
             string key = prefix + files[i].substr(0, files[i].size()-4);

--- a/travis/script-docs.py
+++ b/travis/script-docs.py
@@ -81,7 +81,9 @@ def check_file(fname):
 def main():
     """Check that all DFHack scripts include documentation"""
     err = 0
-    for root, _, files in os.walk(SCRIPT_PATH):
+    exclude = set(['internal'])
+    for root, dirs, files in os.walk(SCRIPT_PATH, topdown=True):
+        dirs[:] = [d for d in dirs if d not in exclude]
         for f in files:
             if f[-3:] in {'.rb', 'lua'}:
                 err += check_file(join(root, f))


### PR DESCRIPTION
#499 Enables the quickfort script to span multiple .lua files without polluting the output of #DFHack ls

This could also be useful for advfort, which is split into a main file and a module, but the module gets uselessly listed when we run ls -a