### PR TITLE
[embark-assistant] reduce memory footprint

### DIFF
--- a/plugins/embark-assistant/defs.h
+++ b/plugins/embark-assistant/defs.h
@@ -146,10 +146,10 @@ namespace embark_assist {
             std::vector<bool> minerals;
             std::vector<int16_t> neighbors;  //  entity_raw indices
             uint8_t necro_neighbors;
-            mid_level_tile north_row[16];
-            mid_level_tile south_row[16];
-            mid_level_tile west_column[16];
-            mid_level_tile east_column[16];
+            mid_level_tile_incursion_base north_row[16];
+            mid_level_tile_incursion_base south_row[16];
+            mid_level_tile_incursion_base west_column[16];
+            mid_level_tile_incursion_base east_column[16];
             uint8_t north_corner_selection[16]; //  0 - 3. For some reason DF stores everything needed for incursion
             uint8_t west_corner_selection[16];  //  detection in 17:th row/colum data in the region details except
                                                 //  this info, so we have to go to neighboring world tiles to fetch it.

--- a/plugins/embark-assistant/defs.h
+++ b/plugins/embark-assistant/defs.h
@@ -68,9 +68,9 @@ namespace embark_assist {
             Woodland,
             Heavily_Forested
         };
-		
-		// only contains those attributes that are being handled during incursion processing
-		struct mid_level_tile_incursion_base {
+        
+        // only contains those attributes that are being handled during incursion processing
+        struct mid_level_tile_incursion_base {
             uint8_t aquifer = Clear_Aquifer_Bits;
             bool clay = false;
             bool sand = false;
@@ -82,7 +82,7 @@ namespace embark_assist {
             uint8_t evilness_level;  // 0 - 2
         };
 
-		// contains all attributes (some by inheritance), used for regular survey/matching
+        // contains all attributes (some by inheritance), used for regular survey/matching
         struct mid_level_tile : public mid_level_tile_incursion_base {
             bool flux = false;
             bool coal = false;

--- a/plugins/embark-assistant/defs.h
+++ b/plugins/embark-assistant/defs.h
@@ -68,24 +68,29 @@ namespace embark_assist {
             Woodland,
             Heavily_Forested
         };
-
-        struct mid_level_tile {
+		
+		// only contains those attributes that are being handled during incursion processing
+		struct mid_level_tile_incursion_base {
             uint8_t aquifer = Clear_Aquifer_Bits;
             bool clay = false;
             bool sand = false;
-            bool flux = false;
-            bool coal = false;
             int8_t soil_depth;
-            int8_t offset;
             int16_t elevation;
-            river_sizes river_size = river_sizes::None;
-            int16_t river_elevation = 100;
-            int8_t adamantine_level;  // -1 = none, 0 .. 3 = cavern 1 .. magma sea. Currently not used beyond present/absent.
-            int8_t magma_level;  // -1 = none, 0 .. 3 = cavern 3 .. surface/volcano
             int8_t biome_offset;
             tree_levels trees;
             uint8_t savagery_level;  // 0 - 2
             uint8_t evilness_level;  // 0 - 2
+        };
+
+		// contains all attributes (some by inheritance), used for regular survey/matching
+        struct mid_level_tile : public mid_level_tile_incursion_base {
+            bool flux = false;
+            bool coal = false;
+            int8_t offset;
+            river_sizes river_size = river_sizes::None;
+            int16_t river_elevation = 100;
+            int8_t adamantine_level;  // -1 = none, 0 .. 3 = cavern 1 .. magma sea. Currently not used beyond present/absent.
+            int8_t magma_level;  // -1 = none, 0 .. 3 = cavern 3 .. surface/volcano
             std::vector<bool> metals;
             std::vector<bool> economics;
             std::vector<bool> minerals;

--- a/plugins/embark-assistant/matcher.cpp
+++ b/plugins/embark-assistant/matcher.cpp
@@ -68,7 +68,7 @@ namespace embark_assist {
 
         void process_embark_incursion(matcher_info *result,
             embark_assist::defs::world_tile_data *survey_results,
-            embark_assist::defs::mid_level_tile *mlt,  // Note this is a single tile, as opposed to most usages of this variable name.
+            embark_assist::defs::mid_level_tile_incursion_base *mlt,  // Note this is a single tile, as opposed to most usages of this variable name.
             embark_assist::defs::finders *finder,
             int16_t elevation,
             uint16_t x,
@@ -2699,7 +2699,7 @@ namespace embark_assist {
 
         void merge_incursion_into_world_tile(embark_assist::defs::region_tile_datum* current,
             embark_assist::defs::region_tile_datum* target_tile,
-            embark_assist::defs::mid_level_tile* target_mlt) {
+            embark_assist::defs::mid_level_tile_incursion_base* target_mlt) {
             df::world_data* world_data = world->world_data;
 
             current->aquifer |= target_mlt->aquifer;

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -455,7 +455,7 @@ namespace embark_assist {
 
         void process_embark_incursion(embark_assist::defs::site_infos *site_info,
             embark_assist::defs::world_tile_data *survey_results,
-            embark_assist::defs::mid_level_tile *mlt,  // Note this is a single tile, as opposed to most usages of this variable name.
+            embark_assist::defs::mid_level_tile_incursion_base *mlt,  // Note this is a single tile, as opposed to most usages of this variable name.
             int16_t elevation,
             uint16_t x,
             uint16_t y) {

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -1381,50 +1381,50 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
         tile->west_column[i].sand = mlt->at(0).at(i).sand;
         tile->east_column[i].sand = mlt->at(15).at(i).sand;
 
-        tile->north_row[i].flux = mlt->at(i).at(0).flux;  //  Not used
-        tile->south_row[i].flux = mlt->at(i).at(15).flux;
-        tile->west_column[i].flux = mlt->at(0).at(i).flux;
-        tile->east_column[i].flux = mlt->at(15).at(i).flux;
+        // tile->north_row[i].flux = mlt->at(i).at(0).flux;  //  Not used
+        // tile->south_row[i].flux = mlt->at(i).at(15).flux;
+        // tile->west_column[i].flux = mlt->at(0).at(i).flux;
+        // tile->east_column[i].flux = mlt->at(15).at(i).flux;
 
-        tile->north_row[i].coal = mlt->at(i).at(0).coal; //  Not used
-        tile->south_row[i].coal = mlt->at(i).at(15).coal;
-        tile->west_column[i].coal = mlt->at(0).at(i).coal;
-        tile->east_column[i].coal = mlt->at(15).at(i).coal;
+        // tile->north_row[i].coal = mlt->at(i).at(0).coal; //  Not used
+        // tile->south_row[i].coal = mlt->at(i).at(15).coal;
+        // tile->west_column[i].coal = mlt->at(0).at(i).coal;
+        // tile->east_column[i].coal = mlt->at(15).at(i).coal;
 
         tile->north_row[i].soil_depth = mlt->at(i).at(0).soil_depth;
         tile->south_row[i].soil_depth = mlt->at(i).at(15).soil_depth;
         tile->west_column[i].soil_depth = mlt->at(0).at(i).soil_depth;
         tile->east_column[i].soil_depth = mlt->at(15).at(i).soil_depth;
 
-        tile->north_row[i].offset = mlt->at(i).at(0).offset; //  Not used
-        tile->south_row[i].offset = mlt->at(i).at(15).offset;
-        tile->west_column[i].offset = mlt->at(0).at(i).offset;
-        tile->east_column[i].offset = mlt->at(15).at(i).offset;
+        // tile->north_row[i].offset = mlt->at(i).at(0).offset; //  Not used
+        // tile->south_row[i].offset = mlt->at(i).at(15).offset;
+        // tile->west_column[i].offset = mlt->at(0).at(i).offset;
+        // tile->east_column[i].offset = mlt->at(15).at(i).offset;
 
         tile->north_row[i].elevation = mlt->at(i).at(0).elevation;
         tile->south_row[i].elevation = mlt->at(i).at(15).elevation;
         tile->west_column[i].elevation = mlt->at(0).at(i).elevation;
         tile->east_column[i].elevation = mlt->at(15).at(i).elevation;
 
-        tile->north_row[i].river_size = mlt->at(i).at(0).river_size; //  Not used
-        tile->south_row[i].river_size = mlt->at(i).at(15).river_size;
-        tile->west_column[i].river_size = mlt->at(0).at(i).river_size;
-        tile->east_column[i].river_size = mlt->at(15).at(i).river_size;
+        // tile->north_row[i].river_size = mlt->at(i).at(0).river_size; //  Not used
+        // tile->south_row[i].river_size = mlt->at(i).at(15).river_size;
+        // tile->west_column[i].river_size = mlt->at(0).at(i).river_size;
+        // tile->east_column[i].river_size = mlt->at(15).at(i).river_size;
 
-        tile->north_row[i].river_elevation = mlt->at(i).at(0).river_elevation; //  Not used
-        tile->south_row[i].river_elevation = mlt->at(i).at(15).river_elevation;
-        tile->west_column[i].river_elevation = mlt->at(0).at(i).river_elevation;
-        tile->east_column[i].river_elevation = mlt->at(15).at(i).river_elevation;
+        // tile->north_row[i].river_elevation = mlt->at(i).at(0).river_elevation; //  Not used
+        // tile->south_row[i].river_elevation = mlt->at(i).at(15).river_elevation;
+        // tile->west_column[i].river_elevation = mlt->at(0).at(i).river_elevation;
+        // tile->east_column[i].river_elevation = mlt->at(15).at(i).river_elevation;
 
-        tile->north_row[i].adamantine_level = mlt->at(i).at(0).adamantine_level; //  Not used
-        tile->south_row[i].adamantine_level = mlt->at(i).at(15).adamantine_level;
-        tile->west_column[i].adamantine_level = mlt->at(0).at(i).adamantine_level;
-        tile->east_column[i].adamantine_level = mlt->at(15).at(i).adamantine_level;
+        // tile->north_row[i].adamantine_level = mlt->at(i).at(0).adamantine_level; //  Not used
+        // tile->south_row[i].adamantine_level = mlt->at(i).at(15).adamantine_level;
+        // tile->west_column[i].adamantine_level = mlt->at(0).at(i).adamantine_level;
+        // tile->east_column[i].adamantine_level = mlt->at(15).at(i).adamantine_level;
 
-        tile->north_row[i].magma_level = mlt->at(i).at(0).magma_level; //  Not used
-        tile->south_row[i].magma_level = mlt->at(i).at(15).magma_level;
-        tile->west_column[i].magma_level = mlt->at(0).at(i).magma_level;
-        tile->east_column[i].magma_level = mlt->at(15).at(i).magma_level;
+        // tile->north_row[i].magma_level = mlt->at(i).at(0).magma_level; //  Not used
+        // tile->south_row[i].magma_level = mlt->at(i).at(15).magma_level;
+        // tile->west_column[i].magma_level = mlt->at(0).at(i).magma_level;
+        // tile->east_column[i].magma_level = mlt->at(15).at(i).magma_level;
 
         tile->north_row[i].biome_offset = mlt->at(i).at(0).biome_offset;
         tile->south_row[i].biome_offset = mlt->at(i).at(15).biome_offset;
@@ -1446,20 +1446,20 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
         tile->west_column[i].evilness_level = mlt->at(0).at(i).evilness_level;
         tile->east_column[i].evilness_level = mlt->at(15).at(i).evilness_level;
 
-        tile->north_row[i].metals.resize(0);  //  Not used
-        tile->south_row[i].metals.resize(0);
-        tile->west_column[i].metals.resize(0);
-        tile->east_column[i].metals.resize(0);
+        // tile->north_row[i].metals.resize(0);  //  Not used
+        // tile->south_row[i].metals.resize(0);
+        // tile->west_column[i].metals.resize(0);
+        // tile->east_column[i].metals.resize(0);
 
-        tile->north_row[i].economics.resize(0);  //  Not used
-        tile->south_row[i].economics.resize(0);
-        tile->west_column[i].economics.resize(0);
-        tile->east_column[i].economics.resize(0);
+        // tile->north_row[i].economics.resize(0);  //  Not used
+        // tile->south_row[i].economics.resize(0);
+        // tile->west_column[i].economics.resize(0);
+        // tile->east_column[i].economics.resize(0);
 
-        tile->north_row[i].minerals.resize(0);  //  Not used
-        tile->south_row[i].minerals.resize(0);
-        tile->west_column[i].minerals.resize(0);
-        tile->east_column[i].minerals.resize(0);
+        // tile->north_row[i].minerals.resize(0);  //  Not used
+        // tile->south_row[i].minerals.resize(0);
+        // tile->west_column[i].minerals.resize(0);
+        // tile->east_column[i].minerals.resize(0);
 
         tile->north_corner_selection[i] = world_data->region_details[0]->edges.biome_corner[i][0];
         tile->west_corner_selection[i] = world_data->region_details[0]->edges.biome_corner[0][i];

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -1381,50 +1381,15 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
         tile->west_column[i].sand = mlt->at(0).at(i).sand;
         tile->east_column[i].sand = mlt->at(15).at(i).sand;
 
-        // tile->north_row[i].flux = mlt->at(i).at(0).flux;  //  Not used
-        // tile->south_row[i].flux = mlt->at(i).at(15).flux;
-        // tile->west_column[i].flux = mlt->at(0).at(i).flux;
-        // tile->east_column[i].flux = mlt->at(15).at(i).flux;
-
-        // tile->north_row[i].coal = mlt->at(i).at(0).coal; //  Not used
-        // tile->south_row[i].coal = mlt->at(i).at(15).coal;
-        // tile->west_column[i].coal = mlt->at(0).at(i).coal;
-        // tile->east_column[i].coal = mlt->at(15).at(i).coal;
-
         tile->north_row[i].soil_depth = mlt->at(i).at(0).soil_depth;
         tile->south_row[i].soil_depth = mlt->at(i).at(15).soil_depth;
         tile->west_column[i].soil_depth = mlt->at(0).at(i).soil_depth;
         tile->east_column[i].soil_depth = mlt->at(15).at(i).soil_depth;
 
-        // tile->north_row[i].offset = mlt->at(i).at(0).offset; //  Not used
-        // tile->south_row[i].offset = mlt->at(i).at(15).offset;
-        // tile->west_column[i].offset = mlt->at(0).at(i).offset;
-        // tile->east_column[i].offset = mlt->at(15).at(i).offset;
-
         tile->north_row[i].elevation = mlt->at(i).at(0).elevation;
         tile->south_row[i].elevation = mlt->at(i).at(15).elevation;
         tile->west_column[i].elevation = mlt->at(0).at(i).elevation;
         tile->east_column[i].elevation = mlt->at(15).at(i).elevation;
-
-        // tile->north_row[i].river_size = mlt->at(i).at(0).river_size; //  Not used
-        // tile->south_row[i].river_size = mlt->at(i).at(15).river_size;
-        // tile->west_column[i].river_size = mlt->at(0).at(i).river_size;
-        // tile->east_column[i].river_size = mlt->at(15).at(i).river_size;
-
-        // tile->north_row[i].river_elevation = mlt->at(i).at(0).river_elevation; //  Not used
-        // tile->south_row[i].river_elevation = mlt->at(i).at(15).river_elevation;
-        // tile->west_column[i].river_elevation = mlt->at(0).at(i).river_elevation;
-        // tile->east_column[i].river_elevation = mlt->at(15).at(i).river_elevation;
-
-        // tile->north_row[i].adamantine_level = mlt->at(i).at(0).adamantine_level; //  Not used
-        // tile->south_row[i].adamantine_level = mlt->at(i).at(15).adamantine_level;
-        // tile->west_column[i].adamantine_level = mlt->at(0).at(i).adamantine_level;
-        // tile->east_column[i].adamantine_level = mlt->at(15).at(i).adamantine_level;
-
-        // tile->north_row[i].magma_level = mlt->at(i).at(0).magma_level; //  Not used
-        // tile->south_row[i].magma_level = mlt->at(i).at(15).magma_level;
-        // tile->west_column[i].magma_level = mlt->at(0).at(i).magma_level;
-        // tile->east_column[i].magma_level = mlt->at(15).at(i).magma_level;
 
         tile->north_row[i].biome_offset = mlt->at(i).at(0).biome_offset;
         tile->south_row[i].biome_offset = mlt->at(i).at(15).biome_offset;
@@ -1445,21 +1410,6 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
         tile->south_row[i].evilness_level = mlt->at(i).at(15).evilness_level;
         tile->west_column[i].evilness_level = mlt->at(0).at(i).evilness_level;
         tile->east_column[i].evilness_level = mlt->at(15).at(i).evilness_level;
-
-        // tile->north_row[i].metals.resize(0);  //  Not used
-        // tile->south_row[i].metals.resize(0);
-        // tile->west_column[i].metals.resize(0);
-        // tile->east_column[i].metals.resize(0);
-
-        // tile->north_row[i].economics.resize(0);  //  Not used
-        // tile->south_row[i].economics.resize(0);
-        // tile->west_column[i].economics.resize(0);
-        // tile->east_column[i].economics.resize(0);
-
-        // tile->north_row[i].minerals.resize(0);  //  Not used
-        // tile->south_row[i].minerals.resize(0);
-        // tile->west_column[i].minerals.resize(0);
-        // tile->east_column[i].minerals.resize(0);
 
         tile->north_corner_selection[i] = world_data->region_details[0]->edges.biome_corner[i][0];
         tile->west_corner_selection[i] = world_data->region_details[0]->edges.biome_corner[0][i];


### PR DESCRIPTION
By defining an additional struct "mid_level_tile_incursion_base" that only contains those attributes that are actually used during incursion processing - notably not the vectors for the inorganics (e.g. metals, economic stone and minerals) as those had the biggest impact on the memory footprint even when empty (48 bytes per vector on Windows) - it is possible to reduce memory consumption of the plugin significantly. 
While users likely won't notice this for small world, for large world (257*257) this amounts to savings of at least 580MiB/608MB.
(48 bytes * 3 vectors * 64 mlt_per_world_tile * world_width * world_height)
Using this new struct as parent for embark_assist::defs::mid_level_tile allows this adaptation with only minimal changes in some classes.

forum discussion for reference
http://www.bay12forums.com/smf/index.php?topic=169634.msg8128622#msg8128622
and more current
http://www.bay12forums.com/smf/index.php?topic=169634.msg8235898#msg8235898

@PatrikLundell: The name of the new struct is absolutely open for discussion. I originally called it "mid_level_tile_basic" but that name is not even half the truth.