### PR TITLE
alt_getopt.lua: allow `?` as an option

### DIFF
--- a/library/lua/3rdparty/alt_getopt.lua
+++ b/library/lua/3rdparty/alt_getopt.lua
@@ -50,7 +50,7 @@ local function get_opt_map(opts)
     local len = #opts
     local options = {}
 
-    for short_opt, accept_arg in opts:gmatch('(%w)(:?)') do
+    for short_opt, accept_arg in opts:gmatch('([%w%?])(:?)') do
         options[short_opt] = #accept_arg
     end
 


### PR DESCRIPTION
This would allow `script -?`