### PR TITLE
[lua] ensure printall, ~, and @ behave in lua 5.3.6

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -50,6 +50,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## API
 - The ``Items`` module ``moveTo*`` and ``remove`` functions now handle projectiles
 
+## Lua
+- new global function: ``safe_pairs(iterable[, iterator_fn])`` will iterate over the ``iterable`` (a table or iterable userdata)  with the ``iterator_fn`` (``pairs`` if not otherwise specified) if iteration is possible. If iteration is not possible or would throw an error, for example if ``nil`` is passed as the ``iterable``, the iteration is just silently skipped.
+
 ## Documentation
 - `quickfort-library-guide`: updated dreamfort documentation and added screenshots
 

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -175,7 +175,7 @@ end
 
 function safe_pairs(t, iterator_fn)
     iterator_fn = iterator_fn or pairs
-    if (pcall(pairs, t)) then
+    if (pcall(iterator_fn, t)) then
         return _wrap_iterator(iterator_fn(t))
     else
         return function() end

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -176,15 +176,11 @@ local function print_element(k, v)
 end
 
 function printall(table)
-    if not safe_iterate(table, pairs, print_element) then
-        dfhack.println(tostring(table))
-    end
+    safe_iterate(table, pairs, print_element)
 end
 
 function printall_ipairs(table)
-    if not safe_iterate(table, ipairs, print_element) then
-        dfhack.println(tostring(table))
-    end
+    safe_iterate(table, ipairs, print_element)
 end
 
 local do_print_recurse

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -172,18 +172,18 @@ local function safe_iterate(table, iterate_fn, elem_cb)
 end
 
 local function print_element(k, v)
-    print(string.format("%-23s\t = %s", tostring(k), tostring(v)))
+    dfhack.println(string.format("%-23s\t = %s", tostring(k), tostring(v)))
 end
 
 function printall(table)
     if not safe_iterate(table, pairs, print_element) then
-        print(tostring(table))
+        dfhack.println(tostring(table))
     end
 end
 
 function printall_ipairs(table)
     if not safe_iterate(table, ipairs, print_element) then
-        print(tostring(table))
+        dfhack.println(tostring(table))
     end
 end
 

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -163,6 +163,7 @@ COMMA = ","
 PERIOD = "."
 
 function printall(table)
+    if type(table) ~= 'table' then print(tostring(table)) return end
     local ok,f,t,k = pcall(pairs,table)
     if ok then
         for k,v in f,t,k do
@@ -534,11 +535,11 @@ function dfhack.interpreter(prompt,hfile,env)
         end,
         ['~'] = function(data)
             print(table.unpack(data,2,data.n))
-            printall(data[2])
+            if type(data[2]) == 'table' then printall(data[2]) end
         end,
         ['@'] = function(data)
             print(table.unpack(data,2,data.n))
-            printall_ipairs(data[2])
+            if type(data[2]) == 'table' then printall_ipairs(data[2]) end
         end,
         ['^'] = function(data)
             printall_recurse(data[2])

--- a/test/library/misc.lua
+++ b/test/library/misc.lua
@@ -10,6 +10,9 @@ function test.safe_pairs()
     for k,v in safe_pairs({}) do
         expect.fail('an empty table should not be iterable')
     end
+    for k,v in safe_pairs(df.item._identity) do
+        expect.fail('a non-iterable light userdata var should not be iterable')
+    end
 
     local iterated = 0
     local t = {a='hello', b='world', [1]='extra'}

--- a/test/library/misc.lua
+++ b/test/library/misc.lua
@@ -22,3 +22,19 @@ function test.safe_pairs()
     end
     expect.eq(3, iterated)
 end
+
+function test.safe_pairs_ipairs()
+    local t = {1, 2}
+    setmetatable(t, {
+        __pairs = function()
+            expect.fail('pairs() should not be called')
+        end,
+    })
+
+    local iterated = 0
+    for k,v in safe_pairs(t, ipairs) do
+        expect.eq(k, v)
+        iterated = iterated + 1
+    end
+    expect.eq(#t, iterated)
+end

--- a/test/library/misc.lua
+++ b/test/library/misc.lua
@@ -1,0 +1,21 @@
+-- tests misc functions added by dfhack.lua
+
+function test.safe_pairs()
+    for k,v in safe_pairs(nil) do
+        expect.fail('nil should not be iterable')
+    end
+    for k,v in safe_pairs('a') do
+        expect.fail('a string should not be iterable')
+    end
+    for k,v in safe_pairs({}) do
+        expect.fail('an empty table should not be iterable')
+    end
+
+    local iterated = 0
+    local t = {a='hello', b='world', [1]='extra'}
+    for k,v in safe_pairs(t) do
+        expect.eq(t[k], v)
+        iterated = iterated + 1
+    end
+    expect.eq(3, iterated)
+end

--- a/test/library/print.lua
+++ b/test/library/print.lua
@@ -42,8 +42,24 @@ function test.printall_function()
     expect.eq(0, mock_print.call_count)
 end
 
+local function new_int_vector()
+    -- create a vector of integers by cloning one from world. we do it this way
+    -- because we can't allocate typed vectors from lua directly.
+    local vector = df.global.world.busy_buildings:new()
+    vector:resize(0)
+    return vector
+end
+
 function test.printall_userdata()
-    -- TODO
+    local utable = new_int_vector()
+    dfhack.with_temp_object(utable, function()
+            utable:insert(0, 10)
+            utable:insert(1, 20)
+            printall(utable)
+            expect.eq(2, mock_print.call_count)
+            expect.true_(mock_print.call_args[1][1]:find('0%s+= 10'))
+            expect.true_(mock_print.call_args[2][1]:find('1%s+= 20'))
+        end)
 end
 
 function test.printall_ipairs_table()
@@ -79,7 +95,15 @@ function test.printall_ipairs_function()
 end
 
 function test.printall_ipairs_userdata()
-    -- TODO
+    local utable = new_int_vector()
+    dfhack.with_temp_object(utable, function()
+            utable:insert(0, 10)
+            utable:insert(1, 20)
+            printall_ipairs(utable)
+            expect.eq(2, mock_print.call_count)
+            expect.true_(mock_print.call_args[1][1]:find('0%s+= 10'))
+            expect.true_(mock_print.call_args[2][1]:find('1%s+= 20'))
+        end)
 end
 
 function test.printall_recurse()

--- a/test/library/print.lua
+++ b/test/library/print.lua
@@ -1,0 +1,97 @@
+-- tests print-related functions added by dfhack.lua
+
+local dfhack = dfhack
+
+local mock_print = mock.func()
+local function test_wrapper(test_fn)
+    mock.patch({{dfhack, 'print', mock_print},
+                {dfhack, 'println', mock_print}},
+               test_fn)
+    mock_print = mock.func()
+end
+config.wrapper = test_wrapper
+
+function test.printall_table()
+    printall({a='b'})
+    expect.eq(1, mock_print.call_count)
+    expect.true_(mock_print.call_args[1][1]:find('a%s+= b'))
+end
+
+function test.printall_string()
+    printall('a')
+    expect.eq(1, mock_print.call_count)
+    expect.eq('a', mock_print.call_args[1][1])
+end
+
+function test.printall_number()
+    printall(10)
+    expect.eq(1, mock_print.call_count)
+    expect.eq('10', mock_print.call_args[1][1])
+end
+
+function test.printall_nil()
+    printall(nil)
+    expect.eq(1, mock_print.call_count)
+    expect.eq('nil', mock_print.call_args[1][1])
+end
+
+function test.printall_boolean()
+    printall(false)
+    expect.eq(1, mock_print.call_count)
+    expect.eq('false', mock_print.call_args[1][1])
+end
+
+function test.printall_function()
+    printall(function() end)
+    expect.eq(1, mock_print.call_count)
+    expect.true_(mock_print.call_args[1][1]:find('^function: 0x'))
+end
+
+function test.printall_userdata()
+    -- TODO
+end
+
+function test.printall_ipairs_table()
+    printall_ipairs({'a', 'b'})
+    expect.eq(2, mock_print.call_count)
+    expect.true_(mock_print.call_args[1][1]:find('1%s+= a'))
+    expect.true_(mock_print.call_args[2][1]:find('2%s+= b'))
+end
+
+function test.printall_ipairs_string()
+    printall_ipairs('a')
+    expect.eq(1, mock_print.call_count)
+    expect.eq('a', mock_print.call_args[1][1])
+end
+
+function test.printall_ipairs_number()
+    printall_ipairs(10)
+    expect.eq(1, mock_print.call_count)
+    expect.eq('10', mock_print.call_args[1][1])
+end
+
+function test.printall_ipairs_nil()
+    printall_ipairs(nil)
+    expect.eq(1, mock_print.call_count)
+    expect.eq('nil', mock_print.call_args[1][1])
+end
+
+function test.printall_ipairs_boolean()
+    printall_ipairs(false)
+    expect.eq(1, mock_print.call_count)
+    expect.eq('false', mock_print.call_args[1][1])
+end
+
+function test.printall_ipairs_function()
+    printall_ipairs(function() end)
+    expect.eq(1, mock_print.call_count)
+    expect.true_(mock_print.call_args[1][1]:find('^function: 0x'))
+end
+
+function test.printall_ipairs_userdata()
+    -- TODO
+end
+
+function test.printall_recurse()
+    -- TODO
+end

--- a/test/library/print.lua
+++ b/test/library/print.lua
@@ -19,32 +19,27 @@ end
 
 function test.printall_string()
     printall('a')
-    expect.eq(1, mock_print.call_count)
-    expect.eq('a', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_number()
     printall(10)
-    expect.eq(1, mock_print.call_count)
-    expect.eq('10', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_nil()
     printall(nil)
-    expect.eq(1, mock_print.call_count)
-    expect.eq('nil', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_boolean()
     printall(false)
-    expect.eq(1, mock_print.call_count)
-    expect.eq('false', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_function()
     printall(function() end)
-    expect.eq(1, mock_print.call_count)
-    expect.true_(mock_print.call_args[1][1]:find('^function: 0x'))
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_userdata()
@@ -60,32 +55,27 @@ end
 
 function test.printall_ipairs_string()
     printall_ipairs('a')
-    expect.eq(1, mock_print.call_count)
-    expect.eq('a', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_ipairs_number()
     printall_ipairs(10)
-    expect.eq(1, mock_print.call_count)
-    expect.eq('10', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_ipairs_nil()
     printall_ipairs(nil)
-    expect.eq(1, mock_print.call_count)
-    expect.eq('nil', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_ipairs_boolean()
     printall_ipairs(false)
-    expect.eq(1, mock_print.call_count)
-    expect.eq('false', mock_print.call_args[1][1])
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_ipairs_function()
     printall_ipairs(function() end)
-    expect.eq(1, mock_print.call_count)
-    expect.true_(mock_print.call_args[1][1]:find('^function: 0x'))
+    expect.eq(0, mock_print.call_count)
 end
 
 function test.printall_ipairs_userdata()


### PR DESCRIPTION
prepares for the Lua upgrade in #1915

suggested fix for lua 5.3.6 change to how `pairs` works (or doesn't) with non-table input.

This ensures `!`, `^`, `@`, `~`, and plain `printall` all behave sanely with both table and non-table input.
```
[[lua]# !('hi')
hi
[lua]# ^('hi')
hi
[lua]# @('hi')
hi
[lua]# ~('hi')
hi
[lua]# printall('hi')
hi
[lua]# !({'hi'})
table: 0x7fffd0113680
[lua]# ^({'hi'})
table: 0x7fffd01137c0
1                       = hi
[lua]# @({'hi'})
table: 0x7fffd00927b0
1                        = hi
[lua]# ~({'hi'})
table: 0x7fffd00c2ad0
1                        = hi
[lua]# printall({'hi'})
1                        = hi
```