### PR TITLE
embark-assistant early waterfall quit removed

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `dwarfvet`: fixed a crash that could occur with hospitals overlapping with other buildings in certain ways
 - ``quickfortress.csv`` blueprint: fixed refuse stockpile config and prevented stockpiles from covering stairways
 - `stonesense`: fixed a crash that could occur when ctrl+scrolling or closing the Stonesense window
+- `embark-assistant`: faulty early exit when searching for waterfalls in first search attempt removed
 
 ## Misc Improvements
 - `blueprint`: make ``depth`` and ``name`` parameters optional. ``depth`` now defaults to ``1`` (current level only) and ``name`` defaults to "blueprint"

--- a/plugins/embark-assistant/help_ui.cpp
+++ b/plugins/embark-assistant/help_ui.cpp
@@ -340,7 +340,7 @@ namespace embark_assist{
                 help_text.push_back("  the N, followed by the one to the W, and lastly the one acting as the");
                 help_text.push_back("  reference. This means there's a risk embarks with such 'trouble' corners");
                 help_text.push_back("  may get affected corner(s) evaluated incorrectly.");
-                help_text.push_back("Version 0.13 2020-12-03");
+                help_text.push_back("Version 0.14 2021-06-13");
 
                 break;
             }

--- a/plugins/embark-assistant/matcher.cpp
+++ b/plugins/embark-assistant/matcher.cpp
@@ -1642,7 +1642,7 @@ namespace embark_assist {
 
                 //  Waterfall
                 if (finder->min_waterfall > tile->max_waterfall) {  //  N/A = -1 is always smaller
-                    if (trace) out.print("matcher::world_tile_match: Waterfall (%i, %i)\n", x, y);
+                    if (trace) out.print("matcher::world_tile_match: Waterfall (%i, %i), finder: %i, tile: %i\n", x, y, finder->min_waterfall, tile->max_waterfall);
                     return false;
                 }
                 if (finder->min_waterfall == 0 &&  // Absent
@@ -2276,16 +2276,11 @@ namespace embark_assist {
                     }
                 }
 
-                // Aquifer  //  Requires survey
+                //  Aquifer  //  Requires survey
 
-                // River size  //  Requires survey
+                //  River size  //  Requires survey
 
-                //  Waterfall
-                if (finder->min_waterfall > 0 &&
-                    tile->min_river_size == embark_assist::defs::river_sizes::None) {
-                    if (trace) out.print("matcher::world_tile_match: NS Waterfall (%i, %i)\n", x, y);
-                    return false;
-                }
+                //  Waterfall  //  Requires survey
 
                 //  Flat. No world tile checks. Need to look at the details
                


### PR DESCRIPTION
An attempt to compare world tile data to the search profile before the world tile data had been collected for waterfalls was removed.