### PR TITLE
identify bars as non_economic items

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -1132,7 +1132,7 @@ Job module
   Does basic sanity checks to verify if the suggested item type matches
   the flags in the job item.
 
-* ``dfhack.job.isSuitableMaterial(job_item, mat_type, mat_index)``
+* ``dfhack.job.isSuitableMaterial(job_item, mat_type, mat_index, item_type)``
 
   Likewise, if replacing material.
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -50,6 +50,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## API
 - `buildingplan`: added Lua interface API
+- `job-module`: add item type param to dfhack.job.isSuitableMaterial() so the non_economic flag can be properly handled (it was being matched for all item types instead of just boulders)
 
 # 0.47.04-r3
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -50,7 +50,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## API
 - `buildingplan`: added Lua interface API
-- `job-module`: add item type param to dfhack.job.isSuitableMaterial() so the non_economic flag can be properly handled (it was being matched for all item types instead of just boulders)
+- add item type param to dfhack.job.isSuitableMaterial() so the non_economic flag can be properly handled (it was being matched for all item types instead of just boulders)
 
 # 0.47.04-r3
 

--- a/library/include/modules/Items.h
+++ b/library/include/modules/Items.h
@@ -88,7 +88,9 @@ namespace DFHack
         bool find(const std::string &token);
 
         bool matches(df::job_item_vector_id vec_id);
-        bool matches(const df::job_item &item, MaterialInfo *mat = NULL, bool skip_vector = false);
+        bool matches(const df::job_item &item, MaterialInfo *mat = NULL,
+                     bool skip_vector = false,
+                     df::item_type itype = df::item_type::NONE);
     };
 
     inline bool operator== (const ItemTypeInfo &a, const ItemTypeInfo &b) {

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -102,7 +102,9 @@ namespace DFHack
                                          int filter_idx = -1, int insert_idx = -1);
 
         DFHACK_EXPORT bool isSuitableItem(df::job_item *item, df::item_type itype, int isubtype);
-        DFHACK_EXPORT bool isSuitableMaterial(df::job_item *item, int mat_type, int mat_index, df::item_type itype = df::item_type::NONE);
+        DFHACK_EXPORT bool isSuitableMaterial(df::job_item *item, int mat_type,
+                                              int mat_index,
+                                              df::item_type itype);
         DFHACK_EXPORT std::string getName(df::job *job);
     }
 

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -102,7 +102,7 @@ namespace DFHack
                                          int filter_idx = -1, int insert_idx = -1);
 
         DFHACK_EXPORT bool isSuitableItem(df::job_item *item, df::item_type itype, int isubtype);
-        DFHACK_EXPORT bool isSuitableMaterial(df::job_item *item, int mat_type, int mat_index);
+        DFHACK_EXPORT bool isSuitableMaterial(df::job_item *item, int mat_type, int mat_index, df::item_type itype = df::item_type::NONE);
         DFHACK_EXPORT std::string getName(df::job *job);
     }
 

--- a/library/include/modules/Materials.h
+++ b/library/include/modules/Materials.h
@@ -78,7 +78,6 @@ namespace DFHack
 
         int16_t type;
         int32_t index;
-        df::item_type itype;
 
         df::material *material;
 
@@ -99,7 +98,7 @@ namespace DFHack
         df::historical_figure *figure;
 
     public:
-        MaterialInfo(int16_t type = -1, int32_t index = -1, df::item_type itype = df::item_type::NONE) { decode(type, index, itype); }
+        MaterialInfo(int16_t type = -1, int32_t index = -1) { decode(type, index); }
         MaterialInfo(const t_matpair &mp) { decode(mp.mat_type, mp.mat_index); }
         template<class T> MaterialInfo(T *ptr) { decode(ptr); }
 
@@ -114,7 +113,7 @@ namespace DFHack
         bool isAnyInorganic() const { return type == 0; }
         bool isInorganicWildcard() const { return isAnyInorganic() && isBuiltin(); }
 
-        bool decode(int16_t type, int32_t index = -1, df::item_type itype = df::item_type::NONE);
+        bool decode(int16_t type, int32_t index = -1);
         bool decode(df::item *item);
         bool decode(const df::material_vec_ref &vr, int idx);
         bool decode(const t_matpair &mp) { return decode(mp.mat_type, mp.mat_index); }
@@ -157,7 +156,8 @@ namespace DFHack
 
         bool matches(const df::job_material_category &cat);
         bool matches(const df::dfhack_material_category &cat);
-        bool matches(const df::job_item &item);
+        bool matches(const df::job_item &item,
+                     df::item_type itype = df::item_type::NONE);
     };
 
     DFHACK_EXPORT bool parseJobMaterialCategory(df::job_material_category *cat, const std::string &token);

--- a/library/include/modules/Materials.h
+++ b/library/include/modules/Materials.h
@@ -78,6 +78,7 @@ namespace DFHack
 
         int16_t type;
         int32_t index;
+        df::item_type itype;
 
         df::material *material;
 
@@ -98,7 +99,7 @@ namespace DFHack
         df::historical_figure *figure;
 
     public:
-        MaterialInfo(int16_t type = -1, int32_t index = -1) { decode(type, index); }
+        MaterialInfo(int16_t type = -1, int32_t index = -1, df::item_type itype = df::item_type::NONE) { decode(type, index, itype); }
         MaterialInfo(const t_matpair &mp) { decode(mp.mat_type, mp.mat_index); }
         template<class T> MaterialInfo(T *ptr) { decode(ptr); }
 
@@ -113,7 +114,7 @@ namespace DFHack
         bool isAnyInorganic() const { return type == 0; }
         bool isInorganicWildcard() const { return isAnyInorganic() && isBuiltin(); }
 
-        bool decode(int16_t type, int32_t index = -1);
+        bool decode(int16_t type, int32_t index = -1, df::item_type itype = df::item_type::NONE);
         bool decode(df::item *item);
         bool decode(const df::material_vec_ref &vr, int idx);
         bool decode(const t_matpair &mp) { return decode(mp.mat_type, mp.mat_index); }

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -279,12 +279,13 @@ bool ItemTypeInfo::matches(df::job_item_vector_id vec_id)
     return true;
 }
 
-bool ItemTypeInfo::matches(const df::job_item &item, MaterialInfo *mat, bool skip_vector)
+bool ItemTypeInfo::matches(const df::job_item &item, MaterialInfo *mat,
+                           bool skip_vector, df::item_type itype)
 {
     using namespace df::enums::item_type;
 
     if (!isValid())
-        return mat ? mat->matches(item) : false;
+        return mat ? mat->matches(item, itype) : false;
 
     if (Items::isCasteMaterial(type) && mat && !mat->isNone())
         return false;

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -605,7 +605,7 @@ bool Job::isSuitableItem(df::job_item *item, df::item_type itype, int isubtype)
     ItemTypeInfo iinfo(itype, isubtype);
     MaterialInfo minfo(item);
 
-    return iinfo.isValid() && iinfo.matches(*item, &minfo, true, itype);
+    return iinfo.isValid() && iinfo.matches(*item, &minfo, false, itype);
 }
 
 bool Job::isSuitableMaterial(
@@ -619,7 +619,7 @@ bool Job::isSuitableMaterial(
     ItemTypeInfo iinfo(item);
     MaterialInfo minfo(mat_type, mat_index);
 
-    return minfo.isValid() && iinfo.matches(*item, &minfo, true, itype);
+    return minfo.isValid() && iinfo.matches(*item, &minfo, false, itype);
 }
 
 std::string Job::getName(df::job *job)

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -608,7 +608,8 @@ bool Job::isSuitableItem(df::job_item *item, df::item_type itype, int isubtype)
     return iinfo.isValid() && iinfo.matches(*item, &minfo);
 }
 
-bool Job::isSuitableMaterial(df::job_item *item, int mat_type, int mat_index)
+bool Job::isSuitableMaterial(
+    df::job_item *item, int mat_type, int mat_index, df::item_type itype)
 {
     CHECK_NULL_POINTER(item);
 
@@ -616,7 +617,7 @@ bool Job::isSuitableMaterial(df::job_item *item, int mat_type, int mat_index)
         return true;
 
     ItemTypeInfo iinfo(item);
-    MaterialInfo minfo(mat_type, mat_index);
+    MaterialInfo minfo(mat_type, mat_index, itype);
 
     return minfo.isValid() && iinfo.matches(*item, &minfo);
 }

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -605,7 +605,7 @@ bool Job::isSuitableItem(df::job_item *item, df::item_type itype, int isubtype)
     ItemTypeInfo iinfo(itype, isubtype);
     MaterialInfo minfo(item);
 
-    return iinfo.isValid() && iinfo.matches(*item, &minfo);
+    return iinfo.isValid() && iinfo.matches(*item, &minfo, true, itype);
 }
 
 bool Job::isSuitableMaterial(
@@ -617,9 +617,9 @@ bool Job::isSuitableMaterial(
         return true;
 
     ItemTypeInfo iinfo(item);
-    MaterialInfo minfo(mat_type, mat_index, itype);
+    MaterialInfo minfo(mat_type, mat_index);
 
-    return minfo.isValid() && iinfo.matches(*item, &minfo);
+    return minfo.isValid() && iinfo.matches(*item, &minfo, true, itype);
 }
 
 std::string Job::getName(df::job *job)

--- a/library/modules/Materials.cpp
+++ b/library/modules/Materials.cpp
@@ -75,8 +75,7 @@ bool MaterialInfo::decode(df::item *item)
     if (!item)
         return decode(-1);
     else
-        return decode(item->getActualMaterial(),
-                      item->getActualMaterialIndex());
+        return decode(item->getActualMaterial(), item->getActualMaterialIndex());
 }
 
 bool MaterialInfo::decode(const df::material_vec_ref &vr, int idx)
@@ -518,6 +517,7 @@ void MaterialInfo::getMatchBits(df::job_item_flags2 &ok, df::job_item_flags2 &ma
     TEST(magma_safe, material->heat.melting_point > 12000);
     TEST(deep_material, FLAG(inorganic, inorganic_flags::SPECIAL));
     TEST(non_economic, !inorganic || !(ui && vector_get(ui->economic_stone, index)));
+
     TEST(plant, plant);
     TEST(silk, MAT_FLAG(SILK));
     TEST(leather, MAT_FLAG(LEATHER));

--- a/library/modules/Materials.cpp
+++ b/library/modules/Materials.cpp
@@ -75,7 +75,9 @@ bool MaterialInfo::decode(df::item *item)
     if (!item)
         return decode(-1);
     else
-        return decode(item->getActualMaterial(), item->getActualMaterialIndex());
+        return decode(item->getActualMaterial(),
+                      item->getActualMaterialIndex(),
+                      item->getType());
 }
 
 bool MaterialInfo::decode(const df::material_vec_ref &vr, int idx)
@@ -86,10 +88,11 @@ bool MaterialInfo::decode(const df::material_vec_ref &vr, int idx)
         return decode(vr.mat_type[idx], vr.mat_index[idx]);
 }
 
-bool MaterialInfo::decode(int16_t type, int32_t index)
+bool MaterialInfo::decode(int16_t type, int32_t index, df::item_type itype)
 {
     this->type = type;
     this->index = index;
+    this->itype = itype;
 
     material = NULL;
     mode = Builtin; subtype = 0;
@@ -513,7 +516,7 @@ void MaterialInfo::getMatchBits(df::job_item_flags2 &ok, df::job_item_flags2 &ma
     TEST(fire_safe, material->heat.melting_point > 11000);
     TEST(magma_safe, material->heat.melting_point > 12000);
     TEST(deep_material, FLAG(inorganic, inorganic_flags::SPECIAL));
-    TEST(non_economic, !inorganic || !(ui && vector_get(ui->economic_stone, index)));
+    TEST(non_economic, !inorganic || !(ui && vector_get(ui->economic_stone, index)) || itype == df::item_type::BAR);
 
     TEST(plant, plant);
     TEST(silk, MAT_FLAG(SILK));

--- a/plugins/buildingplan-planner.cpp
+++ b/plugins/buildingplan-planner.cpp
@@ -224,7 +224,7 @@ bool ItemFilter::matches(df::item *item) const
 
     auto imattype = item->getActualMaterial();
     auto imatindex = item->getActualMaterialIndex();
-    auto item_mat = DFHack::MaterialInfo(imattype, imatindex, item->getType());
+    auto item_mat = DFHack::MaterialInfo(imattype, imatindex);
 
     return (materials.size() == 0) ? matchesMask(item_mat) : matches(item_mat);
 }

--- a/plugins/buildingplan-planner.cpp
+++ b/plugins/buildingplan-planner.cpp
@@ -224,7 +224,7 @@ bool ItemFilter::matches(df::item *item) const
 
     auto imattype = item->getActualMaterial();
     auto imatindex = item->getActualMaterialIndex();
-    auto item_mat = DFHack::MaterialInfo(imattype, imatindex);
+    auto item_mat = DFHack::MaterialInfo(imattype, imatindex, item->getType());
 
     return (materials.size() == 0) ? matchesMask(item_mat) : matches(item_mat);
 }

--- a/plugins/buildingplan-planner.cpp
+++ b/plugins/buildingplan-planner.cpp
@@ -825,7 +825,8 @@ static bool matchesFilters(df::item * item,
     return DFHack::Job::isSuitableItem(
             job_item, item->getType(), item->getSubtype())
         && DFHack::Job::isSuitableMaterial(
-            job_item, item->getMaterial(), item->getMaterialIndex())
+            job_item, item->getMaterial(), item->getMaterialIndex(),
+            item->getType())
         && item_filter.matches(item);
 }
 


### PR DESCRIPTION
Fixes #1699

allows MaterialInfo to match metal bars as a building material. This allows metal bars to be used for construction in buildingplan.