### PR TITLE
[embark-assistant] early return from embark_update during an active search to improve performance

### DIFF
--- a/plugins/embark-assistant/embark-assistant.cpp
+++ b/plugins/embark-assistant/embark-assistant.cpp
@@ -57,6 +57,12 @@ namespace embark_assist {
         //===============================================================================
 
         void embark_update() {
+            // not updating the embark overlay during an active find/match/survey phase
+            // which leads to better performance
+            if (state != nullptr && state->match_iterator.active) {
+                return;
+            }
+
             auto screen = Gui::getViewscreenByType<df::viewscreen_choose_start_sitest>(0);
             embark_assist::defs::mid_level_tiles mlt;
             embark_assist::survey::initiate(&mlt);

--- a/plugins/embark-assistant/matcher.cpp
+++ b/plugins/embark-assistant/matcher.cpp
@@ -3065,6 +3065,12 @@ uint16_t embark_assist::matcher::find(embark_assist::defs::match_iterators *iter
         iterator->active = !(iterator->i > world->worldgen.worldgen_parms.dim_y / 16);
 
         if (!iterator->active) {
+            // if the cursor was positioned in the lower right corner before the search it has to be moved to a neighbouring tile manually 
+            // to force another call to embark_update when all (incursion) data is finally collected to make sure this specific world tile is properly reevaluated
+            // see the embark_update() in embark-assistant
+            if (iterator->x == world->worldgen.worldgen_parms.dim_x - 1 && iterator->y == world->worldgen.worldgen_parms.dim_y - 1) {
+                embark_assist::matcher::move_cursor(iterator->x - 1, iterator->y);
+            }
             embark_assist::matcher::move_cursor(iterator->x, iterator->y);
 
             if (!survey_results->at(0).at(0).survey_completed) {  // Every world tile has gone through preliminary survey, so add possible incursion resources to each tile.

--- a/plugins/embark-assistant/matcher.cpp
+++ b/plugins/embark-assistant/matcher.cpp
@@ -3065,7 +3065,7 @@ uint16_t embark_assist::matcher::find(embark_assist::defs::match_iterators *iter
         iterator->active = !(iterator->i > world->worldgen.worldgen_parms.dim_y / 16);
 
         if (!iterator->active) {
-            // if the cursor was positioned in the lower right corner before the search it has to be moved to a neighbouring tile manually 
+            // if the cursor was positioned in the lower right corner before the search it has to be moved to a neighbouring tile manually
             // to force another call to embark_update when all (incursion) data is finally collected to make sure this specific world tile is properly reevaluated
             // see the embark_update() in embark-assistant
             if (iterator->x == world->worldgen.worldgen_parms.dim_x - 1 && iterator->y == world->worldgen.worldgen_parms.dim_y - 1) {


### PR DESCRIPTION
details: 
- embark-assistant.cpp: checking if a search is active, if so return early

Especially for large worlds the repeated calls to embark_update during the survey phase can burn a significant amount of cycles while the user often can't see the results before they are reset with the next ones.

@PatrikLundell: ... and here as well.