### PR TITLE
Add filter support for bookcases, display cases, and offering places

### DIFF
--- a/library/lua/dfhack/buildings.lua
+++ b/library/lua/dfhack/buildings.lua
@@ -179,6 +179,9 @@ local building_inputs = {
     [df.building_type.Slab] = { { item_type=df.item_type.SLAB } },
     [df.building_type.NestBox] = { { has_tool_use=df.tool_uses.NEST_BOX, item_type=df.item_type.TOOL } },
     [df.building_type.Hive] = { { has_tool_use=df.tool_uses.HIVE, item_type=df.item_type.TOOL } },
+    [df.building_type.OfferingPlace] = { { has_tool_use=df.tool_uses.PLACE_OFFERING, item_type=df.item_type.TOOL } },
+    [df.building_type.Bookcase] = { { has_tool_use=df.tool_uses.BOOKCASE, item_type=df.item_type.TOOL } },
+    [df.building_type.DisplayFurniture] = { { has_tool_use=df.tool_uses.DISPLAY_OBJECT, item_type=df.item_type.TOOL } },
     [df.building_type.Rollers] = {
         {
             name='mechanism',


### PR DESCRIPTION
Code added to https://github.com/DFHack/dfhack/pull/1675#discussion_r506725773 for applying these filters.

changelog entry for quickfort attached to DFHack/scripts#212 (though technically buildingplan and anything else that directly or indirectly uses dfhack.buildings.getFiltersByType() will benefit)