### PR TITLE
Fix label early key detection in scrolling logic

### DIFF
--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -442,7 +442,6 @@ function Label:onInput(keys)
                 v = -self.frame_body.height
             end
             self:scroll(v)
-            return false
         end
     end
     return check_text_keys(self, keys)


### PR DESCRIPTION
Current logic is because @myk002 fixed it so label would allow other widgets control when label(s) are present. However that breaks label key detection for default scroll keys. This can be worked around by setting scrollkeys to empty.

TBH: label is quite complicated and used everwhere so i'm reluctant to touch it and would love for someone to look over if i'm correct.