### PR TITLE
only reset extents in Buildings::setSize() if they are unusable

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -1679,7 +1679,11 @@ Low-level building creation functions:
   Returns *false* if the building cannot be placed, or *true, width,
   height, rect_area, true_area*. Returned width and height are the
   final values used by the building; true_area is less than rect_area
-  if any tiles were removed from designation.
+  if any tiles were removed from designation. You can specify a non-rectangular
+  designation for building types that support extents by setting the
+  ``room.extents`` bitmap before calling this function. The extents will be
+  reset, however, if the size returned by this function doesn't match the
+  input size parameter.
 
 * ``dfhack.buildings.constructAbstract(building)``
 
@@ -1768,7 +1772,9 @@ Among them are:
 
   - ``fields = { ... }``
 
-    Initializes fields of the building object after creation with ``df.assign``.
+    Initializes fields of the building object after creation with
+    ``df.assign``. If ``room.extents`` is assigned this way and this function
+    returns with error, the memory allocated for the extents is freed.
 
   - ``width = ..., height = ..., direction = ...``
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## API
 - `buildingplan`: added Lua interface API
 - add item type param to dfhack.job.isSuitableMaterial() so the non_economic flag can be properly handled (it was being matched for all item types instead of just boulders)
+- reuse existing extents when possible in ``Buildings::setSize()``
 
 ## Lua
 - ``utils.addressof()``: fixed for raw userdata

--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -162,6 +162,8 @@ DFHACK_EXPORT bool hasSupport(df::coord pos, df::coord2d size);
 
 /**
  * Sets the size of the building, using size and direction as guidance.
+ * Any custom extents set for the building will be cleared if the size passed in
+ * as guidance cannot be applied to the building.
  * Returns true if the building can be created at its position, using that size.
  */
 DFHACK_EXPORT bool setSize(df::building *bld, df::coord2d size, int direction = 0);

--- a/library/lua/dfhack/buildings.lua
+++ b/library/lua/dfhack/buildings.lua
@@ -485,6 +485,11 @@ function buildings.constructBuilding(info)
     local to_delete = instance
     return dfhack.with_finalize(
         function()
+            -- ensure we don't leak extents created by Buildings::checkFreeTiles
+            if to_delete and to_delete.room.extents then
+                df.delete(to_delete.room.extents)
+                to_delete.room.extents = nil
+            end
             df.delete(to_delete)
         end,
         function()

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -758,17 +758,18 @@ bool Buildings::setSize(df::building *bld, df::coord2d size, int direction)
     CHECK_NULL_POINTER(bld);
     CHECK_INVALID_ARGUMENT(bld->id == -1);
 
-    // Delete old extents
-    if (bld->room.extents)
+    // Compute correct size and apply it
+    df::coord2d old_size = size;
+    df::coord2d center;
+    getCorrectSize(size, center, bld->getType(), bld->getSubtype(),
+                   bld->getCustomType(), direction);
+
+    // Delete old extents if size has changed.
+    if (old_size != size && bld->room.extents)
     {
         delete[] bld->room.extents;
         bld->room.extents = NULL;
     }
-
-    // Compute correct size and apply it
-    df::coord2d center;
-    getCorrectSize(size, center, bld->getType(), bld->getSubtype(),
-                   bld->getCustomType(), direction);
 
     bld->x2 = bld->x1 + size.x - 1;
     bld->y2 = bld->y1 + size.y - 1;


### PR DESCRIPTION
This allows callers of `Buildings::setSize()` to "pre-initialize" the extents to declare non-rectangular structures. The main beneficiary of this change is quickfort, which currently has a bug where non-rectangular structures *appear* correct on the map, but the occupancy is set incorrectly for non-occupied tiles within the bounds of the extent.

From inspection, the existing code appears to clear existing extents to protect against the case where the passed-in size does not match the size eventually assigned to the building. We can check for that case, though so the extents can still be reset as before if the size of the building doesn't match the caller's expectations.

This commit also fixes a memory leak when `setSize()` allocates memory for extents, but the memory is not deallocated if the building is ultimately invalid for some reason.