### PR TITLE
[Lua] getopt-compatible lua script args parser

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -34,6 +34,7 @@ tinythread_     Zlib          \(c\) 2010, Marcus Geelnard
 tinyxml_        Zlib          \(c\) 2000-2006, Lee Thomason
 UTF-8-decoder_  MIT           \(c\) 2008-2010, Bjoern Hoehrmann
 xlsxio_         MIT           \(c\) 2016-2020, Brecht Sanders
+alt-getopt_     MIT           \(c\) 2009 Aleksey Cheusov
 =============== ============= =================================================
 
 .. _DFHack: https://github.com/DFHack/dfhack
@@ -52,6 +53,7 @@ xlsxio_         MIT           \(c\) 2016-2020, Brecht Sanders
 .. _tinyxml: http://www.sourceforge.net/projects/tinyxml
 .. _UTF-8-decoder: http://bjoern.hoehrmann.de/utf-8/decoder/dfa
 .. _xlsxio: https://github.com/brechtsanders/xlsxio
+.. _alt-getopt: https://github.com/LuaDist/alt-getopt
 
 .. _CC-BY-SA: http://creativecommons.org/licenses/by/3.0/deed.en_US
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 
+## API
+- ``processArgs2()`` added to utils.lua, providing a callback interface for parameter parsing and getopt-like flexibility for parameter ordering and combination (see docs in ``library/lua/utils.lua`` and ``library/lua/3rdparty/alt_getopt.lua`` for details).
+
 # 0.47.04-r4
 
 ## Fixes

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,7 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 
-## API
+## Lua
 - ``processArgs2()`` added to utils.lua, providing a callback interface for parameter parsing and getopt-like flexibility for parameter ordering and combination (see docs in ``library/lua/utils.lua`` and ``library/lua/3rdparty/alt_getopt.lua`` for details).
 
 # 0.47.04-r4
@@ -1171,4 +1171,3 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - The ``ui_menu_width`` global is now a 2-byte array; the second item is the former ``ui_area_map_width`` global, which is now removed
 - The former ``announcements`` global is now a field in ``d_init``
 - ``world`` fields formerly beginning with ``job_`` are now fields of ``world.jobs``, e.g. ``world.job_list`` is now ``world.jobs.list``
-

--- a/library/lua/3rdparty/alt_getopt.lua
+++ b/library/lua/3rdparty/alt_getopt.lua
@@ -1,0 +1,171 @@
+-- Copyright (c) 2009 Aleksey Cheusov <vle@gmx.net>
+--
+-- Permission is hereby granted, free of charge, to any person obtaining
+-- a copy of this software and associated documentation files (the
+-- "Software"), to deal in the Software without restriction, including
+-- without limitation the rights to use, copy, modify, merge, publish,
+-- distribute, sublicense, and/or sell copies of the Software, and to
+-- permit persons to whom the Software is furnished to do so, subject to
+-- the following conditions:
+--
+-- The above copyright notice and this permission notice shall be
+-- included in all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+-- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+-- NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+-- LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+-- OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+-- WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-- based on https://github.com/LuaDist/alt-getopt/blob/master/alt_getopt.lua
+-- MIT licence
+-- modified to support non-options and to not call os.exit()
+-- intended to be used via utils.processArgs2()
+
+local _ENV = mkmodule('alt_getopt')
+
+local function convert_short2long (opts)
+   local i = 1
+   local len = #opts
+   local ret = {}
+
+   for short_opt, accept_arg in opts:gmatch("(%w)(:?)") do
+      ret[short_opt]=#accept_arg
+   end
+
+   return ret
+end
+
+local function exit_with_error (msg, exit_status)
+   io.stderr:write (msg)
+   os.exit (exit_status)
+end
+
+local function err_unknown_opt (opt)
+   exit_with_error ("Unknown option `-" ..
+		    (#opt > 1 and "-" or "") .. opt .. "'\n", 1)
+end
+
+local function canonize (options, opt)
+   if not options [opt] then
+      err_unknown_opt (opt)
+   end
+
+   while type (options [opt]) == "string" do
+      opt = options [opt]
+
+      if not options [opt] then
+	 err_unknown_opt (opt)
+      end
+   end
+
+   return opt
+end
+
+function get_ordered_opts (arg, sh_opts, long_opts)
+   local i      = 1
+   local count  = 1
+   local opts   = {}
+   local optarg = {}
+
+   local options = convert_short2long (sh_opts)
+   for k,v in pairs (long_opts) do
+      options [k] = v
+   end
+
+   while i <= #arg do
+      local a = arg [i]
+
+      if a == "--" then
+	 i = i + 1
+	 break
+
+      elseif a == "-" then
+	 break
+
+      elseif a:sub (1, 2) == "--" then
+	 local pos = a:find ("=", 1, true)
+
+	 if pos then
+	    local opt = a:sub (3, pos-1)
+
+	    opt = canonize (options, opt)
+
+	    if options [opt] == 0 then
+	       exit_with_error ("Bad usage of option `" .. a .. "'\n", 1)
+	    end
+
+	    optarg [count] = a:sub (pos+1)
+	    opts [count] = opt
+	 else
+	    local opt = a:sub (3)
+
+	    opt = canonize (options, opt)
+
+	    if options [opt] == 0 then
+	       opts [count] = opt
+	    else
+	       if i == #arg then
+		  exit_with_error ("Missed value for option `" .. a .. "'\n", 1)
+	       end
+
+	       optarg [count] = arg [i+1]
+	       opts [count] = opt
+	       i = i + 1
+	    end
+	 end
+	 count = count + 1
+
+      elseif a:sub (1, 1) == "-" then
+	 local j
+	 for j=2,a:len () do
+	    local opt = canonize (options, a:sub (j, j))
+
+	    if options [opt] == 0 then
+	       opts [count] = opt
+	       count = count + 1
+	    elseif a:len () == j then
+	       if i == #arg then
+		  exit_with_error ("Missed value for option `-" .. opt .. "'\n", 1)
+	       end
+
+	       optarg [count] = arg [i+1]
+	       opts [count] = opt
+	       i = i + 1
+	       count = count + 1
+	       break
+	    else
+	       optarg [count] = a:sub (j+1)
+	       opts [count] = opt
+	       count = count + 1
+	       break
+	    end
+	 end
+      else
+	 break
+      end
+
+      i = i + 1
+   end
+
+   return opts,i,optarg
+end
+
+function get_opts (arg, sh_opts, long_opts)
+   local ret = {}
+
+   local opts,optind,optarg = get_ordered_opts (arg, sh_opts, long_opts)
+   for i,v in ipairs (opts) do
+      if optarg [i] then
+	 ret [v] = optarg [i]
+      else
+	 ret [v] = 1
+      end
+   end
+
+   return ret,optind
+end
+
+return _ENV

--- a/library/lua/utils.lua
+++ b/library/lua/utils.lua
@@ -613,6 +613,55 @@ function processArgs(args, validArgs)
     return result
 end
 
+-- processes commandline options according to optionActions and returns all
+-- argument strings that are not options.
+--
+-- optionActions is a vector with elements in the following format:
+-- {shortOptionName, longOptionAlias, hasArg=boolean, handler=fn}
+-- shortOptionName and handler are required. If the option takes an argument,
+-- it will be passed to the handler function.
+-- longOptionAlias is optional.
+-- hasArgument defaults to false.
+--
+-- example usage:
+--
+-- local filename = nil
+-- local open_readonly = false
+-- local nonoptions = processArgs2(args, {
+--   {'r', handler=function() open_readonly = true end},
+--   {'f', 'filename', hasArg=true,
+--    handler=function(optarg) filename = optarg end}
+-- })
+--
+-- when args is {'first', '-f', 'fname', 'second'}
+-- then filename will be fname and nonoptions will contain {'first', 'second'}
+function processArgs2(args, optionActions)
+    local sh_opts, long_opts = '', {}
+    local handlers = {}
+    for _,optionAction in ipairs(optionActions) do
+        local sh_opt,long_opt = optionAction[1], optionAction[2]
+        if not sh_opt or type(sh_opt) ~= 'string' or #sh_opt ~= 1 then
+            qerror('optionAction missing option letter at index 1')
+        end
+        if not optionAction.handler then
+            qerror(string.format('handler missing for option "%s"', sh_opt))
+        end
+        sh_opts = sh_opts .. sh_opt
+        if optionAction.hasArg then sh_opts = sh_opts .. ':' end
+        handlers[sh_opt] = optionAction.handler
+        if long_opt then
+            long_opts[long_opt] = sh_opt
+            handlers[long_opt] = optionAction.handler
+        end
+    end
+    local getopt = require('3rdparty.alt_getopt').get_ordered_opts
+    local opts, optargs, nonoptions = getopt(args, sh_opts, long_opts)
+    for i,v in ipairs(opts) do
+        handlers[v](optargs[i])
+    end
+    return nonoptions
+end
+
 function fillTable(table1,table2)
     for k,v in pairs(table2) do
         table1[k] = v


### PR DESCRIPTION
Happy new year! This PR introduces a more flexible alternative to the existing `processArgs()` function in utils.lua

In addition to a more powerful argument handling syntax, this implementation don’t force "flag" options to be at the end. For example, with processArgs, `quickfort list dreamfort -l` is legal but `quickfort list -l dreamfort` is not. This causes confusion when users try the second (IMHO, more natural) syntax.

The new implementation is based on https://github.com/LuaDist/alt-getopt (MIT license), modified to support non-flag options and to replace calls to `os.exit()` with `qerror()`.

The new `processArgs2()` function is a wrapper of the core getopt logic and provides a handler callback interface for processing parameters. Documentation for the new function is in utils.lua. Is there anywhere else that these functions should be documented?