### PR TITLE
update Windows build docs for Visual C++ 2015

### DIFF
--- a/docs/Authors.rst
+++ b/docs/Authors.rst
@@ -193,4 +193,5 @@ Will Rogers             wjrogers
 ZechyW                  ZechyW
 Zhentar                 Zhentar
 zilpin                  zilpin
+Zishi Wu                zishiwu123
 ======================= ======================= ===========================

--- a/docs/Compile.rst
+++ b/docs/Compile.rst
@@ -485,11 +485,54 @@ other versions won't work against Dwarf Fortress due to ABI and STL incompatibil
 
 You can install Visual Studio 2015_ or 2017_ Community edition for free, which
 include all the features needed by DFHack. You can also download just the
-`build tools`_ if you aren't going to use Visual Studio to edit code.
+Visual C++ 2015 `build tools`_ if you aren't going to use Visual Studio to edit code.
+
+Option 1: Build Tools Only
+++++++++++++++++++++++++++
+Click `build tools`_ and you will be prompted to login to your Microsoft account.
+Then you should be redirected to a page with various download options with 2015
+in their name. If this redirect doesn't occur, just copy, paste, and enter the
+download link again and you should see the options. You need to get:
+Visual C++ Build Tools for Visual Studio 2015 with Update 3.
+Click the download button next to it and a dropdown of download formats will appear.
+Select the DVD format to download an ISO file. When the donwload is complete,
+click on the ISO file and a folder will popup with the following contents:
+
+* packages (folder)
+* VCPlusPlusBuildTools2015Update3_x64_Files.cat
+* VisualCppBuildTools_Full.exe
+
+The packages folder contains the dependencies that are required by the build tools.
+These include:
+
+* Microsoft .NET Framework 4.6.1 Developer Pack
+* Microsoft Visual C++ 2015 Redistributable (x64) - 14.0.24210
+* Windows 10 Universal SDK - 10.0.10240
+* Windows 8.1 SDK
+
+Click VisualCppBuildTools_Full.exe and use the default options provided by the installer
+wizard that appears. After the installation is completed, add the path where MSBuild.exe
+was installed to your PATH environment variable. The path should be:
+
+* ``C:\Program Files (x86)\MSBuild\14.0\Bin``
+
+Option 2: IDE + Build Tools
++++++++++++++++++++++++++++
+Click Visual Studio 2015_ or 2017_ to download an installer wizard that will prompt you
+to select the optional tools you want to download alongside the IDE. If you are not sure
+what options to check, it can be helpful to download the `build tools`_ and open the
+ISO file to see the required dependencies in the packages folder. For Visual Studio 2017,
+it is important to select the v140 build tools option. DFHack requires v140 and not
+the v141 version that comes in a bundle when you click the Desktop Development with C++
+option from the installer.
+
+.. warning::
+  Do not run the build tools installer together with the Visual Studio installer as they
+  will have conflicts with each other by trying to install the same dependencies.
 
 .. _2015: https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2015-and-other-products
 .. _2017: https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15
-.. _build tools: https://visualstudio.microsoft.com/vs/older-downloads/#microsoft-build-tools-2015-update-3
+.. _build tools: https://my.visualstudio.com/Downloads?q=visual%20studio%202015&wt.mc_id=o~msft~vscom~older-downloads
 
 Additional dependencies: installing with the Chocolatey Package Manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -94,6 +94,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``argparse.processArgsGetopt()``: you can now have long form parameters that are not an alias for a short form parameter. For example, you can now have a parameter like ``--longparam`` without needing to have an equivalent one-letter ``-l`` param.
 - ``dwarfmode.enterSidebarMode()``: ``df.ui_sidebar_mode.DesignateMine`` is now a suported target sidebar mode
 
+## Documentation
+- Updated download link and installation instructions for Visual C++ 2015 build tools on Windows
+
 ## Removed
 - `fortplan`: please use `quickfort` instead
 


### PR DESCRIPTION
Related to #1743 but for Visual C++ 2015 build tools, not Visual Studio IDE 2017-19. Enhancement to Windows build documentation.

**Before PR**
Windows build docs for Visual C++ 2015 previously instructed users who wanted to only download build tools to use [this link](https://visualstudio.microsoft.com/vs/older-downloads/#microsoft-build-tools-2015-update-3). However, downloading Microsoft Build Tools 2015 Update 3 option from that link is not enough. The installer wizard will fail and display and error message about missing dependencies without explicitly telling the user what was missing.

**After PR**
[Old link](https://visualstudio.microsoft.com/vs/older-downloads/#microsoft-build-tools-2015-update-3) has been replaced with a [new link](https://my.visualstudio.com/Downloads?q=visual%20studio%202015&wt.mc_id=o~msft~vscom~older-downloads) to download the Visual C++ Build Tools for Visual Studio 2015 with Update 3. The user only needs to login to their Microsoft account to access the downloads. The [Windows build tools documetation](https://github.com/DFHack/dfhack/blob/develop/docs/Compile.rst#microsoft-visual-studio-2015) has also been updated with instructions for users to download the build tools ISO file from new link because:
- The installer wizard inside the ISO file contains all the dependencies required by MSBuild v14.0, the version required by DFHack. Dependencies include:
  - Microsoft .NET Framework 4.6.1 Developer Pack
  - Microsoft Visual C++ 2015 Redistributable (x64) - 14.0.24210
  - Windows 10 Universal SDK - 10.0.10240
  - Windows 8.1 SDK
- The installer wizard is straightforward as the user only needs to stick to the default options and click next.
- Users who prefer getting the build tools as part of the Visual Studio IDE installations can still benefit from checking the dependencies listed in the build tools ISO file. It informs them what optional tools must be installed with the IDE to ensure that MSBuild v14.0 has all its dependencies met.

**Notes**
- I was unable to build DFHack for win64 until I changed the `build\win64\generate-MSVC-<options>.bat` files to use `v140` instead of `v140_xp` as [mentioned here](https://github.com/DFHack/dfhack/issues/1518#issuecomment-620938952). Then I was able to run `generate-MSVC-minimal.bat` and build DFHack.
- I was able to build DFHack for win32 using `v140_xp`.
- I found it easier to download just the build tools (v140) rather than download the Visual Studio IDE + build tools together. The build tools only was the only setup that worked for me, but [some people](https://github.com/DFHack/dfhack/issues/1518#issuecomment-622132767) have reported better luck with installing Visual Studio IDE + build tools together. Here are the 3 setups listed below:
  - Visual C++ 2015 build tools only
  - VS 2015 IDE + build tools (got ISO file for it from same link as the build tools only)
  - VS 2017 IDE + build tools (got from [here](https://my.visualstudio.com/Downloads?q=visual%20studio%202017&wt.mc_id=o~msft~vscom~older-downloads))
- The VS 2015 IDE installer also came in the form of an ISO file, but it was very slow to install and even slower to remove. It installed random things into my computer for mobile development and SQL Server, which I had to manually remove some folders because the installer wizard did not delete these folders even though I specified everything to be removed. It might be because I clicked the Windows 8.1 SDK option, which came with mobile app development tools. I saw that was a dependencies in the build tools only ISO file; hence why I clicked that option.
- The VS 2017 IDE installer downloaded MSBuild v15.0 which did not allow me to build because DFHack requires MSBuild v14.0. Here is the path to the MSBuild integrated with VS 2017 IDE: `C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin`.

**Suggestions**:
- Update the `build\win64\generate-MSVC-<options>.bat` files to use `v140` instead of `v140_xp` as this error has already been reported in #1518. Not sure how many users of DFHack are running Windows XP as their main gaming platform. But I don't think there are enough that we need to have backwards compatibility with Windows XP at the cost of not being able to build for Windows 10. This opinion only applies to win64.
- [Some people](https://github.com/DFHack/dfhack/issues/1518#issuecomment-753334092) and are able to install newer versions of Visual Studio IDE (e.g. 2019) along with older build tools (MSBuild v14.0 which corresponds to the `v140` flag). But if someone does not already have VS2015 installed as [mentioned here](https://github.com/DFHack/dfhack/issues/1743#issuecomment-1068496970), I would advise them to install just the build tools like I did.