### PR TITLE
[test] exempt lua test files from docstring requirements

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 - Added more client library implementations to the `remote interface docs <remote-client-libs>`
 
+## Internals
+- Lua test files are no longer required to start with standard script documentation (since they aren't runnable scripts)
+
 # 0.47.05-r1
 
 ## Fixes

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -317,7 +317,7 @@ static void listScripts(PluginManager *plug_mgr, std::map<string,string> &pset, 
                 pset[key] = help;
             }
         }
-        else if (all && !files[i].empty() && files[i][0] != '.' && files[i] != "internal")
+        else if (all && !files[i].empty() && files[i][0] != '.' && files[i] != "internal" && files[i] != "test")
         {
             listScripts(plug_mgr, pset, path+files[i]+"/", all, prefix+files[i]+"/");
         }

--- a/travis/script-docs.py
+++ b/travis/script-docs.py
@@ -81,7 +81,7 @@ def check_file(fname):
 def main():
     """Check that all DFHack scripts include documentation"""
     err = 0
-    exclude = set(['internal'])
+    exclude = set(['internal', 'test'])
     for root, dirs, files in os.walk(SCRIPT_PATH, topdown=True):
         dirs[:] = [d for d in dirs if d not in exclude]
         for f in files:


### PR DESCRIPTION
#1690 

exempt lua test files from docstring requirements and don't display them with 'ls'

this prevents test files from cluttering up the ls output. users can't run them directly anyway, and as far as I can see, it doesn't seem that seeing the list of test files in ls output is valuable.

this also removes test/main from ls output. is that ok?