### PR TITLE
fix bug: buckets are missing lye_milk_free attribute in item matcher

### DIFF
--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -379,6 +379,7 @@ bool ItemTypeInfo::matches(const df::job_item &item, MaterialInfo *mat, bool ski
         break;
 
     case BUCKET:
+        OK(2,lye_milk_free);
     case FLASK:
         OK(1,milk);
         xmask1.bits.cookable = true;


### PR DESCRIPTION
otherwise the bucket for wells (and asheries and dyer's workshops) can never be matched