### PR TITLE
new library string function: wrap()

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -51,6 +51,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `embark-assistant`: slightly improved performance of surveying and improved code a little
 
 ## Lua
+- new string utility function: ``string:wrap(width)`` wraps a string at space-separated word boundaries
 - ``gui.Painter``: fixed error when calling ``viewport()`` method
 - `reveal`: now exposes ``unhideFlood(pos)`` functionality to Lua
 - ``utils.processArgsGetopt()``: now returns negative numbers (e.g. ``-10``) in the list of positional parameters instead of treating it as an option string equivalent to ``-1 -0``

--- a/test/library/string.lua
+++ b/test/library/string.lua
@@ -1,0 +1,24 @@
+-- tests string functions added by dfhack.lua
+
+function test.startswith()
+    expect.true_(('abcd'):startswith(''))
+    expect.true_(('abcd'):startswith('abc'))
+    expect.false_(('abcd'):startswith('bcd'))
+end
+
+function test.endswith()
+    expect.true_(('abcd'):endswith(''))
+    expect.true_(('abcd'):endswith('bcd'))
+    expect.false_(('abcd'):endswith('abc'))
+end
+
+function test.wrap()
+    expect.eq('hello world', ('hello world'):wrap(20))
+    expect.eq('hello   world', ('hello   world'):wrap(20))
+    expect.eq('hello world\nhow are you?',('hello world how are you?'):wrap(12))
+    expect.eq('hello\nworld', ('hello world'):wrap(5))
+    expect.eq('hello\nworld', ('hello        world'):wrap(5))
+    expect.eq('hello\nworld', ('hello world'):wrap(8))
+    expect.eq('hel\nlo\nwor\nld', ('hello world'):wrap(3))
+    expect.eq('hel\nloo\nwor\nldo', ('helloo  worldo'):wrap(3))
+end


### PR DESCRIPTION
added to the string class like `startswith()` and `endswith()`

refactored and improved from the implementation in `quickfort`'s `dialog.lua`