### PR TITLE
[blueprint] normalize pathnames and handle dirs as basenames

### DIFF
--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -587,11 +587,20 @@ static string get_tile_query(df::building* b)
     return " ";
 }
 
+// can remove once we move to C++20
+static bool ends_with(const string &str, const string &sv)
+{
+    if (sv.size() > str.size())
+        return false;
+    return str.substr(str.size() - sv.size()) == sv;
+}
+
 // returns filename
 static string init_stream(ofstream &out, string basename, string target)
 {
     std::ostringstream out_path;
-    out_path << basename << "-" << target << ".csv";
+    string separator = ends_with(basename, "/") ? "" : "-";
+    out_path << basename << separator << target << ".csv";
     string path = out_path.str();
     out.open(path, ofstream::trunc);
     out << "#" << target << endl;

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -69,8 +69,8 @@ local function parse_positionals(opts, args, start_argidx)
                :format(args[argidx]))
     end
     argidx = argidx + 1
-    -- normalize paths to forward slashes
-    opts.name = name:gsub(package.config:sub(1,1), "/")
+    -- normalize paths and remove leading slashes
+    opts.name = utils.normalizePath(name):gsub('^/', '')
 
     local auto_phase = true
     local phase = args[argidx]


### PR DESCRIPTION
Depends on #1890 for the path normalization library function

uses the new path normalization library function and fixes handling of blueprint basenames that end in a slash (that is, basenames that are directories). For a basename of `dirname/` the code previously generated the following files:
```
blueprints/dirname/-dig.csv
blueprints/dirname/-build.csv
...
```
it now drops the dash and generates files like:
```
blueprints/dirname/dig.csv
blueprints/dirname/build.csv
...
```