### PR TITLE
Allow searches for higher waterfalls in embark-assistant

### DIFF
--- a/docs/Authors.rst
+++ b/docs/Authors.rst
@@ -75,6 +75,7 @@ kane-t                  kane-t
 Kelly Kinkade           ab9rf
 KlonZK                  KlonZK
 Kris Parker             kaypy
+Kristjan Moore          kristjanmoore
 Kromtec                 Kromtec
 Kurik Amudnil
 Lethosor                lethosor

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `stockpiles`: fixed a crash when loading food stockpiles
 
+## Misc Improvements
+- `embark-assistant`: changed UI to allow users to search for taller waterfalls
+
 # 0.47.04-r2
 
 ## New Tweaks

--- a/plugins/embark-assistant/defs.h
+++ b/plugins/embark-assistant/defs.h
@@ -318,7 +318,7 @@ namespace embark_assist {
             aquifer_ranges aquifer;
             river_ranges min_river;
             river_ranges max_river;
-            int8_t min_waterfall; // N/A(-1), Absent, 1-9
+            int8_t min_waterfall; // N/A(-1), Absent, 1-50
             yes_no_ranges flat;
             present_absent_ranges clay;
             present_absent_ranges sand;

--- a/plugins/embark-assistant/finder_ui.cpp
+++ b/plugins/embark-assistant/finder_ui.cpp
@@ -535,19 +535,16 @@ namespace embark_assist {
                 break;
 
                 case fields::min_waterfall:
-                    for (int16_t k = -1; k <= 9; k++) {
-                        if (k == -1) {
-                            element->list.push_back({ "N/A", k });
-                        }
-                        else if (k == 0) {
-                            element->list.push_back({ "Absent", k });
-                        }
-                        else {
-                            element->list.push_back({ std::to_string(k), k });
-                        }
+
+                    element->list.push_back({ "N/A", -1 });
+                    element->list.push_back({ "Absent", 0 });
+
+                    for (int16_t k = 1; k <= 9; k++) {
+                        element->list.push_back({ std::to_string(k), k });
                     }
+
                     for (int16_t k = 10; k <= 50; k+=5) {
-                            element->list.push_back({ std::to_string(k), k });
+                        element->list.push_back({ std::to_string(k), k });
                     }
 
                 break;

--- a/plugins/embark-assistant/finder_ui.cpp
+++ b/plugins/embark-assistant/finder_ui.cpp
@@ -546,6 +546,9 @@ namespace embark_assist {
                             element->list.push_back({ std::to_string(k), k });
                         }
                     }
+                    for (int16_t k = 10; k <= 50; k+=5) {
+                            element->list.push_back({ std::to_string(k), k });
+                    }
 
                 break;
 


### PR DESCRIPTION
In worlds generated with very low erosion count and "periodically erode extremes" off, you can find many waterfalls with very tall drops that are well over the original maximum embark-assistant search limit of 9 Z-levels.

An example: in one such world I created, embark-assistant found 906 waterfalls over 9 Z-levels tall, and by skimming the results manually I could see that quite a few were over 30 Z-levels. I wanted to find the most precipitous without inspecting every single result by hand. After making the edits in this merge request, embark-assistant located it for me: it was 47 Z-levels tall!