### PR TITLE
Properly calculate valid tiles for civzones in the Buildings module

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -1617,12 +1617,13 @@ General
   using width and height for flexible dimensions.
   Returns *is_flexible, width, height, center_x, center_y*.
 
-* ``dfhack.buildings.checkFreeTiles(pos,size[,extents,change_extents,allow_occupied,is_civzone])``
+* ``dfhack.buildings.checkFreeTiles(pos,size[,extents,change_extents,allow_occupied,allow_wall])``
 
   Checks if the rectangle defined by ``pos`` and ``size``, and possibly extents,
   can be used for placing a building. If ``change_extents`` is true, bad tiles
   are removed from extents. If ``allow_occupied``, the occupancy test is skipped.
-  Set ``is_civzone`` to true if the building is a civzone (like an activity zone).
+  Set ``allow_wall`` to true if the building is unhindered by walls (such as an
+  activity zone).
 
 * ``dfhack.buildings.countExtentTiles(extents,defval)``
 

--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -1617,11 +1617,12 @@ General
   using width and height for flexible dimensions.
   Returns *is_flexible, width, height, center_x, center_y*.
 
-* ``dfhack.buildings.checkFreeTiles(pos,size[,extents,change_extents,allow_occupied])``
+* ``dfhack.buildings.checkFreeTiles(pos,size[,extents,change_extents,allow_occupied,is_civzone])``
 
   Checks if the rectangle defined by ``pos`` and ``size``, and possibly extents,
   can be used for placing a building. If ``change_extents`` is true, bad tiles
   are removed from extents. If ``allow_occupied``, the occupancy test is skipped.
+  Set ``is_civzone`` to true if the building is a civzone (like an activity zone).
 
 * ``dfhack.buildings.countExtentTiles(extents,defval)``
 

--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -143,7 +143,7 @@ DFHACK_EXPORT bool checkFreeTiles(df::coord pos, df::coord2d size,
                                   df::building_extents *ext = NULL,
                                   bool create_ext = false,
                                   bool allow_occupied = false,
-                                  bool is_civzone = false);
+                                  bool allow_wall = false);
 
 /**
  * Returns the number of tiles included by the extent, or defval.

--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -141,7 +141,9 @@ DFHACK_EXPORT bool getCorrectSize(df::coord2d &size, df::coord2d &center,
  */
 DFHACK_EXPORT bool checkFreeTiles(df::coord pos, df::coord2d size,
                                   df::building_extents *ext = NULL,
-                                  bool create_ext = false, bool allow_occupied = false);
+                                  bool create_ext = false,
+                                  bool allow_occupied = false,
+                                  bool is_civzone = false);
 
 /**
  * Returns the number of tiles included by the extent, or defval.

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -576,7 +576,7 @@ bool Buildings::checkFreeTiles(df::coord pos, df::coord2d size,
                                df::building_extents *ext,
                                bool create_ext,
                                bool allow_occupied,
-                               bool is_civzone)
+                               bool allow_wall)
 {
     bool found_any = false;
 
@@ -611,7 +611,7 @@ bool Buildings::checkFreeTiles(df::coord pos, df::coord2d size,
             else
             {
                 auto tile = block->tiletype[btile.x][btile.y];
-                if (!is_civzone && !HighPassable(tile))
+                if (!allow_wall && !HighPassable(tile))
                     allowed = false;
             }
 

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -574,7 +574,9 @@ bool Buildings::getCorrectSize(df::coord2d &size, df::coord2d &center,
 
 bool Buildings::checkFreeTiles(df::coord pos, df::coord2d size,
                                df::building_extents *ext,
-                               bool create_ext, bool allow_occupied)
+                               bool create_ext,
+                               bool allow_occupied,
+                               bool is_civzone)
 {
     bool found_any = false;
 
@@ -609,7 +611,7 @@ bool Buildings::checkFreeTiles(df::coord pos, df::coord2d size,
             else
             {
                 auto tile = block->tiletype[btile.x][btile.y];
-                if (!HighPassable(tile))
+                if (!is_civzone && !HighPassable(tile))
                     allowed = false;
             }
 
@@ -659,7 +661,9 @@ static bool checkBuildingTiles(df::building *bld, bool can_change)
 
     return Buildings::checkFreeTiles(psize.first, psize.second, &bld->room,
                                      can_change && bld->isExtentShaped(),
-                                     !bld->isSettingOccupancy());
+                                     !bld->isSettingOccupancy(),
+                                     bld->getType() ==
+                                        df::building_type::Civzone);
 }
 
 int Buildings::countExtentTiles(df::building_extents *ext, int defval)


### PR DESCRIPTION
#499 
I ran into trouble in the quickfort script while constructing activity zones. Zones that happened to be taken up by trees on the surface were failing to get created. Creating such zones in the UI works fine, so I investigated.

It turns out checkFreeTiles doesn't handle civzones properly. It assumes that no "building" can be placed in a wall, which is usually true, but not for civzones.  There was no other way to get whether the building is a civzone in that function, so I added an optional parameter to pass the information in. I would have liked to handle it at a higher level, but checkFreeTiles has useful side effects (like allocating extents) that are difficult to factor out.