### PR TITLE
Bump max GCC in GitHub Actions build matrix to 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - default
         include:
         - os: ubuntu-20.04
-          gcc: 10
+          gcc: 11
           plugins: all
     steps:
     - name: Set up Python 3


### PR DESCRIPTION
`apt install gcc-11` in GitHub's Ubuntu 20.04 environment seems to pull from https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test, which gives GCC 11.1, not 11.2. I vaguely recall a difference in warnings between the two.

Nevertheless, this increases the coverage of our build matrix slightly.