### PR TITLE
[blueprint] generate labels in blueprint modelines

### DIFF
--- a/data/blueprints/library/test/ecosystem/in/allbuildings-build.csv
+++ b/data/blueprints/library/test/ecosystem/in/allbuildings-build.csv
@@ -1,4 +1,4 @@
-#build
+#build label(build)
 a,Mg, ,CS,trackN, , , , , ,`, ,`,`,`, , , , ,`,`,`,`,`,#
 b,Mh(1x1),S,CSa,trackS, , , , , ,Mw, ,`,wm,`, , , , ,`,`,`,`,`,#
 c,Mhs(1x1),m,CSaa,trackE, ,`, , , ,`, ,`,`,`, , , , ,`,`,D,`,`,#

--- a/data/blueprints/library/test/ecosystem/in/allbuildings-dig.csv
+++ b/data/blueprints/library/test/ecosystem/in/allbuildings-dig.csv
@@ -1,4 +1,4 @@
-#dig
+#dig label(dig)
 d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,#
 d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,#
 d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,d,#

--- a/data/blueprints/library/test/ecosystem/in/basic-build.csv
+++ b/data/blueprints/library/test/ecosystem/in/basic-build.csv
@@ -1,4 +1,4 @@
-#build
+#build label(build)
  , ,d, , ,#
  ,f, , , ,#
 d, ,b, ,d,#

--- a/data/blueprints/library/test/ecosystem/in/basic-dig.csv
+++ b/data/blueprints/library/test/ecosystem/in/basic-dig.csv
@@ -1,4 +1,4 @@
-#dig
+#dig label(dig)
  , ,d, , ,#
  ,d,d,d, ,#
 d,d,d,d,d,#

--- a/data/blueprints/library/test/ecosystem/in/basic-place.csv
+++ b/data/blueprints/library/test/ecosystem/in/basic-place.csv
@@ -1,4 +1,4 @@
-#place
+#place label(place)
  , , , , ,#
  , , , , ,#
  ,f(1x1), ,f(1x1), ,#

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - `automaterial`: ensure construction tiles are laid down in order when using `buildingplan` to plan the constructions
 - `blueprint`: all blueprint phases are now written to a single file, using `quickfort` multi-blueprint file syntax. to get the old behavior of each phase in its own file, pass the ``--splitby=phase`` parameter to ``blueprint``
+- `blueprint`: generated blueprints now have labels so `quickfort` can address them by name
 
 # 0.47.05-r3
 

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -628,6 +628,14 @@ static bool get_filename(string &fname,
     return true;
 }
 
+static string get_modeline(const string &phase)
+{
+    std::ostringstream modeline;
+    modeline << "#" << phase << " label(" << phase << ")";
+
+    return modeline.str();
+}
+
 static bool write_blueprint(color_ostream &out,
                             std::map<string, ofstream*> &output_files,
                             const blueprint_options &opts,
@@ -641,7 +649,7 @@ static bool write_blueprint(color_ostream &out,
         output_files[fname] = new ofstream(fname, ofstream::trunc);
 
     ofstream &ofile = *output_files[fname];
-    ofile << "#" << phase << endl;
+    ofile << get_modeline(phase) << endl;
     ofile << stream.str();
     return true;
 }


### PR DESCRIPTION
part of milestone 2 of #1842

this allows quickfort to address the blueprints by name instead of their default numeric label.

ecosystem tests updated to incorporate the new labels.