### PR TITLE
ignore build/.cmake cache created by kdevelop

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -4,3 +4,4 @@ VC2015_32
 DF_PATH.txt
 _CPack_Packages
 *.tar.*
+.cmake


### PR DESCRIPTION
kdevelop (I'm running 5.5.2) creates this cache. it seems harmless, but should be ignored. here's a sample of the files inside:
```
build/.cmake/
build/.cmake/api
build/.cmake/api/v1
build/.cmake/api/v1/query
build/.cmake/api/v1/query/client-kdevelop
build/.cmake/api/v1/query/client-kdevelop/query.json
build/.cmake/api/v1/reply
build/.cmake/api/v1/reply/target-autohauler-Release-2cf2e423cc3f1bf66cd3.json
build/.cmake/api/v1/reply/target-confirm-Release-e79f0253fdba29c5f26d.json
build/.cmake/api/v1/reply/target-dfhack-Release-fdf0a7ef6226ca73777e.json
...
```