### PR TITLE
[luacov] enable luacov coverage monitoring if DFHACK_ENABLE_LUACOV is set

### DIFF
--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -535,6 +535,10 @@ on UNIX-like systems:
 - ``DFHACK_LOG_MEM_RANGES`` (macOS only): if set, logs memory ranges to
   ``stderr.log``. Note that `devel/lsmem` can also do this.
 
+- ``DFHACK_ENABLE_LUACOV``: if set, enables coverage analysis of Lua scripts.
+  Use the `devel/luacov` script to generage coverage reports from the gathered
+  metrics.
+
 Other (non-DFHack-specific) variables that affect DFHack:
 
 - ``TERM``: if this is set to ``dumb`` or ``cons25`` on \*nix, the console will

--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -536,7 +536,7 @@ on UNIX-like systems:
   ``stderr.log``. Note that `devel/lsmem` can also do this.
 
 - ``DFHACK_ENABLE_LUACOV``: if set, enables coverage analysis of Lua scripts.
-  Use the `devel/luacov` script to generage coverage reports from the gathered
+  Use the `devel/luacov` script to generate coverage reports from the collected
   metrics.
 
 Other (non-DFHack-specific) variables that affect DFHack:

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1190,7 +1190,7 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
                 con.printerr(
                     "Failed to register hook. This can happen if you have"
                     " lua profiling or coverage monitoring enabled. Use"
-                    " 'kill-lua force' to force, but this will disable"
+                    " 'kill-lua force' to force, but this may disable"
                     " profiling and coverage monitoring.\n");
             }
         }

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1186,7 +1186,13 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
                     force = true;
             }
             if (!Lua::Interrupt(force))
-                con.printerr("Failed to register hook - use 'kill-lua force' to force\n");
+            {
+                con.printerr(
+                    "Failed to register hook. This can happen if you have"
+                    " lua profiling or coverage monitoring enabled. Use"
+                    " 'kill-lua force' to force, but this will disable"
+                    " profiling and coverage monitoring.\n");
+            }
         }
         else if (builtin == "script")
         {

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -1757,7 +1757,7 @@ lua_State *DFHack::Lua::Open(color_ostream &out, lua_State *state)
         // reads config from .luacov or uses defaults if file doesn't exist.
         // note that luacov overrides the debug hook installed by
         // interrupt_init() above.
-        if (PushModulePublic(out, state, "luacov_helper", "init") &&
+        if (PushModulePublic(out, state, "luacov.runner", "init") &&
             SafeCall(out, state, 0, 0))
         {
             out.print("Initialized luacov coverage monitoring\n");

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -51,6 +51,26 @@ if dfhack.is_core_context then
     SC_UNPAUSED = 8
 end
 
+-- redirect any output explicitly sent to io.stdout or io.stderr to the standard
+-- output sinks. note that although the functions take and pass ...,
+-- only the first string argument will be printed by dfhack.printerr().
+if not io_write_rerouted then
+    local io_file_methods = getmetatable(io.stderr).__index
+    local std_io_file_write = io_file_methods.write
+    io_file_methods.write = function(f, ...)
+            if f == io.stdout then
+                print(...)
+                return f
+            end
+            if f == io.stderr then
+                dfhack.printerr(...)
+                return f
+            end
+            return std_io_file_write(f, ...)
+        end
+    io_write_rerouted = true
+end
+
 -- Error handling
 
 safecall = dfhack.safecall

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -51,26 +51,6 @@ if dfhack.is_core_context then
     SC_UNPAUSED = 8
 end
 
--- redirect any output explicitly sent to io.stdout or io.stderr to the standard
--- output sinks. note that although the functions take and pass ...,
--- only the first string argument will be printed by dfhack.printerr().
-if not io_write_rerouted then
-    local io_file_methods = getmetatable(io.stderr).__index
-    local std_io_file_write = io_file_methods.write
-    io_file_methods.write = function(f, ...)
-            if f == io.stdout then
-                print(...)
-                return f
-            end
-            if f == io.stderr then
-                dfhack.printerr(...)
-                return f
-            end
-            return std_io_file_write(f, ...)
-        end
-    io_write_rerouted = true
-end
-
 -- Error handling
 
 safecall = dfhack.safecall

--- a/library/lua/luacov_helper.lua
+++ b/library/lua/luacov_helper.lua
@@ -1,0 +1,30 @@
+-- Luacov helper functions. Note that this is not a dfhack module since it can't
+-- depend on dfhack.lua.
+
+local runner = require('luacov.runner')
+
+print('runner.debug_hook:', runner.debug_hook)
+
+function init()
+    runner.init()
+    print('** initializing luacov')
+    print('**   set debug hook to:', debug.gethook())
+end
+
+-- Called by LuaTools.cpp to set the debug hook for new threads. We could do
+-- this in C++, but that's complicated and scary.
+function with_luacov(f)
+    print('** wrapping function', f)
+    return function(...)
+        print('** setting debug hook')
+        print('**   was:', debug.gethook())
+        debug.sethook(runner.debug_hook, "l")
+        print('**   is now:', debug.gethook())
+        print('**   running function:', f)
+        print('**   params:', ...)
+        return f(...)
+    end
+end
+
+
+return _ENV

--- a/library/lua/luacov_helper.lua
+++ b/library/lua/luacov_helper.lua
@@ -3,28 +3,13 @@
 
 local runner = require('luacov.runner')
 
-print('runner.debug_hook:', runner.debug_hook)
-
-function init()
-    runner.init()
-    print('** initializing luacov')
-    print('**   set debug hook to:', debug.gethook())
-end
-
 -- Called by LuaTools.cpp to set the debug hook for new threads. We could do
 -- this in C++, but that's complicated and scary.
 function with_luacov(f)
-    print('** wrapping function', f)
     return function(...)
-        print('** setting debug hook')
-        print('**   was:', debug.gethook())
         debug.sethook(runner.debug_hook, "l")
-        print('**   is now:', debug.gethook())
-        print('**   running function:', f)
-        print('**   params:', ...)
         return f(...)
     end
 end
-
 
 return _ENV


### PR DESCRIPTION
#1690

Use the DFHACK_ENABLE_LUACOV environment var to control whether we initialize and patch luacov in to Lua threads owned by the DFHack core context.

This PR depends on DFHack/scripts#261 for the `devel/luacov` doc header reference (the docs added by this PR will fail until that PR is merged).

On initialization, we load `luacov.runner` and initialize it directly from C++. We also need to ensure the debug hook is installed correctly for coroutine threads. Since creating coroutines in C++ bypasses the [monkey patching luacov does](https://github.com/keplerproject/luacov/blob/master/src/luacov/runner.lua#L449) to inject itself into coroutine contexts, we compensate by reimplementing the monkey patch in our code. We use our own little lua helper function to do this because luacov's similar `with_luacov()` function calls `has_hook_per_thread()`, which would cause an infinite loop when it creates its test coroutine to figure out whether it needs to install its wrapper.

If multiple instances of luacov were to be instantiated, we would be in one of two problematic situations:
1 the `tick` option is not specified in `.luacov` (this is the default). then the coverage metrics gathered by the runner that is not in the same context as the scripts/devel/luacov report generation script are effectively inaccessible, and therefore useless.
2 the `tick` option is specified in a customer `.luacov` and the two runners conflict when they attempt to write to the same output files.

To address this, we only initialize luacov for the core context. Lua files accessed from other contexts will not be included in the coverage reports. If this is a problem, we can implement the proper plumbing to differentiate the configurations among the active luacov runners and make them all accessible for report generation. A dev could also hack it into working by directly calling `devel/luacov` directly from the script in the appropriate context.