### PR TITLE
[blueprint] don't produce empty blueprints for action-less phases

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -45,6 +45,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `blueprint`: generated blueprints now have labels so `quickfort` can address them by name
 - `blueprint`: all building types are now supported
 - `blueprint`: multi-type and non-rectangular stockpiles are now supported
+- `blueprint`: blueprints are no longer generated for phases that have nothing to do (unless those phases are explicitly enabled on the commandline or gui)
 - `dig-now`: no longer leaves behind a designated tile when a tile was designated beneath a tile designated for channeling
 - `quickfort`, `dfhack-examples-guide`: Dreamfort blueprint set improvements based on playtesting and feedback. includes updated profession definitions.
 

--- a/test/quickfort/ecosystem.lua
+++ b/test/quickfort/ecosystem.lua
@@ -192,15 +192,9 @@ local function designate_area(pos, spec)
 end
 
 local function run_blueprint(basename, set, pos)
-    local blueprint_args = {tostring(set.spec.width),
-                            tostring(set.spec.height),
-                            tostring(-set.spec.depth),
-                            output_dir..basename, get_cursor_arg(pos),
-                            '-tphase'}
-    for _,mode_name in pairs(mode_names) do
-        if set.modes[mode_name] then table.insert(blueprint_args, mode_name) end
-    end
-    blueprint.run(table.unpack(blueprint_args))
+    blueprint.run(tostring(set.spec.width), tostring(set.spec.height),
+                  tostring(-set.spec.depth), output_dir..basename,
+                  get_cursor_arg(pos), '-tphase')
 end
 
 local function reset_area(area, spec)


### PR DESCRIPTION
completes milestone 3 of #1842 

prevents a blueprint from being written unless there is data to write or the phase was explicitly requested on the commandline/gui.

adjusts the ecosystem integration tests to make use of the feature.