### PR TITLE
update autogems to respect workshop profiles

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - Core: ``alt`` keydown state is now cleared when DF loses and regains focus, ensuring the ``alt`` modifier state is not stuck on for systems that don't send standard keyup events in response to ``alt-tab`` window manager events
+- `autogems`: no longer assigns gem cutting jobs to workshops with gem cutting prohibited in the workshop profile
 
 ## Misc Improvements
 - `buildingplan`: now displays which items are attached and which items are still missing for planned buildings

--- a/plugins/autogems.cpp
+++ b/plugins/autogems.cpp
@@ -155,6 +155,12 @@ void create_jobs() {
             continue;
         }
 
+        auto profile = workshop->getWorkshopProfile();
+        if (profile && profile->blocked_labors[df::unit_labor::CUT_GEM]) {
+            // workshop profile does not allow cut gem jobs (fixes #1263)
+            continue;
+        }
+
         if (links.size() > 0) {
             for (auto l = links.begin(); l != links.end() && workshop->jobs.size() <= MAX_WORKSHOP_JOBS; ++l) {
                 auto stockpile = virtual_cast<df::building_stockpilest>(*l);


### PR DESCRIPTION
Add a test so that autogems will not assign cut gem jobs to workshops that are not allowed to do them.

Fixes #1263