### PR TITLE
[quickfort] update quickfort library aliases

### DIFF
--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -315,6 +315,10 @@ disablefinishedgoods: {finishedgoodsprefix}d^
 crafts: {finishedgoodsprefix}{Right}f{Right}{Down 9}{togglesequence 9}^
 jugs:   {finishedgoodsprefix}{Right}f{Right}{Up 2}&{Left}{Down 2}f{Down}f{Down}f^
 
+forbidcrafts: {finishedgoodsprefix}{Right 2}{Down 9}{togglesequence 9}^
+
+permitcrafts: {forbidcrafts}
+
 
 ##################################
 # cloth

--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -384,18 +384,21 @@ disablearmor: {armorprefix}d^
 metalarmor:  {forbidotherarmor}
 otherarmor:  {forbidmetalarmor}
 ironarmor:   {metalarmor}{forbidmetalarmor}{permitironarmor}
+bronzearmor: {metalarmor}{forbidmetalarmor}{permitbronzearmor}
 copperarmor: {metalarmor}{forbidmetalarmor}{permitcopperarmor}
 steelarmor:  {metalarmor}{forbidmetalarmor}{permitsteelarmor}
 
 forbidmetalarmor:  {armorprefix}{Right}{Down 6}f^
 forbidotherarmor:  {armorprefix}{Right}{Down 7}f^
 forbidironarmor:   {armorprefix}{Right}{Down 6}{Right}&^
+forbidbronzearmor: {armorprefix}{Right}{Down 6}{Right}{Down 6}&^
 forbidcopperarmor: {armorprefix}{Right}{Down 6}{Right}{Down 3}&^
 forbidsteelarmor:  {armorprefix}{Right}{Down 6}{Right}{Down 8}&^
 
 permitmetalarmor:   {armorprefix}{Right}{Down 6}p^
 permitotherarmor:   {armorprefix}{Right}{Down 7}p^
 permitironarmor:    {forbidironarmor}
+permitcopperarmor:  {forbidbronzearmor}
 permitcopperarmor:  {forbidcopperarmor}
 permitsteelarmor:   {forbidsteelarmor}
 

--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -338,9 +338,9 @@ enableweapons:  {weaponsprefix}e^
 disableweapons: {weaponsprefix}d^
 
 metalweapons:  {forbidtrapcomponents}{forbidstoneweapons}{forbidotherweapons}
-ironweapons:   {metalweapons}{forbidweapons}{permitironweapons}
-copperweapons: {metalweapons}{forbidweapons}{permitcopperweapons}
-steelweapons:  {metalweapons}{forbidweapons}{permitsteelweapons}
+ironweapons:   {metalweapons}{forbidmetalweapons}{permitironweapons}
+copperweapons: {metalweapons}{forbidmetalweapons}{permitcopperweapons}
+steelweapons:  {metalweapons}{forbidmetalweapons}{permitsteelweapons}
 
 forbidweapons:        {weaponsprefix}{Right}f^
 forbidtrapcomponents: {weaponsprefix}{Right}{Down}f^

--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -339,6 +339,7 @@ disableweapons: {weaponsprefix}d^
 
 metalweapons:  {forbidtrapcomponents}{forbidstoneweapons}{forbidotherweapons}
 ironweapons:   {metalweapons}{forbidmetalweapons}{permitironweapons}
+bronzeweapons: {metalweapons}{forbidmetalweapons}{permitbronzeweapons}
 copperweapons: {metalweapons}{forbidmetalweapons}{permitcopperweapons}
 steelweapons:  {metalweapons}{forbidmetalweapons}{permitsteelweapons}
 
@@ -348,6 +349,7 @@ forbidmetalweapons:   {weaponsprefix}{Right}{Down 2}f^
 forbidstoneweapons:   {weaponsprefix}{Right}{Down 3}f^
 forbidotherweapons:   {weaponsprefix}{Right}{Down 4}f^
 forbidironweapons:    {weaponsprefix}{Right}{Down 2}{Right}&^
+forbidbronzeweapons:  {weaponsprefix}{Right}{Down 2}{Right}{Down 6}&^
 forbidcopperweapons:  {weaponsprefix}{Right}{Down 2}{Right}{Down 3}&^
 forbidsteelweapons:   {weaponsprefix}{Right}{Down 2}{Right}{Down 8}&^
 
@@ -357,6 +359,7 @@ permitmetalweapons:   {weaponsprefix}{Right}{Down 2}p^
 permitstoneweapons:   {weaponsprefix}{Right}{Down 3}p^
 permitotherweapons:   {weaponsprefix}{Right}{Down 4}p^
 permitironweapons:    {forbidironweapons}
+permitbronzeweapons:  {forbidbronzeweapons}
 permitcopperweapons:  {forbidcopperweapons}
 permitsteelweapons:   {forbidsteelweapons}
 

--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -398,7 +398,7 @@ forbidsteelarmor:  {armorprefix}{Right}{Down 6}{Right}{Down 8}&^
 permitmetalarmor:   {armorprefix}{Right}{Down 6}p^
 permitotherarmor:   {armorprefix}{Right}{Down 7}p^
 permitironarmor:    {forbidironarmor}
-permitcopperarmor:  {forbidbronzearmor}
+permitbronzearmor:  {forbidbronzearmor}
 permitcopperarmor:  {forbidcopperarmor}
 permitsteelarmor:   {forbidsteelarmor}
 

--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -104,7 +104,7 @@ plants:         {foodprefix}b{Right}{Down 4}p^
 booze:          {foodprefix}b{Right}{Down 5}p{Down}p^
 seeds:          {foodprefix}b{Right}{Down 9}p^
 dye:            {foodprefix}b{Right}{Down 11}{Right}{Down 28}{togglesequence 4}^
-tallow:         {foodprefix}b{Right}{Down 13}{Right}{Down}{togglesequence2 811}^
+tallow:         {foodprefix}b{Right}{Down 13}{Right}{Down}{togglesequence2 822}^
 miscliquid:     {foodprefix}b{Right}{Down 18}p^
 
 forbidpreparedfood:   {foodprefix}u^
@@ -113,7 +113,7 @@ forbidplants:         {foodprefix}{Right}{Down 4}f^
 forbidbooze:          {foodprefix}{Right}{Down 5}f{Down}f^
 forbidseeds:          {foodprefix}{Right}{Down 9}f^
 forbiddye:            {foodprefix}{Right}{Down 11}{Right}{Down 28}{togglesequence 4}^
-forbidtallow:         {foodprefix}{Right}{Down 13}{Right}{Down}{togglesequence2 811}^
+forbidtallow:         {foodprefix}{Right}{Down 13}{Right}{Down}{togglesequence2 822}^
 forbidmiscliquid:     {foodprefix}{Right}{Down 18}f^
 
 permitpreparedfood:   {forbidpreparedfood}

--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -312,7 +312,8 @@ finishedgoodsprefix:  {enter_sp_config}{Down 10}
 enablefinishedgoods:  {finishedgoodsprefix}e^
 disablefinishedgoods: {finishedgoodsprefix}d^
 
-jugs: {finishedgoodsprefix}{Right}f{Right}{Up 2}&{Left}{Down 2}f{Down}f{Down}f^
+crafts: {finishedgoodsprefix}{Right}f{Right}{Down 9}{togglesequence 9}^
+jugs:   {finishedgoodsprefix}{Right}f{Right}{Up 2}&{Left}{Down 2}f{Down}f{Down}f^
 
 
 ##################################

--- a/data/quickfort/aliases-common.txt
+++ b/data/quickfort/aliases-common.txt
@@ -104,7 +104,7 @@ plants:         {foodprefix}b{Right}{Down 4}p^
 booze:          {foodprefix}b{Right}{Down 5}p{Down}p^
 seeds:          {foodprefix}b{Right}{Down 9}p^
 dye:            {foodprefix}b{Right}{Down 11}{Right}{Down 28}{togglesequence 4}^
-tallow:         {foodprefix}b{Right}{Down 13}{Right}{Down}{togglesequence2 822}^
+tallow:         {foodprefix}b{Right}{Down 13}{Right}stallow&p^
 miscliquid:     {foodprefix}b{Right}{Down 18}p^
 
 forbidpreparedfood:   {foodprefix}u^
@@ -113,7 +113,7 @@ forbidplants:         {foodprefix}{Right}{Down 4}f^
 forbidbooze:          {foodprefix}{Right}{Down 5}f{Down}f^
 forbidseeds:          {foodprefix}{Right}{Down 9}f^
 forbiddye:            {foodprefix}{Right}{Down 11}{Right}{Down 28}{togglesequence 4}^
-forbidtallow:         {foodprefix}{Right}{Down 13}{Right}{Down}{togglesequence2 822}^
+forbidtallow:         {foodprefix}{Right}{Down 13}{Right}stallow&f^
 forbidmiscliquid:     {foodprefix}{Right}{Down 18}f^
 
 permitpreparedfood:   {forbidpreparedfood}
@@ -122,7 +122,7 @@ permitplants:         {foodprefix}{Right}{Down 4}p^
 permitbooze:          {foodprefix}{Right}{Down 5}p{Down}p^
 permitseeds:          {foodprefix}{Right}{Down 9}p^
 permitdye:            {forbiddye}
-permittallow:         {forbidtallow}
+permittallow:         {foodprefix}{Right}{Down 13}{Right}stallow&p^
 permitmiscliquid:     {foodprefix}{Right}{Down 18}p^
 
 # the next two aliases are for compatibility with previous implementations of

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,7 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 - `embark-assistant`: improved performance of surveying
-- `quickfort`: fix library aliases for iron, copper, and steel weapons; add aliases for bronze weapons and armor
+- `quickfort`: fix library aliases for iron, copper, and steel weapons; add aliases for bronze weapons and armor; add alias for tradeable crafts
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,7 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 - `embark-assistant`: improved performance of surveying
-- `quickfort`: fix library aliases for iron, copper, and steel weapons
+- `quickfort`: fix library aliases for iron, copper, and steel weapons; add aliases for bronze weapons
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,7 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 - `embark-assistant`: improved performance of surveying
-- `quickfort`: fix library aliases for iron, copper, and steel weapons; add aliases for bronze weapons
+- `quickfort`: fix library aliases for iron, copper, and steel weapons; add aliases for bronze weapons and armor
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 - `embark-assistant`: improved performance of surveying
+- `quickfort`: fix library aliases for iron, copper, and steel weapons
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,7 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed order of factors when calculating min temperature
 - `embark-assistant`: improved performance of surveying
-- `quickfort`: fix library aliases for iron, copper, and steel weapons; add aliases for bronze weapons and armor; add alias for tradeable crafts
+- `quickfort`: fix library aliases for tallow and iron, copper, and steel weapons; add aliases for bronze weapons and armor; add alias for tradeable crafts
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``

--- a/docs/guides/quickfort-alias-guide.rst
+++ b/docs/guides/quickfort-alias-guide.rst
@@ -291,8 +291,8 @@ with your aliases just like they do with library aliases. In this case, using
 with both stockpiles and hauling routes.
 
 Note that some aliases use the DFHack-provided search prompts. If you get errors
-while running ``#query`` blueprints, ensure the DFHack `search <search-plugin>`
-plugin is enabled.
+while running ``#query`` blueprints, ensure the DFHack `search-plugin` plugin is
+enabled.
 
 Naming aliases
 ~~~~~~~~~~~~~~

--- a/docs/guides/quickfort-alias-guide.rst
+++ b/docs/guides/quickfort-alias-guide.rst
@@ -282,13 +282,17 @@ library, discussing their intended usage and detailing sub-aliases that you
 can define to customize their behavior.
 
 If you do define your own custom aliases in
-``dfhack-config/quickfort/aliases.txt``, try to build on the library aliases.
-For example, if you create an alias to modify particular furniture stockpile
-settings, start your alias with ``{furnitureprefix}`` instead of
-``s{Down 2}``. Using library prefixes will allow sub-aliases to work with your
-aliases just like they do with library aliases. In this case, using
+``dfhack-config/quickfort/aliases.txt``, try to build on library alias
+components. For example, if you create an alias to modify particular furniture
+stockpile settings, start your alias with ``{furnitureprefix}`` instead of
+``s{Down 2}``. Using library prefixes will allow library sub-aliases to work
+with your aliases just like they do with library aliases. In this case, using
 ``{furnitureprefix}`` will allow your stockpile customization alias to work
 with both stockpiles and hauling routes.
+
+Note that some aliases use the DFHack-provided search prompts. If you get errors
+while running ``#query`` blueprints, ensure the DFHack `search <search-plugin>`
+plugin is enabled.
 
 Naming aliases
 ~~~~~~~~~~~~~~

--- a/docs/guides/quickfort-alias-guide.rst
+++ b/docs/guides/quickfort-alias-guide.rst
@@ -760,11 +760,12 @@ cutstone     forbidcutstone
 Finished goods stockpile adjustments
 ````````````````````````````````````
 
-+-----------+
-| Exclusive |
-+===========+
-| jugs      |
-+-----------+
+=========  ============  ============
+Exclusive  Forbid        Permit
+=========  ============  ============
+jugs
+crafts     forbidcrafts  permitcrafts
+=========  ============  ============
 
 Cloth stockpile adjustments
 ```````````````````````````
@@ -793,6 +794,7 @@ metalweapons       forbidmetalweapons        permitmetalweapons
 \                  forbidstoneweapons        permitstoneweapons
 \                  forbidotherweapons        permitotherweapons
 ironweapons        forbidironweapons         permitironweapons
+bronzeweapons      forbidbronzeweapons       permitbronzeweapons
 copperweapons      forbidcopperweapons       permitcopperweapons
 steelweapons       forbidsteelweapons        permitsteelweapons
 masterworkweapons  forbidmasterworkweapons   permitmasterworkweapons
@@ -808,6 +810,7 @@ Exclusive        Forbid                  Permit
 metalarmor       forbidmetalarmor        permitmetalarmor
 otherarmor       forbidotherarmor        permitotherarmor
 ironarmor        forbidironarmor         permitironarmor
+bronzearmor      forbidbronzearmor       permitbronzearmor
 copperarmor      forbidcopperarmor       permitcopperarmor
 steelarmor       forbidsteelarmor        permitsteelarmor
 masterworkarmor  forbidmasterworkarmor   permitmasterworkarmor


### PR DESCRIPTION
discovered by ldog on the [forums](http://www.bay12forums.com/smf/index.php?topic=176889.120)

fixed aliases for tallow, iron, copper, and steel weapons; added aliases for bronze and crafts