### PR TITLE
[argparse] add support for standalone long-form params in processArgsGetopt()

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -44,6 +44,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `blueprint`: generated blueprints now have labels so `quickfort` can address them by name
 - `quickfort`, `dfhack-examples-guide`: Dreamfort blueprint set improvements based on playtesting and feedback. includes updated profession definitions.
 
+## Lua
+- ``argparse.processArgsGetopt()``: you can now have long form parameters that are not an alias for a short form parameter. For example, you can now have a parameter like ``--longparam`` without needing to have an equivalent one-letter ``-l`` param.
+
 # 0.47.05-r3
 
 ## New Plugins

--- a/library/lua/argparse.lua
+++ b/library/lua/argparse.lua
@@ -75,12 +75,13 @@ end
 -- as positional parameters and returned in the nonoptions list.
 --
 -- optionActions is a vector with elements in the following format:
--- {shortOptionName, longOptionAlias, hasArg=boolean, handler=fn}
+--   {shortOptionName, longOptionAlias, hasArg=boolean, handler=fn}
 -- shortOptionName and handler are required. If the option takes an argument,
 -- it will be passed to the handler function.
 -- longOptionAlias is optional.
 -- hasArg defaults to false.
--- to have an option that has only a long form, pass '' as the shortOptionName.
+-- To have an option that has only a long form, pass nil or '' as the
+-- shortOptionName.
 --
 -- example usage:
 --
@@ -101,16 +102,21 @@ function processArgsGetopt(args, optionActions)
     local handlers = {}
     for _,optionAction in ipairs(optionActions) do
         local sh_opt,long_opt = optionAction[1], optionAction[2]
-        -- sh_opt can be zero-length if long_opt is specified
-        if not sh_opt or type(sh_opt) ~= 'string'  or
-                (#sh_opt ~= 1 and not (#sh_opt == 0 and long_opt)) then
+        if sh_opt and (type(sh_opt) ~= 'string'  or #sh_opt > 1) then
             error('option letter not found')
         end
         if long_opt and (type(long_opt) ~= 'string' or #long_opt == 0) then
             error('long option name must be a string with length >0')
         end
+        if not sh_opt then
+            sh_opt = ''
+        end
+        if not long_opt and #sh_opt == 0 then
+            error('at least one of sh_opt and long_opt must be specified')
+        end
         if not optionAction.handler then
-            error(string.format('handler missing for option "%s"', sh_opt))
+            error(string.format('handler missing for option "%s"',
+                                #sh_opt > 0 and sh_opt or long_opt))
         end
         if #sh_opt > 0 then
             sh_opts = sh_opts .. sh_opt

--- a/test/library/argparse.lua
+++ b/test/library/argparse.lua
@@ -58,16 +58,22 @@ function test.processArgsGetopt_happy_path()
 end
 
 function test.processArgsGetopt_action_errors()
-    expect.error_match('missing option letter',
+    expect.error_match('option letter not found',
         function()
             argparse.processArgsGetopt({}, {{handler=function() end}})
         end)
 
-    expect.error_match('missing option letter',
+    expect.error_match('option letter not found',
         function() argparse.processArgsGetopt({}, {{'notoneletter'}}) end)
 
-    expect.error_match('missing option letter',
+    expect.error_match('option letter not found',
         function() argparse.processArgsGetopt({}, {{function() end}}) end)
+
+    expect.error_match('long option name',
+        function() argparse.processArgsGetopt({}, {{'', ''}}) end)
+
+    expect.error_match('long option name',
+        function() argparse.processArgsGetopt({}, {{'a', ''}}) end)
 
     expect.error_match('handler missing',
         function() argparse.processArgsGetopt({}, {{'r'}}) end)
@@ -105,6 +111,15 @@ function test.processArgsGetopt_parsing_errors()
                                       handler=function() end}})
                        end,
                        'fail to pass value to long param that requires one')
+end
+
+function test.processArgsGetopt_long_opt_without_short_opt()
+    local var = false
+    local nonoptions = argparse.processArgsGetopt(
+                            {'--long'},
+                            {{'', 'long', handler=function() var = true end}})
+    expect.true_(var)
+    expect.table_eq({}, nonoptions)
 end
 
 function test.stringList()

--- a/test/library/argparse.lua
+++ b/test/library/argparse.lua
@@ -58,7 +58,7 @@ function test.processArgsGetopt_happy_path()
 end
 
 function test.processArgsGetopt_action_errors()
-    expect.error_match('option letter not found',
+    expect.error_match('at least one of sh_opt and long_opt',
         function()
             argparse.processArgsGetopt({}, {{handler=function() end}})
         end)
@@ -71,6 +71,9 @@ function test.processArgsGetopt_action_errors()
 
     expect.error_match('long option name',
         function() argparse.processArgsGetopt({}, {{'', ''}}) end)
+
+    expect.error_match('long option name',
+        function() argparse.processArgsGetopt({}, {{nil, ''}}) end)
 
     expect.error_match('long option name',
         function() argparse.processArgsGetopt({}, {{'a', ''}}) end)
@@ -118,6 +121,13 @@ function test.processArgsGetopt_long_opt_without_short_opt()
     local nonoptions = argparse.processArgsGetopt(
                             {'--long'},
                             {{'', 'long', handler=function() var = true end}})
+    expect.true_(var)
+    expect.table_eq({}, nonoptions)
+
+    var = false
+    nonoptions = argparse.processArgsGetopt(
+                    {'--long'},
+                    {{nil, 'long', handler=function() var = true end}})
     expect.true_(var)
     expect.table_eq({}, nonoptions)
 end


### PR DESCRIPTION
Implement handling for long form parameters that are not an alias for a short form parameter. For example, you can now have a parameter like `--longparam` without needing to have an equivalent one-letter `-l` param.

This is useful for esoteric parameters that you don't want to waste a precious one-letter param on.