### PR TITLE
[test] allow mock.func() to return multiple values

### DIFF
--- a/library/lua/test_util/mock.lua
+++ b/library/lua/test_util/mock.lua
@@ -81,9 +81,9 @@ function mock.restore(...)
     return _patch_impl(patches, callback, true)
 end
 
-function mock.func(return_value)
+function mock.func(...)
     local f = {
-        return_value = return_value,
+        return_values = {...},
         call_count = 0,
         call_args = {},
     }
@@ -92,7 +92,7 @@ function mock.func(return_value)
         __call = function(self, ...)
             self.call_count = self.call_count + 1
             table.insert(self.call_args, {...})
-            return self.return_value
+            return table.unpack(self.return_values)
         end,
     })
 

--- a/test/library/test_util/mock.lua
+++ b/test/library/test_util/mock.lua
@@ -203,6 +203,14 @@ end
 function test.func_call_return_value()
     local f = mock.func(7)
     expect.eq(f(), 7)
-    f.return_value = 9
+    f.return_values = {9}
     expect.eq(f(), 9)
+end
+
+function test.func_call_return_multiple_values()
+    local f = mock.func(7,5,{imatable='snarfsnarf'})
+    local a, b, c = f()
+    expect.eq(7, a)
+    expect.eq(5, b)
+    expect.table_eq({imatable='snarfsnarf'}, c)
 end


### PR DESCRIPTION
so we can mock functions like `screen.getCursorPos()` which returns `x`, `y` and not an otherwise mockable table of `{x=x, y=y}`

I changed the field value from `return_value` to `return_values` to highlight the change in semantics. I verified that no current code references this field (other than the unit tests, which I modified accordingly).