### PR TITLE
cache zones so Buildings::findCivzonesAt() is O(1) instead of O(N)

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `quickfort-library-guide`: added pump stack blueprints (with step-by-step usage guide) to the quickfort blueprint library
 - `quickfort`: Dreamfort blueprint set improvements: added iron and flux stock level indicators on the industry level
 
+## API
+- ``Buildings::findCivzonesAt()``: lookups now complete in constant time instead of linearly scanning through all civzones in the game
+
 ## Lua
 - ``argparse.processArgsGetopt()``: you can now have long form parameters that are not an alias for a short form parameter. For example, you can now have a parameter like ``--longparam`` without needing to have an equivalent one-letter ``-l`` param.
 - ``dwarfmode.enterSidebarMode()``: ``df.ui_sidebar_mode.DesignateMine`` is now a suported target sidebar mode

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -102,6 +102,7 @@ struct CoordHash {
 };
 
 static unordered_map<df::coord, int32_t, CoordHash> locationToBuilding;
+static unordered_map<df::coord, vector<int32_t>, CoordHash> locationToCivzones;
 
 static df::building_extents_type *getExtentTile(df::building_extents &extent, df::coord2d tile)
 {
@@ -305,20 +306,97 @@ df::building *Buildings::findAtTile(df::coord pos)
     return NULL;
 }
 
-bool Buildings::findCivzonesAt(std::vector<df::building_civzonest*> *pvec, df::coord pos)
-{
+static unordered_map<int32_t, df::coord> corner1;
+static unordered_map<int32_t, df::coord> corner2;
+static void cacheBuilding(df::building *building) {
+    int32_t id = building->id;
+    bool is_civzone = !building->isSettingOccupancy();
+    df::coord p1(min(building->x1, building->x2), min(building->y1,building->y2), building->z);
+    df::coord p2(max(building->x1, building->x2), max(building->y1,building->y2), building->z);
+
+    if (!is_civzone) {
+        // civzones can be dynamically shrunk so we don't bother to cache
+        // their boundaries. findCivzonesAt() will trim the cache as needed.
+        corner1[id] = p1;
+        corner2[id] = p2;
+    }
+
+    for (int32_t x = p1.x; x <= p2.x; x++) {
+        for (int32_t y = p1.y; y <= p2.y; y++) {
+            df::coord pt(x, y, building->z);
+            if (Buildings::containsTile(building, pt, is_civzone)) {
+                if (is_civzone)
+                    locationToCivzones[pt].push_back(id);
+                else
+                    locationToBuilding[pt] = id;
+            }
+        }
+    }
+}
+
+static int32_t nextCivzone = 0;
+static void cacheNewCivzones() {
+    if (!world || !building_next_id)
+        return;
+
+    int32_t nextBuildingId = *building_next_id;
+    for (int32_t id = nextCivzone; id < nextBuildingId; ++id) {
+        auto &vec = world->buildings.other[buildings_other_id::ANY_ZONE];
+        int32_t idx = df::building::binsearch_index(vec, id);
+        if (idx > -1)
+            cacheBuilding(vec[idx]);
+    }
+    nextCivzone = nextBuildingId;
+}
+
+bool Buildings::findCivzonesAt(std::vector<df::building_civzonest*> *pvec,
+                               df::coord pos) {
     pvec->clear();
 
-    auto &vec = world->buildings.other[buildings_other_id::ANY_ZONE];
+    // Tiles have an occupancy->bits.building flag to quickly determine if it is
+    // covered by a buildling, but there is no such flag for civzones.
+    // Therefore, we need to make sure that our cache is authoratative.
+    // Otherwise, we would have to fall back to linearly scanning the list of
+    // all civzones on a cache miss.
+    //
+    // Since we guarantee our cache contains *at least* all tiles that are
+    // currently covered by civzones, we can conclude that if a tile is not in
+    // the cache, there is no civzone there. Civzones *can* be dynamically
+    // shrunk, so we still need to verify that civzones that once covered this
+    // tile continue to cover this tile.
+    cacheNewCivzones();
 
-    for (size_t i = 0; i < vec.size(); i++)
-    {
-        auto bld = strict_virtual_cast<df::building_civzonest>(vec[i]);
+    auto civzones_it = locationToCivzones.find(pos);
+    if (civzones_it == locationToCivzones.end())
+        return false;
 
-        if (!bld || bld->z != pos.z || !containsTile(bld, pos))
+    set<int32_t> ids_to_remove;
+    auto &civzones = civzones_it->second;
+    for (int32_t id : civzones) {
+        int32_t idx = df::building::binsearch_index(
+                world->buildings.other[buildings_other_id::ANY_ZONE], id);
+        df::building_civzonest *civzone = NULL;
+        if (idx > -1)
+            civzone = world->buildings.other.ANY_ZONE[idx];
+        if (!civzone || civzone->z != pos.z ||
+                !containsTile(civzone, pos, true)) {
+            ids_to_remove.insert(id);
             continue;
+        }
+        pvec->push_back(civzone);
+    }
 
-        pvec->push_back(bld);
+    // civzone no longer occupies this tile; update the cache
+    if (!ids_to_remove.empty()) {
+        for (auto it = civzones.begin(); it != civzones.end(); ) {
+            if (ids_to_remove.count(*it)) {
+                it = civzones.erase(it);
+                continue;
+            }
+            ++it;
+        }
+        if (civzones.empty())
+            locationToCivzones.erase(pos);
     }
 
     return !pvec->empty();
@@ -1218,47 +1296,29 @@ bool Buildings::markedForRemoval(df::building *bld)
     return false;
 }
 
-static unordered_map<int32_t, df::coord> corner1;
-static unordered_map<int32_t, df::coord> corner2;
-
 void Buildings::clearBuildings(color_ostream& out) {
     corner1.clear();
     corner2.clear();
     locationToBuilding.clear();
+    locationToCivzones.clear();
+    nextCivzone = 0;
 }
 
-void Buildings::updateBuildings(color_ostream& out, void* ptr)
+void Buildings::updateBuildings(color_ostream&, void* ptr)
 {
     int32_t id = (int32_t)(intptr_t)ptr;
     auto building = df::building::find(id);
 
     if (building)
     {
-        // Already cached -> weird, so bail out
-        if (corner1.count(id))
-            return;
-        // Civzones cannot be cached because they can
-        // overlap each other and normal buildings.
-        if (!building->isSettingOccupancy())
-            return;
-
-        df::coord p1(min(building->x1, building->x2), min(building->y1,building->y2), building->z);
-        df::coord p2(max(building->x1, building->x2), max(building->y1,building->y2), building->z);
-
-        corner1[id] = p1;
-        corner2[id] = p2;
-
-        for ( int32_t x = p1.x; x <= p2.x; x++ ) {
-            for ( int32_t y = p1.y; y <= p2.y; y++ ) {
-                df::coord pt(x,y,building->z);
-                if (containsTile(building, pt, false))
-                    locationToBuilding[pt] = id;
-            }
-        }
+        if (!corner1.count(id))
+            cacheBuilding(building);
     }
     else if (corner1.count(id))
     {
-        //existing building: destroy it
+        // existing building: destroy it
+        // note that civzones are lazy-destroyed in findCivzonesAt() and are
+        // not handled here
         df::coord p1 = corner1[id];
         df::coord p2 = corner2[id];
 


### PR DESCRIPTION
tl;dr: This PR allows `Buildings::findCivzonesAt()` to execute in amortized constant time. The memory cost is proportional to the combined area of all civzones, but is not significant compared to the total memory usage of DF+DFHack.

Long version:
The `blueprint` plugin recently acquired the ability to create `#zone` blueprints to record the layout of civzones in a map area. When scanning for zones, `blueprint` will call `Buildings::findCivzonesAt()` for each tile in the transcription area. Each call to `findCivzonesAt()` has to scan every civzone in the game since there is no way to directly look up which civzones cover which tiles. This isn't so slow when the number of civzones is very small, but as the player allocates more civzones, the algorithm starts to crawl. With thousands of civzones, `blueprint` runtime goes from 200 milliseconds to more than 2 minutes! This also affects `quickfort` since it scans tiles for civzones in `#query` and `#zone` modes.

We can get our runtime back to 200 milliseconds by caching civzone locations in a hashmap so lookups are O(1) instead of O(N) in the total number of civzones. We do something similar for buildings so that `Buildings::findAtTile()` can return in constant time instead of linearly scanning through all buildings in the game. However, there are a few critical differences between buildings and civzones that make civzones more difficult to cache:

1. multiple civzones can overlap the same tile
2. civzone boundaries can be mutated without destroying and recreating the civzone
3. tiles have a flag that indicate whether there is a building covering the tile. there is no such flag for civzones.

We can address (1) by hashing a position to a vector of IDs (not a set, since we want to maintain the order so we know which is the "top" zone) instead of just an ID like the building cache does. We will have to do a linear walk of the vector, but we expect that vector to be much much smaller than the list of all civzones.

(2) is trickier. If civzones could be dynamically expanded, a cache would be useless since we'd always need to double check to see if a tile is newly covered by an existing civzone. Luckily, civzones can only be dynamically shrunk: tiles can be removed from a civzone, but new tiles cannot be added to an existing civzone. We can scan newly created civzones to cache their tiles, and when there is a cache hit, we can just verify that the civzones that we *think* cover that tile still cover that tile. If it turns out that a civzone no longer covers that tile, the cache can be updated at lookup time to reflect the new knowledge.

(3) is the kicker. Tiles have a flag that tracks whether any building covers the tile. If it is false, there is no need to scan the buildings list, since you already know you won't find anything. This allows the building cache to be best-effort without much loss in performance. Specifically, the building cache is updated by the `EventManager` module every 100 ticks. If a call is made to `findAtTile()` before the cache is updated, and the tile flag is true but the cache does not contain the target building ID, you *know* you need to do a linear scan to look for the building. If the flag is false, you can just skip it and not pay any performance penalty.

If we were to take the same approach for civzones, however, we would not be able to differentiate the absence of a civzone from a missing cache entry, so we would *always* need to do a full linear scan. And even if we get a cache hit, we can't be sure that our vector of ids is complete and we'd need to do a scan there too. In order to guarantee an O(1) lookup, civzones need an authoritative cache that guarantees a cache hit means all civzone ids that cover the tile are known, and a cache miss means there are exactly 0 civzones that cover the tile.

My first attempt at an authoritative cache involved forcing `EventManager` to fire `BUILDING` events immediately whenever a civzone was created. I tried two strategies to get this to work. First, I created a `forceEvent(etype)` API for `EventManager` and called it from places where buildings are created (e.g. `Buildings::constructAbstract()`). This caused a lot of events to fire when a large number of buildlings were created, which was inefficient. Moreover, it didn't catch civzones created manually via the DF UI.

My second attempt was to schedule the `BUILDING` event to fire on every tick. This was also inefficient, and also didn't catch the case where a civzone was created and then queried *without unpausing* (i.e. between ticks), which is a common case when running `quickfort`.

I concluded that `EventManager` was not suitable for my needs. However, I took note of how `EventManager` scans for new buildings, and I realized that if I could run that algorithm whenever `findCivzonesAt()` is called, then I could guarantee that all new civzones would be known to the cache before we attempted a lookup. I could also still use the `EventManager` events to keep the cache kinda up to date so `findCivzonesAt()` wouldn't have too much catch-up to do at any one time.

So the final implementation here is a degenerate form of the `EventManager` algorithm that just scans for new civzones. As mentioned in (2), we don't care about civzone deletion since we'll pick that up when we look at the tiles that it used to cover.

Testing has shown the code in this PR to work as advertised, but my understanding of zones may be incomplete. Feedback is welcomed.

Incidentally, I think there is a bug in the interaction between the `EventManager` `BUILDING` event and the building cache. If a planned-but-as-yet-unconstructed building is canceled and another building is built in the same spot, and both actions happen between `EventManager` `BUILDING` events, I believe the building cache will become inconsistent. This happens because `EventManager` reports both removed and newly built buildings in the same event, but it reports the new ones before the removed ones. This causes the building cache to ignore the new building (since it thinks it already has a building in that spot cached), but then it clears the cache at that position when it gets notified of the removed building. I believe we can fix this by reporting removed buildings before new ones in the `BUILDING` event, but I haven't investigated this fully yet, and I don't know if anything relies on the current ordering.

Also, we could modify the building cache to update itself in `findAtTile()` like this PR does for civzones. This would allow the building cache to be useful for buildings that have been created since the last `BUILDING` event.