### PR TITLE
[buildingplan] make isPlanModeEnabled() consider enable_all

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -35,6 +35,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - `buildingplan`: fixed an issue where planned constructions designated with DF's sizing keys (``umkh``) would sometimes be larger than requested
+- `buildingplan`: make ``isPlanModeEnabled()`` always return true if "enable all" is set. this fixes the `automaterial` plugin interface when building constructions and buildingplan's "enable all" setting is set.
 - `command-prompt`: fixed issues where overlays created by running certain commands (e.g. `gui/liquids`, `gui/teleport`) would not update the parent screen correctly
 - ``quickfortress.csv`` blueprint: fixed refuse stockpile config and prevented stockpiles from covering stairways
 

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -1087,7 +1087,7 @@ DFhackCExport command_result plugin_shutdown(color_ostream &)
 static bool isPlanModeEnabled(df::building_type type,
                               int16_t subtype,
                               int32_t custom) {
-    return planmode_enabled[toBuildingTypeKey(type, subtype, custom)];
+    return is_planmode_enabled(toBuildingTypeKey(type, subtype, custom));
 }
 
 static bool isPlannableBuilding(df::building_type type,


### PR DESCRIPTION
this lets ``isPlanModeEnabled()`` return true when "enable all" is set. this fixes the `automaterial` plugin interface when building constructions and buildingplan's "enable all" setting is set.