### PR TITLE
[orders] support reaction-specific item traits

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,7 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `buildingplan`: now displays which items are attached and which items are still missing for planned buildings
-- `orders`: support reaction-specific item condition traits, like "lye-containing" for soap production orders
+- `orders`: support importing and exporting reaction-specific item conditions, like "lye-containing" for soap production orders
 - `tiletypes-here`, `tiletypes-here-point`: add --cursor and --quiet options to support non-interactive use cases
 
 ## Documentation

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,6 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `buildingplan`: now displays which items are attached and which items are still missing for planned buildings
+- `orders`: support reaction-specific item condition traits, like "lye-containing" for soap production orders
 - `tiletypes-here`, `tiletypes-here-point`: add --cursor and --quiet options to support non-interactive use cases
 
 ## Documentation

--- a/test/plugins/orders.lua
+++ b/test/plugins/orders.lua
@@ -9,38 +9,61 @@ local TMP_FILE_NAME = 'tmp-test'
 local TMP_FILE_PATH = FILE_PATH_PATTERN:format(TMP_FILE_NAME)
 
 local function test_wrapper(test_fn)
-    -- save active orders
+    -- backup and clear active orders
     dfhack.run_command_silent{'orders', 'export', BACKUP_FILE_NAME}
+    dfhack.run_command_silent{'orders', 'clear'}
+    df.global.world.manager_order_next_id = 0
     return dfhack.with_finalize(
         function()
-            -- clear test orders, restore original orders, remove temp file
+            -- clear test orders, restore original orders, remove temp files
             dfhack.run_command_silent{'orders', 'clear'}
-            print('reimporting')
             dfhack.run_command_silent{'orders', 'import', BACKUP_FILE_NAME}
+            df.global.world.manager_order_next_id =
+                    #df.global.world.manager_orders
             os.remove(BACKUP_FILE_PATH)
+            os.remove(TMP_FILE_PATH)
         end,
         test_fn)
 end
 config.wrapper = test_wrapper
 
+-- returns export command result and exported file content
+function run_orders_export()
+    local _, result = dfhack.run_command_silent{'orders', 'export',
+                                                TMP_FILE_NAME}
+    local f = io.open(TMP_FILE_PATH, 'r')
+    return dfhack.with_finalize(
+        function() f:close() end,
+        function() return result, f:read('*all') end)
+end
+
 function run_orders_import(file_content)
     local f = io.open(TMP_FILE_PATH, 'w')
     f:write(file_content)
     f:close()
-
-    return dfhack.with_finalize(
-        function()
-            os.remove(TMP_FILE_PATH)
-        end,
-        function()
-            return dfhack.run_command_silent{'orders', 'import', TMP_FILE_NAME}
-        end
-    )
+    return dfhack.run_command_silent{'orders', 'import', TMP_FILE_NAME}
 end
 
-function check_import_success(file_content)
+local function normalize_whitespace(str)
+    return str:gsub('%s+', ' '):trim()
+end
+
+function check_export_success(expected_file_content)
+    local result, file_content = run_orders_export()
+    expect.eq(result, CR_OK)
+
+    -- ignore whitespace (otherwise the expected file content is impossible to
+    -- format properly in this file)
+    expect.eq(normalize_whitespace(expected_file_content),
+              normalize_whitespace(file_content))
+end
+
+function check_import_success(file_content, comment, num_expected_orders)
+    local prev_num_orders = #df.global.world.manager_orders
     local output, result = run_orders_import(file_content)
     expect.eq(result, CR_OK)
+    expect.eq(prev_num_orders + num_expected_orders,
+              #df.global.world.manager_orders)
 end
 
 function check_import_fail(file_content, comment, prefix)
@@ -55,7 +78,7 @@ function check_import_fail(file_content, comment, prefix)
 end
 
 function test.import_empty()
-    check_import_success('[]')
+    check_import_success('[]', 'empty input', 0)
 end
 
 function test.import_non_array()
@@ -140,4 +163,97 @@ function test.import_valid_and_invalid_orders()
             }
         ]
     ]], 'empty order before valid order')
+end
+
+function test.import_export_reaction_condition()
+    local file_content = [[
+        [
+            {
+                "amount_left" : 1,
+                "amount_total" : 1,
+                "frequency" : "Daily",
+                "id" : 0,
+                "is_active" : false,
+                "is_validated" : false,
+                "item_conditions" :
+                [
+                    {
+                        "condition" : "AtLeast",
+                        "contains" :
+                        [
+                            "lye"
+                        ],
+                        "reaction_id" : "MAKE_SOAP_FROM_TALLOW",
+                        "value" : 5
+                    }
+                ],
+                "job" : "CustomReaction",
+                "reaction" : "MAKE_SOAP_FROM_TALLOW"
+            }
+        ]
+    ]]
+    check_import_success(file_content, 'valid reaction condition', 1)
+    check_export_success(file_content)
+end
+
+local function get_last_order()
+    return df.global.world.manager_orders[#df.global.world.manager_orders-1]
+end
+
+function test.import_invalid_reaction_conditions()
+    check_import_success([[
+        [
+            {
+                "amount_left" : 1,
+                "amount_total" : 1,
+                "frequency" : "OneTime",
+                "id" : 0,
+                "is_active" : false,
+                "is_validated" : true,
+                "item_conditions" :
+                [
+                    {
+                        "condition" : "AtLeast",
+                        "contains" :
+                        [
+                            "lye"
+                        ],
+                        "reaction_id" : "MAKE_SOAP_FROM_TALLOW_xxx",
+                        "value" : 5
+                    }
+                ],
+                "job" : "CustomReaction",
+                "reaction" : "MAKE_SOAP_FROM_TALLOW"
+            }
+        ]
+    ]], 'condition ignored for bad reaction id', 1)
+    expect.eq(0, #get_last_order().item_conditions)
+
+    check_import_success([[
+        [
+            {
+                "amount_left" : 1,
+                "amount_total" : 1,
+                "frequency" : "OneTime",
+                "id" : 0,
+                "is_active" : false,
+                "is_validated" : true,
+                "item_conditions" :
+                [
+                    {
+                        "condition" : "AtLeast",
+                        "contains" :
+                        [
+                            "lye_xxx"
+                        ],
+                        "reaction_id" : "MAKE_SOAP_FROM_TALLOW",
+                        "value" : 5
+                    }
+                ],
+                "job" : "CustomReaction",
+                "reaction" : "MAKE_SOAP_FROM_TALLOW"
+            }
+        ]
+    ]], 'condition ignored for bad reagent name', 1)
+    expect.eq(0, #get_last_order().item_conditions)
 end

--- a/test/plugins/orders.lua
+++ b/test/plugins/orders.lua
@@ -17,6 +17,7 @@ local function test_wrapper(test_fn)
         function()
             -- clear test orders, restore original orders, remove temp files
             dfhack.run_command_silent{'orders', 'clear'}
+            df.global.world.manager_order_next_id = 0
             dfhack.run_command_silent{'orders', 'import', BACKUP_FILE_NAME}
             df.global.world.manager_order_next_id =
                     #df.global.world.manager_orders

--- a/test/plugins/orders.lua
+++ b/test/plugins/orders.lua
@@ -62,9 +62,9 @@ end
 function check_import_success(file_content, comment, num_expected_orders)
     local prev_num_orders = #df.global.world.manager_orders
     local output, result = run_orders_import(file_content)
-    expect.eq(result, CR_OK)
+    expect.eq(result, CR_OK, comment)
     expect.eq(prev_num_orders + num_expected_orders,
-              #df.global.world.manager_orders)
+              #df.global.world.manager_orders, comment)
 end
 
 function check_import_fail(file_content, comment, prefix)


### PR DESCRIPTION
implemented for both import and export

uses the new test wrapper functionality to export current orders, run the test, clear orders, import the player's previous orders, and remove temp files. this prevents the tests from having visible side effects. The tests will reset the next order id, but this isn't visible to the player.