### PR TITLE
[stockflow] don't steal input during building rename

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `embark-assistant`: fixed order of factors when calculating min temperature
 - `embark-assistant`: improved performance of surveying
 - `quickfort`: creating zones no longer causes eventual crashes
+- `stockflow`: fixed 'j' character not being allowed in stockpile names
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``

--- a/plugins/stockflow.cpp
+++ b/plugins/stockflow.cpp
@@ -266,6 +266,9 @@ struct stockflow_hook : public df::viewscreen_dwarfmodest {
     typedef df::viewscreen_dwarfmodest interpose_base;
 
     bool handleInput(set<df::interface_key> *input) {
+        if (Gui::inRenameBuilding())
+            return false;
+
         building_stockpilest *sp = get_selected_stockpile();
         if (!sp)
             return false;


### PR DESCRIPTION
discovered while testing quickfort when my "jugs" stockpile never got named correctly and messed up the remainder of the blueprint.