### PR TITLE
tweak hide-priority: make toggle state persist across designation menu uses

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `buildingplan`: fixed an issue where planned constructions designated with DF's sizing keys (``umkh``) would sometimes be larger than requested
 - `command-prompt`: fixed issues where overlays created by running certain commands (e.g. `gui/liquids`, `gui/teleport`) would not update the parent screen correctly
 
+## Misc Improvements
+- `tweak` hide-priority: changed so that priorities stay hidden (or visible) when exiting and re-entering the designations menu
+
 ## Lua
 - ``gui.Painter``: fixed error when calling ``viewport()`` method
 - `xlsxreader`: Added Lua class wrappers for the xlsxreader plugin API


### PR DESCRIPTION
To reproduce:
1. Enter the `d`esignation menu
2. Press `-+` to change priorities
3. Create a designation
4. Press `Alt-p` to hide priorities
5. Exit and re-enter the designation menu (`Esc`, `d`)

Previously, priorities would be visible again after step 5. With this change, they are not visible until you press `Alt-p` again.

Fixes #1068. Note that this is a relatively unobtrusive fix: selecting a priority with `+-` will still result in priorities being shown again. This is native DF behavior that I am reluctant to override because users of designation priorities likely want to see them.