### PR TITLE
[stockpile, stockflow] resolve hotkey help text conflict

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `embark-assistant`: fixed order of factors when calculating min temperature
 - `embark-assistant`: improved performance of surveying
 - `quickfort`: creating zones no longer causes eventual crashes
+- `stockpiles`: no longer outputs hotkey help text beneath `stockflow` hotkey help text
 
 ## Misc Improvements
 - `buildingplan`: set global settings from the ``DFHack#`` prompt: e.g.  ``buildingplan set boulders false``

--- a/plugins/stockpiles/stockpiles.cpp
+++ b/plugins/stockpiles/stockpiles.cpp
@@ -409,18 +409,7 @@ struct stockpiles_import_hook : public df::viewscreen_dwarfmodest
         auto dims = Gui::getDwarfmodeViewDims();
         int left_margin = dims.menu_x1 + 1;
         int x = left_margin;
-        int y = dims.y2 - 3;
-
-        int links = 0;
-        links += sp->links.give_to_pile.size();
-        links += sp->links.take_from_pile.size();
-        links += sp->links.give_to_workshop.size();
-        links += sp->links.take_from_workshop.size();
-        if ( links + 12 >= y )
-        {
-            y += 1;
-        }
-
+        int y = dims.y2 - 7; // above automelt, autotrade, stocks, and stockflow
         OutputHotkeyString ( x, y, "Load/Save Settings", "l", true, left_margin, COLOR_WHITE, COLOR_LIGHTRED );
     }
 };


### PR DESCRIPTION
They were overwriting each other when both plugins are enabled.

I removed stockpiles's dynamic placement code as well. it attempted to move the hotkey help text down if it covered any stockpile links, but this will no longer work since other hotkey text already takes up all the lines below stockpiles' hotkey text.

there are five plugins (that I know of) outputting hotkey help text at the bottom of stockpile screens: automelt, autotrade, stockpile, stocks, and stockflow. I suspect this is not the last conflict between that set that we'll see.