### PR TITLE
Fix crash in tiletypes

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `blueprint`: fixed passing incorrect parameters to `gui/blueprint` when you run ``blueprint gui`` with optional params
 - `blueprint`: key sequences for constructed walls and down stairs are now correct
 - `tailor`: fixed some inconsistencies (and possible crashes) when parsing certain subcommands, e.g. ``tailor help``
+- `tiletypes-here`, `tiletypes-here-point`: fix crash when running from an unsuspended core context
 
 ## Misc Improvements
 - Core: DFHack now prints the name of the init script it is running to the console and stderr

--- a/plugins/tiletypes.cpp
+++ b/plugins/tiletypes.cpp
@@ -1093,6 +1093,8 @@ static bool get_options(color_ostream &out,
 
 command_result df_tiletypes_here (color_ostream &out, vector <string> & parameters)
 {
+    CoreSuspender suspend;
+
     tiletypes_options opts;
     if (!get_options(out, opts, parameters) || opts.help)
     {
@@ -1112,6 +1114,8 @@ command_result df_tiletypes_here (color_ostream &out, vector <string> & paramete
 
 command_result df_tiletypes_here_point (color_ostream &out, vector <string> & parameters)
 {
+    CoreSuspender suspend;
+
     tiletypes_options opts;
     if (!get_options(out, opts, parameters) || opts.help)
     {


### PR DESCRIPTION
The code path was fine when run from another script, but crashed when run from the DFHack command line. The issue was that the code required a suspended core, but we never explicitly suspended. It was fine when run from another script because being in a script implied the core was already suspended.