### PR TITLE
quickfort: listbox filter can match strings after punctuation

### DIFF
--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -792,7 +792,8 @@ function FilteredList:setFilter(filter, pos)
             local ok = true
             local search_key = v.search_key or v.text
             for _,key in ipairs(tokens) do
-                if key ~= '' and not string.match(search_key, '%f[^%s\x00]'..key) then
+                if key ~= '' and
+                        not string.match(search_key, '%f[^%s%p\x00]'..key) then
                     ok = false
                     break
                 end


### PR DESCRIPTION
#499
The FilteredList class already provides a string filtering mechanism, but it failed to match many of the strings I needed it to match because it only looks for strings that come after spaces. This change allows it to match strings after spaces or punctuation. I *think* this is a general improvement in functionality, but if there are reasons not to make this change, I can instead change the format of my search key that this regex is applied against.