### PR TITLE
Normalize search

### DIFF
--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -128,6 +128,45 @@ std::string toLower(const std::string &str)
     return rv;
 }
 
+static const char *normalized_table[256] = {
+        //.0  .1    .2    .3    .4    .5    .6    .7    .8    .9    .A    .B    .C    .D    .E    .F
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 0.
+        NULL, NULL, NULL, NULL, NULL, "S", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 1.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 2.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 3.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 4.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 5.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 6.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 7.
+        "C", "u", "e", "a", "a", "a", "a", "c", "e", "e", "e", "i", "i", "i", "A", "A", // 8.
+        "E", "ae", "Ae", "o", "o", "o", "u", "u", "y", "O", "U", "c", "L", "Y", NULL, "f", // 9.
+        "a", "i", "o", "u", "n", "N", "a", "o", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // A.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // B.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // C.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // D.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // E.
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // F.
+};
+
+std::string to_search_normalized(const std::string &str)
+{
+    std::stringbuf result;
+    for (char c : str)
+    {
+        const char *mapped = normalized_table[(uint8_t)c];
+        if (mapped == NULL)
+            result.sputc(tolower(c));
+        else
+            while (*mapped != '\0')
+            {
+                result.sputc(tolower(c));
+                ++mapped;
+            }
+    }
+
+    return result.str();
+}
+
 bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t line_length)
 {
     out->clear();

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -159,7 +159,7 @@ std::string to_search_normalized(const std::string &str)
         else
             while (*mapped != '\0')
             {
-                result.sputc(tolower(c));
+                result.sputc(tolower(*mapped));
                 ++mapped;
             }
     }

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -150,21 +150,22 @@ static const char *normalized_table[256] = {
 
 std::string to_search_normalized(const std::string &str)
 {
-    std::stringbuf result;
+    std::string result;
+    result.reserve(str.size());
     for (char c : str)
     {
         const char *mapped = normalized_table[(uint8_t)c];
         if (mapped == NULL)
-            result.sputc(tolower(c));
+            result += tolower(c);
         else
             while (*mapped != '\0')
             {
-                result.sputc(tolower(*mapped));
+                result += tolower(*mapped);
                 ++mapped;
             }
     }
 
-    return result.str();
+    return result;
 }
 
 bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t line_length)

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -129,23 +129,23 @@ std::string toLower(const std::string &str)
 }
 
 static const char *normalized_table[256] = {
-        //.0  .1    .2    .3    .4    .5    .6    .7    .8    .9    .A    .B    .C    .D    .E    .F
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 0.
-        NULL, NULL, NULL, NULL, NULL, "S", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 1.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 2.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 3.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 4.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 5.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 6.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 7.
-        "C", "u", "e", "a", "a", "a", "a", "c", "e", "e", "e", "i", "i", "i", "A", "A", // 8.
-        "E", "ae", "Ae", "o", "o", "o", "u", "u", "y", "O", "U", "c", "L", "Y", NULL, "f", // 9.
-        "a", "i", "o", "u", "n", "N", "a", "o", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // A.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // B.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // C.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // D.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // E.
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // F.
+    //.0  .1    .2    .3    .4    .5    .6    .7    .8    .9    .A    .B    .C    .D    .E    .F
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 0.
+    NULL, NULL, NULL, NULL, NULL,  "S", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 1.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 2.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 3.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 4.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 5.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 6.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // 7.
+     "C",  "u",  "e",  "a",  "a",  "a",  "a",  "c",  "e",  "e",  "e",  "i",  "i",  "i",  "A",  "A", // 8.
+     "E", "ae", "Ae",  "o",  "o",  "o",  "u",  "u",  "y",  "O",  "U",  "c",  "L",  "Y", NULL,  "f", // 9.
+     "a",  "i",  "o",  "u",  "n",  "N",  "a",  "o", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // A.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // B.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // C.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // D.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // E.
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, // F.
 };
 
 std::string to_search_normalized(const std::string &str)

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -366,6 +366,7 @@ DFHACK_EXPORT std::string join_strings(const std::string &separator, const std::
 
 DFHACK_EXPORT std::string toUpper(const std::string &str);
 DFHACK_EXPORT std::string toLower(const std::string &str);
+DFHACK_EXPORT std::string to_search_normalized(const std::string &str);
 
 DFHACK_EXPORT bool word_wrap(std::vector<std::string> *out,
                              const std::string &str,

--- a/plugins/search.cpp
+++ b/plugins/search.cpp
@@ -396,7 +396,7 @@ protected:
 
         clear_viewscreen_vectors();
 
-        string search_string_l = toLower(search_string);
+        string search_string_l = to_search_normalized(search_string);
         for (size_t i = 0; i < saved_list1.size(); i++ )
         {
             if (force_in_search(i))
@@ -409,7 +409,7 @@ protected:
                 continue;
 
             T element = saved_list1[i];
-            string desc = toLower(get_element_description(element));
+            string desc = to_search_normalized(get_element_description(element));
             if (desc.find(search_string_l) != string::npos)
             {
                 add_to_filtered_list(i);


### PR DESCRIPTION
Normalize searches so that words/names with accented characters and diphthongs are more easily found with a standard keyboard.

This will fix #1598 