### PR TITLE
[buildingplan] display which items are attached and which are pending

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -34,6 +34,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 # Future
 
 ## Misc Improvements
+- `buildingplan`: now displays which items are attached and which items are still missing for planned buildings
 - `tiletypes-here`, `tiletypes-here-point`: add --cursor and --quiet options to support non-interactive use cases
 
 # 0.47.05-r2

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -498,6 +498,17 @@ struct buildingplan_query_hook : public df::viewscreen_dwarfmodest
             INTERPOSE_NEXT(feed)(input);
     }
 
+    static bool is_filter_satisfied(df::building *bld, int filter_idx)
+    {
+        if (!bld
+                || bld->jobs.size() < 1
+                || bld->jobs[0]->job_items.size() <= filter_idx)
+            return false;
+
+        // if all items for this filter are attached, the quantity will be 0
+        return bld->jobs[0]->job_items[filter_idx]->quantity == 0;
+    }
+
     DEFINE_VMETHOD_INTERPOSE(void, render, ())
     {
         INTERPOSE_NEXT(render)();
@@ -515,10 +526,12 @@ struct buildingplan_query_hook : public df::viewscreen_dwarfmodest
         Screen::Pen pen(' ', COLOR_BLACK);
         Screen::fillRect(pen, x, y, dims.menu_x2, y);
 
+        bool attached = is_filter_satisfied(pb->getBuilding(), filter_idx);
+
         auto & filter = pb->getFilters()[filter_idx];
         y = 24;
         std::string item_label =
-            stl_sprintf("Item %d of %d", filter_count - filter_idx, filter_count);
+            stl_sprintf("Item %d of %d (%s)", filter_count - filter_idx, filter_count, attached ? "attached" : "pending");
         OutputString(COLOR_WHITE, x, y, "Planned Building Filter", true, left_margin + 1);
         OutputString(COLOR_WHITE, x, y, item_label.c_str(), true, left_margin + 1);
         OutputString(COLOR_WHITE, x, y, get_item_label(toBuildingTypeKey(bld), filter_idx).c_str(), true, left_margin);


### PR DESCRIPTION
This allows the player to determine which items are missing and need to be produced before a building can be built. It is most useful for buildings that take multiple items, such as dyer's workshops.

the information is visible in the `q`uery sidebar when examining a planned building