### PR TITLE
[test] add pattern matching expect.find()

### DIFF
--- a/library/lua/test_util/expect.lua
+++ b/library/lua/test_util/expect.lua
@@ -47,7 +47,7 @@ function expect.ge(a, b, comment)
     return a >= b, comment, ('%s < %s'):format(a, b)
 end
 
-function expect.find(pattern, str_to_match, comment)
+function expect.str_find(pattern, str_to_match, comment)
     if type(str_to_match) ~= 'string' then
         return false, comment, 'expected string, got ' .. type(str_to_match)
     end

--- a/library/lua/test_util/expect.lua
+++ b/library/lua/test_util/expect.lua
@@ -47,6 +47,14 @@ function expect.ge(a, b, comment)
     return a >= b, comment, ('%s < %s'):format(a, b)
 end
 
+function expect.find(pattern, str_to_match, comment)
+    if type(str_to_match) ~= 'string' then
+        return false, comment, 'expected string, got ' .. type(str_to_match)
+    end
+    return str_to_match:find(pattern), comment,
+            ('pattern "%s" not matched in "%s"'):format(pattern, str_to_match)
+end
+
 local function table_eq_recurse(a, b, keys, known_eq)
     if a == b then return true end
     local checked = {}

--- a/test/library/test_util/expect_unit.lua
+++ b/test/library/test_util/expect_unit.lua
@@ -1,18 +1,18 @@
 local expect_raw = require('test_util.expect')
 
 function test.find()
-    expect.true_(expect_raw.find('a ', 'a str', 'a comment'))
+    expect.true_(expect_raw.str_find('a ', 'a str', 'a comment'))
 
-    local ok, comment, msg = expect_raw.find('ab', 'a str', 'a comment')
+    local ok, comment, msg = expect_raw.str_find('ab', 'a str', 'a comment')
     expect.false_(ok)
     expect.eq('a comment', comment)
     expect.eq('pattern "ab" not matched in "a str"', msg)
 
-    ok, _, msg = expect_raw.find('pattern', nil)
+    ok, _, msg = expect_raw.str_find('pattern', nil)
     expect.false_(ok)
     expect.eq('expected string, got nil', msg)
 
-    ok, _, msg = expect_raw.find('pattern', {})
+    ok, _, msg = expect_raw.str_find('pattern', {})
     expect.false_(ok)
     expect.eq('expected string, got table', msg)
 end

--- a/test/library/test_util/expect_unit.lua
+++ b/test/library/test_util/expect_unit.lua
@@ -1,6 +1,6 @@
 local expect_raw = require('test_util.expect')
 
-function test.find()
+function test.str_find()
     expect.true_(expect_raw.str_find('a ', 'a str', 'a comment'))
 
     local ok, comment, msg = expect_raw.str_find('ab', 'a str', 'a comment')

--- a/test/library/test_util/expect_unit.lua
+++ b/test/library/test_util/expect_unit.lua
@@ -1,5 +1,22 @@
 local expect_raw = require('test_util.expect')
 
+function test.find()
+    expect.true_(expect_raw.find('a ', 'a str', 'a comment'))
+
+    local ok, comment, msg = expect_raw.find('ab', 'a str', 'a comment')
+    expect.false_(ok)
+    expect.eq('a comment', comment)
+    expect.eq('pattern "ab" not matched in "a str"', msg)
+
+    ok, _, msg = expect_raw.find('pattern', nil)
+    expect.false_(ok)
+    expect.eq('expected string, got nil', msg)
+
+    ok, _, msg = expect_raw.find('pattern', {})
+    expect.false_(ok)
+    expect.eq('expected string, got table', msg)
+end
+
 function test.table_eq()
     expect.true_(expect_raw.table_eq({}, {}))
     expect.true_(expect_raw.table_eq({'a'}, {'a'}))


### PR DESCRIPTION
Adding a pattern-matching function to `expect` since I got tired of writing tests like `expect.true_(mock_print.call_args[1][1]:find('^Prioritized 2'))`. This works fine when the test passes, but when it fails it doesn't give you any information about why it failed. The new `expect.find()` function will report the pattern and the string it failed to match.

I settled on `find()` since the string method of the same name has the same semantics.

Other options might be: `str_find()` since it fails on non-string or `match()` (but that might imply that the pattern needs to match the entire string).

No changelog entry for PRs like this, right?