### PR TITLE
[blueprint] don't pass literal "gui" to gui/blueprint when running blueprint gui

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -34,6 +34,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 # Future
 
 ## Fixes
+- `blueprint`: fixed passing incorrect parameters to `gui/blueprint` when you run ``blueprint gui`` with optional params
 - `tailor`: fixed some inconsistencies (and possible crashes) when parsing certain subcommands, e.g. ``tailor help``
 
 # 0.47.05-r3

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -745,9 +745,9 @@ static bool do_blueprint(color_ostream &out,
     {
         std::ostringstream command;
         command << "gui/blueprint";
-        for (const string &param : parameters)
+        for (size_t i = 1; i < parameters.size(); ++i)
         {
-            command << " " << param;
+            command << " " << parameters[i];
         }
         string command_str = command.str();
         out.print("launching %s\n", command_str.c_str());


### PR DESCRIPTION
You can invoke `gui/blueprint` by running `blueprint gui`, and any optional params you pass to `blueprint` will get passed on to `gui/blueprint`. The problem was that `blueprint` was also passing the literal "gui" string as the first parameter, causing `gui/blueprint` to interpret it as the intended name of the generated blueprint. Whoops.

No unit test since we can't mock out the invocation of the `gui/blueprint` script, and running the script can error out depending on the current state of the game.