### PR TITLE
[blueprint] support multiple output file formats

### DIFF
--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -100,6 +100,10 @@ Options:
     Use the specified map coordinates instead of the current cursor position for
     the upper left corner of the blueprint range. If this option is specified,
     then an active game map cursor is not necessary.
+:``-f``, ``--format <format>``:
+    Select the output format of the generated files. See the ``Output Formats``
+    section below for options. If not specified, the output format defaults to
+    "minimal", which will produce a small, fast ``.csv`` file.
 :``-h``, ``--help``:
     Show command help text.
 :``-t``, ``--splitby <strategy>``:
@@ -107,6 +111,17 @@ Options:
     multiple files`` section below for details. If not specified, defaults to
     "none", which will create a standard quickfort
     `multi-blueprint <quickfort-packaging>` file.
+
+Output formats:
+
+Here are the values that can be passed to the ``--format`` flag:
+
+:minimal:
+    Creates ``.csv`` files with minimal file size that are fast to read and
+    write. This is the default.
+:pretty:
+    Makes the blueprints in the ``.csv`` files easier to read and edit with a text
+    editor by adding extra spacing and alignment markers.
 
 Splitting output into multiple files:
 

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -35,6 +35,7 @@
 using std::endl;
 using std::ofstream;
 using std::pair;
+using std::map;
 using std::string;
 using std::vector;
 using namespace DFHack;
@@ -49,6 +50,10 @@ struct blueprint_options {
     // starting tile coordinate of the translation area (if not set then all
     // coordinates are set to -30000)
     df::coord start;
+
+    // output file format. this could be an enum if we set up the boilerplate
+    // for it.
+    string format;
 
     // file splitting strategy. this could be an enum if we set up the
     // boilerplate for it.
@@ -77,6 +82,7 @@ struct blueprint_options {
 static const struct_field_info blueprint_options_fields[] = {
     { struct_field_info::PRIMITIVE, "help",           offsetof(blueprint_options, help),          &df::identity_traits<bool>::identity,    0, 0 },
     { struct_field_info::SUBSTRUCT, "start",          offsetof(blueprint_options, start),         &df::coord::_identity,                   0, 0 },
+    { struct_field_info::PRIMITIVE, "format",         offsetof(blueprint_options, format),         df::identity_traits<string>::get(),     0, 0 },
     { struct_field_info::PRIMITIVE, "split_strategy", offsetof(blueprint_options, split_strategy), df::identity_traits<string>::get(),     0, 0 },
     { struct_field_info::PRIMITIVE, "width",          offsetof(blueprint_options, width),         &df::identity_traits<int32_t>::identity, 0, 0 },
     { struct_field_info::PRIMITIVE, "height",         offsetof(blueprint_options, height),        &df::identity_traits<int32_t>::identity, 0, 0 },
@@ -93,517 +99,498 @@ struct_identity blueprint_options::_identity(sizeof(blueprint_options), &df::all
 
 command_result blueprint(color_ostream &, vector<string> &);
 
-DFhackCExport command_result plugin_init(color_ostream &, vector<PluginCommand> &commands)
-{
+DFhackCExport command_result plugin_init(color_ostream &, vector<PluginCommand> &commands) {
     commands.push_back(PluginCommand("blueprint", "Record the structure of a live game map in a quickfort blueprint file", blueprint, false));
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_shutdown(color_ostream &)
-{
+DFhackCExport command_result plugin_shutdown(color_ostream &) {
     return CR_OK;
 }
 
-static pair<uint32_t, uint32_t> get_building_size(df::building* b)
-{
+struct tile_context {
+    bool pretty = false;
+    df::building* b = NULL;
+};
+
+static pair<uint32_t, uint32_t> get_building_size(df::building *b) {
     return pair<uint32_t, uint32_t>(b->x2 - b->x1 + 1, b->y2 - b->y1 + 1);
 }
 
-static char get_tile_dig(int32_t x, int32_t y, int32_t z)
-{
-    df::tiletype *tt = Maps::getTileType(x, y, z);
-    df::tiletype_shape ts = tileShape(tt ? *tt : tiletype::Void);
-    switch (ts)
+static const char * if_pretty(const tile_context &ctx, const char *c) {
+    return ctx.pretty ? c : "";
+}
+
+static void get_tile_dig(const df::coord &pos, const tile_context &,
+                         string &str) {
+    df::tiletype *tt = Maps::getTileType(pos);
+    switch (tileShape(tt ? *tt : tiletype::Void))
     {
     case tiletype_shape::EMPTY:
     case tiletype_shape::RAMP_TOP:
-        return 'h';
+        str = "h"; break;
     case tiletype_shape::FLOOR:
     case tiletype_shape::BOULDER:
     case tiletype_shape::PEBBLES:
     case tiletype_shape::BROOK_TOP:
-        return 'd';
+        str = "d"; break;
     case tiletype_shape::FORTIFICATION:
-        return 'F';
+        str = "F"; break;
     case tiletype_shape::STAIR_UP:
-        return 'u';
+        str = "u"; break;
     case tiletype_shape::STAIR_DOWN:
-        return 'j';
+        str = "j"; break;
     case tiletype_shape::STAIR_UPDOWN:
-        return 'i';
+        str = "i"; break;
     case tiletype_shape::RAMP:
-        return 'r';
+        str = "r"; break;
+    case tiletype_shape::WALL:
     default:
-        return ' ';
+        break;
     }
 }
 
-static string get_tile_build(uint32_t x, uint32_t y, df::building* b)
-{
-    if (! b)
-        return " ";
-    bool at_nw_corner = int32_t(x) == b->x1 && int32_t(y) == b->y1;
-    bool at_se_corner = int32_t(x) == b->x2 && int32_t(y) == b->y2;
-    bool at_center = int32_t(x) == b->centerx && int32_t(y) == b->centery;
-    pair<uint32_t, uint32_t> size = get_building_size(b);
-    stringstream out;// = stringstream();
-    switch(b->getType())
+static void do_block_building(const tile_context &ctx, string &str, string s,
+                              bool at_target_pos, bool *add_size = NULL) {
+    if(!at_target_pos) {
+        str = if_pretty(ctx, "`");
+        return;
+    }
+    str = s;
+    if (add_size)
+        *add_size = true;
+}
+
+static string get_bridge_str(df::building *b) {
+    df::building_bridgest *bridge = virtual_cast<df::building_bridgest>(b);
+    if (!bridge)
+        return "g";
+
+    switch(bridge->direction) {
+    case df::building_bridgest::T_direction::Retracting: return "gs";
+    case df::building_bridgest::T_direction::Left:       return "ga";
+    case df::building_bridgest::T_direction::Right:      return "gd";
+    case df::building_bridgest::T_direction::Up:         return "gw";
+    case df::building_bridgest::T_direction::Down:       return "gx";
+    default:
+        return "g";
+    }
+}
+
+static string get_siege_str(df::building *b) {
+    df::building_siegeenginest *se =
+            virtual_cast<df::building_siegeenginest>(b);
+    return !se || se->type == df::siegeengine_type::Catapult ? "ic" : "ib";
+}
+
+static string get_workshop_str(df::building *b) {
+    df::building_workshopst *ws = virtual_cast<df::building_workshopst>(b);
+    if (!ws)
+        return "~";
+
+    switch (ws->type) {
+    case workshop_type::Leatherworks:     return "we";
+    case workshop_type::Quern:            return "wq";
+    case workshop_type::Millstone:        return "wM";
+    case workshop_type::Loom:             return "wo";
+    case workshop_type::Clothiers:        return "wk";
+    case workshop_type::Bowyers:          return "wb";
+    case workshop_type::Carpenters:       return "wc";
+    case workshop_type::MetalsmithsForge: return "wf";
+    case workshop_type::MagmaForge:       return "wv";
+    case workshop_type::Jewelers:         return "wj";
+    case workshop_type::Masons:           return "wm";
+    case workshop_type::Butchers:         return "wu";
+    case workshop_type::Tanners:          return "wn";
+    case workshop_type::Craftsdwarfs:     return "wr";
+    case workshop_type::Siege:            return "ws";
+    case workshop_type::Mechanics:        return "wt";
+    case workshop_type::Still:            return "wl";
+    case workshop_type::Farmers:          return "ww";
+    case workshop_type::Kitchen:          return "wz";
+    case workshop_type::Fishery:          return "wh";
+    case workshop_type::Ashery:           return "wy";
+    case workshop_type::Dyers:            return "wd";
+    case workshop_type::Kennels:          return "k";
+    case workshop_type::Custom:
+    case workshop_type::Tool:
+    default:
+        return "~";
+    }
+}
+
+static string get_furnace_str(df::building *b) {
+    df::building_furnacest *furnace = virtual_cast<df::building_furnacest>(b);
+    if (!furnace)
+        return "~";
+
+    switch (furnace->type) {
+    case furnace_type::WoodFurnace:       return "ew";
+    case furnace_type::Smelter:           return "es";
+    case furnace_type::GlassFurnace:      return "eg";
+    case furnace_type::Kiln:              return "ek";
+    case furnace_type::MagmaSmelter:      return "el";
+    case furnace_type::MagmaGlassFurnace: return "ea";
+    case furnace_type::MagmaKiln:         return "en";
+    case furnace_type::Custom:
+    default:
+        return "~";
+    }
+}
+
+static string get_construction_str(df::building *b) {
+    df::building_constructionst *cons =
+            virtual_cast<df::building_constructionst>(b);
+    if (!cons)
+        return "~";
+
+    switch (cons->type) {
+    case construction_type::Fortification: return "CF";
+    case construction_type::Wall:          return "CW";
+    case construction_type::Floor:         return "Cf";
+    case construction_type::UpStair:       return "Cu";
+    case construction_type::DownStair:     return "Cj";
+    case construction_type::UpDownStair:   return "Cx";
+    case construction_type::Ramp:          return "Cr";
+    case construction_type::TrackN:        return "trackN";
+    case construction_type::TrackS:        return "trackS";
+    case construction_type::TrackE:        return "trackE";
+    case construction_type::TrackW:        return "trackW";
+    case construction_type::TrackNS:       return "trackNS";
+    case construction_type::TrackNE:       return "trackNE";
+    case construction_type::TrackNW:       return "trackNW";
+    case construction_type::TrackSE:       return "trackSE";
+    case construction_type::TrackSW:       return "trackSW";
+    case construction_type::TrackEW:       return "trackEW";
+    case construction_type::TrackNSE:      return "trackNSE";
+    case construction_type::TrackNSW:      return "trackNSW";
+    case construction_type::TrackNEW:      return "trackNEW";
+    case construction_type::TrackSEW:      return "trackSEW";
+    case construction_type::TrackNSEW:     return "trackNSEW";
+    case construction_type::TrackRampN:    return "trackrampN";
+    case construction_type::TrackRampS:    return "trackrampS";
+    case construction_type::TrackRampE:    return "trackrampE";
+    case construction_type::TrackRampW:    return "trackrampW";
+    case construction_type::TrackRampNS:   return "trackrampNS";
+    case construction_type::TrackRampNE:   return "trackrampNE";
+    case construction_type::TrackRampNW:   return "trackrampNW";
+    case construction_type::TrackRampSE:   return "trackrampSE";
+    case construction_type::TrackRampSW:   return "trackrampSW";
+    case construction_type::TrackRampEW:   return "trackrampEW";
+    case construction_type::TrackRampNSE:  return "trackrampNSE";
+    case construction_type::TrackRampNSW:  return "trackrampNSW";
+    case construction_type::TrackRampNEW:  return "trackrampNEW";
+    case construction_type::TrackRampSEW:  return "trackrampSEW";
+    case construction_type::TrackRampNSEW: return "trackrampNSEW";
+    case construction_type::NONE:
+    default:
+        return "~";
+    }
+}
+
+static string get_trap_str(df::building *b) {
+    df::building_trapst *trap = virtual_cast<df::building_trapst>(b);
+    if (!trap)
+        return "~";
+
+    switch (trap->trap_type) {
+    case trap_type::StoneFallTrap: return "Ts";
+    case trap_type::WeaponTrap:    return "Tw";
+    case trap_type::Lever:         return "Tl";
+    case trap_type::PressurePlate: return "Tp";
+    case trap_type::CageTrap:      return "Tc";
+    case trap_type::TrackStop:
+        {
+            std::ostringstream buf;
+            buf << "CS";
+            if (trap->use_dump) {
+                if (trap->dump_x_shift == 0) {
+                    buf << "d";
+                    if (trap->dump_y_shift > 0)
+                        buf << "d";
+                } else {
+                    buf << "ddd";
+                    if (trap->dump_x_shift < 0)
+                        buf << "d";
+                }
+            }
+
+            // each case falls through and is additive
+            switch (trap->friction) {
+            case 10:    buf << "a";
+            case 50:    buf << "a";
+            case 500:   buf << "a";
+            case 10000: buf << "a";
+            }
+            return buf.str();
+        }
+    default:
+        return "~";
+    }
+}
+
+static string get_screw_pump_str(df::building *b) {
+    df::building_screw_pumpst *sp = virtual_cast<df::building_screw_pumpst>(b);
+    if (!sp)
+        return "~";
+
+    switch (sp->direction)
     {
+    case screw_pump_direction::FromNorth: return "Msu";
+    case screw_pump_direction::FromEast:  return "Msk";
+    case screw_pump_direction::FromSouth: return "Msm";
+    case screw_pump_direction::FromWest:  return "Msh";
+    default:
+        return "~";
+    }
+}
+
+static string get_water_wheel_str(df::building *b) {
+    df::building_water_wheelst *ww =
+            virtual_cast<df::building_water_wheelst>(b);
+    if (!ww)
+        return "~";
+
+    return ww->is_vertical ? "Mw" : "Mws";
+}
+
+static string get_axle_str(df::building *b) {
+    df::building_axle_horizontalst *ah =
+            virtual_cast<df::building_axle_horizontalst>(b);
+    if (!ah)
+        return "~";
+
+    return ah->is_vertical ? "Mhs" : "Mh";
+}
+
+static string get_roller_str(df::building *b) {
+    df::building_rollersst *r = virtual_cast<df::building_rollersst>(b);
+    if (!r)
+        return "~";
+
+    switch (r->direction) {
+    case screw_pump_direction::FromNorth: return "Mr";
+    case screw_pump_direction::FromEast:  return "Mrs";
+    case screw_pump_direction::FromSouth: return "Mrss";
+    case screw_pump_direction::FromWest:  return "Mrsss";
+    default:
+        return "~";
+    }
+}
+
+static string get_expansion_str(df::building *b) {
+    pair<uint32_t, uint32_t> size = get_building_size(b);
+    std::ostringstream s;
+    s << "(" << size.first << "x" << size.second << ")";
+    return s.str();
+}
+
+static void get_tile_build(const df::coord &pos, const tile_context &ctx,
+                           string &str) {
+    if (!ctx.b || ctx.b->getType() == building_type::Stockpile) {
+        return;
+    }
+
+    bool at_nw_corner = static_cast<int32_t>(pos.x) == ctx.b->x1
+                            && static_cast<int32_t>(pos.y) == ctx.b->y1;
+    bool at_se_corner = static_cast<int32_t>(pos.x) == ctx.b->x2
+                            && static_cast<int32_t>(pos.y) == ctx.b->y2;
+    bool at_center = static_cast<int32_t>(pos.x) == ctx.b->centerx
+                            && static_cast<int32_t>(pos.y) == ctx.b->centery;
+    bool add_size = false;
+
+    switch(ctx.b->getType()) {
     case building_type::Armorstand:
-        return "a";
+        str = "a"; break;
     case building_type::Bed:
-        return "b";
+        str = "b"; break;
     case building_type::Chair:
-        return "c";
+        str = "c"; break;
     case building_type::Door:
-        return "d";
+        str = "d"; break;
     case building_type::Floodgate:
-        return "x";
+        str = "x"; break;
     case building_type::Cabinet:
-        return "f";
+        str = "f"; break;
     case building_type::Box:
-        return "h";
-        //case building_type::Kennel is missing
+        str = "h"; break;
+    //case building_type::Kennel is missing
     case building_type::FarmPlot:
-        if(!at_nw_corner)
-            return "`";
-        out << "p(" << size.first << "x" << size.second << ")";
-        return out.str();
+        do_block_building(ctx, str, "p", at_nw_corner, &add_size); break;
     case building_type::Weaponrack:
-        return "r";
+        str = "r"; break;
     case building_type::Statue:
-        return "s";
+        str = "s"; break;
     case building_type::Table:
-        return "t";
+        str = "t"; break;
     case building_type::RoadPaved:
-        if(! at_nw_corner)
-            return "`";
-        out << "o(" << size.first << "x" << size.second << ")";
-        return out.str();
+        do_block_building(ctx, str, "o", at_nw_corner, &add_size); break;
     case building_type::RoadDirt:
-        if(! at_nw_corner)
-            return "`";
-        out << "O(" << size.first << "x" << size.second << ")";
-        return out.str();
+        do_block_building(ctx, str, "O", at_nw_corner, &add_size); break;
     case building_type::Bridge:
-        if(! at_nw_corner)
-            return "`";
-        switch(((df::building_bridgest*) b)->direction)
-        {
-        case df::building_bridgest::T_direction::Down:
-            out << "gx";
-            break;
-        case df::building_bridgest::T_direction::Left:
-            out << "ga";
-            break;
-        case df::building_bridgest::T_direction::Up:
-            out << "gw";
-            break;
-        case df::building_bridgest::T_direction::Right:
-            out << "gd";
-            break;
-        case df::building_bridgest::T_direction::Retracting:
-            out << "gs";
-            break;
-        }
-        out << "(" << size.first << "x" << size.second << ")";
-        return out.str();
+        do_block_building(ctx, str, get_bridge_str(ctx.b), at_nw_corner,
+                          &add_size);
+        break;
     case building_type::Well:
-        return "l";
+        str = "l"; break;
     case building_type::SiegeEngine:
-        if (! at_center)
-            return "`";
-        return ((df::building_siegeenginest*) b)->type == df::siegeengine_type::Ballista ? "ib" : "ic";
+        do_block_building(ctx, str, get_siege_str(ctx.b), at_center);
+        break;
     case building_type::Workshop:
-        if (! at_center)
-            return "`";
-        switch (((df::building_workshopst*) b)->type)
-        {
-        case workshop_type::Leatherworks:
-            return "we";
-        case workshop_type::Quern:
-            return "wq";
-        case workshop_type::Millstone:
-            return "wM";
-        case workshop_type::Loom:
-            return "wo";
-        case workshop_type::Clothiers:
-            return "wk";
-        case workshop_type::Bowyers:
-            return "wb";
-        case workshop_type::Carpenters:
-            return "wc";
-        case workshop_type::MetalsmithsForge:
-            return "wf";
-        case workshop_type::MagmaForge:
-            return "wv";
-        case workshop_type::Jewelers:
-            return "wj";
-        case workshop_type::Masons:
-            return "wm";
-        case workshop_type::Butchers:
-            return "wu";
-        case workshop_type::Tanners:
-            return "wn";
-        case workshop_type::Craftsdwarfs:
-            return "wr";
-        case workshop_type::Siege:
-            return "ws";
-        case workshop_type::Mechanics:
-            return "wt";
-        case workshop_type::Still:
-            return "wl";
-        case workshop_type::Farmers:
-            return "ww";
-        case workshop_type::Kitchen:
-            return "wz";
-        case workshop_type::Fishery:
-            return "wh";
-        case workshop_type::Ashery:
-            return "wy";
-        case workshop_type::Dyers:
-            return "wd";
-        case workshop_type::Kennels:
-            return "k";
-        case workshop_type::Custom:
-        case workshop_type::Tool:
-            //can't do anything with custom workshop
-            return "`";
-        }
+        do_block_building(ctx, str, get_workshop_str(ctx.b), at_center);
+        break;
     case building_type::Furnace:
-        if (! at_center)
-            return "`";
-        switch (((df::building_furnacest*) b)->type)
-        {
-        case furnace_type::WoodFurnace:
-            return "ew";
-        case furnace_type::Smelter:
-            return "es";
-        case furnace_type::GlassFurnace:
-            return "eg";
-        case furnace_type::Kiln:
-            return "ek";
-        case furnace_type::MagmaSmelter:
-            return "el";
-        case furnace_type::MagmaGlassFurnace:
-            return "ea";
-        case furnace_type::MagmaKiln:
-            return "en";
-        case furnace_type::Custom:
-            //can't do anything with custom furnace
-            return "`";
-        }
+        do_block_building(ctx, str, get_furnace_str(ctx.b), at_center);
+        break;
     case building_type::WindowGlass:
-        return "y";
+        str = "y"; break;
     case building_type::WindowGem:
-        return "Y";
+        str = "Y"; break;
     case building_type::Construction:
-        switch (((df::building_constructionst*) b)->type)
-        {
-        case construction_type::NONE:
-            return "`";
-        case construction_type::Fortification:
-            return "CF";
-        case construction_type::Wall:
-            return "CW";
-        case construction_type::Floor:
-            return "Cf";
-        case construction_type::UpStair:
-            return "Cu";
-        case construction_type::DownStair:
-            return "Cj";
-        case construction_type::UpDownStair:
-            return "Cx";
-        case construction_type::Ramp:
-            return "Cr";
-        case construction_type::TrackN:
-            return "trackN";
-        case construction_type::TrackS:
-            return "trackS";
-        case construction_type::TrackE:
-            return "trackE";
-        case construction_type::TrackW:
-            return "trackW";
-        case construction_type::TrackNS:
-            return "trackNS";
-        case construction_type::TrackNE:
-            return "trackNE";
-        case construction_type::TrackNW:
-            return "trackNW";
-        case construction_type::TrackSE:
-            return "trackSE";
-        case construction_type::TrackSW:
-            return "trackSW";
-        case construction_type::TrackEW:
-            return "trackEW";
-        case construction_type::TrackNSE:
-            return "trackNSE";
-        case construction_type::TrackNSW:
-            return "trackNSW";
-        case construction_type::TrackNEW:
-            return "trackNEW";
-        case construction_type::TrackSEW:
-            return "trackSEW";
-        case construction_type::TrackNSEW:
-            return "trackNSEW";
-        case construction_type::TrackRampN:
-            return "trackrampN";
-        case construction_type::TrackRampS:
-            return "trackrampS";
-        case construction_type::TrackRampE:
-            return "trackrampE";
-        case construction_type::TrackRampW:
-            return "trackrampW";
-        case construction_type::TrackRampNS:
-            return "trackrampNS";
-        case construction_type::TrackRampNE:
-            return "trackrampNE";
-        case construction_type::TrackRampNW:
-            return "trackrampNW";
-        case construction_type::TrackRampSE:
-            return "trackrampSE";
-        case construction_type::TrackRampSW:
-            return "trackrampSW";
-        case construction_type::TrackRampEW:
-            return "trackrampEW";
-        case construction_type::TrackRampNSE:
-            return "trackrampNSE";
-        case construction_type::TrackRampNSW:
-            return "trackrampNSW";
-        case construction_type::TrackRampNEW:
-            return "trackrampNEW";
-        case construction_type::TrackRampSEW:
-            return "trackrampSEW";
-        case construction_type::TrackRampNSEW:
-            return "trackrampNSEW";
-        }
+        str = get_construction_str(ctx.b); break;
     case building_type::Shop:
-        if (! at_center)
-            return "`";
-        return "z";
+        do_block_building(ctx, str, "z", at_center);
+        break;
     case building_type::AnimalTrap:
-        return "m";
+        str = "m"; break;
     case building_type::Chain:
-        return "v";
+        str = "v"; break;
     case building_type::Cage:
-        return "j";
+        str = "j"; break;
     case building_type::TradeDepot:
-        if (! at_center)
-            return "`";
-        return "D";
+        do_block_building(ctx, str, "D", at_center); break;
     case building_type::Trap:
-        switch (((df::building_trapst*) b)->trap_type)
-        {
-        case trap_type::StoneFallTrap:
-            return "Ts";
-        case trap_type::WeaponTrap:
-            return "Tw";
-        case trap_type::Lever:
-            return "Tl";
-        case trap_type::PressurePlate:
-            return "Tp";
-        case trap_type::CageTrap:
-            return "Tc";
-        case trap_type::TrackStop:
-            df::building_trapst* ts = (df::building_trapst*) b;
-            out << "CS";
-            if (ts->use_dump)
-            {
-                if (ts->dump_x_shift == 0)
-                {
-                    if (ts->dump_y_shift > 0)
-                        out << "dd";
-                    else
-                        out << "d";
-                }
-                else
-                {
-                    if (ts->dump_x_shift > 0)
-                        out << "ddd";
-                    else
-                        out << "dddd";
-                }
-            }
-            switch (ts->friction)
-            {
-            case 10:
-                out << "a";
-            case 50:
-                out << "a";
-            case 500:
-                out << "a";
-            case 10000:
-                out << "a";
-            }
-            return out.str();
-        }
+        str = get_trap_str(ctx.b); break;
     case building_type::ScrewPump:
-        if (! at_se_corner) //screw pumps anchor at bottom/right
-            return "`";
-        switch (((df::building_screw_pumpst*) b)->direction)
-        {
-        case screw_pump_direction::FromNorth:
-            return "Msu";
-        case screw_pump_direction::FromEast:
-            return "Msk";
-        case screw_pump_direction::FromSouth:
-            return "Msm";
-        case screw_pump_direction::FromWest:
-            return "Msh";
-        }
+        do_block_building(ctx, str, get_screw_pump_str(ctx.b), at_se_corner);
+        break;
     case building_type::WaterWheel:
-        if (! at_center)
-            return "`";
-        //s swaps orientation which defaults to vertical
-        return ((df::building_water_wheelst*) b)->is_vertical ? "Mw" : "Mws";
+        do_block_building(ctx, str, get_water_wheel_str(ctx.b), at_center);
+        break;
     case building_type::Windmill:
-        if (! at_center)
-            return "`";
-        return "Mm";
+        do_block_building(ctx, str, "Mm", at_center); break;
     case building_type::GearAssembly:
-        return "Mg";
+        str = "Mg"; break;
     case building_type::AxleHorizontal:
-        if (! at_nw_corner) //a guess based on how constructions work
-            return "`";
-        //same as water wheel but reversed
-        out << "Mh" << (((df::building_axle_horizontalst*) b)->is_vertical ? "s" : "")
-            << "(" << size.first << "x" << size.second << ")";
-        return out.str();
+        do_block_building(ctx, str, get_axle_str(ctx.b), at_nw_corner,
+                          &add_size);
+        break;
     case building_type::AxleVertical:
-        return "Mv";
+        str = "Mv"; break;
     case building_type::Rollers:
-        if (! at_nw_corner)
-            return "`";
-        out << "Mr";
-        switch (((df::building_rollersst*) b)->direction)
-        {
-        case screw_pump_direction::FromNorth:
-            break;
-        case screw_pump_direction::FromEast:
-            out << "s";
-        case screw_pump_direction::FromSouth:
-            out << "s";
-        case screw_pump_direction::FromWest:
-            out << "s";
-        }
-        out << "(" << size.first << "x" << size.second << ")";
-        return out.str();
+        do_block_building(ctx, str, get_roller_str(ctx.b), at_nw_corner,
+                          &add_size);
+        break;
     case building_type::Support:
-        return "S";
+        str = "S"; break;
     case building_type::ArcheryTarget:
-        return "A";
+        str = "A"; break;
     case building_type::TractionBench:
-        return "R";
+        str = "R"; break;
     case building_type::Hatch:
-        return "H";
+        str = "H"; break;
     case building_type::Slab:
         //how to mine alt key?!?
         //alt+s
-        return " ";
+        str = "~"; break;
     case building_type::NestBox:
-        return "N";
+        str = "N"; break;
     case building_type::Hive:
         //alt+h
-        return " ";
+        str = "~"; break;
     case building_type::GrateWall:
-        return "W";
+        str = "W"; break;
     case building_type::GrateFloor:
-        return "G";
+        str = "G"; break;
     case building_type::BarsVertical:
-        return "B";
+        str = "B"; break;
     case building_type::BarsFloor:
         //alt+b
-        return " ";
+        str = "~"; break;
     default:
-        return " ";
+        str = if_pretty(ctx, "~");
+        break;
     }
+
+    if (add_size)
+        str.append(get_expansion_str(ctx.b));
 }
 
-static string get_tile_place(uint32_t x, uint32_t y, df::building* b)
-{
-    if (! b || b->getType() != building_type::Stockpile)
-        return " ";
-    if (b->x1 != int32_t(x) || b->y1 != int32_t(y))
-        return "`";
-    pair<uint32_t, uint32_t> size = get_building_size(b);
-    df::building_stockpilest* sp = (df::building_stockpilest*) b;
-    stringstream out;// = stringstream();
+static void get_tile_place(const df::coord &pos, const tile_context &ctx,
+                           string &str) {
+    if (!ctx.b || ctx.b->getType() != building_type::Stockpile)
+        return;
+
+    if (ctx.b->x1 != static_cast<int32_t>(pos.x)
+            || ctx.b->y1 != static_cast<int32_t>(pos.y)) {
+        str = if_pretty(ctx, "`");
+        return;
+    }
+
+    df::building_stockpilest* sp =
+            virtual_cast<df::building_stockpilest>(ctx.b);
+    if (!sp) {
+        str = "~";
+        return;
+    }
+
     switch (sp->settings.flags.whole)
     {
-    case df::stockpile_group_set::mask_animals:
-        out << "a";
-        break;
-    case df::stockpile_group_set::mask_food:
-        out << "f";
-        break;
-    case df::stockpile_group_set::mask_furniture:
-        out << "u";
-        break;
-    case df::stockpile_group_set::mask_corpses:
-        out << "y";
-        break;
-    case df::stockpile_group_set::mask_refuse:
-        out << "r";
-        break;
-    case df::stockpile_group_set::mask_wood:
-        out << "w";
-        break;
-    case df::stockpile_group_set::mask_stone:
-        out << "s";
-        break;
-    case df::stockpile_group_set::mask_gems:
-        out << "e";
-        break;
-    case df::stockpile_group_set::mask_bars_blocks:
-        out << "b";
-        break;
-    case df::stockpile_group_set::mask_cloth:
-        out << "h";
-        break;
-    case df::stockpile_group_set::mask_leather:
-        out << "l";
-        break;
-    case df::stockpile_group_set::mask_ammo:
-        out << "z";
-        break;
-    case df::stockpile_group_set::mask_coins:
-        out << "n";
-        break;
-    case df::stockpile_group_set::mask_finished_goods:
-        out << "g";
-        break;
-    case df::stockpile_group_set::mask_weapons:
-        out << "p";
-        break;
-    case df::stockpile_group_set::mask_armor:
-        out << "d";
-        break;
-    default: //multiple stockpile type
-        return "`";
+    case df::stockpile_group_set::mask_animals:        str = "a"; break;
+    case df::stockpile_group_set::mask_food:           str = "f"; break;
+    case df::stockpile_group_set::mask_furniture:      str = "u"; break;
+    case df::stockpile_group_set::mask_corpses:        str = "y"; break;
+    case df::stockpile_group_set::mask_refuse:         str = "r"; break;
+    case df::stockpile_group_set::mask_wood:           str = "w"; break;
+    case df::stockpile_group_set::mask_stone:          str = "s"; break;
+    case df::stockpile_group_set::mask_gems:           str = "e"; break;
+    case df::stockpile_group_set::mask_bars_blocks:    str = "b"; break;
+    case df::stockpile_group_set::mask_cloth:          str = "h"; break;
+    case df::stockpile_group_set::mask_leather:        str = "l"; break;
+    case df::stockpile_group_set::mask_ammo:           str = "z"; break;
+    case df::stockpile_group_set::mask_coins:          str = "n"; break;
+    case df::stockpile_group_set::mask_finished_goods: str = "g"; break;
+    case df::stockpile_group_set::mask_weapons:        str = "p"; break;
+    case df::stockpile_group_set::mask_armor:          str = "d"; break;
+    default: // multiple stockpile types
+        str = "~";
+        return;
     }
-    out << "("<< size.first << "x" << size.second << ")";
-    return out.str();
+
+    str.append(get_expansion_str(ctx.b));
 }
 
-static string get_tile_query(df::building* b)
-{
-    if (b && b->is_room)
-        return "r+";
-    return " ";
+static void get_tile_query(const df::coord &, const tile_context &ctx,
+                           string &str) {
+    if (ctx.b && ctx.b->is_room)
+        str = "r+";
+}
+
+static bool create_output_dir(color_ostream &out,
+                              const blueprint_options &opts) {
+    string basename = "blueprints/" + opts.name;
+    size_t last_slash = basename.find_last_of("/");
+    string parent_path = basename.substr(0, last_slash);
+
+    // create output directory if it doesn't already exist
+    if (!Filesystem::mkdir_recursive(parent_path)) {
+        out.printerr("could not create output directory: '%s'\n",
+                     parent_path.c_str());
+        return false;
+    }
+    return true;
 }
 
 static bool get_filename(string &fname,
                          color_ostream &out,
                          blueprint_options opts, // copy because we can't const
-                         const string &phase)
-{
+                         const string &phase) {
     auto L = Lua::Core::State;
     Lua::StackUnwinder top(L);
 
     if (!lua_checkstack(L, 3) ||
         !Lua::PushModulePublic(
-            out, L, "plugins.blueprint", "get_filename"))
-    {
+            out, L, "plugins.blueprint", "get_filename")) {
         out.printerr("Failed to load blueprint Lua code\n");
         return false;
     }
@@ -611,15 +598,13 @@ static bool get_filename(string &fname,
     Lua::Push(L, &opts);
     Lua::Push(L, phase);
 
-    if (!Lua::SafeCall(out, L, 2, 1))
-    {
+    if (!Lua::SafeCall(out, L, 2, 1)) {
         out.printerr("Failed Lua call to get_filename\n");
         return false;
     }
 
     const char *s = lua_tostring(L, -1);
-    if (!s)
-    {
+    if (!s) {
         out.printerr("Failed to retrieve filename from get_filename\n");
         return false;
     }
@@ -628,8 +613,80 @@ static bool get_filename(string &fname,
     return true;
 }
 
-static string get_modeline(const string &phase)
-{
+typedef map<int16_t /* x */, string> bp_row;
+typedef map<int16_t /* y */, bp_row> bp_area;
+typedef map<int16_t /* z */, bp_area> bp_volume;
+
+static const bp_area NEW_AREA;
+static const bp_row NEW_ROW;
+
+typedef void (get_tile_fn)(const df::coord &pos, const tile_context &ctx,
+                           string &str);
+typedef void (init_ctx_fn)(const df::coord &pos, tile_context &ctx);
+
+struct blueprint_processor {
+    bp_volume mapdata;
+    string phase;
+    get_tile_fn *get_tile;
+    init_ctx_fn *init_ctx;
+    blueprint_processor(const string &phase, get_tile_fn *get_tile,
+                        init_ctx_fn *init_ctx = NULL)
+        : phase(phase), get_tile(get_tile), init_ctx(init_ctx) { }
+};
+
+static void write_minimal(ofstream &ofile, const blueprint_options &opts,
+                          const bp_volume &mapdata) {
+    if (mapdata.begin() == mapdata.end())
+        return;
+
+    const string z_key = opts.depth > 0 ? "#<" : "#>";
+
+    int16_t zprev = 0;
+    for (auto area : mapdata) {
+        for ( ; zprev < area.first; ++zprev)
+            ofile << z_key << endl;
+        int16_t yprev = 0;
+        for (auto row : area.second) {
+            for ( ; yprev < row.first; ++yprev)
+                ofile << endl;
+            int16_t xprev = 0;
+            for (auto tile : row.second) {
+                for ( ; xprev < tile.first; ++xprev)
+                    ofile << ",";
+                ofile << tile.second;
+            }
+        }
+        ofile << endl;
+    }
+}
+
+static void write_pretty(ofstream &ofile, const blueprint_options &opts,
+                         const bp_volume &mapdata) {
+    const string z_key = opts.depth > 0 ? "#<" : "#>";
+
+    int16_t absdepth = abs(opts.depth);
+    for (int16_t z = 0; z < absdepth; ++z) {
+        const bp_area *area = NULL;
+        if (mapdata.count(z))
+            area = &mapdata.at(z);
+        for (int16_t y = 0; y < opts.height; ++y) {
+            const bp_row *row = NULL;
+            if (area && area->count(y))
+                row = &area->at(y);
+            for (int16_t x = 0; x < opts.width; ++x) {
+                const string *tile = NULL;
+                if (row && row->count(x))
+                    tile = &row->at(x);
+                ofile << (tile ? *tile : " ") << ",";
+            }
+            ofile << "#" << endl;
+        }
+        if (z < absdepth - 1)
+            ofile << z_key << endl;
+    }
+}
+
+static string get_modeline(const string &phase) {
     std::ostringstream modeline;
     modeline << "#" << phase << " label(" << phase << ")";
 
@@ -639,110 +696,95 @@ static string get_modeline(const string &phase)
 static bool write_blueprint(color_ostream &out,
                             std::map<string, ofstream*> &output_files,
                             const blueprint_options &opts,
-                            const string &phase,
-                            const std::ostringstream &stream)
-{
+                            const blueprint_processor &processor,
+                            bool pretty) {
     string fname;
-    if (!get_filename(fname, out, opts, phase))
+    if (!get_filename(fname, out, opts, processor.phase))
         return false;
     if (!output_files.count(fname))
         output_files[fname] = new ofstream(fname, ofstream::trunc);
 
     ofstream &ofile = *output_files[fname];
-    ofile << get_modeline(phase) << endl;
-    ofile << stream.str();
+    ofile << get_modeline(processor.phase) << endl;
+
+    if (pretty)
+        write_pretty(ofile, opts, processor.mapdata);
+    else
+        write_minimal(ofile, opts, processor.mapdata);
+
     return true;
 }
 
+void ensure_building(const df::coord &pos, tile_context &ctx) {
+    if (ctx.b)
+        return;
+    ctx.b = Buildings::findAtTile(pos);
+}
+
 static bool do_transform(color_ostream &out,
-                         const DFCoord &start, const DFCoord &end,
+                         const df::coord &start, const df::coord &end,
                          const blueprint_options &opts,
-                         vector<string> &filenames)
-{
-    std::ostringstream dig, build, place, query;
+                         vector<string> &filenames) {
+    vector<blueprint_processor> processors;
 
-    string basename = "blueprints/" + opts.name;
-    size_t last_slash = basename.find_last_of("/");
-    string parent_path = basename.substr(0, last_slash);
+    if (opts.auto_phase || opts.dig)
+        processors.push_back(blueprint_processor("dig", get_tile_dig));
+    if (opts.auto_phase || opts.build)
+        processors.push_back(blueprint_processor("build", get_tile_build,
+                                                 ensure_building));
+    if (opts.auto_phase || opts.place)
+        processors.push_back(blueprint_processor("place", get_tile_place,
+                                                 ensure_building));
+    if (opts.auto_phase || opts.query)
+        processors.push_back(blueprint_processor("query", get_tile_query,
+                                                 ensure_building));
 
-    // create output directory if it doesn't already exist
-    std::error_code ec;
-    if (!Filesystem::mkdir_recursive(parent_path))
-    {
-        out.printerr("could not create output directory: '%s'\n",
-                     parent_path.c_str());
+    if (processors.empty()) {
+        out.printerr("no phases requested! nothing to do!\n");
         return false;
     }
 
+    if (!create_output_dir(out, opts))
+        return false;
+
+    const bool pretty = opts.format != "minimal";
     const int32_t z_inc = start.z < end.z ? 1 : -1;
-    const string z_key = start.z < end.z ? "#<" : "#>";
-    for (int32_t z = start.z; z != end.z; z += z_inc)
-    {
-        for (int32_t y = start.y; y < end.y; y++)
-        {
-            for (int32_t x = start.x; x < end.x; x++)
-            {
-                df::building* b = Buildings::findAtTile(DFCoord(x, y, z));
-                if (opts.auto_phase || opts.query)
-                    query << get_tile_query(b) << ',';
-                if (opts.auto_phase || opts.place)
-                    place << get_tile_place(x, y, b) << ',';
-                if (opts.auto_phase || opts.build)
-                    build << get_tile_build(x, y, b) << ',';
-                if (opts.auto_phase || opts.dig)
-                    dig << get_tile_dig(x, y, z) << ',';
+    for (int32_t z = start.z; z != end.z; z += z_inc) {
+        for (int32_t y = start.y; y < end.y; y++) {
+            for (int32_t x = start.x; x < end.x; x++) {
+                df::coord pos(x, y, z);
+                tile_context ctx;
+                ctx.pretty = pretty;
+                for (blueprint_processor &processor : processors) {
+                    if (processor.init_ctx)
+                        processor.init_ctx(pos, ctx);
+                    string tile_str;
+                    processor.get_tile(pos, ctx, tile_str);
+                    if (!tile_str.empty()) {
+                        // ensure our z-index is in the order we want to write
+                        auto area = processor.mapdata.emplace(abs(z - start.z),
+                                                              NEW_AREA);
+                        auto row = area.first->second.emplace(y - start.y,
+                                                              NEW_ROW);
+                        row.first->second[x - start.x] = tile_str;
+                    }
+                }
             }
-            if (opts.auto_phase || opts.query)
-                query << "#" << endl;
-            if (opts.auto_phase || opts.place)
-                place << "#" << endl;
-            if (opts.auto_phase || opts.build)
-                build << "#" << endl;
-            if (opts.auto_phase || opts.dig)
-                dig << "#" << endl;
-        }
-        if (z != end.z - z_inc)
-        {
-            if (opts.auto_phase || opts.query)
-                query << z_key << endl;
-            if (opts.auto_phase || opts.place)
-                place << z_key << endl;
-            if (opts.auto_phase || opts.build)
-                build << z_key << endl;
-            if (opts.auto_phase || opts.dig)
-                dig << z_key << endl;
         }
     }
 
     std::map<string, ofstream*> output_files;
-    string fname;
-    if (opts.auto_phase || opts.dig)
-    {
-        if (!write_blueprint(out, output_files, opts, "dig", dig))
-            return false;
-    }
-    if (opts.auto_phase || opts.build)
-    {
-        if (!write_blueprint(out, output_files, opts, "build", build))
-            return false;
-    }
-    if (opts.auto_phase || opts.place)
-    {
-        if (!write_blueprint(out, output_files, opts, "place", place))
-            return false;
-    }
-    if (opts.auto_phase || opts.query)
-    {
-        if (!write_blueprint(out, output_files, opts, "query", query))
+    for (blueprint_processor &processor : processors) {
+        if (!write_blueprint(out, output_files, opts, processor, pretty))
             return false;
     }
 
-    for (auto &it : output_files)
-    {
+    for (auto &it : output_files) {
         filenames.push_back(it.first);
         it.second->close();
         delete(it.second);
     }
+    output_files.clear();
 
     return true;
 }
@@ -756,8 +798,7 @@ static bool get_options(color_ostream &out,
 
     if (!lua_checkstack(L, parameters.size() + 2) ||
         !Lua::PushModulePublic(
-            out, L, "plugins.blueprint", "parse_commandline"))
-    {
+            out, L, "plugins.blueprint", "parse_commandline")) {
         out.printerr("Failed to load blueprint Lua code\n");
         return false;
     }
@@ -773,8 +814,7 @@ static bool get_options(color_ostream &out,
     return true;
 }
 
-static void print_help(color_ostream &out)
-{
+static void print_help(color_ostream &out) {
     auto L = Lua::Core::State;
     Lua::StackUnwinder top(L);
 
@@ -790,16 +830,13 @@ static void print_help(color_ostream &out)
 // names of the files that were generated
 static bool do_blueprint(color_ostream &out,
                          const vector<string> &parameters,
-                         vector<string> &files)
-{
+                         vector<string> &files) {
     CoreSuspender suspend;
 
-    if (parameters.size() >= 1 && parameters[0] == "gui")
-    {
+    if (parameters.size() >= 1 && parameters[0] == "gui") {
         std::ostringstream command;
         command << "gui/blueprint";
-        for (size_t i = 1; i < parameters.size(); ++i)
-        {
+        for (size_t i = 1; i < parameters.size(); ++i) {
             command << " " << parameters[i];
         }
         string command_str = command.str();
@@ -810,31 +847,26 @@ static bool do_blueprint(color_ostream &out,
     }
 
     blueprint_options options;
-    if (!get_options(out, options, parameters) || options.help)
-    {
+    if (!get_options(out, options, parameters) || options.help) {
         print_help(out);
         return options.help;
     }
 
-    if (!Maps::IsValid())
-    {
+    if (!Maps::IsValid()) {
         out.printerr("Map is not available!\n");
         return false;
     }
 
     // start coordinates can come from either the commandline or the map cursor
-    DFCoord start(options.start);
-    if (start.x == -30000)
-    {
-        if (!Gui::getCursorCoords(start))
-        {
+    df::coord start(options.start);
+    if (start.x == -30000) {
+        if (!Gui::getCursorCoords(start)) {
             out.printerr("Can't get cursor coords! Make sure you specify the"
                     " --cursor parameter or have an active cursor in DF.\n");
             return false;
         }
     }
-    if (!Maps::isValidTilePos(start))
-    {
+    if (!Maps::isValidTilePos(start)) {
         out.printerr("Invalid start position: %d,%d,%d\n",
                      start.x, start.y, start.z);
         return false;
@@ -842,8 +874,8 @@ static bool do_blueprint(color_ostream &out,
 
     // end coords are one beyond the last processed coordinate. note that
     // options.depth can be negative.
-    DFCoord end(start.x + options.width, start.y + options.height,
-                start.z + options.depth);
+    df::coord end(start.x + options.width, start.y + options.height,
+                  start.z + options.depth);
 
     // crop end coordinate to map bounds. we've already verified that start is
     // a valid coordinate, and width, height, and depth are non-zero, so our
@@ -862,13 +894,11 @@ static bool do_blueprint(color_ostream &out,
 }
 
 // entrypoint when called from Lua. returns the names of the generated files
-static int run(lua_State *L)
-{
+static int run(lua_State *L) {
     int argc = lua_gettop(L);
     vector<string> argv;
 
-    for (int i = 1; i <= argc; ++i)
-    {
+    for (int i = 1; i <= argc; ++i) {
         const char *s = lua_tostring(L, i);
         if (s == NULL)
             luaL_error(L, "all parameters must be strings");
@@ -879,8 +909,7 @@ static int run(lua_State *L)
     color_ostream *out = Lua::GetOutput(L);
     if (!out)
         out = &Core::getInstance().getConsole();
-    if (do_blueprint(*out, argv, files))
-    {
+    if (do_blueprint(*out, argv, files)) {
         Lua::PushVector(L, files);
         return 1;
     }
@@ -888,11 +917,9 @@ static int run(lua_State *L)
     return 0;
 }
 
-command_result blueprint(color_ostream &out, vector<string> &parameters)
-{
+command_result blueprint(color_ostream &out, vector<string> &parameters) {
     vector<string> files;
-    if (do_blueprint(out, parameters, files))
-    {
+    if (do_blueprint(out, parameters, files)) {
         out.print("Generated blueprint file(s):\n");
         for (string &fname : files)
             out.print("  %s\n", fname.c_str());

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -113,6 +113,52 @@ struct tile_context {
     df::building* b = NULL;
 };
 
+// the number of different strings we use is very small so we use a string cache
+// to limit the number of memory allocations we make. this significantly speeds
+// up processing and allows us to handle very large maps (e.g. 16x16 embarks)
+// without running out of memory.
+// if NULL is passed as the str, the cache is cleared
+static const char * cache(const char *str) {
+    // this local static assumes that no two blueprints are being generated at
+    // the same time, which is currently ensured by the higher-level DFHack
+    // command handling code. if this assumption ever becomes untrue, we'll
+    // need to protect the cache with thread synchronization primitives.
+    static std::set<string> _cache;
+    if (!str) {
+        _cache.clear();
+        return NULL;
+    }
+    return _cache.emplace(str).first->c_str();
+}
+
+static const char * get_tile_dig(const df::coord &pos, const tile_context &) {
+    df::tiletype *tt = Maps::getTileType(pos);
+    switch (tileShape(tt ? *tt : tiletype::Void))
+    {
+    case tiletype_shape::EMPTY:
+    case tiletype_shape::RAMP_TOP:
+        return "h";
+    case tiletype_shape::FLOOR:
+    case tiletype_shape::BOULDER:
+    case tiletype_shape::PEBBLES:
+    case tiletype_shape::BROOK_TOP:
+        return "d";
+    case tiletype_shape::FORTIFICATION:
+        return "F";
+    case tiletype_shape::STAIR_UP:
+        return "u";
+    case tiletype_shape::STAIR_DOWN:
+        return "j";
+    case tiletype_shape::STAIR_UPDOWN:
+        return "i";
+    case tiletype_shape::RAMP:
+        return "r";
+    case tiletype_shape::WALL:
+    default:
+        return NULL;
+    }
+}
+
 static pair<uint32_t, uint32_t> get_building_size(df::building *b) {
     return pair<uint32_t, uint32_t>(b->x2 - b->x1 + 1, b->y2 - b->y1 + 1);
 }
@@ -121,47 +167,18 @@ static const char * if_pretty(const tile_context &ctx, const char *c) {
     return ctx.pretty ? c : "";
 }
 
-static void get_tile_dig(const df::coord &pos, const tile_context &,
-                         string &str) {
-    df::tiletype *tt = Maps::getTileType(pos);
-    switch (tileShape(tt ? *tt : tiletype::Void))
-    {
-    case tiletype_shape::EMPTY:
-    case tiletype_shape::RAMP_TOP:
-        str = "h"; break;
-    case tiletype_shape::FLOOR:
-    case tiletype_shape::BOULDER:
-    case tiletype_shape::PEBBLES:
-    case tiletype_shape::BROOK_TOP:
-        str = "d"; break;
-    case tiletype_shape::FORTIFICATION:
-        str = "F"; break;
-    case tiletype_shape::STAIR_UP:
-        str = "u"; break;
-    case tiletype_shape::STAIR_DOWN:
-        str = "j"; break;
-    case tiletype_shape::STAIR_UPDOWN:
-        str = "i"; break;
-    case tiletype_shape::RAMP:
-        str = "r"; break;
-    case tiletype_shape::WALL:
-    default:
-        break;
-    }
-}
-
-static void do_block_building(const tile_context &ctx, string &str, string s,
-                              bool at_target_pos, bool *add_size = NULL) {
+static const char * do_block_building(const tile_context &ctx, const char *s,
+                                      bool at_target_pos,
+                                      bool *add_size = NULL) {
     if(!at_target_pos) {
-        str = if_pretty(ctx, "`");
-        return;
+        return if_pretty(ctx, "`");
     }
-    str = s;
     if (add_size)
         *add_size = true;
+    return s;
 }
 
-static string get_bridge_str(df::building *b) {
+static const char * get_bridge_str(df::building *b) {
     df::building_bridgest *bridge = virtual_cast<df::building_bridgest>(b);
     if (!bridge)
         return "g";
@@ -177,13 +194,13 @@ static string get_bridge_str(df::building *b) {
     }
 }
 
-static string get_siege_str(df::building *b) {
+static const char * get_siege_str(df::building *b) {
     df::building_siegeenginest *se =
             virtual_cast<df::building_siegeenginest>(b);
     return !se || se->type == df::siegeengine_type::Catapult ? "ic" : "ib";
 }
 
-static string get_workshop_str(df::building *b) {
+static const char * get_workshop_str(df::building *b) {
     df::building_workshopst *ws = virtual_cast<df::building_workshopst>(b);
     if (!ws)
         return "~";
@@ -219,7 +236,7 @@ static string get_workshop_str(df::building *b) {
     }
 }
 
-static string get_furnace_str(df::building *b) {
+static const char * get_furnace_str(df::building *b) {
     df::building_furnacest *furnace = virtual_cast<df::building_furnacest>(b);
     if (!furnace)
         return "~";
@@ -238,7 +255,7 @@ static string get_furnace_str(df::building *b) {
     }
 }
 
-static string get_construction_str(df::building *b) {
+static const char * get_construction_str(df::building *b) {
     df::building_constructionst *cons =
             virtual_cast<df::building_constructionst>(b);
     if (!cons)
@@ -288,7 +305,7 @@ static string get_construction_str(df::building *b) {
     }
 }
 
-static string get_trap_str(df::building *b) {
+static const char * get_trap_str(df::building *b) {
     df::building_trapst *trap = virtual_cast<df::building_trapst>(b);
     if (!trap)
         return "~";
@@ -322,14 +339,14 @@ static string get_trap_str(df::building *b) {
             case 500:   buf << "a";
             case 10000: buf << "a";
             }
-            return buf.str();
+            return cache(buf.str().c_str());
         }
     default:
         return "~";
     }
 }
 
-static string get_screw_pump_str(df::building *b) {
+static const char * get_screw_pump_str(df::building *b) {
     df::building_screw_pumpst *sp = virtual_cast<df::building_screw_pumpst>(b);
     if (!sp)
         return "~";
@@ -345,7 +362,7 @@ static string get_screw_pump_str(df::building *b) {
     }
 }
 
-static string get_water_wheel_str(df::building *b) {
+static const char * get_water_wheel_str(df::building *b) {
     df::building_water_wheelst *ww =
             virtual_cast<df::building_water_wheelst>(b);
     if (!ww)
@@ -354,7 +371,7 @@ static string get_water_wheel_str(df::building *b) {
     return ww->is_vertical ? "Mw" : "Mws";
 }
 
-static string get_axle_str(df::building *b) {
+static const char * get_axle_str(df::building *b) {
     df::building_axle_horizontalst *ah =
             virtual_cast<df::building_axle_horizontalst>(b);
     if (!ah)
@@ -363,7 +380,7 @@ static string get_axle_str(df::building *b) {
     return ah->is_vertical ? "Mhs" : "Mh";
 }
 
-static string get_roller_str(df::building *b) {
+static const char * get_roller_str(df::building *b) {
     df::building_rollersst *r = virtual_cast<df::building_rollersst>(b);
     if (!r)
         return "~";
@@ -378,192 +395,192 @@ static string get_roller_str(df::building *b) {
     }
 }
 
-static string get_expansion_str(df::building *b) {
-    pair<uint32_t, uint32_t> size = get_building_size(b);
-    std::ostringstream s;
-    s << "(" << size.first << "x" << size.second << ")";
-    return s.str();
-}
-
-static void get_tile_build(const df::coord &pos, const tile_context &ctx,
-                           string &str) {
-    if (!ctx.b || ctx.b->getType() == building_type::Stockpile) {
-        return;
-    }
-
+static const char * get_build_keys(const df::coord &pos,
+                                   const tile_context &ctx,
+                                   bool &add_size) {
     bool at_nw_corner = static_cast<int32_t>(pos.x) == ctx.b->x1
                             && static_cast<int32_t>(pos.y) == ctx.b->y1;
     bool at_se_corner = static_cast<int32_t>(pos.x) == ctx.b->x2
                             && static_cast<int32_t>(pos.y) == ctx.b->y2;
     bool at_center = static_cast<int32_t>(pos.x) == ctx.b->centerx
                             && static_cast<int32_t>(pos.y) == ctx.b->centery;
-    bool add_size = false;
 
     switch(ctx.b->getType()) {
     case building_type::Armorstand:
-        str = "a"; break;
+        return "a";
     case building_type::Bed:
-        str = "b"; break;
+        return "b";
     case building_type::Chair:
-        str = "c"; break;
+        return "c";
     case building_type::Door:
-        str = "d"; break;
+        return "d";
     case building_type::Floodgate:
-        str = "x"; break;
+        return "x";
     case building_type::Cabinet:
-        str = "f"; break;
+        return "f";
     case building_type::Box:
-        str = "h"; break;
+        return "h";
     //case building_type::Kennel is missing
     case building_type::FarmPlot:
-        do_block_building(ctx, str, "p", at_nw_corner, &add_size); break;
+        return do_block_building(ctx, "p", at_nw_corner, &add_size);
     case building_type::Weaponrack:
-        str = "r"; break;
+        return "r";
     case building_type::Statue:
-        str = "s"; break;
+        return "s";
     case building_type::Table:
-        str = "t"; break;
+        return "t";
     case building_type::RoadPaved:
-        do_block_building(ctx, str, "o", at_nw_corner, &add_size); break;
+        return do_block_building(ctx, "o", at_nw_corner, &add_size);
     case building_type::RoadDirt:
-        do_block_building(ctx, str, "O", at_nw_corner, &add_size); break;
+        return do_block_building(ctx, "O", at_nw_corner, &add_size);
     case building_type::Bridge:
-        do_block_building(ctx, str, get_bridge_str(ctx.b), at_nw_corner,
+        return do_block_building(ctx, get_bridge_str(ctx.b), at_nw_corner,
                           &add_size);
-        break;
     case building_type::Well:
-        str = "l"; break;
+        return "l";
     case building_type::SiegeEngine:
-        do_block_building(ctx, str, get_siege_str(ctx.b), at_center);
-        break;
+        return do_block_building(ctx, get_siege_str(ctx.b), at_center);
     case building_type::Workshop:
-        do_block_building(ctx, str, get_workshop_str(ctx.b), at_center);
-        break;
+        return do_block_building(ctx, get_workshop_str(ctx.b), at_center);
     case building_type::Furnace:
-        do_block_building(ctx, str, get_furnace_str(ctx.b), at_center);
-        break;
+        return do_block_building(ctx, get_furnace_str(ctx.b), at_center);
     case building_type::WindowGlass:
-        str = "y"; break;
+        return "y";
     case building_type::WindowGem:
-        str = "Y"; break;
+        return "Y";
     case building_type::Construction:
-        str = get_construction_str(ctx.b); break;
+        return get_construction_str(ctx.b);
     case building_type::Shop:
-        do_block_building(ctx, str, "z", at_center);
-        break;
+        return do_block_building(ctx, "z", at_center);
     case building_type::AnimalTrap:
-        str = "m"; break;
+        return "m";
     case building_type::Chain:
-        str = "v"; break;
+        return "v";
     case building_type::Cage:
-        str = "j"; break;
+        return "j";
     case building_type::TradeDepot:
-        do_block_building(ctx, str, "D", at_center); break;
+        return do_block_building(ctx, "D", at_center);
     case building_type::Trap:
-        str = get_trap_str(ctx.b); break;
+        return get_trap_str(ctx.b);
     case building_type::ScrewPump:
-        do_block_building(ctx, str, get_screw_pump_str(ctx.b), at_se_corner);
-        break;
+        return do_block_building(ctx, get_screw_pump_str(ctx.b), at_se_corner);
     case building_type::WaterWheel:
-        do_block_building(ctx, str, get_water_wheel_str(ctx.b), at_center);
-        break;
+        return do_block_building(ctx, get_water_wheel_str(ctx.b), at_center);
     case building_type::Windmill:
-        do_block_building(ctx, str, "Mm", at_center); break;
+        return do_block_building(ctx, "Mm", at_center);
     case building_type::GearAssembly:
-        str = "Mg"; break;
+        return "Mg";
     case building_type::AxleHorizontal:
-        do_block_building(ctx, str, get_axle_str(ctx.b), at_nw_corner,
-                          &add_size);
-        break;
+        return do_block_building(ctx, get_axle_str(ctx.b), at_nw_corner,
+                                 &add_size);
     case building_type::AxleVertical:
-        str = "Mv"; break;
+        return "Mv";
     case building_type::Rollers:
-        do_block_building(ctx, str, get_roller_str(ctx.b), at_nw_corner,
-                          &add_size);
-        break;
+        return do_block_building(ctx, get_roller_str(ctx.b), at_nw_corner,
+                                 &add_size);
     case building_type::Support:
-        str = "S"; break;
+        return "S";
     case building_type::ArcheryTarget:
-        str = "A"; break;
+        return "A";
     case building_type::TractionBench:
-        str = "R"; break;
+        return "R";
     case building_type::Hatch:
-        str = "H"; break;
+        return "H";
     case building_type::Slab:
         //how to mine alt key?!?
         //alt+s
-        str = "~"; break;
+        return "~";
     case building_type::NestBox:
-        str = "N"; break;
+        return "N";
     case building_type::Hive:
         //alt+h
-        str = "~"; break;
+        return "~";
     case building_type::GrateWall:
-        str = "W"; break;
+        return "W";
     case building_type::GrateFloor:
-        str = "G"; break;
+        return "G";
     case building_type::BarsVertical:
-        str = "B"; break;
+        return "B";
     case building_type::BarsFloor:
         //alt+b
-        str = "~"; break;
+        return "~";
     default:
-        str = if_pretty(ctx, "~");
-        break;
+        return "~";
     }
-
-    if (add_size)
-        str.append(get_expansion_str(ctx.b));
 }
 
-static void get_tile_place(const df::coord &pos, const tile_context &ctx,
-                           string &str) {
-    if (!ctx.b || ctx.b->getType() != building_type::Stockpile)
-        return;
+// returns "~" if keys is NULL; otherwise returns the keys with the building
+// dimensions in the expansion syntax
+static const char * add_expansion_syntax(const tile_context &ctx,
+                                         const char *keys) {
+    if (!keys)
+        return "~";
+    std::ostringstream s;
+    pair<uint32_t, uint32_t> size = get_building_size(ctx.b);
+    s << keys << "(" << size.first << "x" << size.second << ")";
+    return cache(s.str().c_str());
+}
 
-    if (ctx.b->x1 != static_cast<int32_t>(pos.x)
-            || ctx.b->y1 != static_cast<int32_t>(pos.y)) {
-        str = if_pretty(ctx, "`");
-        return;
+static const char * get_tile_build(const df::coord &pos,
+                                   const tile_context &ctx) {
+    if (!ctx.b || ctx.b->getType() == building_type::Stockpile) {
+        return NULL;
     }
 
+    bool add_size = false;
+    const char *keys = get_build_keys(pos, ctx, add_size);
+
+    if (!add_size)
+        return keys;
+    return add_expansion_syntax(ctx, keys);
+}
+
+static const char * get_place_keys(const tile_context &ctx) {
     df::building_stockpilest* sp =
             virtual_cast<df::building_stockpilest>(ctx.b);
     if (!sp) {
-        str = "~";
-        return;
+        return NULL;
     }
 
-    switch (sp->settings.flags.whole)
-    {
-    case df::stockpile_group_set::mask_animals:        str = "a"; break;
-    case df::stockpile_group_set::mask_food:           str = "f"; break;
-    case df::stockpile_group_set::mask_furniture:      str = "u"; break;
-    case df::stockpile_group_set::mask_corpses:        str = "y"; break;
-    case df::stockpile_group_set::mask_refuse:         str = "r"; break;
-    case df::stockpile_group_set::mask_wood:           str = "w"; break;
-    case df::stockpile_group_set::mask_stone:          str = "s"; break;
-    case df::stockpile_group_set::mask_gems:           str = "e"; break;
-    case df::stockpile_group_set::mask_bars_blocks:    str = "b"; break;
-    case df::stockpile_group_set::mask_cloth:          str = "h"; break;
-    case df::stockpile_group_set::mask_leather:        str = "l"; break;
-    case df::stockpile_group_set::mask_ammo:           str = "z"; break;
-    case df::stockpile_group_set::mask_coins:          str = "n"; break;
-    case df::stockpile_group_set::mask_finished_goods: str = "g"; break;
-    case df::stockpile_group_set::mask_weapons:        str = "p"; break;
-    case df::stockpile_group_set::mask_armor:          str = "d"; break;
-    default: // multiple stockpile types
-        str = "~";
-        return;
+    switch (sp->settings.flags.whole) {
+    case df::stockpile_group_set::mask_animals:        return "a";
+    case df::stockpile_group_set::mask_food:           return "f";
+    case df::stockpile_group_set::mask_furniture:      return "u";
+    case df::stockpile_group_set::mask_corpses:        return "y";
+    case df::stockpile_group_set::mask_refuse:         return "r";
+    case df::stockpile_group_set::mask_wood:           return "w";
+    case df::stockpile_group_set::mask_stone:          return "s";
+    case df::stockpile_group_set::mask_gems:           return "e";
+    case df::stockpile_group_set::mask_bars_blocks:    return "b";
+    case df::stockpile_group_set::mask_cloth:          return "h";
+    case df::stockpile_group_set::mask_leather:        return "l";
+    case df::stockpile_group_set::mask_ammo:           return "z";
+    case df::stockpile_group_set::mask_coins:          return "n";
+    case df::stockpile_group_set::mask_finished_goods: return "g";
+    case df::stockpile_group_set::mask_weapons:        return "p";
+    case df::stockpile_group_set::mask_armor:          return "d";
+    default: // TODO: handle stockpiles with multiple types
+        return NULL;
     }
-
-    str.append(get_expansion_str(ctx.b));
 }
 
-static void get_tile_query(const df::coord &, const tile_context &ctx,
-                           string &str) {
-    if (ctx.b && ctx.b->is_room)
-        str = "r+";
+static const char * get_tile_place(const df::coord &pos,
+                                   const tile_context &ctx) {
+    if (!ctx.b || ctx.b->getType() != building_type::Stockpile)
+        return NULL;
+
+    if (ctx.b->x1 != static_cast<int32_t>(pos.x)
+            || ctx.b->y1 != static_cast<int32_t>(pos.y)) {
+        return if_pretty(ctx, "`");
+    }
+
+    return add_expansion_syntax(ctx, get_place_keys(ctx));
+}
+
+static const char * get_tile_query(const df::coord &, const tile_context &ctx) {
+    if (!ctx.b || !ctx.b->is_room)
+        return NULL;
+    return "r+";
 }
 
 static bool create_output_dir(color_ostream &out,
@@ -613,22 +630,22 @@ static bool get_filename(string &fname,
     return true;
 }
 
-typedef map<int16_t /* x */, string> bp_row;
+typedef map<int16_t /* x */, const char *> bp_row;
 typedef map<int16_t /* y */, bp_row> bp_area;
 typedef map<int16_t /* z */, bp_area> bp_volume;
 
 static const bp_area NEW_AREA;
 static const bp_row NEW_ROW;
 
-typedef void (get_tile_fn)(const df::coord &pos, const tile_context &ctx,
-                           string &str);
+typedef const char * (get_tile_fn)(const df::coord &pos,
+                                   const tile_context &ctx);
 typedef void (init_ctx_fn)(const df::coord &pos, tile_context &ctx);
 
 struct blueprint_processor {
     bp_volume mapdata;
-    string phase;
-    get_tile_fn *get_tile;
-    init_ctx_fn *init_ctx;
+    const string phase;
+    get_tile_fn * const get_tile;
+    init_ctx_fn * const init_ctx;
     blueprint_processor(const string &phase, get_tile_fn *get_tile,
                         init_ctx_fn *init_ctx = NULL)
         : phase(phase), get_tile(get_tile), init_ctx(init_ctx) { }
@@ -674,10 +691,10 @@ static void write_pretty(ofstream &ofile, const blueprint_options &opts,
             if (area && area->count(y))
                 row = &area->at(y);
             for (int16_t x = 0; x < opts.width; ++x) {
-                const string *tile = NULL;
+                const char *tile = NULL;
                 if (row && row->count(x))
-                    tile = &row->at(x);
-                ofile << (tile ? *tile : " ") << ",";
+                    tile = row->at(x);
+                ofile << (tile ? tile : " ") << ",";
             }
             ofile << "#" << endl;
         }
@@ -758,9 +775,8 @@ static bool do_transform(color_ostream &out,
                 for (blueprint_processor &processor : processors) {
                     if (processor.init_ctx)
                         processor.init_ctx(pos, ctx);
-                    string tile_str;
-                    processor.get_tile(pos, ctx, tile_str);
-                    if (!tile_str.empty()) {
+                    const char *tile_str = processor.get_tile(pos, ctx);
+                    if (tile_str) {
                         // ensure our z-index is in the order we want to write
                         auto area = processor.mapdata.emplace(abs(z - start.z),
                                                               NEW_AREA);
@@ -890,7 +906,9 @@ static bool do_blueprint(color_ostream &out,
     if (end.z < -1)
         end.z = -1;
 
-    return do_transform(out, start, end, options, files);
+    bool ok = do_transform(out, start, end, options, files);
+    cache(NULL);
+    return ok;
 }
 
 // entrypoint when called from Lua. returns the names of the generated files

--- a/plugins/blueprint.cpp
+++ b/plugins/blueprint.cpp
@@ -114,7 +114,7 @@ struct tile_context {
 };
 
 // the number of different strings we use is very small so we use a string cache
-// to limit the number of memory allocations we make. this significantly speeds
+// to limit the number of string instances we store. this significantly speeds
 // up processing and allows us to handle very large maps (e.g. 16x16 embarks)
 // without running out of memory.
 // if NULL is passed as the str, the cache is cleared
@@ -732,7 +732,7 @@ static bool write_blueprint(color_ostream &out,
     return true;
 }
 
-void ensure_building(const df::coord &pos, tile_context &ctx) {
+static void ensure_building(const df::coord &pos, tile_context &ctx) {
     if (ctx.b)
         return;
     ctx.b = Buildings::findAtTile(pos);
@@ -792,7 +792,7 @@ static bool do_transform(color_ostream &out,
     std::map<string, ofstream*> output_files;
     for (blueprint_processor &processor : processors) {
         if (!write_blueprint(out, output_files, opts, processor, pretty))
-            return false;
+            break;
     }
 
     for (auto &it : output_files) {
@@ -800,7 +800,6 @@ static bool do_transform(color_ostream &out,
         it.second->close();
         delete(it.second);
     }
-    output_files.clear();
 
     return true;
 }

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -4,7 +4,8 @@ local b = require('plugins.blueprint')
 function test.parse_gui_commandline()
     local opts = {}
     b.parse_gui_commandline(opts, {})
-    expect.table_eq({auto_phase=true, split_strategy='none', name='blueprint'},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint'},
                     opts)
 
     opts = {}
@@ -13,38 +14,56 @@ function test.parse_gui_commandline()
 
     opts = {}
     b.parse_gui_commandline(opts, {'--help'})
-    expect.table_eq({help=true}, opts)
+    expect.table_eq({help=true, format='minimal', split_strategy='none'}, opts)
 
     opts = {}
     b.parse_gui_commandline(opts, {'-h'})
-    expect.table_eq({help=true}, opts)
+    expect.table_eq({help=true, format='minimal', split_strategy='none'}, opts)
 
     opts = {}
     mock.patch(dfhack.maps, 'isValidTilePos', mock.func(true),
                function()
                    b.parse_gui_commandline(opts, {'--cursor=1,2,3'})
                end)
-    expect.table_eq({auto_phase=true, split_strategy='none', name='blueprint',
-                     start={x=1,y=2,z=3}},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', start={x=1,y=2,z=3}},
                     opts)
 
     opts = {}
+    b.parse_gui_commandline(opts, {'-fminimal'})
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint'},
+                    opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'--format', 'pretty'})
+    expect.table_eq({auto_phase=true, format='pretty', split_strategy='none',
+                     name='blueprint'},
+                    opts)
+
+    opts = {}
+    expect.error_match('unknown format',
+                       function() b.parse_gui_commandline(opts, {'-ffoo'}) end)
+
+    opts = {}
     b.parse_gui_commandline(opts, {'-tnone'})
-    expect.table_eq({auto_phase=true, split_strategy='none', name='blueprint'},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint'},
                     opts)
 
     opts = {}
     b.parse_gui_commandline(opts, {'--splitby', 'phase'})
-    expect.table_eq({auto_phase=true, split_strategy='phase', name='blueprint'},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='phase',
+                     name='blueprint'},
                     opts)
 
     opts = {}
-    expect.error_match('unknown split strategy',
+    expect.error_match('unknown split_strategy',
                        function() b.parse_gui_commandline(opts, {'-tfoo'}) end)
 
     opts = {}
     b.parse_gui_commandline(opts, {'imaname'})
-    expect.table_eq({auto_phase=true, split_strategy='none',
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
                      name='imaname'},
                     opts)
 
@@ -54,8 +73,8 @@ function test.parse_gui_commandline()
 
     opts = {}
     b.parse_gui_commandline(opts, {'imaname', 'dig', 'query'})
-    expect.table_eq({auto_phase=false, split_strategy='none', name='imaname',
-                     dig=true, query=true},
+    expect.table_eq({auto_phase=false, format='minimal', split_strategy='none',
+                     name='imaname', dig=true, query=true},
                     opts)
 
     opts = {}
@@ -67,44 +86,44 @@ end
 function test.parse_commandline()
     local opts = {}
     b.parse_commandline(opts, '1', '2')
-    expect.table_eq({auto_phase=true, split_strategy='none', name='blueprint',
-                     width=1, height=2, depth=1},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', width=1, height=2, depth=1},
                     opts)
 
     opts = {}
     b.parse_commandline(opts, '1', '2', '3')
-    expect.table_eq({auto_phase=true, split_strategy='none', name='blueprint',
-                     width=1, height=2, depth=3},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', width=1, height=2, depth=3},
                     opts)
 
     opts = {}
     b.parse_commandline(opts, '1', '2', '-3')
-    expect.table_eq({auto_phase=true, split_strategy='none', name='blueprint',
-                     width=1, height=2, depth=-3},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', width=1, height=2, depth=-3},
                     opts)
 
     opts = {}
     b.parse_commandline(opts, '1', '2', 'imaname')
-    expect.table_eq({auto_phase=true, split_strategy='none', name='imaname',
-                     width=1, height=2, depth=1},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='imaname', width=1, height=2, depth=1},
                     opts)
 
     opts = {}
     b.parse_commandline(opts, '1', '2', '10imaname')
-    expect.table_eq({auto_phase=true, split_strategy='none', name='10imaname',
-                     width=1, height=2, depth=1},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='10imaname', width=1, height=2, depth=1},
                     opts, 'invalid depth is considered a basename')
 
     opts = {}
     b.parse_commandline(opts, '1', '2', '-10imaname')
-    expect.table_eq({auto_phase=true, split_strategy='none', name='-10imaname',
-                     width=1, height=2, depth=1},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='-10imaname', width=1, height=2, depth=1},
                     opts, 'invalid negative depth is considered a basename')
 
     opts = {}
     b.parse_commandline(opts, '1', '2', '3', 'imaname')
-    expect.table_eq({auto_phase=true, split_strategy='none', name='imaname',
-                     width=1, height=2, depth=3},
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='imaname', width=1, height=2, depth=3},
                     opts)
 
     opts = {}

--- a/test/quickfort/ecosystem.lua
+++ b/test/quickfort/ecosystem.lua
@@ -158,6 +158,7 @@ local function get_test_area(area, spec)
             area.width, area.height, area.depth =
                     spec.width, spec.height, spec.depth
             area.pos = {x=1, y=1, z=z_start}
+            area.endpos = {x=area.width, y=area.height, z=z_start-area.depth+1}
             return true
         end
         ::continue::
@@ -223,6 +224,10 @@ local function reset_area(area, spec)
     dfhack.run_command('tiletypes-here', '--quiet', get_cursor_arg(pos))
 end
 
+local function format_pos(pos)
+    return ('%s,%s,%s'):format(pos.x, pos.y, pos.z)
+end
+
 function test.end_to_end()
     -- read in test plan
     local sets = get_blueprint_sets()
@@ -249,7 +254,8 @@ function test.end_to_end()
         end
 
         -- run dig-now to dig out designated tiles
-        dfhack.run_command('dig-now', '--clean')
+        dfhack.run_command('dig-now', format_pos(area.pos),
+                           format_pos(area.endpos), '--clean')
 
         -- quickfort run remaining blueprints
         for _,mode_name in pairs(mode_names) do

--- a/test/quickfort/ecosystem.lua
+++ b/test/quickfort/ecosystem.lua
@@ -194,7 +194,7 @@ local function run_blueprint(basename, set, pos)
                             tostring(set.spec.height),
                             tostring(-set.spec.depth),
                             output_dir..basename, get_cursor_arg(pos),
-                            '-tphase'}
+                            '-tphase', '-fpretty'}
     for _,mode_name in pairs(mode_names) do
         if set.modes[mode_name] then table.insert(blueprint_args, mode_name) end
     end
@@ -249,7 +249,7 @@ function test.end_to_end()
         end
 
         -- run dig-now to dig out designated tiles
-        dfhack.run_command('dig-now')
+        dfhack.run_command('dig-now', '--clean')
 
         -- quickfort run remaining blueprints
         for _,mode_name in pairs(mode_names) do


### PR DESCRIPTION
Part of milestone 2 of #1842

Add the ability to output in either "pretty" format (equivalent to the old behavior) or "minimal" format (the new default). Minimal blueprints don't include any annotations or "shadows" of building footprints, but are much faster to read and write. This allows us to optimize for the use case where a player is generating blueprints to play back later without manual editing. More advanced users that want to edit the generated blueprints should continue to use "pretty" format.

I am confident that there was no behavior change for "pretty" blueprints since the `quickfort` `ecosystem` integration/regression tests continue to pass without modification. I did make a few modifications to the `ecosystem` test harness to make it more efficient, but I did not need to change any of the golden regression test files.

This PR involved rewriting the core `blueprint` data structures and algorithm to allow the plugin to support multiple output formats. The new data structures will also support features planned for future milestones. My first attempt used sparse `std::map`s and `std::string`s for all data, but that ended up being much slower than the old implementation and, more importantly, ran out of memory and crashed on larger maps.

My second attempt used sparse `std::map`s and `const char *`, which significantly cut down on runtime, but was still too memory hungry. This was actually not as complex as I feared since pointers to string literals in the code can be passed up the stack without having to dynamically copy them into the heap. I did implement a static cache for the few strings that were constructed on the stack so that the pointers would be valid when returned from functions.

My third attempt used sparse `std::map`s for the higher-level `z` and `y` coordinate structures but a pre-allocated `std::vector` for the `x` coordinate structure (the one that actually held the `const char *` pointers). This was the key that brought both the runtime and memory utilization down below the original implementation.

Testing on a 16x16 embark for maximum scale (that's 768 by 768 by 198 = 116 million tiles), I get the following numbers:

old implementation: 18s, 1.1G memory
new implementation, pretty format: 17s, 0.6G memory
new implementation, minimal format: 8s, 0.6G memory

The difference in runtime between the new pretty and minimal formats is mostly due to I/O.

I did a further experiment using only `std::vector`s and no maps at all. This brought the runtime down by one second for the minimal format, but memory utilization stayed the same. However, it significantly complicated the code and required a lot of manual indexing and careful memory management. I decided that a 1 second savings on a 16x16 embark is just not worth the complexity cost. For the common, non-pathological case, the blueprint area will be much smaller and runtime will be near-instantaneous. I don't need to optimize for more speed. I'm satisfied that the new data structures have half the memory footprint of the old data structures, and I am confident that anything that worked before will continue to work.

The test is a little biased because most of the map was solid wall, which incurs a memory cost for the old implementation but is zero cost for the new implementation (we now only allocate memory if we have something to store). If the entire map were hollowed out then the new implementation would likely be on par with the memory consumption of the old algorithm.

I will be continuing to make significant structural changes to the `blueprint` plugin in the upcoming weeks and months, so I don't want to spend your time on a review quite yet. Perhaps if we get close to releasing a new version of DFHack, or once meta blueprints are implemented in milestone 5, whichever comes first.