### PR TITLE
[core] Debug logging facelift

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -41,6 +41,7 @@ using namespace std;
 #include "MemAccess.h"
 #include "Core.h"
 #include "DataDefs.h"
+#include "Debug.h"
 #include "Console.h"
 #include "MiscUtils.h"
 #include "Module.h"
@@ -101,6 +102,9 @@ static bool parseKeySpec(std::string keyspec, int *psym, int *pmod, std::string 
 size_t loadScriptFiles(Core* core, color_ostream& out, const vector<std::string>& prefix, const std::string& folder);
 
 namespace DFHack {
+
+DBG_DECLARE(core,script,DebugCategory::LINFO);
+
 class MainThread {
 public:
     //! MainThread::suspend keeps the main DF thread suspended from Core::Init to
@@ -1401,7 +1405,7 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
 bool Core::loadScriptFile(color_ostream &out, string fname, bool silent)
 {
     if(!silent) {
-        out << "Loading script: " << fname << std::endl;
+        INFO(script,out) << "Loading script: " << fname << std::endl;
         cerr << "Loading script: " << fname << std::endl;
     }
     ifstream script(fname.c_str());

--- a/library/Debug.cpp
+++ b/library/Debug.cpp
@@ -80,11 +80,11 @@ static color_value selectColor(const DebugCategory::level msgLevel)
 {
     switch(msgLevel) {
     case DebugCategory::LTRACE:
-        return COLOR_GREY;
+        return COLOR_BROWN;
     case DebugCategory::LDEBUG:
         return COLOR_LIGHTBLUE;
     case DebugCategory::LINFO:
-        return COLOR_CYAN;
+        return COLOR_GREY;
     case DebugCategory::LWARNING:
         return COLOR_YELLOW;
     case DebugCategory::LERROR:
@@ -113,31 +113,56 @@ DebugCategory::ostream_proxy_prefix::ostream_proxy_prefix(
         const DebugCategory::level msgLevel) :
     color_ostream_proxy(target)
 {
+    DebugManager &dm = DebugManager::getInstance();
+    const DebugManager::HeaderConfig &config = dm.getHeaderConfig();
+
     color(selectColor(msgLevel));
-    auto now = std::chrono::system_clock::now();
-    tm local{};
-    //! \todo c++ 2020 will have std::chrono::to_stream(fmt, system_clock::now())
-    //! but none implements it yet.
-    std::time_t now_c = std::chrono::system_clock::to_time_t(now);
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
-    // Output time in format %02H:%02M:%02S.%03ms
+
+    bool has_header = false;
+    if (config.timestamp) {
+        has_header = true;
+        auto now = std::chrono::system_clock::now();
+        tm local{};
+        //! \todo c++ 2020 will have std::chrono::to_stream(fmt, system_clock::now())
+        //! but none implements it yet.
+        std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+        // Output time in format %02H:%02M:%02S.%03ms
 #if __GNUC__ < 5
-    // Fallback for gcc 4
-    char buffer[32];
-    size_t sz = strftime(buffer, sizeof(buffer)/sizeof(buffer[0]),
-            "%T.", localtime_r(&now_c, &local));
-    *this << (sz > 0 ? buffer : "HH:MM:SS.")
+        // Fallback for gcc 4
+        char buffer[32];
+        size_t sz = strftime(buffer, sizeof(buffer)/sizeof(buffer[0]),
+                             "%T", localtime_r(&now_c, &local));
+        *this << (sz > 0 ? buffer : "HH:MM:SS");
 #else
-    *this << std::put_time(localtime_r(&now_c, &local),"%T.")
+        *this << std::put_time(localtime_r(&now_c, &local),"%T");
 #endif
-        << std::setfill('0') << std::setw(3) << ms.count()
+        if (config.timestamp_ms) {
+            auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    now.time_since_epoch()) % 1000;
+            *this << '.' << std::setfill('0') << std::setw(3) << ms.count();
+        }
+        *this << ':';
+    }
+    if (config.thread_id) {
+        has_header = true;
         // Thread id is allocated in the thread creation order to a thread_local
         // variable
-        << ":t" << thread_id
-        // Output plugin and category names to make it easier to locate where
-        // the message is coming. It would be easy replaces these with __FILE__
-        // and __LINE__ passed from the macro if that would be preferred prefix.
-        << ':' << cat.plugin() << ':' << cat.category() << ": ";
+        *this << 't' << thread_id << ':';
+    }
+    if (config.plugin) {
+        has_header = true;
+        *this << cat.plugin() << ':';
+    }
+    if (config.category) {
+        has_header = true;
+        *this << cat.category() << ':';
+    }
+    // It would be easy to pass __FILE__ and __LINE__ from the logging macros
+    // and include that information as well, if we want to.
+
+    if (has_header) {
+        *this << ' ';
+    }
 }
 
 

--- a/library/Debug.cpp
+++ b/library/Debug.cpp
@@ -83,14 +83,14 @@ static color_value selectColor(const DebugCategory::level msgLevel)
         return COLOR_BROWN;
     case DebugCategory::LDEBUG:
         return COLOR_LIGHTBLUE;
-    case DebugCategory::LINFO:
-        return COLOR_GREY;
     case DebugCategory::LWARNING:
         return COLOR_YELLOW;
     case DebugCategory::LERROR:
         return COLOR_LIGHTRED;
+    case DebugCategory::LINFO:
+    default:
+        return COLOR_RESET;
     }
-    return COLOR_WHITE;
 }
 
 #if __GNUC__

--- a/library/include/Debug.h
+++ b/library/include/Debug.h
@@ -31,17 +31,17 @@ redistribute it freely, subject to the following restrictions:
 namespace DFHack {
 
 /*! \file Debug.h
- * Light weight wrappers to runtime debug output filtering. Idea is to add as
- * little as possible code compared to debug output without filtering. The
+ * Light weight wrappers for runtime debug output filtering. The idea is to add
+ * as little as possible code compared to debug output without filtering. The
  * effect is archived using #TRACE, #DEBUG, #INFO, #WARN and #ERR macros. They
  * "return" color_ostream object or reference that can be then used normally for
  * either printf or stream style debug output.
  *
  * Internally macros do inline filtering check which allows compiler to have a
- * fast path without debug output only checking unlikely condition. But if
- * output is enabled then runtime code will jump to debug printing function
- * calls. The macro setup code will also print standardized leading part of
- * debug string including time stamp, plugin name and debug category name.
+ * fast path when output is disabled. However, if output is enabled then
+ * parameters are evaluated and the printing function is called. The macro setup
+ * code will also print a standard header for each log message, including
+ * timestamp, plugin name, and category name.
  *
  * \code{.cpp}
  * #include "Debug.h"
@@ -60,9 +60,9 @@ namespace DFHack {
  * }
  * \endcode
  *
- * The debug print filtering levels can be changed using debugger. Following
- * gdb example would automatically setup core/init and core/render to trace
- * level when SDL_init is called.
+ * The debug print filtering levels can be changed using a debugger. The
+ * following gdb example will automatically setup core/init and core/render to
+ * trace level when SDL_init is called.
  *
  * \code{.unparsed}
  * break SDL_init
@@ -101,8 +101,11 @@ namespace DFHack {
 //! \}
 
 #ifdef NDEBUG
-//! Reduce minimum compiled in debug levels if NDEBUG is defined
-#define DBG_FILTER DFHack::DebugCategory::LINFO
+/*!
+ * Reduce minimum compiled in debug levels if NDEBUG is defined. This is LDEBUG
+ * and not LINFO so users can usefully increase logging levels for bug reports.
+ */
+#define DBG_FILTER DFHack::DebugCategory::LDEBUG
 #else
 //! Set default compiled in debug levels to include all prints
 #define DBG_FILTER DFHack::DebugCategory::LTRACE
@@ -172,8 +175,7 @@ public:
         ostream_proxy_prefix(const DebugCategory& cat,
                 color_ostream& target,
                 DebugCategory::level level);
-        ~ostream_proxy_prefix()
-        {
+        ~ostream_proxy_prefix() {
             flush();
         }
     };
@@ -255,10 +257,10 @@ public:
 
 
 /*!
- * Declares a debug category. There must be only a declaration per category.
+ * Declares a debug category. There must be only one declaration per category.
  * Declaration should be in same plugin where it is used. If same category name
  * is used in core and multiple plugins they all are changed with same command
- * unless user specifies explicitly plugin name.
+ * unless user explicitly specifies a plugin name.
  *
  * Must be used in one translation unit only.
  *

--- a/library/include/DebugManager.h
+++ b/library/include/DebugManager.h
@@ -72,6 +72,15 @@ public:
         CAT_MODIFIED,
     };
 
+    //! Log message header configuration, controlled via the debug plugin
+    struct HeaderConfig {
+        bool timestamp = false;    // Hour, minute, and seconds
+        bool timestamp_ms = false; // only used if timestamp == true
+        bool thread_id = false;
+        bool plugin = false;
+        bool category = false;
+    };
+
     //! type to help access signal features like Connection and BlockGuard
     using categorySignal_t = Signal<void (signalType, DebugCategory&)>;
 
@@ -91,6 +100,16 @@ public:
         return instance;
     }
 
+    // don't bother to protect these with mutexes. we don't want to pay the
+    // performance cost of locking on every log message, and the consequences
+    // of race conditions are minimal.
+    const HeaderConfig & getHeaderConfig() const {
+        return headerConfig;
+    }
+    void setHeaderConfig(const HeaderConfig &config) {
+        headerConfig = config;
+    }
+
     //! Prevent copies
     DebugManager(const DebugManager&) = delete;
     //! Prevent copies
@@ -101,6 +120,8 @@ public:
     DebugManager& operator=(DebugManager&&) = delete;
 protected:
     DebugManager() = default;
+
+    HeaderConfig headerConfig;
 
     //! Helper for automatic category registering and signaling
     void registerCategory(DebugCategory &);


### PR DESCRIPTION
Fixes #2045 

Init script execution logging will now be configurable via the `debugfilter` command. To turn off script execution logging, add the following line to your `dfhack.init` file:
```
debugfilter set Warning core script
```

This PR, however, is mostly about allowing debug log output to blend seamlessly into our existing messages, and there are a number of policy questions to be answered. Since none of our code really uses the debug log yet, changing things won't break anything, but we do need to decide how things should work going forward, as adoption of the logging framework should increase in the future.

Before this change, log messages output through the debug logging framework had the following format:
`12:27:22.306:t1:core:script: Loading script: dfhack.init`

This is very verbose compared to the line I intended to make filterable (just the message `Loading script: dfhack.init`). If we want the "verbosity-controllable" messages to blend in with our current message output, we'd need to get rid of that long ugly header. However, there will still be cases where the header would be useful, so we can't just delete it wholesale.

Therefore, I made the elements of the header individually controllable with flags (all defaulting to false), and added a new `header` command to the `debugfilter` plugin as a config interface.

All "normal" output messages are currently gray, and I wanted to make INFO messages blend in with those messages. Debug log messages are color coded according to their verbosity. Before this change, INFO messages were cyan and TRACE messages were gray. I changed INFO to gray (again, in order to blend in with "normal" messages) and I changed TRACE messages to brown, which I thought was suitably "tracey".

Finally, the debug log code has the capability to excise all messages below a certain threshold from the binary. It was set to remove all messages below INFO if you compile with NDEBUG and allow all messages otherwise. However, there is no build configuration that doesn't define NDEBUG, so it would effectively make TRACE and DEBUG messages useless. I moved the lower bound to DEBUG so users could potentially see DEBUG level messages to add to bug reports. We could move this down to TRACE as well (for the same reasons), but I thought for now I'd reserve that for devs who do somehow manage to compile with NDEBUG not set.

Also doc updates for the Debug API.