### PR TITLE
[buildingplan] persist global settings across map reloads

### DIFF
--- a/plugins/buildingplan-planner.h
+++ b/plugins/buildingplan-planner.h
@@ -120,6 +120,7 @@ public:
     void doCycle();
 
 private:
+    DFHack::PersistentDataItem config;
     std::map<std::string, bool> global_settings;
     std::unordered_map<BuildingTypeKey,
                        std::vector<ItemFilter>,

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -815,33 +815,6 @@ IMPLEMENT_VMETHOD_INTERPOSE(buildingplan_query_hook, render);
 IMPLEMENT_VMETHOD_INTERPOSE(buildingplan_place_hook, render);
 IMPLEMENT_VMETHOD_INTERPOSE(buildingplan_room_hook, render);
 
-static DFHack::PersistentDataItem get_ui_settings_config()
-{
-    static const std::string settings_persistence_key =
-            "buildingplan/ui_settings";
-
-    bool added;
-    DFHack::PersistentDataItem config =
-            DFHack::World::GetPersistentData(settings_persistence_key, &added);
-    if (added)
-    {
-        config.ival(0) = quickfort_mode;
-    }
-    return config;
-}
-
-static void load_settings()
-{
-    DFHack::PersistentDataItem config = get_ui_settings_config();
-    quickfort_mode = config.ival(0);
-}
-
-static void save_settings()
-{
-    DFHack::PersistentDataItem config = get_ui_settings_config();
-    config.ival(0) = quickfort_mode;
-}
-
 static command_result buildingplan_cmd(color_ostream &out, vector <string> & parameters)
 {
     if (!parameters.empty())
@@ -870,10 +843,7 @@ DFhackCExport command_result plugin_enable(color_ostream &out, bool enable)
     if (enable != is_enabled)
     {
         if (DFHack::Core::getInstance().isMapLoaded())
-        {
-            load_settings();
             planner.reset();
-        }
 
         if (!INTERPOSE_HOOK(buildingplan_query_hook, feed).apply(enable) ||
             !INTERPOSE_HOOK(buildingplan_place_hook, feed).apply(enable) ||
@@ -903,7 +873,6 @@ DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_chan
 {
     switch (event) {
     case SC_MAP_LOADED:
-        load_settings();
         planner.reset();
         roomMonitor.reset(out);
         break;
@@ -961,7 +930,6 @@ static void setSetting(std::string name, bool value) {
     {
         debug("setting quickfort_mode %d -> %d", quickfort_mode, value);
         quickfort_mode = value;
-        save_settings();
         return;
     }
     planner.setGlobalSetting(name, value);


### PR DESCRIPTION
this ensures that a player's preferences are saved across map reloads. this is particularly important for the building material filters, since item fulfillment tasks are regenerated on map load, and any changes in settings when buildingplan is reset will change the item vectors that will be searched for planned buildings. if the settings were allowed to reset, then a player who thought all walls would be made out of blocks would be surprised to find boulders and logs being used after the map is reloaded.

the quickfort_mode setting is intentionally not persisted, as it seems like that would be a "per session" kinda setting. I'd be happy to change that if people think differently, though. It might also depend on what other global settings we end up adding in the future, and whether it makes sense to persist those.

Also fix a small bug where buildingplan was attempting to scan persisted buildings when the plugin was enabled before a map was loaded