### PR TITLE
dig-now: handle carving fortifications

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `luasocket` (and others): return correct status code when closing socket connections
 
 ## Misc Improvements
+- `dig-now`: handle fortification carving
 - `EventManager`: add new event type ``JOB_STARTED``, triggered when a job first gains a worker
 - `EventManager`: add new event type ``NEW_UNIT_ACTIVE``, triggered when a new unit appears on the active list
 - `EventManager`: now each registered handler for an event can have its own frequency instead of all handlers using the lowest frequency of all handlers

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -497,8 +497,19 @@ static bool smooth_tile(color_ostream &out, MapExtras::MapCache &map,
                         const DFCoord &pos) {
     df::tiletype tt = map.tiletypeAt(pos);
 
+    df::tiletype_shape shape = tileShape(tt);
+    df::tiletype_variant variant = tileVariant(tt);
+    df::tiletype_special special = df::tiletype_special::SMOOTH;
+
     TileDirection tdir;
-    if (tileShape(tt) == df::tiletype_shape::WALL) {
+    if (is_smooth_wall(map, pos)) {
+        // engraving is filtered out at a higher level, so this is a
+        // fortification designation
+        shape = tiletype_shape::FORTIFICATION;
+        variant = df::tiletype_variant::NONE;
+        special = df::tiletype_special::NONE;
+    }
+    else if (shape == df::tiletype_shape::WALL) {
         if (adjust_smooth_wall_dir(map, DFCoord(pos.x, pos.y-1, pos.z),
                                    TileDirection(0, 1, 0, 0)))
             tdir.north = 1;
@@ -514,8 +525,7 @@ static bool smooth_tile(color_ostream &out, MapExtras::MapCache &map,
         tdir = ensure_valid_tdir(tdir);
     }
 
-    tt = findTileType(tileShape(tt), tileMaterial(tt), tileVariant(tt),
-                      df::tiletype_special::SMOOTH, tdir);
+    tt = findTileType(shape, tileMaterial(tt), variant, special, tdir);
     if (tt == df::tiletype::Void)
         return false;
 


### PR DESCRIPTION
I originally missed this because fortifications are indicated by the "smooth" field, not the dig designation field.

I would add this to the quickfort ecosystem tests, but `blueprint` will need some work first to properly support fortifications. see https://github.com/DFHack/dfhack/issues/1842#issuecomment-1065964099