### PR TITLE
[buildingplan] add 'enable all' option

### DIFF
--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -765,29 +765,32 @@ and displayed with::
 
 The available settings are:
 
-+----------------+---------+---------------------------------------+
-| Setting        | Default | Description                           |
-+================+=========+=======================================+
-| blocks         | true    | Allow blocks, boulders, logs, or bars |
-+----------------+---------+ to be matched for generic "building   |
-| boulders       | true    | material" items                       |
-+----------------+---------+                                       |
-| logs           | true    |                                       |
-+----------------+---------+                                       |
-| bars           | false   |                                       |
-+----------------+---------+---------------------------------------+
-| quickfort_mode | false   | Enable compatibility mode for the     |
-|                |         | legacy Python Quickfort (not required |
-|                |         | for DFHack quickfort)                 |
-+----------------+---------+---------------------------------------+
++----------------+---------+-----------+---------------------------------------+
+| Setting        | Default | Persisted | Description                           |
++================+=========+===========+=======================================+
+| all_enabled    | false   | no        | Enable planning mode for all building |
+|                |         |           | types.                                |
++----------------+---------+-----------+---------------------------------------+
+| blocks         | true    | yes       | Allow blocks, boulders, logs, or bars |
++----------------+---------+           | to be matched for generic "building   |
+| boulders       | true    |           | material" items                       |
++----------------+---------+           |                                       |
+| logs           | true    |           |                                       |
++----------------+---------+           |                                       |
+| bars           | false   |           |                                       |
++----------------+---------+-----------+---------------------------------------+
+| quickfort_mode | false   | no        | Enable compatibility mode for the     |
+|                |         |           | legacy Python Quickfort (not required |
+|                |         |           | for DFHack quickfort)                 |
++----------------+---------+-----------+---------------------------------------+
 
 For example, to ensure you only use blocks when a "building material" item is required, you
 could add this to your ``onMapLoad.init`` file::
 
     on-new-fortress buildingplan set boulders false; buildingplan set logs false
 
-You only need to set the settings for new fortresses since your current filter settings
-are saved with your game.
+Persisted settings (i.e. ``blocks``, ``boulders``, ``logs``, and ``bars``) are saved with
+your game, so you only need to set them to the values you want once.
 
 .. _confirm:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -39,6 +39,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``
+- `buildingplan`: add 'enable all' option for buildingplan (so you don't have to enable all building types individually). this setting is not persisted (just like quickfort_mode is not persisted), but it can be set from onMapLoad.init
+- `buildingplan`: modified ``Planning Mode`` status in the UI to show whether we're in quickfort mode, enable all mode, or whether just the building type is enabled.
 
 # 0.47.04-r4
 

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -1124,7 +1124,7 @@ static bool setSetting(std::string name, bool value) {
     {
         debug("setting all_enabled %d -> %d", all_enabled, value);
         all_enabled = value;
-        return;
+        return true;
     }
     return planner.setGlobalSetting(name, value);
 }

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -27,6 +27,7 @@ REQUIRE_GLOBAL(world); // used in buildingplan library
 
 bool show_help = false;
 bool quickfort_mode = false;
+bool all_enabled = false;
 bool in_dummy_screen = false;
 std::unordered_map<BuildingTypeKey, bool, BuildingTypeKeyHash> planmode_enabled;
 
@@ -284,7 +285,7 @@ void ViewscreenChooseMaterial::render()
 //START Viewscreen Hook
 static bool is_planmode_enabled(BuildingTypeKey key)
 {
-    return planmode_enabled[key] || quickfort_mode;
+    return planmode_enabled[key] || quickfort_mode || all_enabled;
 }
 
 static std::string get_item_label(const BuildingTypeKey &key, int item_idx)
@@ -387,6 +388,7 @@ static void show_global_settings_dialog()
     lua_newtable(L);
     int ctable = lua_gettop(L);
     Lua::SetField(L, quickfort_mode, ctable, "quickfort_mode");
+    Lua::SetField(L, all_enabled, ctable, "all_enabled");
 
     for (auto & setting : planner.getGlobalSettings())
     {
@@ -629,7 +631,8 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
             show_help = true;
         }
 
-        if (input->count(interface_key::CUSTOM_SHIFT_P))
+        if (!quickfort_mode && !all_enabled
+            && input->count(interface_key::CUSTOM_SHIFT_P))
         {
             planmode_enabled[key] = !planmode_enabled[key];
             if (!is_planmode_enabled(key))
@@ -765,8 +768,16 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
             OutputString(COLOR_WHITE, x, y, "Use Shift-Keys here", true, left_margin);
         }
 
-        OutputToggleString(x, y, "Planning Mode", interface_key::CUSTOM_SHIFT_P,
-            planmode_enabled[key], true, left_margin, COLOR_WHITE, COLOR_LIGHTRED);
+        OutputHotkeyString(x, y, "Planning Mode", interface_key::CUSTOM_SHIFT_P);
+        OutputString(COLOR_WHITE, x, y, ": ");
+        if (quickfort_mode)
+            OutputString(COLOR_YELLOW, x, y, "Quickfort", true, left_margin);
+        else if (all_enabled)
+            OutputString(COLOR_YELLOW, x, y, "All", true, left_margin);
+        else if (planmode_enabled[key])
+            OutputString(COLOR_GREEN, x, y, "On", true, left_margin);
+        else
+            OutputString(COLOR_GREY, x, y, "Off", true, left_margin);
         OutputHotkeyString(x, y, "Global Settings", interface_key::CUSTOM_SHIFT_G,
             true, left_margin, COLOR_WHITE, COLOR_LIGHTRED);
 
@@ -963,6 +974,7 @@ static command_result buildingplan_cmd(color_ostream &out, vector <string> & par
             // display current settings
             out.print("active settings:\n");
 
+            out.print("  all_enabled = %s\n", all_enabled ? "true" : "false");
             for (auto & setting : planner.getGlobalSettings())
             {
                 out.print("  %s = %s\n", setting.first.c_str(),
@@ -1107,6 +1119,12 @@ static bool setSetting(std::string name, bool value) {
         debug("setting quickfort_mode %d -> %d", quickfort_mode, value);
         quickfort_mode = value;
         return true;
+    }
+    if (name == "all_enabled")
+    {
+        debug("setting all_enabled %d -> %d", all_enabled, value);
+        all_enabled = value;
+        return;
     }
     return planner.setGlobalSetting(name, value);
 }

--- a/plugins/lua/buildingplan.lua
+++ b/plugins/lua/buildingplan.lua
@@ -229,7 +229,16 @@ end
     setting is not needed for DFHack quickfort.
 --]]
 function GlobalSettings:init()
+
     self.subviews.label:setText{
+        self:make_setting_label_token('Enable all', 'CUSTOM_E', 'all_enabled', 12),
+            self:make_setting_value_token('all_enabled'), '\n',
+        '  Enables buildingplan for all building types. Use this to avoid having\n',
+        '  to manually enable buildingplan for each building type that you want\n',
+        '  to plan. Note that DFHack quickfort will use buildingplan to manage\n',
+        '  buildings regardless of whether buildingplan is "enabled" for the\n',
+        '  building type.\n',
+        '\n',
         'Allowed types for generic, fire-safe, and magma-safe building material:\n',
         self:make_setting_label_token('Blocks', 'CUSTOM_B', 'blocks', 10),
             self:make_setting_value_token('blocks'), '\n',


### PR DESCRIPTION
A quick way to enable planning mode for all building types. This kind of functionality is much more important now than it used to be since now there are so many supported building types.

Also modified the 'Planning Mode' status on the building placement screen to reflect whether we're in quickfort mode, enable all mode, or whether just the building type is enabled.

this setting is not persisted (just like quickfort_mode is not persisted), but it can be set from onMapLoad.init