### PR TITLE
[buildingplan] step5: support all building types

### DIFF
--- a/data/blueprints/library/dreamfort.csv
+++ b/data/blueprints/library/dreamfort.csv
@@ -2,26 +2,28 @@
 Welcome to the Dreamfort Walkthrough!
 It can be difficult applying a set of blueprints that you did not write yourself. This walkthrough will guide you through the high-level steps of building Dreamfort.
 ""
-"The final fort will have a walled-in area on the surface for livestock, trading, and military. Be sure to bring some blocks with you for the initial set of workshops! One z-level down is the farming level, with related workshops and vents up to the surface for miasma control. The farming level also has a miniature dining hall and dormitory for use until you get the services and apartment levels set up."
+"The final fort will have a walled-in area on the surface for livestock, trading, and military. Be sure to bring some blocks with you for the initial set of workshops! One z-level down is the farming level, with related workshops and vents up to the surface for miasma control. The farming level also has a miniature dining hall and dormitory for use until you get the services and beds levels set up."
 ""
 "Beyond those two, the other layers can be built in any order, at any z-level, according to your preference and the layout peculiarities of your embark site:"
 "- The industry level has a compact, but complete set of workshops and stockpiles (minus what is already provided on the farming level)"
 "- The services level has dining, hospital, and justice services, including a well system. This level is 4 z-levels deep."
-"- The guildhall level has many rooms for building libraries, temples, and guildhalls"
+"- The guildhall level has many empty rooms for building libraries, temples, and guildhalls"
 - The suites level has fancy rooms for your nobles
 - The apartments level(s) has small but well-furnished bedrooms for your other dwarves
 ""
+"Run the ""help"" blueprints for each level for more details."
+""
 "Dreamfort has a central staircase-based design. Choose a tile for your staircase on the surface in a nice, flat area. For all blueprints, the cursor will start on this tile on the z-level where you want to apply the blueprint."
 ""
-"Blueprints that require manual steps (like 'assign animals to pasture') will leave a message telling you so after you apply them. Blueprints will also leave messages with hints when you might want to run ""quickfort orders"" on specific blueprints to start manufacturing needed items."
+"Blueprints that require manual steps (like 'assign minecart to hauling route') will leave a message telling you so after you apply them. Blueprints will also leave messages with hints when you might want to run ""quickfort orders"" on specific blueprints to start manufacturing needed items."
 ""
 "Directly after embark, apply /surface1 on a flat area on the surface and /industry1 somewhere underground (but not immediately below the surface -- that will be for the farming level). Work your way through the steps for those levels: apply /surface2 when /surface1 is done, /industry2 when /industry1 is done, etc. Once you channel out parts of the surface with /surface3, you can start the farming sequence with /farming1. You can start the services, guildhall, suites, and apartments sequences as your fort needs those levels."
 ""
-"This .csv file is generated from source .xlsx files. If you want to look at how these blueprints are put together, including full lists of their features, it will be easier to look at the .xlsx files than this giant .csv. You can view them online at: https://drive.google.com/drive/folders/1iS90EEVqUkxTeZiiukVj1pLloZqabKuP"
+"This .csv file is generated from source .xlsx files. If you want to look at how these blueprints are put together, it will be easier to look at the online spreadsheets than this giant .csv. You can view them at: https://drive.google.com/drive/folders/1iS90EEVqUkxTeZiiukVj1pLloZqabKuP"
 You are welcome to copy those files and make your own modifications!
 "#dreamfort.csv is generated with the following command:
   for fname in dreamfort*.xlsx; do xlsx2csv -a -p '' $fname; done | sed 's/,*$//'"
-#notes label(surface_readme)
+#notes label(surface_help)
 "Sets up a large, protected entrance to your fort in a flat area on the surface."
 ""
 Features:
@@ -46,7 +48,7 @@ Once the area is clear, continue with /surface2.) clear an area and set up pastu
 clear_small/surface_clear_small
 zones/surface_zones
 ""
-"#meta label(surface2) start(staircase center) message(This would be a good time to queue manager orders for /surface4, /surface5, and /surface6. If you want a consistent color for your walls, remember to set the rock material for the manager orders for blocks.
+"#meta label(surface2) start(staircase center) message(This would be a good time to queue manager orders for /surface4, /surface5, and /surface6. If you want a consistent color for your walls, remember to set the rock material in the buildingplan UI and in the manager orders for blocks.
 Once the whole area is clear, continue with /surface3.) set up starting workshops/stockpiles and clear a larger area. if you didn't bring blocks, temporarily turn off the buildings_use_blocks setting so you can use wood or boulders"
 build_start/surface_build_start
 place_start/surface_place_start
@@ -54,14 +56,14 @@ query_start/surface_query_start
 clear/surface_clear
 pick/surface_pick
 ""
-"#meta label(surface3) start(staircase center) message(Once the channels are dug out and you have around 650 blocks, continue with /surface4. You can also start digging out the sub-surface farming level once the channels are done.) channel to prevent miasma in the sub-surface farming level"
+"#meta label(surface3) start(staircase center) message(Once the channels are dug out, continue with /surface4. You can also start digging out the sub-surface farming level once the channels are done.) channel to prevent miasma in the sub-surface farming level"
 dig/surface_channel
 ""
-"#meta label(surface4) start(staircase center) message(Once floors and walls are built and you have completed the manager orders for /surface5, continue with /surface5.) cover up the holes with flooring and build walls"
+"#meta label(surface4) start(staircase center) message(Once floors and walls are built, continue with /surface5.) cover up the holes with flooring and build walls"
 build_floors/surface_floors
 build_walls/surface_walls
 ""
-"#meta label(surface5) start(staircase center) message(Once you have around 1,050 blocks, continue with /surface6) build gates, furniture, the trade depot, and traps"
+"#meta label(surface5) start(staircase center) message(Once buildings have been constructed, continue with /surface6) build gates, furniture, the trade depot, and traps"
 build_bridges/surface_gates
 build_buildings/surface_buildings
 ""
@@ -820,7 +822,7 @@ p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,p,
 
 
 
-#notes label(farming_readme)
+#notes label(farming_help)
 "Sets up farming, food storage, and related industries. Also provides post-embark necessities that can later be disassembed."
 ""
 Features:
@@ -844,7 +846,7 @@ Screw Press
 Manual steps you have to take:
 Assign the office to your manager
 Assign a minecart to your quantum garbage stockpile hauling route
-"if the industry level is already built, configure the jugs, pots, and bags stockpiles to take from the ""Goods"" quantum stockpile on the industry level"
+"If the industry level is already built, configure the jugs, pots, and bags stockpiles to take from the ""Goods"" quantum stockpile on the industry level"
 "#dig label(farming1) start(23; 25; staircase center) message(This would be a good time to queue up manager orders for /farming2. Once the area is dug out, continue with /farming2.)"
 
 
@@ -985,13 +987,13 @@ query_stockpiles/farming_query_stockpiles
 #place label(farming_place) start(23; 25) hidden() use the meta blueprints for normal application
 
 
-,,,,,,,,,`,`,`,`,`,`,`,`,f(3x6),`,`,,`,,`,,f(14x16),`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,,,,`,`,`,`,`,`,`,`,f(3x6),,,,`,,`,,f(14x16),,,,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
-,,,,,,,,,f(8x1),`,`,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
-,,,,,,,,,b(8x1),`,`,`,`,`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,,,,f(8x1),,,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,,,,b(8x1),,,`,`,`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,,,`,,,`,,,`,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
-,,,,,,f(14x10),`,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,f(14x10),,,,`,`,`,`,`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
@@ -1002,7 +1004,7 @@ query_stockpiles/farming_query_stockpiles
 ,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,`,,,,`,,,,`,,,,`,`,`,,,`,,,,`
-,,,,,,,,u,u,u,u,`,`,`,u(5x3),`,`,`,`,,`,`,`,,`,`,`,,`,`,`
+,,,,,,,,u,u,u,u,`,`,`,u(5x3),,,`,`,,`,`,`,,`,`,`,,`,`,`
 ,,,,,,,,g,`,`,u,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,g,g,g,g,`,`,`,`,`,`,`,`,,`,,`,,`,`,`,,`,`,`
 ,,,,,,,,,`,,,,`,,,,`,,,,`,`,`,,,`,,,,`
@@ -1010,20 +1012,20 @@ query_stockpiles/farming_query_stockpiles
 ,,,,,,,,,`,`,`,`,`,`,`,`,`,`,,`,`,`,`,`,,`,`,`,`,`,`,`,`
 ,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,,,,,,,,,,,,,`,`,`,,,,,`,,,,,`
-,,,,,,,,,`,`,`,,f(7x2),`,`,`,`,`,`,,`,,`,,r(2x3),`,`,`,`,,f(1x3),`,`,`
+,,,,,,,,,`,`,`,,f(7x2),,,`,`,`,`,,`,,`,,r(2x3),,,`,`,,f(1x3),,,`
 ,,,,,,,,,`,`,`,,`,`,`,`,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,,`,`,`,`,`,,`,`,`,`
 ,,,,,,,,,`,`,`,,`,`,`,`,`,`,`,,`,`,`,,,,,`,,,,,`
-,,,,,,,,,`,`,`,,`,`,`,`,`,`,`,,`,`,`,,ry(14x10),`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,,,,`,`,`,,`,`,`,`,`,`,`,,`,`,`,,ry(14x10),,,,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
-,,,,,,,,,`,`,`,,f(7x2),`,`,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,,,,`,`,`,,f(7x2),,,`,`,`,`,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,`,`,`,,`,`,`,`,`,`,`,,`,,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,,,,,,,,,,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
-,,,,,,,,,,,,,,,,,,,,,ry(3x3),`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,,,,,,,,,,,,,,,,ry(3x3),,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,,,,,,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,,,,,,,,,,,,,`,`,`,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 ,,,,,,,,,,,,,,,,,,,,,,`,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
-,,,,,,,,,,,,,,,,,,,,,,ry(1x1),,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
+,,,,,,,,,,,,,,,,,,,,,,ry,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 
 
 "#query label(farming_query_stockpiles) start(23; 25) hidden() message(remember to:
@@ -1116,7 +1118,7 @@ query_stockpiles/farming_query_stockpiles
 ,,,,,,,,,,,,,,,,,,,,,,`,,,`,`,`,`,`,`,`,`,`,`,`,`,`,`
 
 
-#notes label(industry_readme)
+#notes label(industry_help)
 Sets up workshops for all non-farming industries
 ""
 Features:
@@ -1303,7 +1305,7 @@ query/industry_query
 ,,,,,,,,,,,`,`,`,`,`,`,`,`,`,`,`,`,`
 
 
-#notes label(services_readme)
+#notes label(services_help)
 "Sets up public services (dining, hospital, etc.)"
 ""
 Features:
@@ -1319,7 +1321,7 @@ Manual steps you have to take:
 "If you want to declare the dining room as a tavern, the bedrooms at the top can be assigned to the tavern as rented rooms."
 "Configure the soap stockpiles to take from the industry level ""Metalworker"" quantum stockpile (which holds all the bars)"
 "Convert the bath pit zones to pond zones when you are ready to fill them with 3-depth water. This is the only really fiddly bit, since you have to carefully disable the pond zone again when the final bucket to bring the water to an even 3-depth is on the way."
-"Fill the cisterns with water, either with a bucket brigade or by plumbing flowing water. Fill so that there are two z-levels of 7-depth water. If you want to fill with buckets, designate a pond zone on the level below the main floor. If you feel adventurous and are experience with water pressure, you can instead route (depressurized!) water to the second-to-bottom level (the one above the up staircases)."
+"Fill the cisterns with water, either with a bucket brigade or by plumbing flowing water. Fill so that there are two z-levels of 7-depth water. If you want to fill with buckets, designate a pond zone on the level below the main floor. If you feel adventurous and are experienced with water pressure, you can instead route (depressurized!) water to the second-to-bottom level (the one above the up staircases)."
 "#dig label(services1) start(23; 22; staircase center) message(This would be a good time to queue manager orders for /services2. Once the area is dug out, continue with /services2.)"
 
 
@@ -1633,7 +1635,7 @@ query_stockpiles/services_query_stockpiles
 ,,`,`,`,`,`,`,,`,`,`,`,`,`
 
 
-#notes label(guildhall_readme)
+#notes label(guildhall_help)
 "Multiple 7x7 rooms for guildhalls, temples, libraries, etc."
 ""
 Features:
@@ -1738,7 +1740,7 @@ Features:
 ,,`,`,`,`,`,`,`,,,,,,`,`,`,`,`,`,`,,,,,,,,`,`,`,`,`,`,`,,,,,,`,`,`,`,`,`,`
 
 
-#notes label(beds_readme)
+#notes label(beds_help)
 Suites for nobles and apartments for the teeming masses
 ""
 Features:

--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -706,14 +706,43 @@ enabled materials, you should be able to place complex constructions more conven
 buildingplan
 ============
 When active (via ``enable buildingplan``), this plugin adds a planning mode for
-furniture placement.  You can then place furniture and other buildings before
-the required materials are available, and the job will be unsuspended when
-the item is created.
+building placement. You can then place furniture, constructions, and other buildings
+before the required materials are available, and they will be created in a suspended
+state. Buildingplan will periodically scan for appropriate items, and the jobs will
+be unsuspended when the items are available.
 
-Very useful when combined with `workflow` - you can set a constraint
+This is very useful when combined with `workflow` - you can set a constraint
 to always have one or two doors/beds/tables/chairs/etc available, and place
-as many as you like.  The plugins then take over and fulfill the orders,
+as many as you like. The plugins then take over and fulfill the orders,
 with minimal space dedicated to stockpiles.
+
+Item filtering
+--------------
+
+While placing a building, you can set filters for what materials you want the building made
+out of, what quality you want the component items to be, and whether you want the items to
+be decorated.
+
+If a building type takes more than one item to construct, use Ctrl+Left and Ctrl+Right to
+select the item that you want to set filters for. Any filters that you set will be used for
+all buildings of the selected type from that point onward (until you set a new filter or
+clear the current one).
+
+For example, you can be sure that all your constructed walls are the same color by setting
+a filter to accept only certain types of stone.
+
+Quickfort mode
+--------------
+
+If you use the external Python Quickfort to apply building blueprints instead of the native
+DFHack `quickfort` script, you must enable Quickfort mode. This temporarily enables
+buildingplan for all building types and adds an extra blank screen after every building
+placement. This "dummy" screen is needed for Python Quickfort to interact successfully with
+Dwarf Fortress.
+
+Note that Quickfort mode is only for compatibility with the legacy Python Quickfort. The
+DFHack `quickfort` script does not need Quickfort mode to be enabled. The `quickfort` script
+will successfully integrate with buildingplan as long as the buildingplan plugin is enabled.
 
 .. _confirm:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `buildingplan`: all buildings, furniture, and constructions are now supported (except for the few building types not supported by dfhack itself)
 - `buildingplan`: now respects building job_item filters when matching items
 - `buildingplan`: default filter setting for max quality changed from ``artifact`` to ``masterwork``
+- `buildingplan`: min quality adjustment hotkeys changed from 'qw' to 'QW' to avoid conflict with existing hotkeys for setting roller speed. max quality adjustment hotkeys changed from 'QW' to 'AS' to make room for the min quality hotkey changes.
 
 ## API
 - `buildingplan`: added Lua interface API

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -34,7 +34,16 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 # Future
 
 ## Fixes
+- `buildingplan`: artifacts are now successfully matched when max quality is set to ``artifacts``
 - `dwarfmonitor`: fixed a crash when opening the ``prefs`` screen if units have vague preferences
+
+## Misc Improvements
+- `buildingplan`: all buildings, furniture, and constructions are now supported (except for the few building types not supported by dfhack itself)
+- `buildingplan`: now respects building job_item filters when matching items
+- `buildingplan`: default filter setting for max quality changed from ``artifact`` to ``masterwork``
+
+## API
+- `buildingplan`: added Lua interface API
 
 # 0.47.04-r3
 

--- a/docs/guides/quickfort-user-guide.rst
+++ b/docs/guides/quickfort-user-guide.rst
@@ -69,7 +69,8 @@ Features
 
 -  Build mode
 
-   -  DFHack buildingplan integration
+   -  DFHack buildingplan integration, so you can place buildings before
+      manufacturing all required source materials
    -  Designate complete constructions at once, without having to wait for each
       tile to become supported before you can build it
    -  Automatic expansion of building footprints to their minimum dimensions, so
@@ -1022,32 +1023,49 @@ allowing for much easier viewing and editing.
 Buildingplan integration
 ------------------------
 
-Buildingplan is a DFHack plugin that keeps jobs in a suspended state until the
-materials required for the job are available. This prevents a building
-designation from being canceled when a dwarf picks up the job but can't find the
-materials.
+Buildingplan is a DFHack plugin that keeps building construction jobs in a
+suspended state until the materials required for the job are available. This
+prevents a building designation from being canceled when a dwarf picks up the
+job but can't find the materials.
 
-For all types that buildingplan supports, quickfort using buildingplan to manage
-construction. Buildings are still constructed immediately if you have the
-materials, but you now have the freedom to apply build blueprints before you
-manufacture all required materials, and the jobs will be fulfilled as the
-materials become available.
+As long as the `buildingplan` plugin is enabled, quickfort will use it to manage
+construction. The buildingplan plugin also has an "enabled" setting for each
+building type, but that setting only applies to the buildingplan user interface;
+quickfort will always use buildingplan to manage everything designated in a
+``#build`` blueprint.
 
-If a ``#build`` blueprint only refers to supported types, the buildingplan
-integration pairs well with the `workflow` plugin, which can build items a few
-at a time continuously as long as they are needed. For building types that are
-not yet supported by buildingplan, a good pattern to follow is to first run
-``quickfort orders`` on the ``#build`` blueprint to manufacture all the required
-items, then apply the blueprint itself.
+However, quickfort *does* use buildingplan's filters for each building type. For
+example, you can use the buildingplan UI to set the stone you want your walls
+made out of. Or you can specify that all buildingplan-managed tables must be of
+Masterful quality. The current filter settings are saved with planned buildings
+when the ``#build`` blueprint is run. This means you can set the filters the way
+you want for one blueprint, run the blueprint, and then freely change them again
+for the next blueprint, even if the first set of buildings haven't been built
+yet.
 
-See the `buildingplan documentation <buildingplan>` for more information. As of
-this writing, buildingplan only supports basic furniture.
+Note that buildings are still constructed immediately if you already have the
+materials. However, with the buildingplan integration you now have the freedom
+to apply ``#build`` blueprints before you manufacture the resources. The
+construction jobs will be fulfilled as the materials become available.
+
+Since it can be difficult to figure out exactly what source materials you need
+for a ``#build`` blueprint, quickfort supplies the ``orders`` command. It
+enqueues manager orders for everything that the buildings in a ``#build``
+blueprint require. See the next section for more details on this.
+
+Alternately, if you know you only need a few types of items, the `workflow`
+plugin can be configured to build those items continuously for as long as they
+are needed.
+
+If the buildingplan plugin is not enabled, run ``quickfort orders`` first and
+make sure all manager orders are fulfilled before applying a ``#build``
+blueprint.
 
 Generating manager orders
 -------------------------
 
 Quickfort can generate manager orders to make sure you have the proper items in
-stock to apply a ``#build`` blueprint.
+stock for a ``#build`` blueprint.
 
 Many items can be manufactured from different source materials. Orders will
 always choose rock when it can, then wood, then cloth, then iron. You can always
@@ -1066,7 +1084,9 @@ If you want your constructions to be in a consistent color, be sure to choose a
 rock type for all of your 'Make rock blocks' orders by selecting the order and
 hitting ``d``. You might want to set the rock type for other non-block orders to
 something different if you fear running out of the type of rock that you want to
-use for blocks.
+use for blocks. You should also set the `buildingplan` material filter for
+construction building types to that type of rock as well so other random blocks
+you might have lying around aren't used.
 
 There are a few building types that will generate extra manager orders for
 related materials:
@@ -1105,23 +1125,16 @@ Tips and tricks
 Caveats and limitations
 -----------------------
 
--  Buildings will be designated regardless of whether you have the required
-   materials, but if materials are not available when the construction job is
-   picked up by a dwarf, the buildings will be canceled and the designations
-   will disappear. Until the buildingplan plugin can be extended to support all
-   building types, you should use ``quickfort orders`` to pre-manufacture all
-   the materials you need for a ``#build`` blueprint before you apply it.
-
 -  If you use the ``jugs`` alias in your ``#query``-mode blueprints, be aware
    that there is no way to differentiate jugs from other types of tools in the
    game. Therefore, ``jugs`` stockpiles will also take nest boxes and other
    tools. The only workaround is not to have other tools lying around in your
    fort.
 
--  Likewise for bags. The game does not differentiate between empty and full
-   bags, so you'll get bags of gypsum power and sand in your bags stockpile
-   unless you avoid collecting sand and are careful to assign all your gypsum to
-   your hospital.
+-  Likewise for the ``bags`` alias. The game does not differentiate between
+   empty and full bags, so you'll get bags of gypsum power and sand in your bags
+   stockpile unless you avoid collecting sand and are careful to assign all your
+   gypsum to your hospital.
 
 -  Weapon traps and upright spear/spike traps can currently only be built with a
    single weapon.
@@ -1260,7 +1273,7 @@ sheet, like in surface's meta sheet.
 things to include in messages are:
 
 * The name of the next blueprint to apply and when to run it
-* Whether quickfort orders should be run for an upcoming step
+* Whether quickfort orders could be run for an upcoming step
 * Any manual actions that have to happen, like assigning minecarts to hauling
   routes or pasturing animals after creating zones
 

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -368,10 +368,19 @@ df::building *Buildings::allocInstance(df::coord pos, df::building_type type, in
             obj->bucket_z = bld->z;
         break;
     }
+    case building_type::Workshop:
+    {
+        if (VIRTUAL_CAST_VAR(obj, df::building_workshopst, bld))
+            obj->profile.max_general_orders = 5;
+        break;
+    }
     case building_type::Furnace:
     {
         if (VIRTUAL_CAST_VAR(obj, df::building_furnacest, bld))
+        {
             obj->melt_remainder.resize(df::inorganic_raw::get_vector().size(), 0);
+            obj->profile.max_general_orders = 5;
+        }
         break;
     }
     case building_type::Coffin:
@@ -417,6 +426,12 @@ df::building *Buildings::allocInstance(df::coord pos, df::building_type type, in
     {
         if (VIRTUAL_CAST_VAR(obj, df::building_bars_floorst, bld))
             obj->gate_flags.bits.closed = true;
+        break;
+    }
+    case building_type::Bridge:
+    {
+        if (VIRTUAL_CAST_VAR(obj, df::building_bridgest, bld))
+            obj->gate_flags.bits.closed = false;
         break;
     }
     default:

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -1,3 +1,4 @@
+#include "df/construction_type.h"
 #include "df/entity_position.h"
 #include "df/interface_key.h"
 #include "df/ui_build_selector.h"
@@ -641,7 +642,9 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
 
         int y = 23;
 
-        if (ui_build_selector->building_type == df::building_type::Construction)
+        if (ui_build_selector->building_type == df::building_type::Construction
+            && ui_build_selector->building_subtype <
+               df::construction_type::TrackN)
         {
             // try not to conflict with the automaterial plugin UI
             y = 34;

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -525,6 +525,10 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
         if (input->count(interface_key::CUSTOM_P) ||
             input->count(interface_key::CUSTOM_F) ||
             input->count(interface_key::CUSTOM_D) ||
+            input->count(interface_key::CUSTOM_Q) ||
+            input->count(interface_key::CUSTOM_W) ||
+            input->count(interface_key::CUSTOM_A) ||
+            input->count(interface_key::CUSTOM_S) ||
             input->count(interface_key::CUSTOM_M))
         {
             show_help = true;
@@ -559,13 +563,13 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
 
         if (input->count(interface_key::CUSTOM_SHIFT_M))
             Screen::show(dts::make_unique<ViewscreenChooseMaterial>(*filter), plugin_self);
-        else if (input->count(interface_key::CUSTOM_Q))
-            filter->decMinQuality();
-        else if (input->count(interface_key::CUSTOM_W))
-            filter->incMinQuality();
         else if (input->count(interface_key::CUSTOM_SHIFT_Q))
-            filter->decMaxQuality();
+            filter->decMinQuality();
         else if (input->count(interface_key::CUSTOM_SHIFT_W))
+            filter->incMinQuality();
+        else if (input->count(interface_key::CUSTOM_SHIFT_A))
+            filter->decMaxQuality();
+        else if (input->count(interface_key::CUSTOM_SHIFT_S))
             filter->incMaxQuality();
         else if (input->count(interface_key::CUSTOM_SHIFT_D))
             filter->toggleDecoratedOnly();
@@ -669,10 +673,10 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
         OutputString(COLOR_WHITE, x, y, title.c_str(), true, left_margin + 1);
         OutputString(COLOR_WHITE, x, y, get_item_label(key, filter_idx).c_str(), true, left_margin);
 
-        OutputHotkeyString(x, y, "Min Quality: ", "qw");
+        OutputHotkeyString(x, y, "Min Quality: ", "QW");
         OutputString(COLOR_BROWN, x, y, filter->getMinQuality(), true, left_margin);
 
-        OutputHotkeyString(x, y, "Max Quality: ", "QW");
+        OutputHotkeyString(x, y, "Max Quality: ", "AS");
         OutputString(COLOR_BROWN, x, y, filter->getMaxQuality(), true, left_margin);
 
         OutputToggleString(x, y, "Decorated Only", "D", filter->getDecoratedOnly(), true, left_margin);

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -641,6 +641,12 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
 
         int y = 23;
 
+        if (ui_build_selector->building_type == df::building_type::Construction)
+        {
+            // try not to conflict with the automaterial plugin UI
+            y = 34;
+        }
+
         if (show_help)
         {
             OutputString(COLOR_BROWN, x, y, "Note: ");

--- a/plugins/lua/buildingplan.lua
+++ b/plugins/lua/buildingplan.lua
@@ -79,18 +79,16 @@ function construct_building_from_ui_state()
         custom=uibs.custom_type, pos=pos, width=width, height=height,
         direction=direction}
     if err then error(err) end
-    -- TODO: assign fields for the types that need them. we can't pass them all
-    -- in to the call to constructBuilding since the unneeded fields will cause
-    -- errors
-    --local fields = {
-    --    friction=uibs.friction,
-    --    use_dump=uibs.use_dump,
-    --    dump_x_shift=uibs.dump_x_shift,
-    --    dump_y_shift=uibs.dump_y_shift,
-    --    speed=uibs.speed
-    --}
-    -- TODO: use quickfort's post_construction_fns? maybe move those functions
-    -- into the library so they get applied automatically
+    -- assign fields for the types that need them. we can't pass them all in to
+    -- the call to constructBuilding since attempting to assign unrelated
+    -- fields to building types that don't support them causes errors.
+    for k,v in pairs(bld) do
+        if k == 'friction' then bld.friction = uibs.friction end
+        if k == 'use_dump' then bld.use_dump = uibs.use_dump end
+        if k == 'dump_x_shift' then bld.dump_x_shift = uibs.dump_x_shift end
+        if k == 'dump_y_shift' then bld.dump_y_shift = uibs.dump_y_shift end
+        if k == 'speed' then bld.speed = uibs.speed end
+    end
     return bld
 end
 


### PR DESCRIPTION
Closes #1640

Allow buildingplan to handle all building types, update the docs, and add in little extra fixes to ensure all the new types work correctly.

Code can be reviewed after #1675 is merged.

There is a keybinding conflict with rollers that we should address. buildingplan takes over interpretation of 'q' and 'w' to adjust the min quality filter when planning mode is enabled for rollers, and then the roller speed can never be set. You can temporarily disable buildingplan for rollers, set the speed, enable buildingplan, and place the building, but that is a poor user experience. It might also break python quickfort blueprints that place rollers.

I don't really want to change the q/w hotkeys that people are used to, but a conflict is a conflict. Maybe just change the min quality hotkeys for rollers? Change all min quality hotkeys to 'A' and 'S'? What are your thoughts?

Edit: solved by changing keybindings for min and max quality.

There is also a confusing UX interaction with the automaterial plugin for constructions. currently, if planning mode is enabled, buildingplan takes precedence and places a single tile of the construction on {Enter}, regardless of what settings are set for automaterial (e.g. box select). I think the solution here is:
- for automaterial-managed constructions, let automat handle placement (that is, buildingplan doesn't intercept the {Enter} key if automaterial is enabled)
- if buildingplan planning mode is enabled for the construction type, automaterial will
  - not show the "Auto Mat-select", "Reselect Type", or "Open Placement" options
  - construct the buildings with filters instead of showing its material selection screen
  - route the building back through buildingplan to let it select materials according to its filter

But I think that can be tackled in a future PR (after I hear your thoughts on this)