### PR TITLE
[Core] Print the names of executed init scripts to console and stderr

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `tailor`: fixed some inconsistencies (and possible crashes) when parsing certain subcommands, e.g. ``tailor help``
 
 ## Misc Improvements
+- Core: DFHack now prints the name of the init script it is running to the console and stderr
 - `automaterial`: ensure construction tiles are laid down in order when using `buildingplan` to plan the constructions
 - `blueprint`: all blueprint phases are now written to a single file, using `quickfort` multi-blueprint file syntax. to get the old behavior of each phase in its own file, pass the ``--splitby=phase`` parameter to ``blueprint``
 - `blueprint`: you can now specify the position where the cursor should be when the blueprint is played back with `quickfort` by passing the ``--playback-start`` parameter

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1400,13 +1400,15 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
 
 bool Core::loadScriptFile(color_ostream &out, string fname, bool silent)
 {
-    if(!silent)
-        out << "Loading script at " << fname << std::endl;
+    if(!silent) {
+        out << "Loading script: " << fname << std::endl;
+        cerr << "Loading script: " << fname << std::endl;
+    }
     ifstream script(fname.c_str());
     if ( !script.good() )
     {
         if(!silent)
-            out.printerr("Error loading script\n");
+            out.printerr("Error loading script: %s\n", fname.c_str());
         return false;
     }
     string command;
@@ -1449,7 +1451,7 @@ static void run_dfhack_init(color_ostream &out, Core *core)
     if (!count || !Filesystem::isfile("dfhack.init"))
     {
         core->runCommand(out, "gui/no-dfhack-init");
-        core->loadScriptFile(out, "dfhack.init-example", true);
+        core->loadScriptFile(out, "dfhack.init-example", false);
     }
 }
 
@@ -2161,7 +2163,10 @@ size_t loadScriptFiles(Core* core, color_ostream& out, const vector<std::string>
     size_t result = 0;
     for ( size_t a = 0; a < scriptFiles.size(); a++ ) {
         result++;
-        core->loadScriptFile(out, folder + "/" + scriptFiles[a], true);
+        std::string path = "";
+        if (folder != ".")
+            path = folder + "/";
+        core->loadScriptFile(out, path + scriptFiles[a], false);
     }
     return result;
 }
@@ -2228,12 +2233,11 @@ void Core::handleLoadAndUnloadScripts(color_ostream& out, state_change_event eve
         {
             if (!it->save_specific)
             {
-                if (!loadScriptFile(out, it->path, true))
-                    out.printerr("Could not load script: %s\n", it->path.c_str());
+                loadScriptFile(out, it->path, false);
             }
             else if (it->save_specific && isWorldLoaded())
             {
-                loadScriptFile(out, rawFolder + it->path, true);
+                loadScriptFile(out, rawFolder + it->path, false);
             }
         }
     }


### PR DESCRIPTION
Fixes #1776

This allows players to figure out where autorun commands are coming from, which is especially useful when an init script is doing something you don't expect and you need to figure out which one to edit.

Logging capability was already in `Core.cpp`, it was just turned off when executing most init scripts. This PR turns it on and adds logging to stderr. Also, to normalize the appearance of the script names, `./` path prefixes (which appear on some init script paths but not others) are not printed.

The names are logged to both the console and stderr since script output goes to the console and the script invocation log is in `stderr.out`.