### PR TITLE
[Core] clear modstate on window focus

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 - `dig-now`: instantly completes dig designations (including smoothing and carving tracks)
 
+## Fixes
+- Core: ``alt`` keydown state is now cleared when DF loses and regains focus, ensuring the ``alt`` modifier state is not stuck on for systems that don't send standard keyup events in response to ``alt-tab`` window manager events
+
 ## Misc Improvements
 - `tiletypes-here`, `tiletypes-here-point`: add --cursor and --quiet options to support non-interactive use cases
 

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2472,13 +2472,20 @@ int UnicodeAwareSym(const SDL::KeyboardEvent& ke)
 //MEMO: return false if event is consumed
 int Core::DFH_SDL_Event(SDL::Event* ev)
 {
-    //static bool alt = 0;
-
     // do NOT process events before we are ready.
     if(!started) return true;
     if(!ev)
         return true;
-    if(ev && (ev->type == SDL::ET_KEYDOWN || ev->type == SDL::ET_KEYUP))
+
+    if(ev->type == SDL::ET_ACTIVEEVENT && ev->active.gain)
+    {
+        // clear modstate when gaining focus in case alt-tab was used when
+        // losing focus and modstate is now incorrectly set
+        modstate = 0;
+        return true;
+    }
+
+    if(ev->type == SDL::ET_KEYDOWN || ev->type == SDL::ET_KEYUP)
     {
         auto ke = (SDL::KeyboardEvent *)ev;
 


### PR DESCRIPTION
Fixes #1878 (Keybindings sometimes act as if Alt is stuck down)