### PR TITLE
[blueprint] Support new commandline syntax and semantics

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -3756,15 +3756,19 @@ the plugin. See existing files in ``plugins/lua`` for examples.
 blueprint
 =========
 
-Native functions provided by the `blueprint` plugin:
+Lua functions provided by the `blueprint` plugin to programmatically generate
+blueprint files:
 
 * ``dig(start, end, name)``
 * ``build(start, end, name)``
 * ``place(start, end, name)``
 * ``query(start, end, name)``
 
-  ``start`` and ``end`` are tables containing positions (see
-  ``xyz2pos``). ``name`` is used as the basis for the filename.
+  ``start`` and ``end`` are tables containing positions (see ``xyz2pos``).
+  ``name`` is used as the basis for the generated filenames.
+
+The names of the functions are also available as the keys of the
+``valid_phases`` table.
 
 .. _building-hacks:
 

--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -46,38 +46,40 @@ selected interactively with the ``blueprint gui`` command or, if the GUI is not
 used, starts at the active cursor location and extends right and down for the
 requested width and height.
 
-Usage:
+Usage::
 
     blueprint <width> <height> [<depth>] [<name> [<phases>]] [<options>]
     blueprint gui [<name> [<phases>]] [<options>]
 
 Examples:
 
-blueprint gui
+``blueprint gui``
     Runs `gui/blueprint`, the interactive blueprint frontend, where all
     configuration for a ``blueprint`` command can be set visually and
     interactively.
 
-blueprint gui bedrooms dig -\-cursor 108,100,150
-    Starts ``gui/blueprint`` with some configuration options preset to custom
-    values.
-
-blueprint 30 40 bedrooms
+``blueprint 30 40 bedrooms``
     Generates blueprints for an area 30 tiles wide by 40 tiles tall, starting
-    from the active cursor on the current z-level. Output is written to the
-    ``bedrooms.csv`` file in the ``blueprints`` directory.
+    from the active cursor on the current z-level. Output is written to files
+    with names matching the pattern ``bedrooms-PHASE.csv`` in the ``blueprints``
+    directory.
+
+``blueprint 30 40 bedrooms dig --cursor 108,100,150``
+    Generates only the ``bedrooms-dig.csv`` file from the previous example, and
+    the blueprint start coordinate is set to a specific value instead of using
+    the in-game cursor position.
 
 Positional Parameters:
 
-:width:   Width of the area (in tiles) to translate.
-:height:  Height of the area (in tiles) to translate.
-:depth:   Number of z-levels to translate. Positive numbers go *up* from the
-          cursor and negative numbers go *down*. Defaults to 1 if not specified,
-          indicating that the blueprint should only include the current z-level.
-:name:    Base name for blueprint files created in the ``blueprints`` directory.
-          If no name is specified, "blueprint" is used by default. The string
-          must contain some characters other than numbers so the name won't be
-          confused with the optional ``depth`` parameter.
+:``width``:   Width of the area (in tiles) to translate.
+:``height``:  Height of the area (in tiles) to translate.
+:``depth``:   Number of z-levels to translate. Positive numbers go *up* from the
+    cursor and negative numbers go *down*. Defaults to 1 if not specified,
+    indicating that the blueprint should only include the current z-level.
+:``name``:    Base name for blueprint files created in the ``blueprints``
+    directory. If no name is specified, "blueprint" is used by default. The
+    string must contain some characters other than numbers so the name won't be
+    confused with the optional ``depth`` parameter.
 
 Phases:
 
@@ -85,21 +87,21 @@ If you want to generate blueprints only for specific phases, add their names to
 the commandline, anywhere after the blueprint base name. You can list multiple
 phases; just separate them with a space.
 
-:dig:    Generate quickfort ``#dig`` blueprints.
-:build:  Generate quickfort ``#build`` blueprints for constructions and
-         buildings.
-:place:  Generate quickfort ``#place`` blueprints for placing stockpiles.
-:query:  Generate quickfort ``#query`` blueprints for configuring rooms.
+:``dig``:    Generate quickfort ``#dig`` blueprints.
+:``build``:  Generate quickfort ``#build`` blueprints for constructions and
+    buildings.
+:``place``:  Generate quickfort ``#place`` blueprints for placing stockpiles.
+:``query``:  Generate quickfort ``#query`` blueprints for configuring rooms.
 
 If no phases are specified, all blueprints are created.
 
 Options:
 
-:-c, -\-cursor <x>,<y>,<z>:
+:``-c``, ``--cursor <x>,<y>,<z>``:
     Use the specified map coordinates instead of the current cursor position for
     the upper left corner of the blueprint range. If this option is specified,
     then an active game map cursor is not necessary.
-:-h, -\-help:
+:``-h``, ``--help``:
     Show command help text.
 
 .. _remotefortressreader:

--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -37,22 +37,70 @@ For more information, see `the full Stonesense README <stonesense>`.
 
 blueprint
 =========
-Exports a portion of your fortress into QuickFort style blueprint files.
+The ``blueprint`` command exports the structure of a portion of your fortress in
+a blueprint file that you (or anyone else) can later play back with `quickfort`.
 
-Usage::
+Blueprints are ``.csv`` or ``.xlsx`` files created in the ``blueprints``
+subdirectory of your DF folder. The map area to turn into a blueprint is either
+selected interactively with the ``blueprint gui`` command or, if the GUI is not
+used, starts at the active cursor location and extends right and down for the
+requested width and height.
 
-    blueprint <x> <y> <z> <name> [dig] [build] [place] [query]
+Usage:
 
-Options (If only region and name are given, export all):
+    blueprint <width> <height> [<depth>] [<name> [<phases>]] [<options>]
+    blueprint gui [<name> [<phases>]] [<options>]
 
-:x,y,z:     Size of map area to export
-:name:      Name of export files
-:dig:       Export dig commands to "<name>-dig.csv"
-:build:     Export build commands to "<name>-build.csv"
-:place:     Export stockpile commands to "<name>-place.csv"
-:query:     Export query commands to "<name>-query.csv"
+Examples:
 
-Goes very well with `quickfort`, for re-importing.
+blueprint gui
+    Runs `gui/blueprint`, the interactive blueprint frontend, where all
+    configuration for a ``blueprint`` command can be set visually and
+    interactively.
+
+blueprint gui bedrooms dig -\-cursor 108,100,150
+    Starts ``gui/blueprint`` with some configuration options preset to custom
+    values.
+
+blueprint 30 40 bedrooms
+    Generates blueprints for an area 30 tiles wide by 40 tiles tall, starting
+    from the active cursor on the current z-level. Output is written to the
+    ``bedrooms.csv`` file in the ``blueprints`` directory.
+
+Positional Parameters:
+
+:width:   Width of the area (in tiles) to translate.
+:height:  Height of the area (in tiles) to translate.
+:depth:   Number of z-levels to translate. Positive numbers go *up* from the
+          cursor and negative numbers go *down*. Defaults to 1 if not specified,
+          indicating that the blueprint should only include the current z-level.
+:name:    Base name for blueprint files created in the ``blueprints`` directory.
+          If no name is specified, "blueprint" is used by default. The string
+          must contain some characters other than numbers so the name won't be
+          confused with the optional ``depth`` parameter.
+
+Phases:
+
+If you want to generate blueprints only for specific phases, add their names to
+the commandline, anywhere after the blueprint base name. You can list multiple
+phases; just separate them with a space.
+
+:dig:    Generate quickfort ``#dig`` blueprints.
+:build:  Generate quickfort ``#build`` blueprints for constructions and
+         buildings.
+:place:  Generate quickfort ``#place`` blueprints for placing stockpiles.
+:query:  Generate quickfort ``#query`` blueprints for configuring rooms.
+
+If no phases are specified, all blueprints are created.
+
+Options:
+
+:-c, -\-cursor <x>,<y>,<z>:
+    Use the specified map coordinates instead of the current cursor position for
+    the upper left corner of the blueprint range. If this option is specified,
+    then an active game map cursor is not necessary.
+:-h, -\-help:
+    Show command help text.
 
 .. _remotefortressreader:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``quickfortress.csv`` blueprint: fixed refuse stockpile config and prevented stockpiles from covering stairways
 
 ## Misc Improvements
+- `blueprint`: make ``depth`` and ``name`` parameters optional. ``depth`` now defaults to ``1`` (current level only) and ``name`` defaults to "blueprint"
+- `blueprint`: allow ``depth`` to be negative, which will result in the blueprints being written from the highest z-level to the lowest. before, blueprints were always written from the lowest z-level to the highest.
+- `blueprint`: add the ``--cursor`` option to set the starting coordinate for the generated blueprints. a game cursor is no longer necessary if this option is used.
 - `tweak` hide-priority: changed so that priorities stay hidden (or visible) when exiting and re-entering the designations menu
 
 ## Lua

--- a/library/include/modules/Gui.h
+++ b/library/include/modules/Gui.h
@@ -156,6 +156,7 @@ namespace DFHack
         DFHACK_EXPORT bool setViewCoords (const int32_t x, const int32_t y, const int32_t z);
 
         DFHACK_EXPORT bool getCursorCoords (int32_t &x, int32_t &y, int32_t &z);
+        DFHACK_EXPORT bool getCursorCoords (df::coord &pos);
         DFHACK_EXPORT bool setCursorCoords (const int32_t x, const int32_t y, const int32_t z);
 
         DFHACK_EXPORT bool getDesignationCoords (int32_t &x, int32_t &y, int32_t &z);

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -648,13 +648,18 @@ bool Gui::item_details_hotkey(df::viewscreen *top)
     return !!strict_virtual_cast<df::viewscreen_itemst>(top);
 }
 
+static bool has_cursor()
+{
+    return df::global::cursor && df::global::cursor->x != -30000;
+}
+
 bool Gui::cursor_hotkey(df::viewscreen *top)
 {
     if (!dwarfmode_hotkey(top))
         return false;
 
     // Also require the cursor.
-    if (!df::global::cursor || df::global::cursor->x == -30000)
+    if (!has_cursor())
         return false;
 
     return true;
@@ -1788,7 +1793,15 @@ bool Gui::getCursorCoords (int32_t &x, int32_t &y, int32_t &z)
     x = df::global::cursor->x;
     y = df::global::cursor->y;
     z = df::global::cursor->z;
-    return (x == -30000) ? false : true;
+    return has_cursor();
+}
+
+bool Gui::getCursorCoords (df::coord &pos)
+{
+    pos.x = df::global::cursor->x;
+    pos.y = df::global::cursor->y;
+    pos.z = df::global::cursor->z;
+    return has_cursor();
 }
 
 //FIXME: confine writing of coords to map bounds?

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -70,17 +70,17 @@ struct blueprint_options {
     static struct_identity _identity;
 };
 static const struct_field_info blueprint_options_fields[] = {
-    { struct_field_info::PRIMITIVE, "help",         offsetof(blueprint_options, help),         &df::identity_traits<bool>::identity,    0, 0 },
-    { struct_field_info::SUBSTRUCT, "start",        offsetof(blueprint_options, start),        &df::coord::_identity,                   0, 0 },
-    { struct_field_info::PRIMITIVE, "width",        offsetof(blueprint_options, width),        &df::identity_traits<int32_t>::identity, 0, 0 },
-    { struct_field_info::PRIMITIVE, "height",       offsetof(blueprint_options, height),       &df::identity_traits<int32_t>::identity, 0, 0 },
-    { struct_field_info::PRIMITIVE, "depth",        offsetof(blueprint_options, depth),        &df::identity_traits<int32_t>::identity, 0, 0 },
-    { struct_field_info::PRIMITIVE, "name",         offsetof(blueprint_options, name),          df::identity_traits<string>::get(),     0, 0 },
-    { struct_field_info::PRIMITIVE, "auto_phase",   offsetof(blueprint_options, auto_phase),   &df::identity_traits<bool>::identity,    0, 0 },
-    { struct_field_info::PRIMITIVE, "dig",          offsetof(blueprint_options, dig),          &df::identity_traits<bool>::identity,    0, 0 },
-    { struct_field_info::PRIMITIVE, "build",        offsetof(blueprint_options, build),        &df::identity_traits<bool>::identity,    0, 0 },
-    { struct_field_info::PRIMITIVE, "place",        offsetof(blueprint_options, place),        &df::identity_traits<bool>::identity,    0, 0 },
-    { struct_field_info::PRIMITIVE, "query",        offsetof(blueprint_options, query),        &df::identity_traits<bool>::identity,    0, 0 },
+    { struct_field_info::PRIMITIVE, "help",       offsetof(blueprint_options, help),       &df::identity_traits<bool>::identity,    0, 0 },
+    { struct_field_info::SUBSTRUCT, "start",      offsetof(blueprint_options, start),      &df::coord::_identity,                   0, 0 },
+    { struct_field_info::PRIMITIVE, "width",      offsetof(blueprint_options, width),      &df::identity_traits<int32_t>::identity, 0, 0 },
+    { struct_field_info::PRIMITIVE, "height",     offsetof(blueprint_options, height),     &df::identity_traits<int32_t>::identity, 0, 0 },
+    { struct_field_info::PRIMITIVE, "depth",      offsetof(blueprint_options, depth),      &df::identity_traits<int32_t>::identity, 0, 0 },
+    { struct_field_info::PRIMITIVE, "name",       offsetof(blueprint_options, name),        df::identity_traits<string>::get(),     0, 0 },
+    { struct_field_info::PRIMITIVE, "auto_phase", offsetof(blueprint_options, auto_phase), &df::identity_traits<bool>::identity,    0, 0 },
+    { struct_field_info::PRIMITIVE, "dig",        offsetof(blueprint_options, dig),        &df::identity_traits<bool>::identity,    0, 0 },
+    { struct_field_info::PRIMITIVE, "build",      offsetof(blueprint_options, build),      &df::identity_traits<bool>::identity,    0, 0 },
+    { struct_field_info::PRIMITIVE, "place",      offsetof(blueprint_options, place),      &df::identity_traits<bool>::identity,    0, 0 },
+    { struct_field_info::PRIMITIVE, "query",      offsetof(blueprint_options, query),      &df::identity_traits<bool>::identity,    0, 0 },
     { struct_field_info::END }
 };
 struct_identity blueprint_options::_identity(sizeof(blueprint_options), &df::allocator_fn<blueprint_options>, NULL, "blueprint_options", NULL, blueprint_options_fields);

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -792,7 +792,7 @@ command_result blueprint(color_ostream &out, vector<string> &parameters)
 
     // crop end coordinate to map bounds. we've already verified that start is
     // a valid coordinate, and width, height, and depth are non-zero, so our
-    // final are is always going to be at least 1x1x1.
+    // final area is always going to be at least 1x1x1.
     df::world::T_map &map = df::global::world->map;
     if (end.x > map.x_count)
         end.x = map.x_count;

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -691,7 +691,7 @@ static bool get_options(blueprint_options &opts,
         !Lua::PushModulePublic(
             out, L, "plugins.blueprint", "parse_commandline"))
     {
-        out.printerr("Failed to load blueprint Lua code");
+        out.printerr("Failed to load blueprint Lua code\n");
         return false;
     }
 
@@ -701,28 +701,6 @@ static bool get_options(blueprint_options &opts,
         Lua::Push(L, param);
 
     if (!Lua::SafeCall(out, L, parameters.size() + 1, 0))
-        return false;
-
-    return true;
-}
-
-static bool do_gui(const vector<string> &parameters)
-{
-    auto L = Lua::Core::State;
-    color_ostream_proxy out(Core::getInstance().getConsole());
-    Lua::StackUnwinder top(L);
-
-    if (!lua_checkstack(L, parameters.size() + 1) ||
-        !Lua::PushModulePublic(out, L, "plugins.blueprint", "do_gui"))
-    {
-        out.printerr("Failed to load blueprint Lua code");
-        return false;
-    }
-
-    for (const string &param : parameters)
-        Lua::Push(L, param);
-
-    if (!Lua::SafeCall(out, L, parameters.size(), 0))
         return false;
 
     return true;
@@ -738,7 +716,7 @@ static void print_help()
         !Lua::PushModulePublic(out, L, "plugins.blueprint", "print_help") ||
         !Lua::SafeCall(out, L, 0, 0))
     {
-        out.printerr("Failed to load blueprint Lua code");
+        out.printerr("Failed to load blueprint Lua code\n");
     }
 }
 
@@ -746,7 +724,17 @@ command_result blueprint(color_ostream &out, vector<string> &parameters)
 {
     if (parameters.size() >= 1 && parameters[0] == "gui")
     {
-        return do_gui(parameters) ? CR_OK : CR_FAILURE;
+        std::ostringstream command;
+        command << "gui/blueprint";
+        for (const string &param : parameters)
+        {
+            command << " " << param;
+        }
+        string command_str = command.str();
+        out.print("launching %s\n", command_str.c_str());
+
+        Core::getInstance().setHotkeyCmd(command_str);
+        return CR_OK;
     }
 
     blueprint_options options;

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -744,7 +744,7 @@ static void print_help()
 
 command_result blueprint(color_ostream &out, vector<string> &parameters)
 {
-    if (parameters.size() >= 1 and parameters[0] == "gui")
+    if (parameters.size() >= 1 && parameters[0] == "gui")
     {
         return do_gui(parameters) ? CR_OK : CR_FAILURE;
     }

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -754,9 +754,9 @@ command_result blueprint(color_ostream &out, vector<string> &parameters)
 
     // start coordinates can come from either the commandline or the map cursor
     DFCoord start(options.start);
-    if (options.start.x == -30000)
+    if (start.x == -30000)
     {
-        if (!Gui::getCursorCoords(options.start))
+        if (!Gui::getCursorCoords(start))
         {
             out.printerr("Can't get cursor coords! Make sure you specify the"
                     " --cursor parameter or have an active cursor in DF.\n");

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -722,6 +722,8 @@ static void print_help()
 
 command_result blueprint(color_ostream &out, vector<string> &parameters)
 {
+    CoreSuspender suspend;
+
     if (parameters.size() >= 1 && parameters[0] == "gui")
     {
         std::ostringstream command;
@@ -744,7 +746,6 @@ command_result blueprint(color_ostream &out, vector<string> &parameters)
         return options.help ? CR_OK : CR_FAILURE;
     }
 
-    CoreSuspender suspend;
     if (!Maps::IsValid())
     {
         out.printerr("Map is not available!\n");
@@ -755,16 +756,12 @@ command_result blueprint(color_ostream &out, vector<string> &parameters)
     DFCoord start(options.start);
     if (options.start.x == -30000)
     {
-        int32_t x, y, z;
-        if (!Gui::getCursorCoords(x, y, z))
+        if (!Gui::getCursorCoords(options.start))
         {
             out.printerr("Can't get cursor coords! Make sure you specify the"
                     " --cursor parameter or have an active cursor in DF.\n");
             return CR_FAILURE;
         }
-        start.x = x;
-        start.y = y;
-        start.z = z;
     }
     if (!Maps::isValidTilePos(start))
     {

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -25,8 +25,8 @@ blueprint gui
 
 blueprint 30 40 bedrooms
     Generates blueprints for an area 30 tiles wide by 40 tiles tall, starting
-    from the active cursor on the current z-level. Output is written to the
-    "bedrooms.csv" file in the "blueprints" directory.
+    from the active cursor on the current z-level. Output files are written to
+    the "blueprints" directory.
 
 See the online DFHack documentation for more examples and details.
 ]=]

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -1,14 +1,169 @@
 local _ENV = mkmodule('plugins.blueprint')
 
---[[
+local utils = require('utils')
 
- Native functions:
+-- the info here is very basic and minimal, so hopefully we won't need to change
+-- it when features are added and the full blueprint docs in Plugins.rst are
+-- updated.
+local help_text =
+[=[
 
- * dig(start, end, name)
- * build(start, end, name)
- * place(start, end, name)
- * query(start, end, name)
+blueprint
+=========
 
---]]
+Records the structure of a portion of your fortress in quickfort blueprints.
+
+Usage:
+
+    blueprint <width> <height> [<depth>] [<name> [<phases>]] [<options>]
+    blueprint gui [<name> [<phases>]] [<options>]
+
+Examples:
+
+blueprint gui
+    Runs gui/blueprint, the interactive blueprint frontend, where all
+    configuration can be set visually and interactively.
+
+blueprint 30 40 bedrooms
+    Generates blueprints for an area 30 tiles wide by 40 tiles tall, starting
+    from the active cursor on the current z-level. Output is written to the
+    "bedrooms.csv" file in the "blueprints" directory.
+
+See the online DFHack documentation for more examples and details.
+]=]
+
+valid_phases = utils.invert{
+    'dig',
+    'build',
+    'place',
+    'query',
+}
+
+function print_help()
+    print(help_text)
+end
+
+local function parse_cursor(opts, arg)
+    local _, _, x, y, z = arg:find('^(%d+),(%d+),(%d+)$')
+    if not x then
+        qerror(('invalid argument for --cursor option: "%s"; expected format' ..
+                ' is "<x>,<y>,<z>", for example: "30,60,150"'):format(arg))
+    end
+    -- be careful not to replace struct members when called from C++, but also
+    -- create the table as needed when called from lua
+    if not opts.start then opts.start = {} end
+    opts.start.x = tonumber(x)
+    opts.start.y = tonumber(y)
+    opts.start.z = tonumber(z)
+end
+
+-- dimension must be a non-nil integer that is >= 1 (or at least non-zero if
+-- negative_ok is true)
+local function is_bad_dim(dim, negative_ok)
+    return not dim
+            or (not negative_ok and dim < 1 or dim == 0)
+            or dim ~= math.floor(dim)
+end
+
+local function parse_positionals(opts, args, start_argidx)
+    local argidx = start_argidx
+
+    -- set defaults
+    opts.name, opts.auto_phase = 'blueprint', true
+
+    local name = args[argidx]
+    if not name then return end
+    if name == '' then
+        qerror(('invalid basename: "%s"; must be a valid, non-empty pathname')
+               :format(args[argidx]))
+    end
+    argidx = argidx + 1
+    -- normalize paths to forward slashes
+    opts.name = name:gsub(package.config:sub(1,1), "/")
+
+    local auto_phase = true
+    local phase = args[argidx]
+    while phase do
+        if valid_phases[phase] then
+            auto_phase = false
+            opts[phase] = true
+        end
+        argidx = argidx + 1
+        phase = args[argidx]
+    end
+    opts.auto_phase = auto_phase
+end
+
+local function process_args(opts, args)
+    if args[1] == 'help' then
+        opts.help = true
+        return
+    end
+
+    return utils.processArgsGetopt(args, {
+            {'c', 'cursor', hasArg=true,
+             handler=function(optarg) parse_cursor(opts, optarg) end},
+            {'h', 'help', handler=function() opts.help = true end},
+        })
+end
+
+function parse_gui_commandline(opts, args)
+    local positionals = process_args(opts, args)
+    if opts.help then return end
+    parse_positionals(opts, positionals, 1)
+end
+
+function parse_commandline(opts, ...)
+    local positionals = process_args(opts, {...})
+    if opts.help then return end
+
+    local width, height = tonumber(positionals[1]), tonumber(positionals[2])
+    if is_bad_dim(width) or is_bad_dim(height) then
+        qerror(('invalid width and height: "%s" "%s"; width and height must' ..
+                ' be positive integers'):format(positionals[1], positionals[2]))
+    end
+    opts.width, opts.height, opts.depth = width, height, 1
+
+    local depth = tonumber(positionals[3])
+    if depth then
+        if is_bad_dim(depth, true) then
+            qerror(('invalid depth: "%s"; must be a non-zero integer')
+                   :format(positionals[3]))
+        end
+        opts.depth = depth
+    end
+
+    parse_positionals(opts, positionals, depth and 4 or 3)
+end
+
+function do_gui(command, ...)
+    local args = {...}
+    print('launching gui/blueprint')
+    dfhack.timeout(1, 'frames',
+                   function() dfhack.run_script('gui/blueprint',
+                                                table.unpack(args)) end)
+end
+
+-- compatibility with old exported API. we route the request back through
+-- run_command so we have a unified path for parameter processing and invariant
+-- checking.
+local function do_blueprint(start_pos, end_pos, name, phase)
+    local width = math.abs(start_pos.x - end_pos.x) + 1
+    local height = math.abs(start_pos.y - end_pos.y) + 1
+    local depth = math.abs(start_pos.z - end_pos.z) + 1
+    if start_pos.z > end_pos.z then depth = -depth end
+
+    local x = math.min(start_pos.x, end_pos.x)
+    local y = math.min(start_pos.y, end_pos.y)
+    local z = start_pos.z
+
+    local cursor = ('--cursor=%d,%d,%d'):format(x, y, z)
+
+    return dfhack.run_command{'blueprint',
+                              width, height, depth, name, phase, cursor}
+end
+for phase in pairs(valid_phases) do
+    _ENV[phase] = function(s, e, n) do_blueprint(s, e, n, phase) end
+end
 
 return _ENV

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -107,6 +107,7 @@ local function process_args(opts, args)
         })
 end
 
+-- used by the gui/blueprint script
 function parse_gui_commandline(opts, args)
     local positionals = process_args(opts, args)
     if opts.help then return end

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -138,7 +138,7 @@ end
 
 function do_gui(command, ...)
     local args = {...}
-    print('launching gui/blueprint')
+    print(('launching gui/blueprint %s'):format(table.concat(args, ' ')))
     dfhack.timeout(1, 'frames',
                    function() dfhack.run_script('gui/blueprint',
                                                 table.unpack(args)) end)

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -134,14 +134,6 @@ function parse_commandline(opts, ...)
     parse_positionals(opts, positionals, depth and 4 or 3)
 end
 
-function do_gui(command, ...)
-    local args = {...}
-    print(('launching gui/blueprint %s'):format(table.concat(args, ' ')))
-    dfhack.timeout(1, 'frames',
-                   function() dfhack.run_script('gui/blueprint',
-                                                table.unpack(args)) end)
-end
-
 -- compatibility with old exported API. we route the request back through
 -- run_command so we have a unified path for parameter processing and invariant
 -- checking.

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -33,12 +33,14 @@ See the online DFHack documentation for more examples and details.
 
 function print_help() print(help_text) end
 
-valid_phases = utils.invert{
+local valid_phase_list = {
     'dig',
     'build',
     'place',
     'query',
 }
+
+valid_phases = utils.invert(valid_phase_list)
 
 local function parse_cursor(opts, arg)
     local _, _, x, y, z = arg:find('^(%d+),(%d+),(%d+)$')
@@ -73,10 +75,12 @@ local function parse_positionals(opts, args, start_argidx)
     local auto_phase = true
     local phase = args[argidx]
     while phase do
-        if valid_phases[phase] then
-            auto_phase = false
-            opts[phase] = true
+        if not valid_phases[phase] then
+            qerror(('unknown phase: "%s"; expected one of: %s'):
+                   format(phase, table.concat(valid_phase_list, ', ')))
         end
+        auto_phase = false
+        opts[phase] = true
         argidx = argidx + 1
         phase = args[argidx]
     end

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -120,45 +120,6 @@ function test.parse_commandline()
                        'zero depth')
 end
 
-function test.do_gui_no_arg()
-    local mock_print, mock_timeout, mock_run_script =
-            mock.func(), mock.func(), mock.func()
-    mock.patch(
-        {
-            {b, 'print', mock_print},
-            {dfhack, 'timeout', mock_timeout},
-            {dfhack, 'run_script', mock_run_script},
-        },
-        function()
-            b.do_gui('gui')
-            expect.eq(1, mock_print.call_count)
-            expect.eq(1, mock_timeout.call_count)
-            mock_timeout.call_args[1][3]()
-            expect.eq(1, mock_run_script.call_count)
-            expect.table_eq({'gui/blueprint'}, mock_run_script.call_args[1])
-        end)
-end
-
-function test.do_gui_with_args()
-    local mock_print, mock_timeout, mock_run_script =
-            mock.func(), mock.func(), mock.func()
-    mock.patch(
-        {
-            {b, 'print', mock_print},
-            {dfhack, 'timeout', mock_timeout},
-            {dfhack, 'run_script', mock_run_script},
-        },
-        function()
-            b.do_gui('gui', 'arg1', 'arg2', 'arg3')
-            expect.eq(1, mock_print.call_count)
-            expect.eq(1, mock_timeout.call_count)
-            mock_timeout.call_args[1][3]()
-            expect.eq(1, mock_run_script.call_count)
-            expect.table_eq({'gui/blueprint', 'arg1', 'arg2', 'arg3'},
-                            mock_run_script.call_args[1])
-        end)
-end
-
 function test.do_blueprint_positive_dims()
     local mock_run_command = mock.func()
     mock.patch(dfhack, 'run_command', mock_run_command,

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -49,8 +49,9 @@ function test.parse_gui_commandline()
                     opts)
 
     opts = {}
-    b.parse_gui_commandline(opts, {'imaname', 'garbagephase'})
-    expect.table_eq({auto_phase=true, name='imaname'}, opts)
+    expect.error_match('unknown phase',
+                       function() b.parse_gui_commandline(
+                                        opts, {'imaname', 'garbagephase'}) end)
 end
 
 function test.parse_commandline()

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -1,0 +1,202 @@
+local b = require('plugins.blueprint')
+
+-- also covers code shared between parse_gui_commandline and parse_commandline
+function test.parse_gui_commandline()
+    local opts = {}
+    b.parse_gui_commandline(opts, {})
+    expect.table_eq({auto_phase=true, name='blueprint'}, opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'help'})
+    expect.table_eq({help=true}, opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'--help'})
+    expect.table_eq({help=true}, opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'-h'})
+    expect.table_eq({help=true}, opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'--cursor=1,2,3'})
+    expect.table_eq({auto_phase=true, name='blueprint', start={x=1,y=2,z=3}},
+                    opts)
+
+    opts = {}
+    expect.error_match('invalid argument',
+                       function() b.parse_gui_commandline(
+                                        opts, {'--cursor=-1,2,3'}) end,
+                       'negative coordinate')
+
+    opts = {}
+    expect.error_match('invalid argument',
+                       function() b.parse_gui_commandline(
+                                        opts, {'--cursor=1,b,3'}) end,
+                       'non-numeric coordinate')
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'imaname'})
+    expect.table_eq({auto_phase=true, name='imaname'}, opts)
+
+    opts = {}
+    expect.error_match('invalid basename',
+                       function() b.parse_gui_commandline(opts, {''}) end)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'imaname', 'dig', 'query'})
+    expect.table_eq({auto_phase=false, name='imaname', dig=true, query=true},
+                    opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'imaname', 'garbagephase'})
+    expect.table_eq({auto_phase=true, name='imaname'}, opts)
+end
+
+function test.parse_commandline()
+    local opts = {}
+    b.parse_commandline(opts, '1', '2')
+    expect.table_eq({auto_phase=true,name='blueprint',width=1,height=2,depth=1},
+                    opts)
+
+    opts = {}
+    b.parse_commandline(opts, '1', '2', '3')
+    expect.table_eq({auto_phase=true,name='blueprint',width=1,height=2,depth=3},
+                    opts)
+
+    opts = {}
+    b.parse_commandline(opts, '1', '2', '-3')
+    expect.table_eq({auto_phase=true,name='blueprint',width=1,height=2,depth=-3},
+                    opts)
+
+    opts = {}
+    b.parse_commandline(opts, '1', '2', 'imaname')
+    expect.table_eq({auto_phase=true,name='imaname',width=1,height=2,depth=1},
+                    opts)
+
+    opts = {}
+    b.parse_commandline(opts, '1', '2', '10imaname')
+    expect.table_eq({auto_phase=true,name='10imaname',width=1,height=2,depth=1},
+                    opts, 'invalid depth is considered a basename')
+
+    opts = {}
+    b.parse_commandline(opts, '1', '2', '-10imaname')
+    expect.table_eq({auto_phase=true,name='-10imaname',width=1,height=2,depth=1},
+                    opts, 'invalid negative depth is considered a basename')
+
+    opts = {}
+    b.parse_commandline(opts, '1', '2', '3', 'imaname')
+    expect.table_eq({auto_phase=true,name='imaname',width=1,height=2,depth=3},
+                    opts)
+
+    opts = {}
+    expect.error_match('invalid width or height',
+                       function() b.parse_commandline(opts) end,
+                       'missing width')
+
+    opts = {}
+    expect.error_match('invalid width or height',
+                       function() b.parse_commandline(opts, '10') end,
+                       'missing height')
+
+    opts = {}
+    expect.error_match('invalid width or height',
+                       function() b.parse_commandline(opts, '0') end,
+                       'zero height')
+
+    opts = {}
+    expect.error_match('invalid width or height',
+                       function() b.parse_commandline(opts, 'hi') end,
+                       'invalid width')
+
+    opts = {}
+    expect.error_match('invalid width or height',
+                       function() b.parse_commandline(opts, '10', 'hi') end,
+                       'invalid height')
+
+    opts = {}
+    expect.error_match('invalid depth',
+                       function() b.parse_commandline(opts, '1', '2', '0') end,
+                       'zero depth')
+end
+
+function test.do_gui_no_arg()
+    local mock_print, mock_timeout, mock_run_script =
+            mock.func(), mock.func(), mock.func()
+    mock.patch(
+        {
+            {b, 'print', mock_print},
+            {dfhack, 'timeout', mock_timeout},
+            {dfhack, 'run_script', mock_run_script},
+        },
+        function()
+            b.do_gui('gui')
+            expect.eq(1, mock_print.call_count)
+            expect.eq(1, mock_timeout.call_count)
+            mock_timeout.call_args[1][3]()
+            expect.eq(1, mock_run_script.call_count)
+            expect.table_eq({'gui/blueprint'}, mock_run_script.call_args[1])
+        end)
+end
+
+function test.do_gui_with_args()
+    local mock_print, mock_timeout, mock_run_script =
+            mock.func(), mock.func(), mock.func()
+    mock.patch(
+        {
+            {b, 'print', mock_print},
+            {dfhack, 'timeout', mock_timeout},
+            {dfhack, 'run_script', mock_run_script},
+        },
+        function()
+            b.do_gui('gui', 'arg1', 'arg2', 'arg3')
+            expect.eq(1, mock_print.call_count)
+            expect.eq(1, mock_timeout.call_count)
+            mock_timeout.call_args[1][3]()
+            expect.eq(1, mock_run_script.call_count)
+            expect.table_eq({'gui/blueprint', 'arg1', 'arg2', 'arg3'},
+                            mock_run_script.call_args[1])
+        end)
+end
+
+function test.do_blueprint_positive_dims()
+    local mock_run_command = mock.func()
+    mock.patch(dfhack, 'run_command', mock_run_command,
+        function()
+              local spos = {x=10, y=20, z=30}
+              local epos = {x=11, y=21, z=31}
+              b.query(spos, epos, 'imaname')
+              expect.eq(1, mock_run_command.call_count)
+              expect.table_eq({'blueprint', '2', '2', '2', 'imaname', 'query',
+                               '--cursor=10,20,30'},
+                              mock_run_command.call_args[1])
+        end)
+end
+
+function test.do_blueprint_negative_dims()
+    local mock_run_command = mock.func()
+    mock.patch(dfhack, 'run_command', mock_run_command,
+        function()
+              local spos = {x=11, y=21, z=31}
+              local epos = {x=10, y=20, z=30}
+              b.query(spos, epos, 'imaname')
+              expect.eq(1, mock_run_command.call_count)
+              expect.table_eq({'blueprint', '2', '2', '-2', 'imaname', 'query',
+                               '--cursor=10,20,31'},
+                              mock_run_command.call_args[1])
+        end)
+end
+
+function test.do_blueprint_ensure_cursor_is_at_upper_left()
+    local mock_run_command = mock.func()
+    mock.patch(dfhack, 'run_command', mock_run_command,
+        function()
+              local spos = {x=11, y=20, z=30}
+              local epos = {x=10, y=21, z=31}
+              b.query(spos, epos, 'imaname')
+              expect.eq(1, mock_run_command.call_count)
+              expect.table_eq({'blueprint', '2', '2', '2', 'imaname', 'query',
+                               '--cursor=10,20,30'},
+                              mock_run_command.call_args[1])
+        end)
+end


### PR DESCRIPTION
#1842

This is the first stage of the blueprint plugin overhaul.

Depends on #1846 for support for negative depths and #1841 for the MapCache change (though the MapCache commits are included in this PR as well to avoid future merge conflicts)

The `blueprint gui` command has a soft dependency on DFHack/scripts#281. You'll be able to run the `blueprint gui` command, but it won't do anything until the `gui/blueprint` script has something in it.

User visible changes to blueprint:
- `depth` and `name` parameters are now optional (defaulting to `1` and `blueprint` if not specified)
- `depth` can now be negative to indicate that we should iterate through the levels top-down instead of the previous hard-coded bottom-up
- new `--cursor` option for specifying start position (game cursor is not needed if this option is specified)

I tried to touch the original logic as little as possible, but I did add bounds checking for the input and clipping of the translation area at the map edge.

All docs are updated as well.

**question:**
I kept the lua functions that the blueprint plugin previously exported (`dig()`, `place()`, `build()`, and `query()`) though personally I'm not convinced they add any value over just running `blueprint` via `run_command`. In fact, the new implementations of these functions are just a wrapper around `run_command`. I don't see any callers in the repo, but I kept the functions for the sake of backward compatibility.

I should note, though, that I'm planning on changing the semantics of the phases in the future, including splitting the current `query` phase into `config` and `rooms`, so I don't think perfect backward compatibility will be feasible. Should I keep those functions or just remove them?