### PR TITLE
Fix compilation error on macOS with GCC 11.2

### DIFF
--- a/docs/Compile.rst
+++ b/docs/Compile.rst
@@ -338,6 +338,8 @@ from your GCC version and distribute that too, it will fail on older OS X
 versions.) For this reason, if you plan on distributing DFHack, it is highly
 recommended to use GCC 4.8 or 7.
 
+.. _osx-m1-notes:
+
 Notes for M1 users
 ------------------
 
@@ -349,21 +351,13 @@ stackoverflow answer <https://stackoverflow.com/a/64951025>`__ describes the
 process.
 
 Follow the normal macOS steps to install ``cmake`` and ``gcc`` via your x86 copy of
-``homebrew``.
+``homebrew``. Note that this will install a GCC version newer than 7, so see
+`osx-new-gcc-notes`.
 
 In your terminal, ensure you have your path set to the correct homebrew in
 addition to the normal ``CC`` and ``CXX`` flags above::
 
   export PATH=/usr/local/bin:$PATH
-
-In order to ignore certain warnings present in later versions of ``gcc``,
-ensure you pass the following flag to ``cmake``::
-
-  -DCMAKE_CXX_FLAGS="-fpermissive"
-
-An example full cmake command::
-
-  cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<path to DF folder> -DDFHACK_BUILD_ARCH=64 -DCMAKE_CXX_FLAGS="-fpermissive"
 
 .. _osx-setup:
 

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -502,7 +502,7 @@ struct buildingplan_query_hook : public df::viewscreen_dwarfmodest
     {
         if (!bld
                 || bld->jobs.size() < 1
-                || bld->jobs[0]->job_items.size() <= filter_idx)
+                || int(bld->jobs[0]->job_items.size()) <= filter_idx)
             return false;
 
         // if all items for this filter are attached, the quantity will be 0

--- a/plugins/uicommon.h
+++ b/plugins/uicommon.h
@@ -31,7 +31,6 @@ using namespace std;
 using std::string;
 using std::vector;
 using std::map;
-using std::ostringstream;
 using std::set;
 
 using namespace DFHack;
@@ -160,7 +159,9 @@ static inline void OutputToggleString(int &x, int &y, const char *text, df::inte
 
 inline string int_to_string(const int n)
 {
-    return static_cast<ostringstream*>( &(ostringstream() << n) )->str();
+    std::ostringstream ss;
+    ss << n;
+    return ss.str();
 }
 
 static inline void set_to_limit(int &value, const int maximum, const int min = 0)


### PR DESCRIPTION
This should make `-fpermissive` (from #1924) unnecessary, so I also removed those instructions.

@chrismdp could you confirm that this works for you without `-fpermissive`?