### PR TITLE
[autofarm] fallow farms when no further plants requested

### DIFF
--- a/plugins/autofarm.cpp
+++ b/plugins/autofarm.cpp
@@ -201,11 +201,26 @@ public:
     {
         // this algorithm attempts to change as few farms as possible, while ensuring that
         // the number of farms planting each eligible plant is "as equal as possible"
-
-        if (farms.empty() || plants.empty())
-            return; // do nothing if there are no farms or no plantable plants
-
+        
         int season = *df::global::cur_season;
+        
+        if (farms.empty() || plants.empty())
+        {
+            // if no more plants were requested, fallow all farms
+            // if there were no farms, do nothing
+            for (auto farm : farms)
+            {
+                int o = farm->plant_id[season];
+                if (o != -1)
+                {
+                    farm->plant_id[season] = -1;
+                    out << "autofarm: changing farm #" << farm->id <<
+                        " from " << ((o == -1) ? "NONE" : world->raws.plants.all[o]->name) <<
+                        " to NONE" << endl;
+                }
+            }
+            return;
+        }
 
         int min = farms.size() / plants.size(); // the number of farms that should plant each eligible plant, rounded down
         int extra = farms.size() - min * plants.size(); // the remainder that cannot be evenly divided

--- a/plugins/autofarm.cpp
+++ b/plugins/autofarm.cpp
@@ -197,6 +197,27 @@ public:
         }
     }
 
+    string get_plant_name(int plant_id)
+    {
+        df::plant_raw *raw = df::plant_raw::find(plant_id);
+        if (raw)
+            return raw->name;
+        else
+            return "NONE";
+    }
+
+    void set_farm(color_ostream& out, int new_plant_id, df::building_farmplotst* farm, int season)
+    {
+        int old_plant_id = farm->plant_id[season];
+        if (old_plant_id != new_plant_id)
+        {
+            farm->plant_id[season] = new_plant_id;
+            out << "autofarm: changing farm #" << farm->id <<
+                " from " << get_plant_name(old_plant_id) <<
+                " to " << get_plant_name(new_plant_id) << endl;
+        }
+    }
+
     void set_farms(color_ostream& out, set<int> plants, vector<df::building_farmplotst*> farms)
     {
         // this algorithm attempts to change as few farms as possible, while ensuring that
@@ -210,14 +231,7 @@ public:
             // if there were no farms, do nothing
             for (auto farm : farms)
             {
-                int o = farm->plant_id[season];
-                if (o != -1)
-                {
-                    farm->plant_id[season] = -1;
-                    out << "autofarm: changing farm #" << farm->id <<
-                        " from " << ((o == -1) ? "NONE" : world->raws.plants.all[o]->name) <<
-                        " to NONE" << endl;
-                }
+                set_farm(out, -1, farm, season);
             }
             return;
         }
@@ -251,11 +265,7 @@ public:
             {
                 // pick one of the excess farms and change it to plant this plant
                 df::building_farmplotst* farm = toChange.front();
-                int o = farm->plant_id[season];
-                farm->plant_id[season] = n;
-                out << "autofarm: changing farm #" << farm->id <<
-                    " from " << ((o == -1) ? "NONE" : world->raws.plants.all[o]->name) <<
-                    " to " << ((n == -1) ? "NONE" : world->raws.plants.all[n]->name) << endl;
+                set_farm(out, n, farm, season);
                 toChange.pop();
                 if (c++ == min)
                     extra--;


### PR DESCRIPTION
Change the autofarm plugin to set any farm to fallow whenever no plant remains that both
- can be planted on it
- and has not yet reached its user-configured threshold.

This prevents serious excess plant yields when total farm production potential exceeds total plant consumption.

Resolves #1741.

