### PR TITLE
[confirm] Fix typo in help message

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Lua API.rst added: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
 - Update download link and installation instructions for Visual C++ 2015 build tools on Windows
 - Updated information regarding obtaining a compatible Windows build environment
+- `confirm`: Correct the command name in the plugin help text
 
 ## API
 - Added functions reverse-engineered from ambushing unit code: ``Units::isHidden``, ``Units::isFortControlled``, ``Units::getOuterContainerRef``, ``Items::getOuterContainerRef``

--- a/plugins/confirm.cpp
+++ b/plugins/confirm.cpp
@@ -492,8 +492,8 @@ DFhackCExport command_result plugin_init (color_ostream &out, vector <PluginComm
         df_confirm,
         false, //allow non-interactive use
 
-        "  confirmation enable|disable option|all ...\n"
-        "  confirmation help|status\n"
+        "  confirm enable|disable option|all ...\n"
+        "  confirm help|status\n"
     ));
     return CR_OK;
 }


### PR DESCRIPTION
The command is called `confirm`, not `confirmation`.