### PR TITLE
[test] force reloading of scripts under test

### DIFF
--- a/ci/test.lua
+++ b/ci/test.lua
@@ -85,7 +85,7 @@ end
 -- forces clean load of scripts directly or indirectly included from the test
 -- file. we use our own scripts table instead of the one in dfhack.internal so
 -- we don't affect the state scripts that are used outside the test harness.
-local test_scripts = {is_test_scripts=true}
+local test_scripts = {}
 local test_envvars = {}
 local function clean_reqscript(name)
     local path = dfhack.findScript(name)

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -83,8 +83,9 @@ local function clean_require(module)
 end
 
 -- similar to clean_require above; forces clean load of scripts directly
--- included from a test file. note that this does *not* force transitively
--- loaded scripts to be reloaded.
+-- included from a test file. note that this does *not* force indirectly loaded
+-- scripts (that is, scripts that are reqscript()'d by the scripts that are
+-- reqscript()'d by the test file) to be reloaded.
 local function clean_reqscript(name)
     dfhack.internal.scripts[dfhack.findScript(name)] = nil
     return reqscript(name)

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -88,7 +88,17 @@ end
 local test_scripts = {is_test_scripts=true}
 local test_envvars = {}
 local function clean_reqscript(name)
-    return dfhack.script_environment(name, true, test_envvars, test_scripts)
+    local path = dfhack.findScript(name)
+    if test_scripts[path] then return test_scripts[path].env end
+    local _, env = dfhack.run_script_with_env(
+        test_envvars,
+        name,
+        {
+            scripts=test_scripts,
+            module=true,
+            module_strict=true
+        })
+    return env
 end
 test_envvars.require = clean_require
 test_envvars.reqscript = clean_reqscript

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -606,12 +606,10 @@ function dfhack.script_environment(name, strict)
     local scripts = internal.scripts
     local path = dfhack.findScript(name)
     if not scripts[path] or scripts[path]:needs_update() then
-        local _, env = dfhack.run_script_with_env(nil,
-            name,
-            {
-                module=true,
-                module_strict=(strict and true or false)  -- ensure that this key is present if 'strict' is nil
-            })
+        local _, env = dfhack.run_script_with_env(nil, name, {
+            module=true,
+            module_strict=(strict and true or false)  -- ensure that this key is present if 'strict' is nil
+        })
         return env
     else
         if strict and not scripts[path]:get_flags().module then

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -602,15 +602,13 @@ function dfhack.reqscript(name)
 end
 reqscript = dfhack.reqscript
 
-function dfhack.script_environment(name, strict, envVars, scripts)
-    scripts = scripts or internal.scripts
+function dfhack.script_environment(name, strict)
+    local scripts = internal.scripts
     local path = dfhack.findScript(name)
     if not scripts[path] or scripts[path]:needs_update() then
-        local _, env = dfhack.run_script_with_env(
-            envVars,
+        local _, env = dfhack.run_script_with_env(nil,
             name,
             {
-                scripts=scripts,
                 module=true,
                 module_strict=(strict and true or false)  -- ensure that this key is present if 'strict' is nil
             })

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -562,7 +562,6 @@ function Script:get_flags()
 end
 
 internal.scripts = internal.scripts or {}
-local scripts = internal.scripts
 
 local hack_path = dfhack.getHackPath()
 
@@ -583,6 +582,7 @@ local valid_script_flags = {
     module_strict = {required = false},
     alias = {required = false},
     alias_count = {required = false},
+    scripts = {required = false},
 }
 
 function dfhack.run_script(name,...)
@@ -602,13 +602,18 @@ function dfhack.reqscript(name)
 end
 reqscript = dfhack.reqscript
 
-function dfhack.script_environment(name, strict)
+function dfhack.script_environment(name, strict, envVars, scripts)
+    scripts = scripts or internal.scripts
     local path = dfhack.findScript(name)
     if not scripts[path] or scripts[path]:needs_update() then
-        local _, env = dfhack.run_script_with_env(nil, name, {
-            module=true,
-            module_strict=(strict and true or false)  -- ensure that this key is present if 'strict' is nil
-        })
+        local _, env = dfhack.run_script_with_env(
+            envVars,
+            name,
+            {
+                scripts=scripts,
+                module=true,
+                module_strict=(strict and true or false)  -- ensure that this key is present if 'strict' is nil
+            })
         return env
     else
         if strict and not scripts[path]:get_flags().module then
@@ -625,6 +630,7 @@ function dfhack.run_script_with_env(envVars, name, flags, ...)
         error('Could not find script ' .. name)
     end
 
+    local scripts = flags.scripts or internal.scripts
     if scripts[file] == nil then
         scripts[file] = Script(file)
     end


### PR DESCRIPTION
and invalidate scripts once tests are complete. this ensures that the
IN_TEST flag is respected.

note that this invalidates *all* scripts after running tests, even those that did not affect the test itself. we could potentially make this more targeted by remembering which scripts were loaded while IN_TEST was true and only reload those.

ooooorr, we could change the real reqscript to force a reload of the script if the value of IN_TEST in the calling environment doesn't match the value of IN_TEST that was in the environment when the script was loaded.