### PR TITLE
[gui.dwarfmode] new function: enterSidebarMode()

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - ``gui.Painter``: fixed error when calling ``viewport()`` method
+- ``gui.dwarfmode``: new function: ``enterSidebarMode(sidebar_mode, max_esc)`` which uses keypresses to get into the specified sidebar mode from whatever the current screen is
 - `reveal`: now exposes ``unhideFlood(pos)`` functionality to Lua
 - ``utils.processArgsGetopt()``: now returns negative numbers (e.g. ``-10``) in the list of positional parameters instead of treating it as an option string equivalent to ``-1 -0``
 - ``utils.processArgsGetopt()``: now properly handles ``--`` like GNU ``getopt`` as a marker to treat all further parameters as non-options

--- a/test/library/gui/dwarfmode.lua
+++ b/test/library/gui/dwarfmode.lua
@@ -1,0 +1,67 @@
+config = {
+    mode = 'fortress',
+}
+
+local gui = require('gui')
+local guidm = require('gui.dwarfmode')
+
+function test.enterSidebarMode()
+    expect.error_match('Invalid or unsupported sidebar mode',
+                       function() guidm.enterSidebarMode('badmode') end)
+    expect.error_match('Invalid or unsupported sidebar mode',
+                       function() guidm.enterSidebarMode(
+                                        df.ui_sidebar_mode.OrdersRefuse) end)
+
+    expect.error_match('must be a positive number',
+                       function() guidm.enterSidebarMode(0, 'gg') end)
+    expect.error_match('must be a positive number',
+                       function() guidm.enterSidebarMode(0, 0) end)
+    expect.error_match('must be a positive number',
+                       function() guidm.enterSidebarMode(0, '0') end)
+    expect.error_match('must be a positive number',
+                       function() guidm.enterSidebarMode(0, -1) end)
+    expect.error_match('must be a positive number',
+                       function() guidm.enterSidebarMode(0, '-1') end)
+
+    -- Simulate not being able to get to default from a screen via mocks. This
+    -- failure can actually happen in-game in some situations, such as when
+    -- naming a building with ctrl-N (no way to cancel changes).
+    mock.patch({{dfhack.gui, 'getFocusString', mock.func()},
+                {gui, 'simulateInput', mock.func()}},
+               function()
+                   expect.error_match('Unable to get into target sidebar mode',
+                    function()
+                        guidm.enterSidebarMode(df.ui_sidebar_mode.Default)
+                    end)
+               end)
+
+    -- verify expected starting state
+    expect.eq(df.ui_sidebar_mode.Default, df.global.ui.main.mode)
+    expect.eq('dwarfmode/Default', dfhack.gui.getCurFocus(true))
+
+    -- get into the orders screen
+    gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'D_JOBLIST')
+    gui.simulateInput(dfhack.gui.getCurViewscreen(true), 'UNITJOB_MANAGER')
+    expect.eq(df.ui_sidebar_mode.Default, df.global.ui.main.mode)
+    expect.eq('jobmanagement/Main', dfhack.gui.getCurFocus(true))
+
+    -- get back into default from some deep screen
+    guidm.enterSidebarMode(df.ui_sidebar_mode.Default)
+    expect.eq(df.ui_sidebar_mode.Default, df.global.ui.main.mode)
+    expect.eq('dwarfmode/Default', dfhack.gui.getCurFocus(true))
+
+    -- move from default to some other mode
+    guidm.enterSidebarMode(df.ui_sidebar_mode.QueryBuilding)
+    expect.eq(df.ui_sidebar_mode.QueryBuilding, df.global.ui.main.mode)
+    expect.true_(dfhack.gui.getCurFocus(true):find('^dwarfmode/QueryBuilding'))
+
+    -- move between non-default modes
+    guidm.enterSidebarMode(df.ui_sidebar_mode.LookAround)
+    expect.eq(df.ui_sidebar_mode.LookAround, df.global.ui.main.mode)
+    expect.true_(dfhack.gui.getCurFocus(true):find('^dwarfmode/LookAround'))
+
+    -- get back into default from a supported mode
+    guidm.enterSidebarMode(df.ui_sidebar_mode.Default)
+    expect.eq(df.ui_sidebar_mode.Default, df.global.ui.main.mode)
+    expect.eq('dwarfmode/Default', dfhack.gui.getCurFocus(true))
+end


### PR DESCRIPTION
refactored and improved from `quickfort`.

this common implementation will replace the now redundant functions in `quickfort`, `gui/mass-remove`, and `gui/blueprint`.