### PR TITLE
[dwarfmode.lua] allow enterSidebarMode() to switch to the designate menu

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -46,6 +46,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - ``argparse.processArgsGetopt()``: you can now have long form parameters that are not an alias for a short form parameter. For example, you can now have a parameter like ``--longparam`` without needing to have an equivalent one-letter ``-l`` param.
+- ``dwarfmode.enterSidebarMode()``: ``df.ui_sidebar_mode.DesignateMine`` is now a suported target sidebar mode
 
 # 0.47.05-r3
 

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -20,6 +20,7 @@ refreshSidebar = dfhack.gui.refreshSidebar
 -- current screen is 'dwarfmode/Default'
 SIDEBAR_MODE_KEYS = {
     [df.ui_sidebar_mode.Default]='',
+    [df.ui_sidebar_mode.DesignateMine]='D_DESIGNATE',
     [df.ui_sidebar_mode.QueryBuilding]='D_BUILDJOB',
     [df.ui_sidebar_mode.LookAround]='D_LOOK',
     [df.ui_sidebar_mode.BuildingItems]='D_BUILDITEM',


### PR DESCRIPTION
this is useful for gui scripts that want to show dig designations, such as @drummeur's `trackify.lua` script