### PR TITLE
Improves support for dfhack as a sub-project

### DIFF
--- a/CMake/DownloadFile.cmake
+++ b/CMake/DownloadFile.cmake
@@ -11,7 +11,7 @@ endfunction()
 
 function(search_downloads FILE_MD5 VAR)
     set(${VAR} "" PARENT_SCOPE)
-    file(GLOB FILES ${CMAKE_SOURCE_DIR}/CMake/downloads/*)
+    file(GLOB FILES ${dfhack_SOURCE_DIR}/CMake/downloads/*)
     foreach(FILE ${FILES})
         file(MD5 "${FILE}" CUR_MD5)
         if("${CUR_MD5}" STREQUAL "${FILE_MD5}")
@@ -53,7 +53,7 @@ function(download_file_unzip URL ZIP_TYPE ZIP_DEST ZIP_MD5 UNZIP_DEST UNZIP_MD5)
             message("* Decompressing ${FILENAME}")
             if("${ZIP_TYPE}" STREQUAL "gz")
                 execute_process(COMMAND
-                    "${PERL_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/depends/gunzip.pl"
+                    "${PERL_EXECUTABLE}" "${dfhack_SOURCE_DIR}/depends/gunzip.pl"
                     "${ZIP_DEST}" --force)
             else()
                 message(SEND_ERROR "Unknown ZIP_TYPE: ${ZIP_TYPE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if(HAVE_CUCHAR2)
 endif()
 
 # mixing the build system with the source code is ugly and stupid. enforce the opposite :)
-if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+if("${dfhack_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "In-source builds are not allowed.")
 endif()
 
@@ -264,7 +264,7 @@ include(CMake/DownloadFile.cmake)
 
 if(WIN32)
     # Download zlib on Windows
-    set(ZLIB_DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/depends/zlib/lib/win${DFHACK_BUILD_ARCH})
+    set(ZLIB_DOWNLOAD_DIR ${dfhack_SOURCE_DIR}/depends/zlib/lib/win${DFHACK_BUILD_ARCH})
     if(${DFHACK_BUILD_ARCH} STREQUAL "64")
         download_file("https://github.com/DFHack/dfhack-bin/releases/download/0.44.09/win64-zlib.lib"
             ${ZLIB_DOWNLOAD_DIR}/zlib.lib
@@ -277,14 +277,14 @@ if(WIN32)
 
     # Move zlib to the build folder so possible 32 and 64-bit builds
     # in the same source tree don't conflict
-    file(COPY ${CMAKE_SOURCE_DIR}/depends/zlib
+    file(COPY ${dfhack_SOURCE_DIR}/depends/zlib
         DESTINATION ${CMAKE_BINARY_DIR}/depends/)
     file(COPY ${ZLIB_DOWNLOAD_DIR}/zlib.lib
         DESTINATION ${CMAKE_BINARY_DIR}/depends/zlib/lib/)
 
     # Do the same for SDLreal.dll
     # (DFHack doesn't require this at build time, so no need to move it to the build folder)
-    set(SDLREAL_DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/package/windows/win${DFHACK_BUILD_ARCH})
+    set(SDLREAL_DOWNLOAD_DIR ${dfhack_SOURCE_DIR}/package/windows/win${DFHACK_BUILD_ARCH})
     if(${DFHACK_BUILD_ARCH} STREQUAL "64")
         download_file("https://github.com/DFHack/dfhack-bin/releases/download/0.44.09/win64-SDL.dll"
             ${SDLREAL_DOWNLOAD_DIR}/SDLreal.dll
@@ -299,7 +299,7 @@ endif()
 if(APPLE)
     # libstdc++ (GCC 4.8.5 for OS X 10.6)
     # fixes crash-on-unwind bug in DF's libstdc++
-    set(LIBSTDCXX_DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/package/darwin/osx${DFHACK_BUILD_ARCH})
+    set(LIBSTDCXX_DOWNLOAD_DIR ${dfhack_SOURCE_DIR}/package/darwin/osx${DFHACK_BUILD_ARCH})
 
     if(${GCC_VERSION_OUT} VERSION_LESS "4.9")
         set(LIBSTDCXX_GCC_VER "48")

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -242,7 +242,7 @@ add_custom_command(
     COMMAND protoc-bin -I=${CMAKE_CURRENT_SOURCE_DIR}/proto/
         --cpp_out=dllexport_decl=DFHACK_EXPORT:${CMAKE_CURRENT_SOURCE_DIR}/proto/tmp/
         ${PROJECT_PROTOS}
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_SOURCE_DIR}/depends/copy-if-different.pl
+    COMMAND ${PERL_EXECUTABLE} ${dfhack_SOURCE_DIR}/depends/copy-if-different.pl
         ${PROJECT_PROTO_TMP_FILES}
         ${CMAKE_CURRENT_SOURCE_DIR}/proto/
     COMMENT "Generating core protobufs"
@@ -341,15 +341,15 @@ if(DFHACK_PRERELEASE)
 endif()
 
 configure_file(git-describe.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/git-describe.cmake @ONLY)
-if(EXISTS ${CMAKE_SOURCE_DIR}/.git/index AND EXISTS ${CMAKE_SOURCE_DIR}/.git/modules/library/xml/index)
+if(EXISTS ${dfhack_SOURCE_DIR}/.git/index AND EXISTS ${dfhack_SOURCE_DIR}/.git/modules/library/xml/index)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/include/git-describe.h
     COMMAND ${CMAKE_COMMAND}
         -D dfhack_SOURCE_DIR:STRING=${dfhack_SOURCE_DIR}
         -D GIT_EXECUTABLE:STRING=${GIT_EXECUTABLE}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/git-describe.cmake
     COMMENT "Obtaining git commit information"
-    DEPENDS ${CMAKE_SOURCE_DIR}/.git/index
-        ${CMAKE_SOURCE_DIR}/.git/modules/library/xml/index
+    DEPENDS ${dfhack_SOURCE_DIR}/.git/index
+        ${dfhack_SOURCE_DIR}/.git/modules/library/xml/index
         ${CMAKE_CURRENT_SOURCE_DIR}/git-describe.cmake
         include/git-describe.h.in
     )

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -64,7 +64,7 @@ add_custom_command(
                        -I=${CMAKE_CURRENT_SOURCE_DIR}/proto/
             --cpp_out=${CMAKE_CURRENT_SOURCE_DIR}/proto/tmp/
             ${PROJECT_PROTOS}
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_SOURCE_DIR}/depends/copy-if-different.pl
+    COMMAND ${PERL_EXECUTABLE} ${dfhack_SOURCE_DIR}/depends/copy-if-different.pl
             ${PROJECT_PROTO_TMP_FILES}
             ${CMAKE_CURRENT_SOURCE_DIR}/proto/
     COMMENT "Generating plugin protobufs"

--- a/plugins/Plugins.cmake
+++ b/plugins/Plugins.cmake
@@ -94,7 +94,7 @@ macro(dfhack_plugin)
             COMMAND protoc-bin -I=${CMAKE_CURRENT_SOURCE_DIR}/proto/
                 --cpp_out=${CMAKE_CURRENT_SOURCE_DIR}/proto/tmp/
                 ${PLUGIN_PROTOS}
-            COMMAND ${PERL_EXECUTABLE} ${CMAKE_SOURCE_DIR}/depends/copy-if-different.pl
+            COMMAND ${PERL_EXECUTABLE} ${dfhack_SOURCE_DIR}/depends/copy-if-different.pl
                 ${PLUGIN_PROTO_TMP_FILES}
                 ${CMAKE_CURRENT_SOURCE_DIR}/proto/
             COMMENT "Generating plugin ${PLUGIN_NAME} protobufs"


### PR DESCRIPTION
Replaces `CMAKE_SOURCE_DIR` with `dfhack_SOURCE_DIR` in the cmake config chain