### PR TITLE
[orders] implement "sort" command

### DIFF
--- a/data/examples/init/onMapLoad_dreamfort.init
+++ b/data/examples/init/onMapLoad_dreamfort.init
@@ -17,6 +17,7 @@ repeat -name feeding-timers -time 1 -timeUnits months -command [ fix/feeding-tim
 repeat -name stuckdoors -time 1 -timeUnits months -command [ fix/stuckdoors ]
 repeat -name autoShearCreature -time 14 -timeUnits days -command [ workorder ShearCreature ]
 repeat -name autoMilkCreature -time 14 -timeUnits days -command [ workorder "{\"job\":\"MilkCreature\",\"item_conditions\":[{\"condition\":\"AtLeast\",\"value\":2,\"flags\":[\"empty\"],\"item_type\":\"BUCKET\"}]}" ]
+repeat -name orders-sort -time 1 -timeUnits days -command [ orders sort ]
 
 tweak fast-heat 100
 tweak do-job-now

--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -1968,6 +1968,14 @@ Subcommands:
 :export NAME: Exports the current list of manager orders to a file named ``dfhack-config/orders/NAME.json``.
 :import NAME: Imports manager orders from a file named ``dfhack-config/orders/NAME.json``.
 :clear: Deletes all manager orders in the current embark.
+:sort: Sorts current manager orders by repeat frequency so daily orders don't
+    prevent other orders from ever being completed: one-time orders first, then
+    yearly, seasonally, monthly, then finally daily.
+
+You can keep your orders automatically sorted by adding the following command to
+your ``onMapLoad.init`` file::
+
+    repeat -name orders-sort -time 1 -timeUnits days -command [ orders sort ]
 
 .. _nestboxes:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -45,6 +45,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - `buildingplan`: now displays which items are attached and which items are still missing for planned buildings
 - `orders`: support importing and exporting reaction-specific item conditions, like "lye-containing" for soap production orders
+- `orders`: new ``sort`` command. sorts orders according to their repeat frequency. this prevents daily orders from blocking other orders for simlar items from ever getting completed.
 - `tiletypes-here`, `tiletypes-here-point`: add ``--cursor`` and ``--quiet`` options to support non-interactive use cases
 - `quickfort`: Dreamfort blueprint set improvements: extensive revision based on playtesting and feedback. includes updated ``onMapLoad_dreamfort.init`` settings file, enhanced automation orders, and premade profession definitions.  see full changelog at https://github.com/DFHack/dfhack/pull/1921 and https://github.com/DFHack/dfhack/pull/1925
 

--- a/docs/guides/examples-guide.rst
+++ b/docs/guides/examples-guide.rst
@@ -29,6 +29,8 @@ it is useful (and customizable) for any fort. It includes the following config:
   started, so later manual changes will not be overridden.
 - Automates calling of various fort maintenance and `scripts-fix`, like
   `cleanowned` and `fix/stuckdoors`.
+- Keeps your manager orders intelligently ordered with `orders` ``sort`` so no
+  orders block other orders from ever getting completed.
 - Periodically enqueues orders to shear and milk shearable and milkable pets.
 - Sets up `autofarm` to grow 30 units of every crop, except for pig tails, which
   is set to 150 units to support the textile industry.

--- a/plugins/orders.cpp
+++ b/plugins/orders.cpp
@@ -945,10 +945,15 @@ static command_result orders_sort_command(color_ostream & out)
 {
     CoreSuspender suspend;
 
-    std::stable_sort(world->manager_orders.begin(), world->manager_orders.end(),
-                     compare_freq);
-
-    out << "Sorted " << world->manager_orders.size() << " manager orders." << std::endl;
+    if (!std::is_sorted(world->manager_orders.begin(),
+                        world->manager_orders.end(),
+                        compare_freq))
+    {
+        std::stable_sort(world->manager_orders.begin(),
+                         world->manager_orders.end(),
+                         compare_freq);
+        out << "Fixed priority of manager orders." << std::endl;
+    }
 
     return CR_OK;
 }


### PR DESCRIPTION
I have found that orders with daily frequency will prevent lower priority orders for the same types of items from ever getting scheduled. This is a problem when "workflow"-type orders that keep a small stock of a thing will prevent large one time orders for that same type of thing, significantly slowing down the project that the large order was created for.

This PR implements the `sort` command for the orders plugin, which can be called with `repeat` to automatically keep a fort's orders sorted so daily-frequency orders don't "shadow" any other orders.