### PR TITLE
improved pre embark mineral estimates

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -33,6 +33,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 # Future
 
+## Fixes
+- `prospector`: improved pre embark rough estimates
+
 # 0.47.04-r5
 
 ## Fixes


### PR DESCRIPTION
Fix #1772 
It can be noted that I've changed the somewhat arbitrary "average" amounts a little from what I've written in the issue.

Apart from adjusting the calculations, it turned out to be necessary to adjust their summing up, as the previous code applied integer truncation to the parts, resulting in e.g. a faint yellow diamond estimate drop from 128 to 0 when the factor was changed from 42 to 16.

As the comments added indicate, there are more intricacies that can be added, but with doubtful benefit. If someone would perform an analysis to determine more precise "average" cluster, vein, and small cluster sizes it would probably have a greater impact.

The main objective, i.e. to reduce cluster one estimates from 10 times the number of the small cluster material tiles it was enclosed within seems to have been reached, with an estimate of 10 vs an actual number of 9 at the first issue embark indicated in the issue.