### PR TITLE
Add some mock-related test helpers

### DIFF
--- a/ci/test.lua
+++ b/ci/test.lua
@@ -3,6 +3,7 @@
 
 local expect = require 'test_util.expect'
 local json = require 'json'
+local mock = require 'test_util.mock'
 local script = require 'gui.script'
 local utils = require 'utils'
 
@@ -187,6 +188,7 @@ local function build_test_env()
             mode = 'none',
         },
         expect = {},
+        mock = mock,
         delay = delay,
         require = clean_require,
         reqscript = clean_reqscript,

--- a/library/lua/test_util/mock.lua
+++ b/library/lua/test_util/mock.lua
@@ -34,7 +34,7 @@ function mock.patch(...)
         table.insert(patches, p)
     end
 
-    dfhack.with_finalize(
+    return dfhack.with_finalize(
         function()
             for _, p in ipairs(patches) do
                 p.table[p.key] = p.old_value
@@ -44,7 +44,7 @@ function mock.patch(...)
             for _, p in ipairs(patches) do
                 p.table[p.key] = p.new_value
             end
-            callback()
+            return callback()
         end
     )
 end

--- a/library/lua/test_util/mock.lua
+++ b/library/lua/test_util/mock.lua
@@ -1,6 +1,5 @@
 local mock = mkmodule('test_util.mock')
 
-
 --[[
 Usage:
     patch(table, key, value, callback)
@@ -47,6 +46,24 @@ function mock.patch(...)
             return callback()
         end
     )
+end
+
+function mock.func(return_value)
+    local f = {
+        return_value = return_value,
+        call_count = 0,
+        call_args = {},
+    }
+
+    setmetatable(f, {
+        __call = function(self, ...)
+            self.call_count = self.call_count + 1
+            table.insert(self.call_args, {...})
+            return self.return_value
+        end,
+    })
+
+    return f
 end
 
 return mock

--- a/library/lua/test_util/mock.lua
+++ b/library/lua/test_util/mock.lua
@@ -5,15 +5,15 @@ local mock = mkmodule('test_util.mock')
 Usage:
     patch(table, key, value, callback)
     patch({
-        [{table, key}] = value,
-        [{table2, key2}] = value2
+        {table, key, value},
+        {table2, key2, value2}
     }, callback)
 ]]
 function mock.patch(...)
     local args = {...}
     if #args == 4 then
         args = {{
-            [{args[1], args[2]}] = args[3]
+            {args[1], args[2], args[3]}
         }, args[4]}
     end
     if #args ~= 2 then
@@ -22,15 +22,15 @@ function mock.patch(...)
 
     local callback = args[2]
     local patches = {}
-    for k, v in pairs(args[1]) do
+    for _, v in ipairs(args[1]) do
         local p = {
-            table = k[1],
-            key = k[2],
-            new_value = v,
+            table = v[1],
+            key = v[2],
+            new_value = v[3],
         }
         p.old_value = p.table[p.key]
         -- no-op to ensure that the value can be restored by the finalizer below
-        p.table[p.key] = p.table[p.key]
+        p.table[p.key] = p.old_value
         table.insert(patches, p)
     end
 

--- a/library/lua/test_util/mock.lua
+++ b/library/lua/test_util/mock.lua
@@ -1,0 +1,52 @@
+local mock = mkmodule('test_util.mock')
+
+
+--[[
+Usage:
+    patch(table, key, value, callback)
+    patch({
+        [{table, key}] = value,
+        [{table2, key2}] = value2
+    }, callback)
+]]
+function mock.patch(...)
+    local args = {...}
+    if #args == 4 then
+        args = {{
+            [{args[1], args[2]}] = args[3]
+        }, args[4]}
+    end
+    if #args ~= 2 then
+        error('expected 2 or 4 arguments')
+    end
+
+    local callback = args[2]
+    local patches = {}
+    for k, v in pairs(args[1]) do
+        local p = {
+            table = k[1],
+            key = k[2],
+            new_value = v,
+        }
+        p.old_value = p.table[p.key]
+        -- no-op to ensure that the value can be restored by the finalizer below
+        p.table[p.key] = p.table[p.key]
+        table.insert(patches, p)
+    end
+
+    dfhack.with_finalize(
+        function()
+            for _, p in ipairs(patches) do
+                p.table[p.key] = p.old_value
+            end
+        end,
+        function()
+            for _, p in ipairs(patches) do
+                p.table[p.key] = p.new_value
+            end
+            callback()
+        end
+    )
+end
+
+return mock

--- a/test/library/test_util/mock.lua
+++ b/test/library/test_util/mock.lua
@@ -98,3 +98,39 @@ function test.patch_callback_return_value()
     expect.eq(a, 3)
     expect.eq(b, 4)
 end
+
+function test.func_call_count()
+    local f = mock.func()
+    expect.eq(f.call_count, 0)
+    f()
+    expect.eq(f.call_count, 1)
+    f()
+    expect.eq(f.call_count, 2)
+end
+
+function test.func_call_args()
+    local f = mock.func()
+    expect.eq(#f.call_args, 0)
+    f()
+    f(7)
+    expect.eq(#f.call_args, 2)
+    expect.eq(#f.call_args[1], 0)
+    expect.eq(#f.call_args[2], 1)
+    expect.eq(f.call_args[2][1], 7)
+end
+
+function test.func_call_args_nil()
+    local f = mock.func()
+    f(nil)
+    f(2, nil, 4)
+    expect.table_eq(f.call_args[1], {nil})
+    expect.table_eq(f.call_args[2], {2, nil, 4})
+    expect.eq(#f.call_args[2], 3)
+end
+
+function test.func_call_return_value()
+    local f = mock.func(7)
+    expect.eq(f(), 7)
+    f.return_value = 9
+    expect.eq(f(), 9)
+end

--- a/test/library/test_util/mock.lua
+++ b/test/library/test_util/mock.lua
@@ -33,8 +33,8 @@ function test.patch_multiple()
     expect.eq(test_table.func1(), 1)
     expect.eq(test_table.func2(), 2)
     mock.patch({
-        [{test_table, 'func1'}] = function() return 3 end,
-        [{test_table, 'func2'}] = function() return 4 end,
+        {test_table, 'func1', function() return 3 end},
+        {test_table, 'func2', function() return 4 end},
     }, function()
         expect.eq(test_table.func1(), 3)
         expect.eq(test_table.func2(), 4)
@@ -43,3 +43,50 @@ function test.patch_multiple()
     expect.eq(test_table.func2(), 2)
 end
 
+function test.patch_nil_old_value()
+    local t = {}
+    mock.patch(t, 1, 2, function()
+        expect.eq(t[1], 2)
+    end)
+    expect.eq(t[1], nil)
+    expect.eq(#t, 0)
+end
+
+function test.patch_nil_new_value()
+    local t = {2}
+    mock.patch(t, 1, nil, function()
+        expect.eq(t[1], nil)
+        expect.eq(#t, 0)
+    end)
+    expect.eq(t[1], 2)
+end
+
+function test.patch_nil_key()
+    local called = false
+    expect.error_match('table index is nil', function()
+        mock.patch({}, nil, 'value', function()
+            called = true
+        end)
+    end)
+    expect.false_(called)
+end
+
+function test.patch_nil_table()
+    local called = false
+    expect.error(function()
+        mock.patch(nil, 1, 2, function()
+            called = true
+        end)
+    end)
+    expect.false_(called)
+end
+
+function test.patch_complex_key()
+    local key = {'key'}
+    local t = {[key] = 'value'}
+    expect.eq(t[key], 'value')
+    mock.patch(t, key, 2, function()
+        expect.eq(t[key], 2)
+    end)
+    expect.eq(t[key], 'value')
+end

--- a/test/library/test_util/mock.lua
+++ b/test/library/test_util/mock.lua
@@ -90,3 +90,11 @@ function test.patch_complex_key()
     end)
     expect.eq(t[key], 'value')
 end
+
+function test.patch_callback_return_value()
+    local a, b = mock.patch({}, 'k', 'v', function()
+        return 3, 4
+    end)
+    expect.eq(a, 3)
+    expect.eq(b, 4)
+end

--- a/test/library/test_util/mock.lua
+++ b/test/library/test_util/mock.lua
@@ -1,0 +1,45 @@
+local mock = require('test_util.mock')
+
+local test_table = {
+    func1 = function()
+        return 1
+    end,
+    func2 = function()
+        return 2
+    end,
+}
+
+function test.patch_single()
+    expect.eq(test_table.func1(), 1)
+    mock.patch(test_table, 'func1', function() return 3 end, function()
+        expect.eq(test_table.func1(), 3)
+    end)
+    expect.eq(test_table.func1(), 1)
+end
+
+function test.patch_single_nested()
+    expect.eq(test_table.func1(), 1)
+    mock.patch(test_table, 'func1', function() return 3 end, function()
+        expect.eq(test_table.func1(), 3)
+        mock.patch(test_table, 'func1', function() return 5 end, function()
+            expect.eq(test_table.func1(), 5)
+        end)
+        expect.eq(test_table.func1(), 3)
+    end)
+    expect.eq(test_table.func1(), 1)
+end
+
+function test.patch_multiple()
+    expect.eq(test_table.func1(), 1)
+    expect.eq(test_table.func2(), 2)
+    mock.patch({
+        [{test_table, 'func1'}] = function() return 3 end,
+        [{test_table, 'func2'}] = function() return 4 end,
+    }, function()
+        expect.eq(test_table.func1(), 3)
+        expect.eq(test_table.func2(), 4)
+    end)
+    expect.eq(test_table.func1(), 1)
+    expect.eq(test_table.func2(), 2)
+end
+


### PR DESCRIPTION
This is currently a relatively low-level `patch()` implementation, inspired by pytest's `mock.patch()`, since I noticed several recent tests using the same `with_finalize()` pattern to patch builtins (note: most of these tests are in the scripts repo, so I didn't modify them here, but see `ci/test.lua` for example usage). Open to adding other things that might be useful.