### PR TITLE
Fix keybindings in the "Building Material" screen

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `buildingplan`: fixed an issue where planned constructions designated with DF's sizing keys (``umkh``) would sometimes be larger than requested
 - `buildingplan`: fixed an issue preventing other plugins like `automaterial` from planning constructions if the "enable all" buildingplan setting was turned on
+- `buildingplan`: ensure navigation keys work properly in the materials selection screen when alternate keybindings are used
 - `command-prompt`: fixed issues where overlays created by running certain commands (e.g. `gui/liquids`, `gui/teleport`) would not update the parent screen correctly
 - `dwarfvet`: fixed a crash that could occur with hospitals overlapping with other buildings in certain ways
 - ``quickfortress.csv`` blueprint: fixed refuse stockpile config and prevented stockpiles from covering stairways

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -237,12 +237,12 @@ void ViewscreenChooseMaterial::feed(set<df::interface_key> *input)
 
         Screen::dismiss(this);
     }
-    else if (input->count(interface_key::CURSOR_LEFT))
+    else if (input->count(interface_key::STANDARDSCROLL_LEFT))
     {
         --selected_column;
         validateColumn();
     }
-    else if (input->count(interface_key::CURSOR_RIGHT))
+    else if (input->count(interface_key::STANDARDSCROLL_RIGHT))
     {
         selected_column++;
         validateColumn();


### PR DESCRIPTION
Hi,
This PR improves the interactions of the "Building Material" screen.

The key bindings currently used in this interface are:
```
Move selector up/down - for item selection
Move view/cursor left/right - for column selection
```
There will be no problems with the default DF key bindings because "Move selector ..." and "Move view/cursor ..." both use Up/Down/Left/Right. However, if you use different key bindings for them, the problem arises.

This PR uniformly uses "Move selector ..." as key bindings for item/column selection:
```
Move selector up/down - for item selection
Move selector left/right - for column selection
```

