### PR TITLE
scroll Lua Label text when height exceeds viewrect

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 
+## Misc Improvements
+- Lua widget library Label class (used in all standard message boxes) is now scrollable with Up/Down/PgUp/PgDn keys
+
 # 0.47.04-r4
 
 ## Fixes

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -436,7 +436,7 @@ function Label:onInput(keys)
                 v = -self.frame_body.height
             end
             self:scroll(v)
-            return true
+            return false
         end
     end
     return check_text_keys(self, keys)

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -234,11 +234,10 @@ end
 
 function render_text(obj,dc,x0,y0,pen,dpen,disabled)
     local width = 0
-    for iline,line in ipairs(obj.text_lines) do
-        if dc and obj.start_line_num and iline < obj.start_line_num then
-            goto continue
-        end
-        local x = 0
+    -- note that lines outside of the containing frame are not displayed, so
+    -- we only have to bound the start condition, not the end condition
+    for iline = dc and obj.start_line_num or 1, #obj.text_lines do
+        local x, line = 0, obj.text_lines[iline]
         if dc then
             local offset = (obj.start_line_num or 1) - 1
             dc:seek(x+x0,y0+iline-offset-1)
@@ -327,7 +326,6 @@ function render_text(obj,dc,x0,y0,pen,dpen,disabled)
             token.x2 = x
         end
         width = math.max(width, x)
-        ::continue::
     end
     obj.text_width = width
 end

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -235,9 +235,13 @@ end
 function render_text(obj,dc,x0,y0,pen,dpen,disabled)
     local width = 0
     for iline,line in ipairs(obj.text_lines) do
+        if dc and obj.start_line_num and iline < obj.start_line_num then
+            goto continue
+        end
         local x = 0
         if dc then
-            dc:seek(x+x0,y0+iline-1)
+            local offset = (obj.start_line_num or 1) - 1
+            dc:seek(x+x0,y0+iline-offset-1)
         end
         for _,token in ipairs(line) do
             token.line = iline
@@ -323,6 +327,7 @@ function render_text(obj,dc,x0,y0,pen,dpen,disabled)
             token.x2 = x
         end
         width = math.max(width, x)
+        ::continue::
     end
     obj.text_width = width
 end
@@ -340,6 +345,13 @@ end
 
 Label = defclass(Label, Widget)
 
+STANDARDSCROLL = {
+    STANDARDSCROLL_UP = -1,
+    STANDARDSCROLL_DOWN = 1,
+    STANDARDSCROLL_PAGEUP = '-page',
+    STANDARDSCROLL_PAGEDOWN = '+page',
+}
+
 Label.ATTRS{
     text_pen = COLOR_WHITE,
     text_dpen = COLOR_DARKGREY, -- disabled
@@ -350,9 +362,11 @@ Label.ATTRS{
     auto_width = false,
     on_click = DEFAULT_NIL,
     on_rclick = DEFAULT_NIL,
+    scroll_keys = STANDARDSCROLL,
 }
 
 function Label:init(args)
+    self.start_line_num = 1
     self:setText(args.text)
     if not self.text_hpen then
         self.text_hpen = ((tonumber(self.text_pen) or tonumber(self.text_pen.fg) or 0) + 8) % 16
@@ -399,16 +413,33 @@ function Label:onRenderBody(dc)
     render_text(self,dc,0,0,text_pen,self.text_dpen,is_disabled(self))
 end
 
+function Label:scroll(nlines)
+    local n = self.start_line_num + nlines
+    n = math.min(n, self:getTextHeight() - self.frame_body.height)
+    n = math.max(n, 1)
+    self.start_line_num = n
+end
+
 function Label:onInput(keys)
-    if not is_disabled(self) then
-        if keys._MOUSE_L_DOWN and self:getMousePos() and self.on_click then
-            self:on_click()
-        end
-        if keys._MOUSE_R_DOWN and self:getMousePos() and self.on_rclick then
-            self:on_rclick()
-        end
-        return check_text_keys(self, keys)
+    if is_disabled(self) then return false end
+    if keys._MOUSE_L_DOWN and self:getMousePos() and self.on_click then
+        self:on_click()
     end
+    if keys._MOUSE_R_DOWN and self:getMousePos() and self.on_rclick then
+        self:on_rclick()
+    end
+    for k,v in pairs(self.scroll_keys) do
+        if keys[k] then
+            if v == '+page' then
+                v = self.frame_body.height
+            elseif v == '-page' then
+                v = -self.frame_body.height
+            end
+            self:scroll(v)
+            return true
+        end
+    end
+    return check_text_keys(self, keys)
 end
 
 ----------
@@ -416,13 +447,6 @@ end
 ----------
 
 List = defclass(List, Widget)
-
-STANDARDSCROLL = {
-    STANDARDSCROLL_UP = -1,
-    STANDARDSCROLL_DOWN = 1,
-    STANDARDSCROLL_PAGEUP = '-page',
-    STANDARDSCROLL_PAGEDOWN = '+page',
-}
 
 SECONDSCROLL = {
     SECONDSCROLL_UP = -1,

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -234,13 +234,14 @@ end
 
 function render_text(obj,dc,x0,y0,pen,dpen,disabled)
     local width = 0
-    -- note that lines outside of the containing frame are not displayed, so
-    -- we only have to bound the start condition, not the end condition
     for iline = dc and obj.start_line_num or 1, #obj.text_lines do
         local x, line = 0, obj.text_lines[iline]
         if dc then
             local offset = (obj.start_line_num or 1) - 1
-            dc:seek(x+x0,y0+iline-offset-1)
+            local y = y0 + iline - offset - 1
+            -- skip text outside of the containing frame
+            if y > dc.height - 1 then break end
+            dc:seek(x+x0, y)
         end
         for _,token in ipairs(line) do
             token.line = iline


### PR DESCRIPTION
Allows Label text to scroll with Up/Down/PgUp/PgDown keys, just like the ListBox classes.

Not being able to scroll Label text became an issue for quickfort because blueprint help text is displayed in a MessageBox (which uses a Label to display the text). Blueprint help text is user-defined, so long blueprint walkthroughs (I'm looking at you, dreamfort) could not be fully displayed.

I would have loved to accept Space as equivalent to PageDown, but that interacts poorly with text input fields (depending on the order components' onInput() functions are called, it could end up scrolling every time you typed a space into a text field)