### PR TITLE
[blueprint] implement --playback-start parameter

### DIFF
--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -46,12 +46,13 @@ selected interactively with the ``blueprint gui`` command or, if the GUI is not
 used, starts at the active cursor location and extends right and down for the
 requested width and height.
 
-Usage::
+**Usage:**
 
-    blueprint <width> <height> [<depth>] [<name> [<phases>]] [<options>]
-    blueprint gui [<name> [<phases>]] [<options>]
+    ``blueprint <width> <height> [<depth>] [<name> [<phases>]] [<options>]``
 
-Examples:
+    ``blueprint gui [<name> [<phases>]] [<options>]``
+
+**Examples:**
 
 ``blueprint gui``
     Runs `gui/blueprint`, the interactive frontend, where all configuration for
@@ -68,7 +69,7 @@ Examples:
     the blueprint start coordinate is set to a specific value instead of using
     the in-game cursor position.
 
-Positional Parameters:
+**Positional Parameters:**
 
 :``width``:   Width of the area (in tiles) to translate.
 :``height``:  Height of the area (in tiles) to translate.
@@ -80,7 +81,7 @@ Positional Parameters:
     string must contain some characters other than numbers so the name won't be
     confused with the optional ``depth`` parameter.
 
-Phases:
+**Phases:**
 
 If you want to generate blueprints only for specific phases, add their names to
 the commandline, anywhere after the blueprint base name. You can list multiple
@@ -94,36 +95,45 @@ phases; just separate them with a space.
 
 If no phases are specified, all blueprints are created.
 
-Options:
+**Options:**
 
-:``-c``, ``--cursor <x>,<y>,<z>``:
+``-c``, ``--cursor <x>,<y>,<z>``:
     Use the specified map coordinates instead of the current cursor position for
     the upper left corner of the blueprint range. If this option is specified,
     then an active game map cursor is not necessary.
-:``-f``, ``--format <format>``:
-    Select the output format of the generated files. See the ``Output Formats``
+``-f``, ``--format <format>``:
+    Select the output format of the generated files. See the ``Output formats``
     section below for options. If not specified, the output format defaults to
     "minimal", which will produce a small, fast ``.csv`` file.
-:``-h``, ``--help``:
+``-h``, ``--help``:
     Show command help text.
-:``-t``, ``--splitby <strategy>``:
+``-s``, ``--playback-start <x>,<y>,<comment>``:
+    Specify the column and row offsets (relative to the upper-left corner of the
+    blueprint, which is ``1,1``) where the player should put the cursor when the
+    blueprint is played back with `quickfort`, in
+    `quickfort start marker <quickfort-start>` format, for example:
+    ``10,10,central stairs``. If there is a space in the comment, you will need
+    to surround the parameter string in double quotes: ``"-s10,10,central stairs"`` or
+    ``--playback-start "10,10,central stairs"`` or
+    ``"--playback-start=10,10,central stairs"``.
+``-t``, ``--splitby <strategy>``:
     Split blueprints into multiple files. See the ``Splitting output into
     multiple files`` section below for details. If not specified, defaults to
     "none", which will create a standard quickfort
     `multi-blueprint <quickfort-packaging>` file.
 
-Output formats:
+**Output formats:**
 
 Here are the values that can be passed to the ``--format`` flag:
 
-:minimal:
+:``minimal``:
     Creates ``.csv`` files with minimal file size that are fast to read and
     write. This is the default.
-:pretty:
+:``pretty``:
     Makes the blueprints in the ``.csv`` files easier to read and edit with a text
     editor by adding extra spacing and alignment markers.
 
-Splitting output into multiple files:
+**Splitting output into multiple files:**
 
 The ``--splitby`` flag can take any of the following values:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - `automaterial`: ensure construction tiles are laid down in order when using `buildingplan` to plan the constructions
 - `blueprint`: all blueprint phases are now written to a single file, using `quickfort` multi-blueprint file syntax. to get the old behavior of each phase in its own file, pass the ``--splitby=phase`` parameter to ``blueprint``
+- `blueprint`: you can now specify the position where the cursor should be when the blueprint is played back with `quickfort` by passing the ``--playback-start`` parameter
 - `blueprint`: generated blueprints now have labels so `quickfort` can address them by name
 
 # 0.47.05-r3

--- a/docs/guides/quickfort-user-guide.rst
+++ b/docs/guides/quickfort-user-guide.rst
@@ -757,6 +757,8 @@ be "2" if it is not otherwise set, etc. Labels that are explicitly defined must
 start with a letter to ensure the auto-generated labels don't conflict with
 user-defined labels.
 
+.. _quickfort-start:
+
 Start positions
 ```````````````
 
@@ -786,6 +788,9 @@ to the ``masonw`` blueprint above could look like this::
 
    #meta start(center of workshop) a mason workshop
    /masonw
+
+You can use semicolons, commas, or spaces to separate the elements of the
+``start()`` marker, whatever is most convenient.
 
 .. _quickfort-hidden:
 

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -88,12 +88,14 @@ local function parse_start(opts, args)
     local x, y = tonumber(x_str), tonumber(y_str)
     if not is_positive_int(x) or not is_positive_int(y) then
         qerror(('playback start offsets must be positive integers: "%s", "%s"')
-               :format(x_str, y_str))
+               :format(x_str or '', y_str or ''))
     end
 
     if not opts.playback_start then opts.playback_start = {} end
-    opts.playback_start.x, opts.start.y = x, y
-    opts.playback_start_comment = table.concat(arg_list, ', ')
+    opts.playback_start.x, opts.playback_start.y = x, y
+    if #arg_list > 0 then
+        opts.playback_start_comment = table.concat(arg_list, ', ')
+    end
 end
 
 local function parse_split_strategy(opts, strategy)

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -41,9 +41,8 @@ function test.parse_gui_commandline()
                      name='blueprint'},
                     opts)
 
-    opts = {}
     expect.error_match('unknown format',
-                       function() b.parse_gui_commandline(opts, {'-ffoo'}) end)
+                       function() b.parse_gui_commandline({}, {'-ffoo'}) end)
 
     opts = {}
     b.parse_gui_commandline(opts, {'-tnone'})
@@ -52,14 +51,37 @@ function test.parse_gui_commandline()
                     opts)
 
     opts = {}
+    b.parse_gui_commandline(opts, {'--playback-start', '2,3,imacomment'})
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', playback_start={x=2, y=3},
+                     playback_start_comment='imacomment'},
+                    opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'-s2,3'})
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', playback_start={x=2, y=3}},
+                    opts)
+
+    expect.error_match('must be positive integers',
+                       function() b.parse_gui_commandline({}, {'-s10'}) end)
+    expect.error_match('must be positive integers',
+                       function() b.parse_gui_commandline({}, {'-s1,-1'}) end)
+    expect.error_match('must be positive integers',
+                       function() b.parse_gui_commandline({}, {'-s-1,1'}) end)
+    expect.error_match('must be positive integers',
+                       function() b.parse_gui_commandline({}, {'-s1,0'}) end)
+    expect.error_match('must be positive integers',
+                       function() b.parse_gui_commandline({}, {'-s0,1'}) end)
+
+    opts = {}
     b.parse_gui_commandline(opts, {'--splitby', 'phase'})
     expect.table_eq({auto_phase=true, format='minimal', split_strategy='phase',
                      name='blueprint'},
                     opts)
 
-    opts = {}
     expect.error_match('unknown split_strategy',
-                       function() b.parse_gui_commandline(opts, {'-tfoo'}) end)
+                       function() b.parse_gui_commandline({}, {'-tfoo'}) end)
 
     opts = {}
     b.parse_gui_commandline(opts, {'imaname'})
@@ -67,9 +89,8 @@ function test.parse_gui_commandline()
                      name='imaname'},
                     opts)
 
-    opts = {}
     expect.error_match('invalid basename',
-                       function() b.parse_gui_commandline(opts, {''}) end)
+                       function() b.parse_gui_commandline({}, {''}) end)
 
     opts = {}
     b.parse_gui_commandline(opts, {'imaname', 'dig', 'query'})
@@ -77,10 +98,9 @@ function test.parse_gui_commandline()
                      name='imaname', dig=true, query=true},
                     opts)
 
-    opts = {}
     expect.error_match('unknown phase',
                        function() b.parse_gui_commandline(
-                                        opts, {'imaname', 'garbagephase'}) end)
+                                        {}, {'imaname', 'garbagephase'}) end)
 end
 
 function test.parse_commandline()
@@ -126,35 +146,31 @@ function test.parse_commandline()
                      name='imaname', width=1, height=2, depth=3},
                     opts)
 
-    opts = {}
     expect.error_match('invalid width or height',
-                       function() b.parse_commandline(opts) end,
+                       function() b.parse_commandline({}) end,
                        'missing width')
-
-    opts = {}
     expect.error_match('invalid width or height',
-                       function() b.parse_commandline(opts, '10') end,
+                       function() b.parse_commandline({}, '10') end,
                        'missing height')
-
-    opts = {}
     expect.error_match('invalid width or height',
-                       function() b.parse_commandline(opts, '0') end,
+                       function() b.parse_commandline({}, '0') end,
                        'zero height')
-
-    opts = {}
     expect.error_match('invalid width or height',
-                       function() b.parse_commandline(opts, 'hi') end,
+                       function() b.parse_commandline({}, 'hi') end,
                        'invalid width')
-
-    opts = {}
     expect.error_match('invalid width or height',
-                       function() b.parse_commandline(opts, '10', 'hi') end,
+                       function() b.parse_commandline({}, '10', 'hi') end,
                        'invalid height')
-
-    opts = {}
     expect.error_match('invalid depth',
-                       function() b.parse_commandline(opts, '1', '2', '0') end,
+                       function() b.parse_commandline({}, '1', '2', '0') end,
                        'zero depth')
+
+    expect.error_match('x offset outside width of blueprint',
+                       function() b.parse_commandline(
+                                {}, '3', '2', '1', '-s4,1') end)
+    expect.error_match('y offset outside height of blueprint',
+                       function() b.parse_commandline(
+                                {}, '3', '2', '1', '-s1,3') end)
 end
 
 function test.do_phase_positive_dims()


### PR DESCRIPTION
part of milestone 2 for #1842

allows the cursor offset to be specified for when the blueprint is played back with quickfort, corresponding to the [start marker](https://docs.dfhack.org/en/latest/docs/guides/quickfort-user-guide.html#start-positions) in the quickfort modeline.

also reformat docs. parameter syntax help was being split over multiple lines, making it difficult to read.