### PR TITLE
[orders] fix crash on malformed order IDs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `buildingplan`: fixed an issue preventing other plugins like `automaterial` from planning constructions if the "enable all" buildingplan setting was turned on
 - `command-prompt`: fixed issues where overlays created by running certain commands (e.g. `gui/liquids`, `gui/teleport`) would not update the parent screen correctly
 - `dwarfvet`: fixed a crash that could occur with hospitals overlapping with other buildings in certain ways
+- `orders`: don't crash when importing orders with malformed IDs
 - ``quickfortress.csv`` blueprint: fixed refuse stockpile config and prevented stockpiles from covering stairways
 - `stonesense`: fixed a crash that could occur when ctrl+scrolling or closing the Stonesense window
 


### PR DESCRIPTION
Fixes #1893

This is similar to the fix in #1770, which caught errors during initial read, but this PR catches errors thrown during processing. This came up because a manually edited orders json file had a string ID instead of a numeric ID.

I believe this now covers all the places that can throw errors for import. I also believe export is safe since we control the input there and don't do string processing, but I can't say that for absolute certain.