### PR TITLE
[test] support fortress mode

### DIFF
--- a/ci/test.lua
+++ b/ci/test.lua
@@ -166,7 +166,7 @@ local function ensure_fortress(config)
             dfhack.gui.resetDwarfmodeView(true)
             return
         end
-        local scr = dfhack.gui.getCurViewscreen()
+        local scr = dfhack.gui.getCurViewscreen(true)
         if focus_string == 'title' or
                 focus_string == 'dfhack/lua/load_screen' then
             -- qerror()'s on falure

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,7 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - The DFHack test harness is now much easier to use for iterative development.  Configuration can now be specified on the commandline, there are more test filter options, and the test harness can now easily rerun tests that have been run before.
 - The ``test/main`` command to invoke the test harness has been renamed to just ``test``
 - DFHack unit tests must now match any output expected to be printed via ``dfhack.printerr()``
-- ``fortress mode`` is now supported for unit tests (tests that require a fortress map to be loaded)
+- ``fortress mode`` is now supported for unit tests (tests that require a fortress map to be loaded). Note that fortress mode tests will be skipped by the continuous integration framework for now. They'll be re-enabled once we get a reusable fortress save set up.
 
 # 0.47.05-r1
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - The DFHack test harness is now much easier to use for iterative development.  Configuration can now be specified on the commandline, there are more test filter options, and the test harness can now easily rerun tests that have been run before.
 - The ``test/main`` command to invoke the test harness has been renamed to just ``test``
 - DFHack unit tests must now match any output expected to be printed via ``dfhack.printerr()``
+- ``fortress mode`` is now supported for unit tests (tests that require a fortress map to be loaded)
 
 # 0.47.05-r1
 

--- a/travis/run-tests.py
+++ b/travis/run-tests.py
@@ -73,7 +73,7 @@ with open(test_init_file, 'w') as f:
     f.write('''
     devel/dump-rpc dfhack-rpc.txt
     :lua dfhack.internal.addScriptPath(dfhack.getHackPath())
-    test --resume "lua scr.breakdown_level=df.interface_breakdown_types.%s"
+    test --resume --modes=none,title "lua scr.breakdown_level=df.interface_breakdown_types.%s"
     ''' % ('NONE' if args.no_quit else 'QUIT'))
 
 test_config_file = 'test_config.json'


### PR DESCRIPTION
#1690 

- implement navigation function for loading a fortress from the title screen (requires a fortress save to be ready to load).
- navigation function also handles case where a fortress map is already loaded
- ensure we don't try repeatedly to enter a mode that we can't reach (such as getting back to the title screen from fortress mode). failing to enter the mode once will skip all remaining tests in that mode.

This PR combines the VALID_MODES and MODE_NAVIGATE_FNS tables into a new MODES table that contains mode order, state, and related functions