### PR TITLE
buildingplan: fix size calculation for constructions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -33,6 +33,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 # Future
 
+## Fixes
+- `buildingplan`: fixed an issue where planned constructions designated with DF's sizing keys (``umkh``) would sometimes be larger than requested
+
 ## Lua
 - ``gui.Painter``: fixed error when calling ``viewport()`` method
 - `xlsxreader`: Added Lua class wrappers for the xlsxreader plugin API

--- a/plugins/lua/buildingplan.lua
+++ b/plugins/lua/buildingplan.lua
@@ -103,9 +103,9 @@ function construct_buildings_from_ui_state()
     if width == 1 and height == 1 and
             (world.building_width > 1 or world.building_height > 1) then
         min_x = math.ceil(pos.x - world.building_width/2)
-        max_x = math.floor(pos.x + world.building_width/2)
+        max_x = min_x + world.building_width - 1
         min_y = math.ceil(pos.y - world.building_height/2)
-        max_y = math.floor(pos.y + world.building_height/2)
+        max_y = min_y + world.building_height - 1
     end
     local blds = {}
     for y=min_y,max_y do for x=min_x,max_x do


### PR DESCRIPTION
Planning a 4x2 construction with DF's `umkh` keys (i.e. not automaterial's box-select) would previously produce a 5x3 construction instead, for example.