### PR TITLE
[embark-assistant] Improve performance of surveying => faster search (again)

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `tweak` hide-priority: changed so that priorities stay hidden (or visible) when exiting and re-entering the designations menu
+- `embark-assistant`: slightly improved performance of surveying and improved code a little
 
 ## Lua
 - ``gui.Painter``: fixed error when calling ``viewport()`` method

--- a/plugins/embark-assistant/defs.h
+++ b/plugins/embark-assistant/defs.h
@@ -91,9 +91,12 @@ namespace embark_assist {
             int16_t river_elevation = 100;
             int8_t adamantine_level;  // -1 = none, 0 .. 3 = cavern 1 .. magma sea. Currently not used beyond present/absent.
             int8_t magma_level;  // -1 = none, 0 .. 3 = cavern 3 .. surface/volcano
-            std::vector<bool> metals;
-            std::vector<bool> economics;
-            std::vector<bool> minerals;
+            // using uint8_t instead of bool as vector<bool> gets optimized for a small memory footprint which leads to a significant overhead when iterating over all entries, 
+            // also there seems to be no template specialization for std::fill in MSVS C++11 in regards to std::vector<bool> and std::memset does not work as expected (=> not at all that is)
+            // have a look here https://github.com/DFHack/dfhack/pull/1771#discussion_r579498636 for the related discussion and furter resources
+            std::vector<uint8_t> metals;
+            std::vector<uint8_t> economics;
+            std::vector<uint8_t> minerals;
         };
 
         typedef std::array<std::array<mid_level_tile, 16>, 16> mid_level_tiles;

--- a/plugins/embark-assistant/defs.h
+++ b/plugins/embark-assistant/defs.h
@@ -91,7 +91,7 @@ namespace embark_assist {
             int16_t river_elevation = 100;
             int8_t adamantine_level;  // -1 = none, 0 .. 3 = cavern 1 .. magma sea. Currently not used beyond present/absent.
             int8_t magma_level;  // -1 = none, 0 .. 3 = cavern 3 .. surface/volcano
-            // using uint8_t instead of bool as vector<bool> gets optimized for a small memory footprint which leads to a significant overhead when iterating over all entries, 
+            // using uint8_t instead of bool as vector<bool> gets optimized for a small memory footprint which leads to a significant overhead when iterating over all entries,
             // also there seems to be no template specialization for std::fill in MSVS C++11 in regards to std::vector<bool> and std::memset does not work as expected (=> not at all that is)
             // have a look here https://github.com/DFHack/dfhack/pull/1771#discussion_r579498636 for the related discussion and furter resources
             std::vector<uint8_t> metals;

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <vector>
+#include <cstring>
 
 #include "Core.h"
 #include <Console.h>

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -909,15 +909,14 @@ void inline copy_incursion_values(embark_assist::defs::mid_level_tile_incursion_
 //=================================================================================
 
 void reset_mlt_inorganics(embark_assist::defs::mid_level_tiles &mlts) {
-    const uint16_t size = mlts[0][0].metals.size();
     for (uint8_t i = 0; i < 16; i++) {
         for (uint8_t k = 0; k < 16; k++) {
             embark_assist::defs::mid_level_tile &mlt = mlts[i][k];
-            for (uint16_t l = 0; l < size; l++) {
-                mlt.metals[l] = false;
-                mlt.economics[l] = false;
-                mlt.minerals[l] = false;
-            }
+            // std::memset is much faster than std::fill and also faster than direct assignment - also std::fill might be compiled to std::memset but is not guaranteed to happen
+            // have a look here for why: https://travisdowns.github.io/blog/2020/01/20/zero.html
+            std::memset(&mlt.metals[0], false, mlt.metals.size() * sizeof(mlt.metals[0]));
+            std::memset(&mlt.economics[0], false, mlt.economics.size() * sizeof(mlt.economics[0]));
+            std::memset(&mlt.minerals[0], false, mlt.minerals.size() * sizeof(mlt.minerals[0]));
         }
     }
 }


### PR DESCRIPTION
By changing the element type of the 3 vectors used to determine which inorganics (metal, economic stone and minerals) are present on a embark tile it is possible to make use of std::memset instead of manual direct assignment.

std::vector<bool> is being optimized by the compiler which leads to a smaller memory footprint but a significant overhead when  assigning values. Also it prevents the usage of std::memset as the entries in std::vector<bool> are not guaranteed to stored contiguously in memory - compare https://en.cppreference.com/w/cpp/container/vector to https://en.cppreference.com/w/cpp/container/vector_bool.

This change increases the memory usage a little but makes the search faster by around 6 seconds for large regions. Also it makes sure that the actual size of each vector is being respected which prevents errors down the line if the vectors might no longer have all the same size.

See the whole of the prior discussion here:
https://github.com/DFHack/dfhack/pull/1771#discussion_r578943530
Start here for the details:
https://github.com/DFHack/dfhack/pull/1771#discussion_r579720715

@PatrikLundell: as discussed here: 
http://www.bay12forums.com/smf/index.php?topic=169634.msg8276575#msg8276575