### PR TITLE
[manipulator] Tweak colors to make cursor easier to locate

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `gui/create-item`: Added "(chain)" annotation text for armours with the [CHAIN_METAL_TEXT] flag set
 - DFHack log messages now have configurable headers (e.g. timestamp, origin plugin name, etc.) via the ``debugfilter`` command of the `debug` plugin
 - Script execution log messages (e.g. "Loading script: dfhack_extras.init" can now be controlled with the ``debugfilter`` command. To hide the messages, add this line to your ``dfhack.init`` file: ``debugfilter set Warning core script``
+- `manipulator`: Tweak colors to make the cursor easier to locate
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -2083,7 +2083,10 @@ void viewscreen_unitlaborsst::render()
                 }
             }
             else
+            {
+                fg = COLOR_WHITE;
                 bg = COLOR_CYAN;
+            }
             if ((col_offset == sel_column) && (row_offset == sel_row))
             {
                 fg = is_labor_set ? COLOR_WHITE : COLOR_GREY;

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -2052,11 +2052,10 @@ void viewscreen_unitlaborsst::render()
         for (int col = 0; col < col_widths[DISP_COLUMN_LABORS]; col++)
         {
             int col_offset = col + first_column;
-            fg = 15;
-            bg = 0;
+            bool is_labor_set = columns[col_offset].labor != unit_labor::NONE;
+            fg = COLOR_WHITE;
+            bg = COLOR_BLACK;
             uint8_t c = 0xFA;
-            if ((col_offset == sel_column) && (row_offset == sel_row))
-                fg = 9;
             if (columns[col_offset].skill != job_skill::NONE)
             {
                 df::unit_skill *skill = NULL;
@@ -2072,17 +2071,22 @@ void viewscreen_unitlaborsst::render()
                 else
                     c = '-';
             }
-            if (columns[col_offset].labor != unit_labor::NONE)
+            if (is_labor_set)
             {
                 if (unit->status.labors[columns[col_offset].labor])
                 {
-                    bg = 7;
+                    bg = COLOR_GREY;
                     if (columns[col_offset].skill == job_skill::NONE)
                         c = 0xF9;
                 }
             }
             else
-                bg = 3;
+                bg = COLOR_CYAN;
+            if ((col_offset == sel_column) && (row_offset == sel_row))
+            {
+                fg = is_labor_set ? COLOR_BLUE : COLOR_GREY;
+                bg = COLOR_WHITE;
+            }
             Screen::paintTile(Screen::Pen(c, fg, bg), col_offsets[DISP_COLUMN_LABORS] + col, 4 + row);
         }
     }

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -2052,7 +2052,7 @@ void viewscreen_unitlaborsst::render()
         for (int col = 0; col < col_widths[DISP_COLUMN_LABORS]; col++)
         {
             int col_offset = col + first_column;
-            bool is_labor_set = columns[col_offset].labor != unit_labor::NONE;
+            bool is_labor_set = false;
             fg = COLOR_WHITE;
             bg = COLOR_BLACK;
             uint8_t c = 0xFA;
@@ -2071,10 +2071,11 @@ void viewscreen_unitlaborsst::render()
                 else
                     c = '-';
             }
-            if (is_labor_set)
+            if (columns[col_offset].labor != unit_labor::NONE)
             {
                 if (unit->status.labors[columns[col_offset].labor])
                 {
+                    is_labor_set = true;
                     bg = COLOR_GREY;
                     if (columns[col_offset].skill == job_skill::NONE)
                         c = 0xF9;

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -2052,8 +2052,8 @@ void viewscreen_unitlaborsst::render()
         for (int col = 0; col < col_widths[DISP_COLUMN_LABORS]; col++)
         {
             int col_offset = col + first_column;
-            bool is_labor_set = false;
-            fg = COLOR_WHITE;
+            //bool is_labor_set = false;
+            fg = COLOR_GREY;
             bg = COLOR_BLACK;
             uint8_t c = 0xFA;
             if (columns[col_offset].skill != job_skill::NONE)
@@ -2075,18 +2075,20 @@ void viewscreen_unitlaborsst::render()
             {
                 if (unit->status.labors[columns[col_offset].labor])
                 {
-                    is_labor_set = true;
-                    bg = COLOR_GREY;
+                    //is_labor_set = true;
+                    //fg = COLOR_BLACK;
+                    fg = COLOR_WHITE;
+                    bg = COLOR_BLUE;
                     if (columns[col_offset].skill == job_skill::NONE)
                         c = 0xF9;
                 }
             }
             else
-                bg = COLOR_CYAN;
+                bg = COLOR_BROWN;
             if ((col_offset == sel_column) && (row_offset == sel_row))
             {
-                bg = is_labor_set ? COLOR_LIGHTBLUE : COLOR_WHITE;
-                fg = COLOR_BLACK;
+                fg = COLOR_YELLOW; //is_labor_set ? COLOR_LIGHTBLUE : COLOR_BLACK;
+                //bg = is_labor_set ? COLOR_GREY : COLOR_LIGHTCYAN;
             }
             Screen::paintTile(Screen::Pen(c, fg, bg), col_offsets[DISP_COLUMN_LABORS] + col, 4 + row);
         }

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -2085,8 +2085,8 @@ void viewscreen_unitlaborsst::render()
                 bg = COLOR_CYAN;
             if ((col_offset == sel_column) && (row_offset == sel_row))
             {
-                fg = is_labor_set ? COLOR_BLUE : COLOR_GREY;
-                bg = COLOR_WHITE;
+                bg = is_labor_set ? COLOR_LIGHTBLUE : COLOR_WHITE;
+                fg = COLOR_BLACK;
             }
             Screen::paintTile(Screen::Pen(c, fg, bg), col_offsets[DISP_COLUMN_LABORS] + col, 4 + row);
         }

--- a/plugins/manipulator.cpp
+++ b/plugins/manipulator.cpp
@@ -2052,7 +2052,7 @@ void viewscreen_unitlaborsst::render()
         for (int col = 0; col < col_widths[DISP_COLUMN_LABORS]; col++)
         {
             int col_offset = col + first_column;
-            //bool is_labor_set = false;
+            bool is_labor_set = false;
             fg = COLOR_GREY;
             bg = COLOR_BLACK;
             uint8_t c = 0xFA;
@@ -2075,20 +2075,19 @@ void viewscreen_unitlaborsst::render()
             {
                 if (unit->status.labors[columns[col_offset].labor])
                 {
-                    //is_labor_set = true;
-                    //fg = COLOR_BLACK;
+                    is_labor_set = true;
                     fg = COLOR_WHITE;
-                    bg = COLOR_BLUE;
+                    bg = COLOR_GREY;
                     if (columns[col_offset].skill == job_skill::NONE)
                         c = 0xF9;
                 }
             }
             else
-                bg = COLOR_BROWN;
+                bg = COLOR_CYAN;
             if ((col_offset == sel_column) && (row_offset == sel_row))
             {
-                fg = COLOR_YELLOW; //is_labor_set ? COLOR_LIGHTBLUE : COLOR_BLACK;
-                //bg = is_labor_set ? COLOR_GREY : COLOR_LIGHTCYAN;
+                fg = is_labor_set ? COLOR_WHITE : COLOR_GREY;
+                bg = is_labor_set ? COLOR_LIGHTBLUE : COLOR_BLUE;
             }
             Screen::paintTile(Screen::Pen(c, fg, bg), col_offsets[DISP_COLUMN_LABORS] + col, 4 + row);
         }


### PR DESCRIPTION
Use standout colors instead of just a darker foreground to indicate cursor position.

I spend half my time in manipulator jiggling the cursor around trying to spot it. This fixes that for me.