### PR TITLE
Reword the titles of the various guides

### DIFF
--- a/docs/guides/examples-guide.rst
+++ b/docs/guides/examples-guide.rst
@@ -1,6 +1,6 @@
 .. _dfhack-examples-guide:
 
-DFHack Example Configuration File Guide
+DFHack Example Configuration File Index
 =======================================
 
 The :source:`hack/examples <data/examples>` folder contains ready-to-use

--- a/docs/guides/quickfort-alias-guide.rst
+++ b/docs/guides/quickfort-alias-guide.rst
@@ -1,7 +1,7 @@
 .. _quickfort-alias-guide:
 
-Quickfort Alias Guide
-=====================
+Quickfort Keystroke Alias Guide
+===============================
 
 Aliases allow you to use simple words to represent complicated key sequences
 when configuring buildings and stockpiles in quickfort ``#query`` blueprints.

--- a/docs/guides/quickfort-library-guide.rst
+++ b/docs/guides/quickfort-library-guide.rst
@@ -1,6 +1,6 @@
 .. _quickfort-library-guide:
 
-Quickfort Library Guide
+Blueprint Library Index
 =======================
 
 This guide contains a high-level overview of the blueprints available in the

--- a/docs/guides/quickfort-user-guide.rst
+++ b/docs/guides/quickfort-user-guide.rst
@@ -1,8 +1,8 @@
 .. _quickfort-user-guide:
 .. _quickfort-blueprint-guide:
 
-Quickfort Blueprint Guide
-=========================
+Quickfort Blueprint Editing Guide
+=================================
 
 `Quickfort <quickfort>` is a DFHack script that helps you build fortresses from
 "blueprint" .csv and .xlsx files. Many applications exist to edit these files,


### PR DESCRIPTION
So they are more distinct. Even I got confused about the difference between the quickfort library guide (which is about blueprints, but listing the pre-made onces) and the quickfort blueprint guide (which is about blueprints, but editing them)

The file paths and anchor names are unchanged, so current internal and external links still work.