### PR TITLE
[resume] invalidate cache when buildings are added programmatically

### DIFF
--- a/plugins/resume.cpp
+++ b/plugins/resume.cpp
@@ -41,6 +41,7 @@ DFHACK_PLUGIN("resume");
 #define PLUGIN_VERSION 0.2
 
 REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(process_jobs);
 REQUIRE_GLOBAL(ui);
 REQUIRE_GLOBAL(world);
 
@@ -222,6 +223,11 @@ struct resume_hook : public df::viewscreen_dwarfmodest
 
         if (enabled && DFHack::World::ReadPauseState() && ui->main.mode == ui_sidebar_mode::Default)
         {
+            if (*process_jobs)
+            {
+                // something just created some buildings. rescan.
+                clear_scanned();
+            }
             scan_for_suspended_buildings();
             show_suspended_buildings();
         }


### PR DESCRIPTION
It turns out option 5 from https://github.com/DFHack/scripts/pull/284#issuecomment-848815321 was equivalent to option 1, and they're both cheap and effective.  the `process_jobs` flag is handled internally by df on every frame, so it only stays true for one frame. this allows us to invalidate once and rescan only when required.

no changelog entry since this was never a user-visible problem until DFHack/scripts#284