### PR TITLE
fix guidm.enterSidebarMode(DesignateMine)

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
+- ``dwarfmode.enterSidebarMode()``: passing ``df.ui_sidebar_mode.DesignateMine`` now always results in you entering ``DesignateMine`` mode and not ``DesignateChopTrees``, even when you looking at the surface where the default designation mode is ``DesignateChopTrees``
 
 # 0.47.05-r4
 

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -52,6 +52,13 @@ function enterSidebarMode(sidebar_mode, max_esc)
         if df.global.ui.main.mode == df.ui_sidebar_mode.Default and
                 focus_string == 'dwarfmode/Default' then
             if #navkey > 0 then gui.simulateInput(screen, navkey) end
+            if navkey == 'D_DESIGNATE' then
+                -- if the z-level happens to be on the surface, the mode will be
+                -- set to DesignateChopTrees. we need an extra step to get to
+                -- DesignateMine
+                gui.simulateInput(dfhack.gui.getCurViewscreen(true),
+                                 'DESIGNATE_DIG')
+            end
             return
         end
         gui.simulateInput(screen, 'LEAVESCREEN')


### PR DESCRIPTION
it would end up in `DesignateChopTrees` if you happened to be looking at the surface z-level.

this fixes a flaky test that checks the resulting mode for executing `guidm.enterSidebarMode()` with various parameters. the test would pass if you were underground and fail if you were on the surface.