### PR TITLE
[buildingplan] don't eat keys while building is being renamed

### DIFF
--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -431,7 +431,7 @@ struct buildingplan_query_hook : public df::viewscreen_dwarfmodest
 
     bool handleInput(set<df::interface_key> *input)
     {
-        if (!isInPlannedBuildingQueryMode())
+        if (!isInPlannedBuildingQueryMode() || Gui::inRenameBuilding())
             return false;
 
         initStatics();


### PR DESCRIPTION
Fixes #1695

allows buildingplan to prevent unsuspension of planned buildings without also eating the 's' key when the user is trying to use it to give the building a custom name.