### PR TITLE
[luacov] add luacov as a DFHack dependency and install it into hack/lua/luacov

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,4 @@
 [submodule "depends/luacov"]
 	path = depends/luacov
 	url = ../../keplerproject/luacov.git
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,4 +31,3 @@
 [submodule "depends/luacov"]
 	path = depends/luacov
 	url = ../../keplerproject/luacov.git
-	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,7 @@
 	path = depends/libexpat
 	url = ../../DFHack/libexpat.git
 	shallow = true
+[submodule "depends/luacov"]
+	path = depends/luacov
+	url = ../../keplerproject/luacov.git
+	shallow = true

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -47,6 +47,7 @@ alt-getopt_     MIT           \(c\) 2009 Aleksey Cheusov
 .. _libzip: https://github.com/nih-at/libzip
 .. _linenoise: http://github.com/antirez/linenoise
 .. _lua: http://www.lua.org
+.. _luacov: https://github.com/keplerproject/luacov
 .. _luafilesystem: https://github.com/keplerproject/luafilesystem
 .. _lua-profiler: http://lua-users.org/wiki/PepperfishProfiler
 .. _protobuf: https://github.com/google/protobuf

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -27,6 +27,7 @@ libexpat_       MIT           \(c\) 1998-2000 Thai Open Source Software Center L
 libzip_         BSD 3-clause  \(c\) 1999-2020 Dieter Baron and Thomas Klausner
 linenoise_      BSD 2-clause  \(c\) 2010, Salvatore Sanfilippo & Pieter Noordhuis
 lua_            MIT           \(c\) 1994-2008, Lua.org, PUC-Rio.
+luacov_         MIT           \(c\) 2007 - 2018 Hisham Muhammad
 luafilesystem_  MIT           \(c\) 2003-2014, Kepler Project
 lua-profiler_   MIT           \(c\) 2002,2003,2004 Pepperfish
 protobuf_       BSD 3-clause  \(c\) 2008, Google Inc.

--- a/depends/CMakeLists.txt
+++ b/depends/CMakeLists.txt
@@ -22,6 +22,8 @@ option(CLSOCKET_DEP_ONLY "Build for use inside other CMake projects as dependenc
 add_subdirectory(clsocket)
 ide_folder(clsocket "Depends")
 
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/luacov/src/luacov/ DESTINATION ${DFHACK_DATA_DESTINATION}/lua/luacov)
+
 # set the default values of libexpat options - the descriptions are left empty
 # because later option() calls *do* override those
 set(EXPAT_BUILD_EXAMPLES OFF CACHE BOOL "")


### PR DESCRIPTION
#1690

This is just the pure Lua implementation of luacov. I'll investigate possibly integrating with cluacov later. cluacov replaces the debug hook and "improves accuracy", but in my tests I've been perfectly happy with the accuracy of the lua implementation of the debug hook.

I installed it in `hack/lua/luacov` as a generally accessible library even though luacov will not be accessed directly by the majority of scripts. It still needs to be accessible to the luacov report generation script (`scripts/devel/luacov`) and to the C++ code, which calls `luacov.runner.init()` and manages installing the luacov debug hook in coprocesses.

I fixed the luacov repo to the recent 0.15.0 release. This release is mistakenly named '0.14.0' internally, but this is cosmetic.