### PR TITLE
[embark-assistant] removing 2 dead stores to speed up survey::survey_mid_level_tile

### DIFF
--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -996,7 +996,6 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
 
             base_z = elevation - 1;
             features = details->features[i][k];
-            std::map<int, int> layer_bottom, layer_top;
             mlt->at(i).at(k).adamantine_level = -1;
             mlt->at(i).at(k).magma_level = -1;
 
@@ -1027,8 +1026,6 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
                     feature->min_z != -30000) {
                     auto layer = world_data->underground_regions[feature->layer];
 
-                    layer_bottom[layer->layer_depth] = feature->min_z;
-                    layer_top[layer->layer_depth] = feature->max_z;
                     base_z = std::min((int)base_z, (int)feature->min_z);
 
                     if (layer->type == df::world_underground_region::MagmaSea) {

--- a/plugins/embark-assistant/survey.h
+++ b/plugins/embark-assistant/survey.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <map>
 
 #include "DataDefs.h"
 #include "df/coord2d.h"


### PR DESCRIPTION
as it says in the title

details:
- survey.cpp: removing maps layer_bottom and layer_top, which are never read, but slow down survey_mid_level_tile significantly because entries are added quite often into the tree map structure
- survey.h: removing now obsolete include for map

forum discussion for reference
http://www.bay12forums.com/smf/index.php?topic=169634.msg8128622#msg8128622
and more current
http://www.bay12forums.com/smf/index.php?topic=169634.msg8235898#msg8235898

@PatrikLundell: Just remembered that it helps to "@" the reviewer... :facepalm: