### PR TITLE
migrate existing lua code to use new library fns

### DIFF
--- a/library/lua/argparse.lua
+++ b/library/lua/argparse.lua
@@ -199,7 +199,8 @@ function coords(arg, arg_name, skip_validation)
                         check_nonnegative_int(numbers[2]),
                         check_nonnegative_int(numbers[3]))
     if not skip_validation and not dfhack.maps.isValidTilePos(pos) then
-        arg_error('specified coordinates not on current map: "%s"', arg)
+        arg_error(arg_name,
+                  'specified coordinates not on current map: "%s"', arg)
     end
     return pos
 end

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -199,7 +199,7 @@ function parse_label_text(obj)
     for _,v in ipairs(text) do
         local vv
         if type(v) == 'string' then
-            vv = utils.split_string(v, NEWLINE)
+            vv = v:split(NEWLINE)
         else
             vv = { v }
         end
@@ -803,7 +803,7 @@ function FilteredList:setFilter(filter, pos)
     self.edit.text = filter
 
     if filter ~= '' then
-        local tokens = utils.split_string(filter, ' ')
+        local tokens = filter:split()
         local ipos = pos
 
         choices = {}

--- a/library/lua/utils.lua
+++ b/library/lua/utils.lua
@@ -482,16 +482,7 @@ end
 
 -- Split the string by the given delimiter
 function split_string(self, delimiter)
-    local result = { }
-    local from  = 1
-    local delim_from, delim_to = string.find( self, delimiter, from  )
-    while delim_from do
-        table.insert( result, string.sub( self, from , delim_from-1 ) )
-        from  = delim_to + 1
-        delim_from, delim_to = string.find( self, delimiter, from  )
-    end
-    table.insert( result, string.sub( self, from  ) )
-    return result
+    return self:split(delimiter)
 end
 
 -- Ask a yes-no question
@@ -545,9 +536,9 @@ end
 
 -- Normalize directory separator slashes across platforms to '/' and collapse
 -- adjacent slashes into a single slash.
-local platformSlash = package.config:sub(1,1)
+local PLATFORM_SLASH = package.config:sub(1,1)
 function normalizePath(path)
-    return path:gsub(platformSlash, '/'):gsub('/+', '/')
+    return path:gsub(PLATFORM_SLASH, '/'):gsub('/+', '/')
 end
 
 function invert(tab)
@@ -618,7 +609,7 @@ function df_expr_to_ref(expr)
     expr = expr:gsub('%["(.-)"%]', function(field) return '.' .. field end)
         :gsub('%[\'(.-)\'%]', function(field) return '.' .. field end)
         :gsub('%[(%d+)]', function(field) return '.' .. field end)
-    local parts = split_string(expr, '%.')
+    local parts = expr:split('.', true)
     local obj = df_env[parts[1]]
     for i = 2, #parts do
         local key = tonumber(parts[i]) or parts[i]

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -1,5 +1,6 @@
 local _ENV = mkmodule('plugins.blueprint')
 
+local argparse = require('argparse')
 local utils = require('utils')
 
 -- the info here is very basic and minimal, so hopefully we won't need to change
@@ -43,17 +44,11 @@ local valid_phase_list = {
 valid_phases = utils.invert(valid_phase_list)
 
 local function parse_cursor(opts, arg)
-    local _, _, x, y, z = arg:find('^(%d+),(%d+),(%d+)$')
-    if not x then
-        qerror(('invalid argument for --cursor option: "%s"; expected format' ..
-                ' is "<x>,<y>,<z>", for example: "30,60,150"'):format(arg))
-    end
+    local cursor = argparse.coords(arg)
     -- be careful not to replace struct members when called from C++, but also
     -- create the table as needed when called from lua
     if not opts.start then opts.start = {} end
-    opts.start.x = tonumber(x)
-    opts.start.y = tonumber(y)
-    opts.start.z = tonumber(z)
+    utils.assign(opts.start, cursor)
 end
 
 local function parse_positionals(opts, args, start_argidx)
@@ -93,7 +88,7 @@ local function process_args(opts, args)
         return
     end
 
-    return utils.processArgsGetopt(args, {
+    return argparse.processArgsGetopt(args, {
             {'c', 'cursor', hasArg=true,
              handler=function(optarg) parse_cursor(opts, optarg) end},
             {'h', 'help', handler=function() opts.help = true end},

--- a/plugins/lua/stockflow.lua
+++ b/plugins/lua/stockflow.lua
@@ -922,31 +922,6 @@ function matchall(haystack, needles)
     return true
 end
 
-function splitstring(full, pattern)
-    local last = string.len(full)
-    local result = {}
-    local n = 1
-    while n <= last do
-        local start, stop = string.find(full, pattern, n)
-        if not start then
-            result[#result+1] = string.sub(full, n)
-            break
-        elseif start > n then
-            result[#result+1] = string.sub(full, n, start - 1)
-        end
-
-        if stop < n then
-            -- The pattern matches an empty string.
-            -- Avoid an infinite loop.
-            break
-        end
-
-        n = stop + 1
-    end
-
-    return result
-end
-
 function screen:refilter()
     -- Determine which rows to show, and in which colors.
     -- Todo: The official one now has three categories of search results:
@@ -956,7 +931,7 @@ function screen:refilter()
     self.page_size = self.frame_rect.height - ExtraLines
 
     local filtered = {}
-    local needles = splitstring(self.search_string, " ")
+    local needles = self.search_string:split()
     for key, value in ipairs(reaction_list) do
         if matchall(string.upper(value.name), needles) then
             filtered[#filtered+1] = {

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -19,7 +19,10 @@ function test.parse_gui_commandline()
     expect.table_eq({help=true}, opts)
 
     opts = {}
-    b.parse_gui_commandline(opts, {'--cursor=1,2,3'})
+    mock.patch(dfhack.maps, 'isValidTilePos', mock.func(true),
+               function()
+                   b.parse_gui_commandline(opts, {'--cursor=1,2,3'})
+               end)
     expect.table_eq({auto_phase=true, name='blueprint', start={x=1,y=2,z=3}},
                     opts)
 


### PR DESCRIPTION
Fixes #1888 
Depends on #1897 

step 5 of #1888 

This PR migrates library and plugin lua code to use the new string and argparse library functions (with some minor auxiliary cleanup). Each change has been manually tested, with coverage of changed lines verified with luacov (except for stockflow. I verified that it works but for some reason luacov doesn't show coverage for that particular file).