### PR TITLE
[buildingplan] ensure we don't run cycles while the game is paused

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -35,6 +35,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - `buildingplan`: artifacts are now successfully matched when max quality is set to ``artifacts``
+- `buildingplan`: no longer erroneously matches items to buildings while the game is paused
 - `dwarfmonitor`: fixed a crash when opening the ``prefs`` screen if units have vague preferences
 
 ## Misc Improvements

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -897,12 +897,19 @@ DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_chan
     return CR_OK;
 }
 
+static bool is_paused()
+{
+    return World::ReadPauseState() ||
+        ui->main.mode > df::ui_sidebar_mode::Squads ||
+        !strict_virtual_cast<df::viewscreen_dwarfmodest>(Gui::getCurViewscreen(true));
+}
+
 static bool cycle_requested = false;
 
 #define DAY_TICKS 1200
 DFhackCExport command_result plugin_onupdate(color_ostream &)
 {
-    if (Maps::IsValid() && !World::ReadPauseState()
+    if (Maps::IsValid() && !is_paused()
         && (cycle_requested || world->frame_counter % (DAY_TICKS/2) == 0))
     {
         planner.doCycle();


### PR DESCRIPTION
The code previously only checked World::ReadPauseState(), but this flag is not set to true if the game was paused implicitly by going to a submenu or switching modes.

we now also check if we're in a mode other than the default map or squads or if we're in a subscreen.