### PR TITLE
Show adjective in item prompt

### DIFF
--- a/library/lua/gui/materials.lua
+++ b/library/lua/gui/materials.lua
@@ -314,9 +314,16 @@ function ItemTypeDialog(args)
         if defcnt > 0 then
             for subtype = 0,defcnt-1 do
                 local def = dfhack.items.getSubtypeDef(itype, subtype)
+                local text
+                local success, adjective = pcall(function() return def.adjective end)
+                if success and adjective ~= "" then
+                    text = " " .. adjective .. " " .. def.name
+                else
+                    text = " " .. def.name
+                end
                 if not filter or filter(itype,subtype,def) then
                     table.insert(choices, {
-                        icon = '\x1e', text = ' '..def.name, item_type = itype, item_subtype = subtype
+                        icon = '\x1e', text = text, item_type = itype, item_subtype = subtype
                     })
                 end
             end


### PR DESCRIPTION
Useful for high boot/low boot etc.
I think I got that in right...
The pcall is because sometimes the item type is, for example, a toy which doesn't have an adjective field, and it's made to error if you index a nonexistent field.