### PR TITLE
[automaterial] lay down tiles in strict order when using buildingplan

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `tailor`: fixed some inconsistencies (and possible crashes) when parsing certain subcommands, e.g. ``tailor help``
 
+## Misc Improvements
+- `automaterial`: ensure construction tiles are laid down in order when using `buildingplan` to plan the constructions
+
 # 0.47.05-r3
 
 ## New Plugins

--- a/plugins/automaterial.cpp
+++ b/plugins/automaterial.cpp
@@ -998,17 +998,22 @@ struct jobutils_hook : public df::viewscreen_dwarfmodest
             }
 
             // if using buildingplan, we don't need an anchor
-            if (!use_buildingplan && in_future_placement_mode)
+            if (!use_buildingplan)
             {
-                ok_to_continue = find_anchor_in_spiral(valid_building_sites[0].pos);
-            }
-            else if (ok_to_continue)
-            {
-                // First valid site is guaranteed to be anchored, either on a tile or against a valid orthogonal tile
-                // Use it as an anchor point to generate materials list
-                anchor = valid_building_sites.front();
-                valid_building_sites.pop_front();
-                valid_building_sites.push_back(anchor);
+                if (in_future_placement_mode)
+                {
+                    ok_to_continue =
+                            find_anchor_in_spiral(valid_building_sites[0].pos);
+                }
+                else if (ok_to_continue)
+                {
+                    // First valid site is guaranteed to be anchored, either on
+                    // a tile or against a valid orthogonal tile
+                    // Use it as an anchor point to generate materials list
+                    anchor = valid_building_sites.front();
+                    valid_building_sites.pop_front();
+                    valid_building_sites.push_back(anchor);
+                }
             }
 
             if (!ok_to_continue)


### PR DESCRIPTION
Don't extract an anchor tile when using buildingplan. It isn't used in the buildingplan code path and the extraction process puts the tile out of order. this causes the tile to get fulfilled by buildinplan last, which is an unexpected experience for players who are carefully managing the suspension of certain tiles to ensure the corner tiles get built first (before they are blocked by other constructions and become inaccessible).

This is how it *should* have been implemented in 22ac163 where we first integrated with buildingplan.

manually tested with buildingplan enabled and disabled, and with open air placement mode enabled and disabled.