### PR TITLE
Handle projectiles in Items module functions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,6 +47,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `tiletypes-here`, `tiletypes-here-point`: add --cursor and --quiet options to support non-interactive use cases
 - `quickfort`: Dreamfort blueprint set improvements: extensive revision based on playtesting and feedback. includes updated ``onMapLoad.init`` settings file and enhanced automation orders. see full changelog at https://github.com/DFHack/dfhack/pull/1921
 
+## API
+- The ``Items`` module ``moveTo*`` and ``remove`` functions now handle projectiles
+
 ## Documentation
 - `quickfort-library-guide`: updated dreamfort documentation and added screenshots
 

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -310,6 +310,27 @@ Link *linked_list_insert_after(Link *pos, Link *link)
     return link;
 }
 
+/**
+ * Returns true if the item with id idToRemove was found, deleted, and removed
+ * from the list. Otherwise returns false.
+ */
+template<typename Link>
+bool linked_list_remove(Link *head, int32_t idToRemove)
+{
+    for (Link *link = head; link; link = link->next)
+    {
+        if (!link->item || link->item->id != idToRemove)
+            continue;
+
+        link->prev->next = link->next;
+        if (link->next)
+            link->next->prev = link->prev;
+        delete(link);
+        return true;
+    }
+    return false;
+}
+
 template<typename T>
 inline typename T::mapped_type map_find(
     const T &map, const typename T::key_type &key,

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -832,23 +832,12 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
     }
 
     if (auto *ref =
-        virtual_cast<df::general_ref_projectile>(Items::getGeneralRef(item, general_ref_type::PROJECTILE)))
+            virtual_cast<df::general_ref_projectile>(
+                Items::getGeneralRef(item, general_ref_type::PROJECTILE)))
     {
-        int32_t proj_id = ((df::general_ref_projectile *)ref)->projectile_id;
-        df::proj_list_link *link = world->proj_list.next;
-        for (; link; link = link->next)
-        {
-            if (link->item->id != proj_id)
-                continue;
-
-            link->prev->next = link->next;
-            if (link->next)
-                link->next->prev = link->prev;
-            delete(link);
-            break;
-        }
-        return DFHack::removeRef(item->general_refs,
-                                 general_ref_type::PROJECTILE, ref->getID());
+        return linked_list_remove(&world->proj_list, ref->projectile_id) &&
+            DFHack::removeRef(item->general_refs,
+                              general_ref_type::PROJECTILE, ref->getID());
     }
 
     if (item->flags.bits.on_ground)

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -831,8 +831,8 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
         }
     }
 
-    if (df::general_ref *ref =
-                Items::getGeneralRef(item, general_ref_type::PROJECTILE))
+    if (auto *ref =
+        virtual_cast<df::general_ref_projectile>(Items::getGeneralRef(item, general_ref_type::PROJECTILE)))
     {
         int32_t proj_id = ((df::general_ref_projectile *)ref)->projectile_id;
         df::proj_list_link *link = world->proj_list.next;


### PR DESCRIPTION
This allows `moveTo*()` and `remove()` functions to work with projectiles.

This solves the issue with the `build-now` script in DFHack/scripts#310 when an extra item remains in the game world when a construction is built on a tile that has no adjacent walkable tiles.