### PR TITLE
[blueprint] support multi-type and non-rectangular stockpiles

### DIFF
--- a/data/blueprints/library/test/ecosystem/in/allstockpiles-dig.csv
+++ b/data/blueprints/library/test/ecosystem/in/allstockpiles-dig.csv
@@ -1,0 +1,12 @@
+#dig label(dig)
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d
+d,d,d,d,d,d,d,d,d,d,d,d

--- a/data/blueprints/library/test/ecosystem/in/allstockpiles-place.csv
+++ b/data/blueprints/library/test/ecosystem/in/allstockpiles-place.csv
@@ -1,0 +1,12 @@
+#place label(place)
+a(2x2),,f(2x2),,u(2x2),,n(2x2),,y(2x2),,r(2x2)
+
+s(2x2),,w(2x2),,e(2x2),,b(2x2),,h(2x2),,l(2x2)
+
+z(2x2),,S(2x2),,g(2x2),,p(2x2),,d(2x2),,afunyrswebhlzSgpd(2x2)
+
+a,a,g,g,a,,,g,l,w,s,a
+a,,,g,a,a,g,g,w,w,s,a
+u,u,u,,,,,,s,s,s,a
+u,z,u,,,,,,a,a,a,a
+u,u,u

--- a/data/blueprints/library/test/ecosystem/in/allstockpiles-spec.csv
+++ b/data/blueprints/library/test/ecosystem/in/allstockpiles-spec.csv
@@ -1,0 +1,4 @@
+#notes
+description=all the stockpiles, including multi-type
+width=12
+height=11

--- a/data/blueprints/library/test/ecosystem/in/basic-place.csv
+++ b/data/blueprints/library/test/ecosystem/in/basic-place.csv
@@ -1,4 +1,4 @@
 #place label(place)
 
 
-,f(1x1),,f(1x1)
+,f,,f

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -44,6 +44,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `blueprint`: you can now specify the position where the cursor should be when the blueprint is played back with `quickfort` by passing the ``--playback-start`` parameter
 - `blueprint`: generated blueprints now have labels so `quickfort` can address them by name
 - `blueprint`: all building types are now supported
+- `blueprint`: multi-type and non-rectangular stockpiles are now supported
 - `dig-now`: no longer leaves behind a designated tile when a tile was designated beneath a tile designated for channeling
 - `quickfort`, `dfhack-examples-guide`: Dreamfort blueprint set improvements based on playtesting and feedback. includes updated profession definitions.
 


### PR DESCRIPTION
Member of milestone 3 of #1842

also adds integration tests that ensure the generated blueprints can be applied correctly by quickfort.