### PR TITLE
fix crash in eventful due to misaligned fn map

### DIFF
--- a/library/include/modules/EventManager.h
+++ b/library/include/modules/EventManager.h
@@ -17,6 +17,9 @@
 namespace DFHack {
     namespace EventManager {
         namespace EventType {
+            // NOTICE: keep this list synchronized with the eventHandlers array
+            // in plugins/eventful.cpp or else events will go to the wrong
+            // handlers.
             enum EventType {
                 TICK,
                 JOB_INITIATED,

--- a/plugins/eventful.cpp
+++ b/plugins/eventful.cpp
@@ -98,7 +98,7 @@ DEFINE_LUA_EVENT_NH_1(onBuildingCreatedDestroyed, int32_t);
 DEFINE_LUA_EVENT_NH_1(onJobInitiated, df::job*);
 DEFINE_LUA_EVENT_NH_1(onJobStarted, df::job*);
 DEFINE_LUA_EVENT_NH_1(onJobCompleted, df::job*);
-DEFINE_LUA_EVENT_NH_1(onNewUnitActive, int32_t);
+DEFINE_LUA_EVENT_NH_1(onUnitNewActive, int32_t);
 DEFINE_LUA_EVENT_NH_1(onUnitDeath, int32_t);
 DEFINE_LUA_EVENT_NH_1(onItemCreated, int32_t);
 DEFINE_LUA_EVENT_NH_1(onConstructionCreatedDestroyed, df::construction*);
@@ -126,7 +126,7 @@ DFHACK_PLUGIN_LUA_EVENTS {
     DFHACK_LUA_EVENT(onJobInitiated),
     DFHACK_LUA_EVENT(onJobStarted),
     DFHACK_LUA_EVENT(onJobCompleted),
-    DFHACK_LUA_EVENT(onNewUnitActive),
+    DFHACK_LUA_EVENT(onUnitNewActive),
     DFHACK_LUA_EVENT(onUnitDeath),
     DFHACK_LUA_EVENT(onItemCreated),
     DFHACK_LUA_EVENT(onSyndrome),
@@ -154,10 +154,10 @@ void ev_mng_jobCompleted(color_ostream& out, void* job)
     df::job* ptr=reinterpret_cast<df::job*>(job);
     onJobCompleted(out,ptr);
 }
-void ev_mng_newUnitActive(color_ostream& out, void* ptr)
+void ev_mng_unitNewActive(color_ostream& out, void* ptr)
 {
     int32_t myId=(int32_t)(intptr_t)ptr;
-    onNewUnitActive(out,myId);
+    onUnitNewActive(out,myId);
 }
 void ev_mng_unitDeath(color_ostream& out, void* ptr)
 {
@@ -222,11 +222,15 @@ static void ev_mng_interaction(color_ostream& out, void* ptr) {
 }
 std::vector<int> enabledEventManagerEvents(EventManager::EventType::EVENT_MAX,-1);
 typedef void (*handler_t) (color_ostream&,void*);
+
+// NOTICE: keep this list synchronized with the EventManager::EventType enum or
+// else the wrong event handlers will get called.
 static const handler_t eventHandlers[] = {
  NULL,
  ev_mng_jobInitiated,
  ev_mng_jobStarted,
  ev_mng_jobCompleted,
+ ev_mng_unitNewActive,
  ev_mng_unitDeath,
  ev_mng_itemCreate,
  ev_mng_building,


### PR DESCRIPTION
the EventManager got a new event type for new active units, but the handler for the event was not added to the array of handlers in `eventful` so the wrong handlers were being called for some events. In particular, the onUnload event was being sent to the wrong handler and was causing a crash when a map was unloaded.