### PR TITLE
[test] test/main.lua enhancements

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 - Added more client library implementations to the `remote interface docs <remote-client-libs>`
 
+## Internals
+- The DFHack test harness is now much easier to use for iterative development.  Configuration can now be specified on the commandline, there are more test filter options, and the test harness can now easily rerun tests that have been run before.
+
 # 0.47.05-r1
 
 ## Fixes

--- a/test/main.lua
+++ b/test/main.lua
@@ -37,7 +37,7 @@ local done_command = utils.processArgsGetopt({...}, {
         {'h', 'help', handler=function() help = true end},
         {'n', 'nocache', handler=function() nocache = true end},
         {'d', 'test_dir', hasArg=true,
-         handler=function(arg) mode_filter = arg:split(',') end},
+         handler=function(arg) test_dir = arg end},
         {'m', 'modes', hasArg=true,
          handler=function(arg) mode_filter = arg:split(',') end},
         {'t', 'tests', hasArg=true,
@@ -127,8 +127,9 @@ local function table_eq_recurse(a, b, keys, known_eq)
     return true
 end
 function expect.table_eq(a, b, comment)
-    if type(a) ~= 'table' or type(b) ~= 'table' then
-        return false, comment, 'both operands to table_eq must be tables'
+    if (type(a) ~= 'table' and type(a) ~= 'userdata') or
+            (type(b) ~= 'table' and type(b) ~= 'userdata') then
+        return false, comment, 'operands to table_eq must be tables or userdata'
     end
     local keys, known_eq = {}, {}
     local matched, keys_at_diff, diff = table_eq_recurse(a, b, keys, known_eq)

--- a/test/main.lua
+++ b/test/main.lua
@@ -305,7 +305,7 @@ end
 
 local function finish_tests(done_command)
     dfhack.internal.IN_TEST = false
-    if #done_command > 0 then
+    if done_command and #done_command > 0 then
         dfhack.run_command(done_command)
     end
 end

--- a/test/test.lua
+++ b/test/test.lua
@@ -8,6 +8,9 @@ function test.table_eq()
     expect.true_(expect_raw.table_eq({{'a', k='val'}, 'b'},
                                      {{'a', k='val'}, 'b'}))
 
+    expect.false_(expect_raw.table_eq(nil, nil)) -- operands must be non-nil
+    expect.false_(expect_raw.table_eq({}, nil))
+    expect.false_(expect_raw.table_eq(nil, {}))
     expect.false_(expect_raw.table_eq({}, {''}))
     expect.false_(expect_raw.table_eq({''}, {}))
     expect.false_(expect_raw.table_eq({'a', {}}, {'a'}))

--- a/test/test.lua
+++ b/test/test.lua
@@ -1,3 +1,31 @@
 function test.internal_in_test()
     expect.true_(dfhack.internal.IN_TEST)
 end
+
+function test.table_eq()
+    expect.true_(expect_raw.table_eq({}, {}))
+    expect.true_(expect_raw.table_eq({'a'}, {'a'}))
+    expect.true_(expect_raw.table_eq({{'a', k='val'}, 'b'},
+                                     {{'a', k='val'}, 'b'}))
+
+    expect.false_(expect_raw.table_eq({}, {''}))
+    expect.false_(expect_raw.table_eq({''}, {}))
+    expect.false_(expect_raw.table_eq({'a', {}}, {'a'}))
+    expect.false_(expect_raw.table_eq({{'a', k='val1'}, 'b'},
+                                      {{'a', k='val2'}, 'b'}))
+
+    local tab = {a='a', b='b'}
+    expect.true_(expect_raw.table_eq(tab, tab))
+    expect.true_(expect_raw.table_eq({tab}, {tab}))
+
+    local tab1, tab2 = {'a'}, {'a'}
+    tab1.self, tab2.self = tab1, tab2
+    expect.true_(expect_raw.table_eq(tab1, tab2))
+
+    tab1.other, tab2.other = tab2, tab1
+    expect.true_(expect_raw.table_eq(tab1, tab2))
+
+    local tabA, tabB, tabC, tabD = {k='a'}, {k='a'}, {k='a'}, {k='a'}
+    tabA.next, tabB.next, tabC.next, tabD.next = tabB, tabC, tabD, tabA
+    expect.true_(expect_raw.table_eq(tabA, tabB))
+end

--- a/test/test_test.lua
+++ b/test/test_test.lua
@@ -1,3 +1,5 @@
+local expect_raw = reqscript('test/main').expect
+
 function test.internal_in_test()
     expect.true_(dfhack.internal.IN_TEST)
 end

--- a/travis/run-tests.py
+++ b/travis/run-tests.py
@@ -73,7 +73,7 @@ with open(test_init_file, 'w') as f:
     f.write('''
     devel/dump-rpc dfhack-rpc.txt
     :lua dfhack.internal.addScriptPath(dfhack.getHackPath())
-    test/main lua scr.breakdown_level=df.interface_breakdown_types.%s
+    test/main "lua scr.breakdown_level=df.interface_breakdown_types.%s"
     ''' % ('NONE' if args.no_quit else 'QUIT'))
 
 test_config_file = 'test_config.json'

--- a/travis/run-tests.py
+++ b/travis/run-tests.py
@@ -73,7 +73,7 @@ with open(test_init_file, 'w') as f:
     f.write('''
     devel/dump-rpc dfhack-rpc.txt
     :lua dfhack.internal.addScriptPath(dfhack.getHackPath())
-    test/main "lua scr.breakdown_level=df.interface_breakdown_types.%s"
+    test/main lua scr.breakdown_level=df.interface_breakdown_types.%s
     ''' % ('NONE' if args.no_quit else 'QUIT'))
 
 test_config_file = 'test_config.json'


### PR DESCRIPTION
#1690

new test/main API is backwards compatible with existing usage.

- allow configuration set in test_config.json to be dynamically overridden on the commandline
- make `expect.table_eq()` diff recursively (all existing tests that use it still pass)
- fix implementation of testing for multiple test name filters. the original implementation filtered out too many tests if more than one filter was specified.
- add ability to filter by mode (title, none, etc.)
- add ability to rerun tests that have already been run (I'm actually not sure what the purpose of `test_status.json` is. why would we want to skip a test if it has already been run? If you're running the tests again, haven't you just edited the code and wouldn't you want to see if tests that previously passed are now failing?)
- done command can now be passed as space-separated tokens or as one quoted string
- added output text that says what your test dir is and what your filters are
- added tests for new table_eq implementation