### PR TITLE
[lua] fix edge detection in Viewport:isVisibleXY()

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,6 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - ``gui.Painter``: fixed error when calling ``viewport()`` method
+- ``guidm.Viewport:isVisibleXY()``: properly return false for coordinates outside of the viewport
 - `xlsxreader`: Added Lua class wrappers for the xlsxreader plugin API
 
 ## Documentation

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -154,10 +154,10 @@ end
 function Viewport:isVisibleXY(target,gap)
     gap = gap or 0
 
-    return math.max(target.x-gap,0) >= self.x1
-       and math.min(target.x+gap,world_map.x_count-1) <= self.x2
-       and math.max(target.y-gap,0) >= self.y1
-       and math.min(target.y+gap,world_map.y_count-1) <= self.y2
+    return target.x - gap >= self.x1
+       and target.x + gap <= self.x2
+       and target.y - gap >= self.y1
+       and target.y + gap <= self.y2
 end
 
 function Viewport:isVisible(target,gap)


### PR DESCRIPTION
I ran into this while writing `gui/blueprint`. I was using `Viewport:isVisibleXY()` to determine whether the mouse was clicked on the visible game map (and not, for example, the screen frame or the side panel). To my surprise, it came back true every time, even when clicked at what would be tile map coordinate `-1`.

Looking at the code, it seems that the coordinates are being modified before being compared. This looks to me like incorrect behavior -- if you send a coordinate outside of the game map, *shouldn't* `isVisibileXY()` return `false`?

There are other usages of `math.min` and `math.max` in the file, but those usages look correct -- processing *should* stop at the map edges in those cases. Perhaps `isVisibleXY` was copy-pasted from one of these other functions and then modified? This is very old code, and this bug hasn't come up before, so maybe my understanding of what is supposed to happen here is incorrect, though.