### PR TITLE
[orders] don't crash on importing malformed json

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -33,6 +33,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 # Future
 
+## Fixes
+- `orders`: don't crash when importing orders with malformed JSON
+
 # 0.47.04-r5
 
 ## Fixes

--- a/plugins/orders.cpp
+++ b/plugins/orders.cpp
@@ -426,29 +426,38 @@ static command_result orders_import_command(color_ostream & out, const std::stri
         return CR_WRONG_USAGE;
     }
 
+    const std::string filename("dfhack-config/orders/" + name + ".json");
     Json::Value orders;
 
     {
-        std::ifstream file("dfhack-config/orders/" + name + ".json");
+        std::ifstream file(filename);
 
         if (!file.good())
         {
-            out << COLOR_LIGHTRED << "Cannot find orders file." << std::endl;
+            out << COLOR_LIGHTRED << "Cannot find orders file: " << filename << std::endl;
             return CR_FAILURE;
         }
 
-        file >> orders;
+        try
+        {
+            file >> orders;
+        }
+        catch (const std::exception & e)
+        {
+            out << COLOR_LIGHTRED << "Error reading orders file: " << filename << ": " << e.what() << std::endl;
+            return CR_FAILURE;
+        }
 
         if (!file.good())
         {
-            out << COLOR_LIGHTRED << "Error reading orders file." << std::endl;
+            out << COLOR_LIGHTRED << "Error reading orders file: " << filename << std::endl;
             return CR_FAILURE;
         }
     }
 
     if (orders.type() != Json::arrayValue)
     {
-        out << COLOR_LIGHTRED << "Invalid orders file: expected array" << std::endl;
+        out << COLOR_LIGHTRED << "Invalid orders file: " << filename << ": expected array" << std::endl;
         return CR_FAILURE;
     }
 


### PR DESCRIPTION
to reproduce: take a regular exported orders file, remove a comma between two elements, try to import.

this PR also adds the filename to error messages that have to do with file read errors.