### PR TITLE
[blueprint] add --splitby option

### DIFF
--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -54,9 +54,8 @@ Usage::
 Examples:
 
 ``blueprint gui``
-    Runs `gui/blueprint`, the interactive blueprint frontend, where all
-    configuration for a ``blueprint`` command can be set visually and
-    interactively.
+    Runs `gui/blueprint`, the interactive frontend, where all configuration for
+    a ``blueprint`` command can be set visually and interactively.
 
 ``blueprint 30 40 bedrooms``
     Generates blueprints for an area 30 tiles wide by 40 tiles tall, starting
@@ -103,6 +102,21 @@ Options:
     then an active game map cursor is not necessary.
 :``-h``, ``--help``:
     Show command help text.
+:``-t``, ``--splitby <strategy>``:
+    Split blueprints into multiple files. See the ``Splitting output into
+    multiple files`` section below for details. If not specified, defaults to
+    "none", which will create a standard quickfort
+    `multi-blueprint <quickfort-packaging>` file.
+
+Splitting output into multiple files:
+
+The ``--splitby`` flag can take any of the following values:
+
+:``none``:
+    Writes all blueprints into a single file. This is the standard format for
+    quickfort fortress blueprint bundles and is the default.
+:``phase``:
+    Creates a separate file for each phase.
 
 .. _remotefortressreader:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `automaterial`: ensure construction tiles are laid down in order when using `buildingplan` to plan the constructions
+- `blueprint`: all blueprint phases are now written to a single file, using `quickfort` multi-blueprint file syntax. to get the old behavior of each phase in its own file, pass the ``--splitby=phase`` parameter to ``blueprint``
 
 # 0.47.05-r3
 

--- a/test/quickfort/ecosystem.lua
+++ b/test/quickfort/ecosystem.lua
@@ -18,9 +18,7 @@
 -- test blueprints that #build flooring and then #build a workshop on top, again
 -- since the flooring is never actually built.
 
-config = {
-    mode = 'fortress',
-}
+config.mode = 'fortress'
 
 local blueprint = require('plugins.blueprint')
 local quickfort_list = reqscript('internal/quickfort/list')
@@ -31,6 +29,19 @@ local input_dir = 'library/test/ecosystem/in/'
 local output_dir = 'library/test/ecosystem/out/'
 
 local mode_names = {'dig', 'build', 'place', 'query'}
+
+-- clear the output dir before each test run (but not after -- to allow
+-- inspection of the results)
+local function test_wrapper(test_fn)
+    local outdir = blueprints_dir .. output_dir
+    for _, v in ipairs(dfhack.filesystem.listdir_recursive(outdir)) do
+        if not v.isdir then
+            os.remove(v.path)
+        end
+    end
+    test_fn()
+end
+config.wrapper = test_wrapper
 
 local function bad_spec(expected, varname, basename, bad_value)
     qerror(('expected %s for %s in "%s" test spec; got "%s"'):
@@ -182,7 +193,8 @@ local function run_blueprint(basename, set, pos)
     local blueprint_args = {tostring(set.spec.width),
                             tostring(set.spec.height),
                             tostring(-set.spec.depth),
-                            output_dir..basename, get_cursor_arg(pos)}
+                            output_dir..basename, get_cursor_arg(pos),
+                            '-tphase'}
     for _,mode_name in pairs(mode_names) do
         if set.modes[mode_name] then table.insert(blueprint_args, mode_name) end
     end


### PR DESCRIPTION
Part of milestone 2 of #1842

`--splitby=none` is the new default, allowing all blueprint phases to be written to a single file. old behavior of one phase per file is supported via `--splitby=phase`.