### PR TITLE
[embark-assistant] Improve performance of surveying => faster search

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `embark-assistant`: fixed bug in soil depth determination for ocean tiles
 
+## Misc Improvements
+- `embark-assistant`: slightly improved performance of surveying
+
 # 0.47.04-r5
 
 ## Fixes

--- a/plugins/embark-assistant/embark-assistant.cpp
+++ b/plugins/embark-assistant/embark-assistant.cpp
@@ -285,7 +285,6 @@ command_result embark_assistant(color_ostream &out, std::vector <std::string> & 
     }
 
     embark_assist::main::state = new embark_assist::main::states;
-    embark_assist::survey::initiate(&embark_assist::main::state->mlt);
 
     embark_assist::main::state->match_iterator.active = false;
 
@@ -310,6 +309,7 @@ command_result embark_assistant(color_ostream &out, std::vector <std::string> & 
     }
 
     embark_assist::survey::setup(embark_assist::main::state->max_inorganic);
+    embark_assist::survey::initiate(&embark_assist::main::state->mlt);
     embark_assist::matcher::setup();
     embark_assist::main::state->geo_summary.resize(world_data->geo_biomes.size());
     embark_assist::main::state->survey_results.resize(world->worldgen.worldgen_parms.dim_x);

--- a/plugins/embark-assistant/embark-assistant.cpp
+++ b/plugins/embark-assistant/embark-assistant.cpp
@@ -47,6 +47,7 @@ namespace embark_assist {
             embark_assist::defs::match_results match_results;
             embark_assist::defs::match_iterators match_iterator;
             uint16_t max_inorganic;
+            embark_assist::defs::mid_level_tiles mlt;
         };
 
         static states *state = nullptr;
@@ -64,14 +65,12 @@ namespace embark_assist {
             }
 
             auto screen = Gui::getViewscreenByType<df::viewscreen_choose_start_sitest>(0);
-            embark_assist::defs::mid_level_tiles mlt;
-            embark_assist::survey::initiate(&mlt);
 
             embark_assist::survey::survey_mid_level_tile(&state->geo_summary,
                 &state->survey_results,
-                &mlt);
+                &state->mlt);
 
-            embark_assist::survey::survey_embark(&mlt,
+            embark_assist::survey::survey_embark(&state->mlt,
                 &state->survey_results,
                 &state->site_info,
                 false);
@@ -129,6 +128,7 @@ namespace embark_assist {
         void shutdown() {
 //            color_ostream_proxy out(Core::getInstance().getConsole());
             embark_assist::survey::shutdown();
+            embark_assist::matcher::shutdown();
             embark_assist::finder_ui::shutdown();
             embark_assist::overlay::shutdown();
             delete state;
@@ -285,6 +285,7 @@ command_result embark_assistant(color_ostream &out, std::vector <std::string> & 
     }
 
     embark_assist::main::state = new embark_assist::main::states;
+    embark_assist::survey::initiate(&embark_assist::main::state->mlt);
 
     embark_assist::main::state->match_iterator.active = false;
 
@@ -309,6 +310,7 @@ command_result embark_assistant(color_ostream &out, std::vector <std::string> & 
     }
 
     embark_assist::survey::setup(embark_assist::main::state->max_inorganic);
+    embark_assist::matcher::setup();
     embark_assist::main::state->geo_summary.resize(world_data->geo_biomes.size());
     embark_assist::main::state->survey_results.resize(world->worldgen.worldgen_parms.dim_x);
 
@@ -378,7 +380,7 @@ command_result embark_assistant(color_ostream &out, std::vector <std::string> & 
     embark_assist::survey::survey_region_sites(&embark_assist::main::state->region_sites);
     embark_assist::overlay::set_sites(&embark_assist::main::state->region_sites);
 
-    embark_assist::defs::mid_level_tiles mlt;
+    embark_assist::defs::mid_level_tiles &mlt = embark_assist::main::state->mlt;
     embark_assist::survey::survey_mid_level_tile(&embark_assist::main::state->geo_summary, &embark_assist::main::state->survey_results, &mlt);
     embark_assist::survey::survey_embark(&mlt, &embark_assist::main::state->survey_results, &embark_assist::main::state->site_info, false);
     embark_assist::overlay::set_embark(&embark_assist::main::state->site_info);

--- a/plugins/embark-assistant/matcher.cpp
+++ b/plugins/embark-assistant/matcher.cpp
@@ -64,6 +64,12 @@ namespace embark_assist {
             bool mineral_3;
         };
 
+        struct states {
+            embark_assist::defs::mid_level_tiles mlt;
+        };
+
+        static states *state;
+
         //=======================================================================================
 
         void process_embark_incursion(matcher_info *result,
@@ -2681,14 +2687,13 @@ namespace embark_assist {
             uint16_t y) {
 
 //            color_ostream_proxy out(Core::getInstance().getConsole());
-            embark_assist::defs::mid_level_tiles mlt;
 
             embark_assist::survey::survey_mid_level_tile(geo_summary,
                 survey_results,
-                &mlt);
+                &state->mlt);
 
             mid_level_tile_match(survey_results,
-                &mlt,
+                &state->mlt,
                 x,
                 y,
                 finder,
@@ -2715,6 +2720,19 @@ namespace embark_assist {
 
 //=======================================================================================
 //  Visible operations
+//=======================================================================================
+
+void embark_assist::matcher::setup() {
+    embark_assist::matcher::state = new(embark_assist::matcher::states);
+    embark_assist::survey::initiate(&state->mlt);
+}
+
+//=======================================================================================
+
+void embark_assist::matcher::shutdown() {
+    delete state;
+}
+
 //=======================================================================================
 
 void embark_assist::matcher::move_cursor(uint16_t x, uint16_t y) {

--- a/plugins/embark-assistant/matcher.cpp
+++ b/plugins/embark-assistant/matcher.cpp
@@ -68,7 +68,7 @@ namespace embark_assist {
             embark_assist::defs::mid_level_tiles mlt;
         };
 
-        static states *state;
+        static states *state = nullptr;
 
         //=======================================================================================
 
@@ -2731,6 +2731,7 @@ void embark_assist::matcher::setup() {
 
 void embark_assist::matcher::shutdown() {
     delete state;
+    state = nullptr;
 }
 
 //=======================================================================================

--- a/plugins/embark-assistant/matcher.h
+++ b/plugins/embark-assistant/matcher.h
@@ -17,5 +17,8 @@ namespace embark_assist {
             embark_assist::defs::geo_data *geo_summary,
             embark_assist::defs::world_tile_data *survey_results,
             embark_assist::defs::match_results *match_results);
+
+        void setup();
+        void shutdown();
     }
 }

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -902,6 +902,21 @@ void embark_assist::survey::high_level_world_survey(embark_assist::defs::geo_dat
 
 //=================================================================================
 
+void reset_mlt_inorganics(embark_assist::defs::mid_level_tiles *mlts, const uint16_t max_inorganic) {
+    for (uint8_t i = 0; i < 16; i++) {
+        for (uint8_t k = 0; k < 16; k++) {
+            embark_assist::defs::mid_level_tile &mlt = mlts->at(i).at(k);
+            for (uint16_t i = 0; i < max_inorganic; i++) {
+                mlt.metals[i] = false;
+                mlt.economics[i] = false;
+                mlt.minerals[i] = false;
+            }
+        }
+    }
+}
+
+//=================================================================================
+
 void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data *geo_summary,
     embark_assist::defs::world_tile_data *survey_results,
     embark_assist::defs::mid_level_tiles *mlt) {
@@ -935,13 +950,7 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
         tile->minerals[i] = 0;
     }
 
-    for (uint8_t i = 0; i < 16; i++) {
-        for (uint8_t k = 0; k < 16; k++) {
-            mlt->at(i).at(k).metals.resize(state->max_inorganic);
-            mlt->at(i).at(k).economics.resize(state->max_inorganic);
-            mlt->at(i).at(k).minerals.resize(state->max_inorganic);
-        }
-    }
+    reset_mlt_inorganics(mlt, state->max_inorganic);
 
     for (uint8_t i = 1; i < 10; i++) survey_results->at(x).at(y).biome_index[i] = -1;
 

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -75,7 +75,7 @@ namespace embark_assist {
             uint16_t max_inorganic;
         };
 
-        static states *state;
+        static states *state = nullptr;
 
         //=======================================================================================
 
@@ -2548,5 +2548,6 @@ void embark_assist::survey::survey_embark(embark_assist::defs::mid_level_tiles *
 
 void embark_assist::survey::shutdown() {
     delete state;
+    state = nullptr;
 }
 

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -902,14 +902,15 @@ void embark_assist::survey::high_level_world_survey(embark_assist::defs::geo_dat
 
 //=================================================================================
 
-void reset_mlt_inorganics(embark_assist::defs::mid_level_tiles *mlts, const uint16_t max_inorganic) {
+void reset_mlt_inorganics(embark_assist::defs::mid_level_tiles &mlts) {
+    const uint16_t size = mlts[0][0].metals.size();
     for (uint8_t i = 0; i < 16; i++) {
         for (uint8_t k = 0; k < 16; k++) {
-            embark_assist::defs::mid_level_tile &mlt = mlts->at(i).at(k);
-            for (uint16_t i = 0; i < max_inorganic; i++) {
-                mlt.metals[i] = false;
-                mlt.economics[i] = false;
-                mlt.minerals[i] = false;
+            embark_assist::defs::mid_level_tile &mlt = mlts[i][k];
+            for (uint16_t l = 0; l < size; l++) {
+                mlt.metals[l] = false;
+                mlt.economics[l] = false;
+                mlt.minerals[l] = false;
             }
         }
     }
@@ -950,7 +951,7 @@ void embark_assist::survey::survey_mid_level_tile(embark_assist::defs::geo_data 
         tile->minerals[i] = 0;
     }
 
-    reset_mlt_inorganics(mlt, state->max_inorganic);
+    reset_mlt_inorganics(*mlt);
 
     for (uint8_t i = 1; i < 10; i++) survey_results->at(x).at(y).biome_index[i] = -1;
 


### PR DESCRIPTION
@PatrikLundell: as announced.
I'll do some comparisons between the current version and the one with the following changes "in place" before removing the "WIP" just to be sure - but the code is mostly taken from the index feature branch which I scrutinized repeatedly concerning the performance of those changes.

Replace the local/automatic mid_level_tiles variable in matcher::match_world_tile with a dynamic one that is created and initialized once during the setup phase. The dynamic part of the contained 768 vectors is being allocated on the heap in both cases - which made the repeated instantiations of the automatic variable so slow/expensive in the first place.

Also replace calls to vector<bool>.resize in nested loops with direct assignments to those vectors, which curiously even after a lot of profiling is the fastest way to reset the inorganic vectors - at least on Windows - as there seems not to exist a template specialization for std::fill in MSVS C++11 in regards to std::vector<bool>.

- embark-assistant.cpp: Replace 2 local/automatic mid_level_tiles variables with a single dynamic variable that is created and initialized during setup as well; add calls to matcher::setup() and matcher::shutdown()
- matcher.cpp/.h: add state with mid_level_tiles member; add setup and shutdown functions
- survey.cpp: add function reset_mlt_inorganics as replacement for the looped calls to vector::resize as all inorganic vectors are now expected to have the proper size when entering survey::survey_mid_level_tile