### PR TITLE
Upgrade Ruby

### DIFF
--- a/plugins/ruby/ruby.cpp
+++ b/plugins/ruby/ruby.cpp
@@ -298,7 +298,6 @@ static VALUE Qnil = 4;
 #define RUBY_METHOD_FUNC(func) ((VALUE(*)(...))func)
 
 void (*ruby_init_stack)(VALUE*);
-void (*ruby_sysinit)(int *, const char ***);
 void (*ruby_init)(void);
 void (*ruby_init_loadpath)(void);
 void (*ruby_script)(const char*);
@@ -350,8 +349,6 @@ static int df_loadruby(void)
         return 0;
     }
 
-    // ruby_sysinit is optional (ruby1.9 only)
-    ruby_sysinit = (decltype(ruby_sysinit))LookupPlugin(libruby_handle, "ruby_sysinit");
 #define rbloadsyma(s,a) do { if (!(s = (decltype(s))LookupPlugin(libruby_handle, #a))) { \
         fprintf(stderr, "Symbol not found: %s\n", #a); \
         return 0; \
@@ -437,13 +434,6 @@ static void df_rubythread(void *p)
     // may need to be run from df main thread?
     VALUE foo;
     ruby_init_stack(&foo);
-
-    if (ruby_sysinit) {
-        // ruby1.9 specific API
-        static int argc;
-        static const char *argv[] = { "dfhack", 0 };
-        ruby_sysinit(&argc, (const char ***)&argv);
-    }
 
     // initialize the ruby interpreter
     ruby_init();

--- a/plugins/ruby/ruby.cpp
+++ b/plugins/ruby/ruby.cpp
@@ -298,6 +298,7 @@ static VALUE Qnil = 4;
 #define RUBY_METHOD_FUNC(func) ((VALUE(*)(...))func)
 
 void (*ruby_init_stack)(VALUE*);
+void (*ruby_sysinit)(int *, const char ***);
 void (*ruby_init)(void);
 void (*ruby_init_loadpath)(void);
 void (*ruby_script)(const char*);
@@ -349,6 +350,8 @@ static int df_loadruby(void)
         return 0;
     }
 
+    // ruby_sysinit is optional (ruby1.9 only)
+    ruby_sysinit = (decltype(ruby_sysinit))LookupPlugin(libruby_handle, "ruby_sysinit");
 #define rbloadsyma(s,a) do { if (!(s = (decltype(s))LookupPlugin(libruby_handle, #a))) { \
         fprintf(stderr, "Symbol not found: %s\n", #a); \
         return 0; \
@@ -434,6 +437,15 @@ static void df_rubythread(void *p)
     // may need to be run from df main thread?
     VALUE foo;
     ruby_init_stack(&foo);
+
+#ifdef _WIN32
+    if (ruby_sysinit) {
+        // ruby1.9 specific API
+        static int argc;
+        static const char *argv[] = { "dfhack", 0 };
+        ruby_sysinit(&argc, (const char ***)&argv);
+    }
+#endif
 
     // initialize the ruby interpreter
     ruby_init();

--- a/plugins/ruby/ruby.cpp
+++ b/plugins/ruby/ruby.cpp
@@ -307,7 +307,8 @@ ID (*rb_intern)(const char*);
 VALUE (*rb_funcall)(VALUE, ID, int, ...);
 VALUE (*rb_define_module)(const char*);
 void (*rb_define_singleton_method)(VALUE, const char*, VALUE(*)(...), int);
-VALUE (*rb_gv_get)(const char*);
+VALUE (*rb_errinfo)(void);
+void (*rb_set_errinfo)(VALUE);
 VALUE (*rb_str_new)(const char*, long);
 char* (*rb_string_value_ptr)(VALUE*);
 VALUE (*rb_eval_string_protect)(const char*, int*);
@@ -365,7 +366,8 @@ static int df_loadruby(void)
     rbloadsym(rb_funcall);
     rbloadsym(rb_define_module);
     rbloadsym(rb_define_singleton_method);
-    rbloadsym(rb_gv_get);
+    rbloadsym(rb_errinfo);
+    rbloadsym(rb_set_errinfo);
     rbloadsym(rb_str_new);
     rbloadsym(rb_string_value_ptr);
     rbloadsym(rb_eval_string_protect);
@@ -410,7 +412,7 @@ static void dump_rb_error(void)
 {
     VALUE s, err;
 
-    err = rb_gv_get("$!");
+    err = rb_errinfo();
 
     s = rb_funcall(err, rb_intern("class"), 0);
     s = rb_funcall(s, rb_intern("name"), 0);
@@ -423,6 +425,8 @@ static void dump_rb_error(void)
     for (int i=0 ; i<8 ; ++i)
         if ((s = rb_ary_shift(err)) != Qnil)
             printerr(" %s\n", rb_string_value_ptr(&s));
+
+    rb_set_errinfo(Qnil);
 }
 
 // ruby thread main loop


### PR DESCRIPTION
This is intended to eventually fix #1718 - see issue for details. Currently it just updates the `ruby` plugin to work with Ruby 2.7. Builds of Ruby 2.7 are available at https://github.com/lethosor/ruby-build/actions and are not yet downloaded/installed on this branch.

Opening a PR primarily to trigger CI builds for other platforms.