### PR TITLE
Quick'n'Dirty autocomplete for Posix console

### DIFF
--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -614,3 +614,9 @@ bool Console::show()
     ShowWindow( GetConsoleWindow(), SW_RESTORE );
     return true;
 }
+
+void Console::update_command_list(const CommandList& command_list)
+{
+    //TODO: Currently not supported
+}
+

--- a/library/dfhack-run.cpp
+++ b/library/dfhack-run.cpp
@@ -43,6 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <istream>
 #include <string>
+#include <set>
 #include <stdint.h>
 
 #include "Console.h"

--- a/library/include/Console.h
+++ b/library/include/Console.h
@@ -32,6 +32,7 @@ distribution.
 #include <assert.h>
 #include <iostream>
 #include <string>
+#include <set>
 namespace tthread
 {
     class mutex;
@@ -41,6 +42,7 @@ namespace tthread
 }
 namespace  DFHack
 {
+    using CommandList = std::set<std::string>;
     class CommandHistory
     {
     public:
@@ -167,6 +169,8 @@ namespace  DFHack
 
         bool hide();
         bool show();
+        void update_command_list(const CommandList& command_list);
+        
     private:
         Private * d;
         tthread::recursive_mutex * wlock;


### PR DESCRIPTION
Hello.
I have added quick'n'dirty support for TAB auto-completion for Linux (Posix) console.
Since I have almost no experience with programming for windows I am not able to add such support for M$ OS.
This auto-completion is based on statically generated list off all commands I mean builtin, plugins and scripts.
If someone drops a script when DF is running it will not be included in autocomplete list.
That is most simple and naive implementation with no sub-command support.

Cheers
P