### PR TITLE
quickfort: allow row_height to be set from the ListBox class

### DIFF
--- a/library/lua/gui/dialogs.lua
+++ b/library/lua/gui/dialogs.lua
@@ -155,6 +155,7 @@ ListBox.ATTRS{
     on_select = DEFAULT_NIL,
     on_select2 = DEFAULT_NIL,
     select2_hint = DEFAULT_NIL,
+    row_height = DEFAULT_NIL,
 }
 
 function ListBox:preinit(info)
@@ -196,6 +197,7 @@ function ListBox:init(info)
             end,
             on_submit2 = on_submit2,
             frame = { l = 0, r = 0 },
+            row_height = info.row_height,
         }
     }
 end


### PR DESCRIPTION
#499
While implementing the quickfort GUI, I needed to be able to set the row_height for ListBox rows. The lower-level FilteredList provides the config option, but ListBox didn't have a way to pass the config through.