### PR TITLE
only designate enough trees to reach max_logs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -54,6 +54,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Script execution log messages (e.g. "Loading script: dfhack_extras.init" can now be controlled with the ``debugfilter`` command. To hide the messages, add this line to your ``dfhack.init`` file: ``debugfilter set Warning core script``
 - `manipulator`: Tweak colors to make the cursor easier to locate
 - `autochop`: only designate the amount of trees required to reach ``max_logs``
+- `autochop`: preferably designate larger trees over smaller ones
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `gui/create-item`: Added "(chain)" annotation text for armours with the [CHAIN_METAL_TEXT] flag set
 - DFHack log messages now have configurable headers (e.g. timestamp, origin plugin name, etc.) via the ``debugfilter`` command of the `debug` plugin
 - Script execution log messages (e.g. "Loading script: dfhack_extras.init" can now be controlled with the ``debugfilter`` command. To hide the messages, add this line to your ``dfhack.init`` file: ``debugfilter set Warning core script``
+- `autochop`: only designate the amount of trees required to reach ``max_logs``
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -340,7 +340,7 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
 
     //designate
     multimap<int, int>::iterator itr;
-    for (size_t itr = trees_by_size.begin(); itr != trees_by_size.end(); itr++)
+    for (itr = trees_by_size.begin(); itr != trees_by_size.end(); itr++)
     {
         const df::plant *plant = world->plants.all[itr->second];
 

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -47,6 +47,8 @@ DFHACK_PLUGIN("autochop");
 REQUIRE_GLOBAL(world);
 REQUIRE_GLOBAL(ui);
 
+static int get_log_count();
+
 static bool autochop_enabled = false;
 static int min_logs, max_logs;
 static const int LOG_CAP_MAX = 99999;

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -307,6 +307,41 @@ static int estimate_logs(const df::plant *plant)
     return trunks;
 }
 
+static int get_log_count()
+{
+    std::vector<df::item*> &items = world->items.other[items_other_id::IN_PLAY];
+
+    // Pre-compute a bitmask with the bad flags
+    df::item_flags bad_flags;
+    bad_flags.whole = 0;
+
+#define F(x) bad_flags.bits.x = true;
+    F(dump); F(forbid); F(garbage_collect);
+    F(hostile); F(on_fire); F(rotten); F(trader);
+    F(in_building); F(construction); F(artifact);
+    F(spider_web); F(owned); F(in_job);
+#undef F
+
+    size_t valid_count = 0;
+    for (size_t i = 0; i < items.size(); i++)
+    {
+        df::item *item = items[i];
+
+        if (item->getType() != item_type::WOOD)
+            continue;
+
+        if (item->flags.whole & bad_flags.whole)
+            continue;
+
+        if (!is_valid_item(item))
+            continue;
+
+        ++valid_count;
+    }
+
+    return valid_count;
+}
+
 static int do_chop_designation(bool chop, bool count_only, int *skipped = nullptr)
 {
     int count = 0;
@@ -406,41 +441,6 @@ static bool is_valid_item(df::item *item)
     }
 
     return true;
-}
-
-static int get_log_count()
-{
-    std::vector<df::item*> &items = world->items.other[items_other_id::IN_PLAY];
-
-    // Pre-compute a bitmask with the bad flags
-    df::item_flags bad_flags;
-    bad_flags.whole = 0;
-
-#define F(x) bad_flags.bits.x = true;
-    F(dump); F(forbid); F(garbage_collect);
-    F(hostile); F(on_fire); F(rotten); F(trader);
-    F(in_building); F(construction); F(artifact);
-    F(spider_web); F(owned); F(in_job);
-#undef F
-
-    size_t valid_count = 0;
-    for (size_t i = 0; i < items.size(); i++)
-    {
-        df::item *item = items[i];
-
-        if (item->getType() != item_type::WOOD)
-            continue;
-
-        if (item->flags.whole & bad_flags.whole)
-            continue;
-
-        if (!is_valid_item(item))
-            continue;
-
-        ++valid_count;
-    }
-
-    return valid_count;
 }
 
 static void set_threshold_check(bool state)

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -339,9 +339,9 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
 
     //designate
     multimap<int, int>::iterator itr;
-    for (itr = trees_by_size.begin(); itr != trees_by_size.end(); itr++)
+    for (auto & entry : trees_by_size)
     {
-        const df::plant *plant = itr->second;
+        const df::plant * plant = entry.second;
 
         if ((estimated_yield >= max_logs) && chop)
             break;

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -325,7 +325,7 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
         bool restricted = false;
 
         if ((estimated_yield >= max_logs) && chop)
-            continue;
+            break;
 
         if (skip_plant(plant, &restricted))
         {

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -334,7 +334,7 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
             continue;
         }
 
-        trees_by_size.insert(pair<int, int>(estimate_logs(plant), plant));
+        trees_by_size.insert(pair<int, df::plant *>(estimate_logs(plant), plant));
     }
 
     //designate

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -307,6 +307,42 @@ static int estimate_logs(const df::plant *plant)
     return trunks;
 }
 
+static bool is_valid_item(df::item *item)
+{
+    for (size_t i = 0; i < item->general_refs.size(); i++)
+    {
+        df::general_ref *ref = item->general_refs[i];
+
+        switch (ref->getType())
+        {
+        case general_ref_type::CONTAINED_IN_ITEM:
+            return false;
+
+        case general_ref_type::UNIT_HOLDER:
+            return false;
+
+        case general_ref_type::BUILDING_HOLDER:
+            return false;
+
+        default:
+            break;
+        }
+    }
+
+    for (size_t i = 0; i < item->specific_refs.size(); i++)
+    {
+        df::specific_ref *ref = item->specific_refs[i];
+
+        if (ref->type == specific_ref_type::JOB)
+        {
+            // Ignore any items assigned to a job
+            return false;
+        }
+    }
+
+    return true;
+}
+
 static int get_log_count()
 {
     std::vector<df::item*> &items = world->items.other[items_other_id::IN_PLAY];
@@ -405,42 +441,6 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
     }
 
     return count;
-}
-
-static bool is_valid_item(df::item *item)
-{
-    for (size_t i = 0; i < item->general_refs.size(); i++)
-    {
-        df::general_ref *ref = item->general_refs[i];
-
-        switch (ref->getType())
-        {
-        case general_ref_type::CONTAINED_IN_ITEM:
-            return false;
-
-        case general_ref_type::UNIT_HOLDER:
-            return false;
-
-        case general_ref_type::BUILDING_HOLDER:
-            return false;
-
-        default:
-            break;
-        }
-    }
-
-    for (size_t i = 0; i < item->specific_refs.size(); i++)
-    {
-        df::specific_ref *ref = item->specific_refs[i];
-
-        if (ref->type == specific_ref_type::JOB)
-        {
-            // Ignore any items assigned to a job
-            return false;
-        }
-    }
-
-    return true;
 }
 
 static void set_threshold_check(bool state)

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -313,7 +313,7 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
 {
     int count = 0;
     int estimated_yield = get_log_count();
-    multimap<int, int> trees_by_size;
+    multimap<int, df::plant *> trees_by_size;
 
     if (skipped)
     {
@@ -335,14 +335,14 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
             continue;
         }
 
-        trees_by_size.insert(pair<int, int>(estimate_logs(plant), i));
+        trees_by_size.insert(pair<int, int>(estimate_logs(plant), plant));
     }
 
     //designate
     multimap<int, int>::iterator itr;
     for (itr = trees_by_size.begin(); itr != trees_by_size.end(); itr++)
     {
-        const df::plant *plant = world->plants.all[itr->second];
+        const df::plant *plant = itr->second;
 
         if ((estimated_yield >= max_logs) && chop)
             break;

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -313,19 +313,18 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
 {
     int count = 0;
     int estimated_yield = get_log_count();
+    multimap<int, int> trees_by_size;
 
     if (skipped)
     {
         *skipped = 0;
     }
 
+    //get trees
     for (size_t i = 0; i < world->plants.all.size(); i++)
     {
         const df::plant *plant = world->plants.all[i];
         bool restricted = false;
-
-        if ((estimated_yield >= max_logs) && chop)
-            break;
 
         if (skip_plant(plant, &restricted))
         {
@@ -335,6 +334,18 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
             }
             continue;
         }
+
+        trees_by_size.insert(pair<int, int>(estimate_logs(plant), i));
+    }
+
+    //designate
+    multimap<int, int>::iterator itr;
+    for (size_t itr = trees_by_size.begin(); itr != trees_by_size.end(); itr++)
+    {
+        const df::plant *plant = world->plants.all[itr->second];
+
+        if ((estimated_yield >= max_logs) && chop)
+            break;
 
         if (!count_only && !watchedBurrows.isValidPos(plant->pos))
             continue;
@@ -350,7 +361,7 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
             {
                 if (Designations::markPlant(plant))
                 {
-                    estimated_yield += estimate_logs(plant);
+                    estimated_yield += itr->first;
                     count++;
                 }
             }

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -338,7 +338,6 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
     }
 
     //designate
-    multimap<int, int>::iterator itr;
     for (auto & entry : trees_by_size)
     {
         const df::plant * plant = entry.second;
@@ -360,7 +359,7 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
             {
                 if (Designations::markPlant(plant))
                 {
-                    estimated_yield += itr->first;
+                    estimated_yield += entry->first;
                     count++;
                 }
             }

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -359,7 +359,7 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
             {
                 if (Designations::markPlant(plant))
                 {
-                    estimated_yield += entry->first;
+                    estimated_yield += entry.first;
                     count++;
                 }
             }

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -321,9 +321,8 @@ static int do_chop_designation(bool chop, bool count_only, int *skipped = nullpt
     }
 
     //get trees
-    for (size_t i = 0; i < world->plants.all.size(); i++)
+    for (auto plant : world->plants.all)
     {
-        const df::plant *plant = world->plants.all[i];
         bool restricted = false;
 
         if (skip_plant(plant, &restricted))


### PR DESCRIPTION
redo of https://github.com/DFHack/dfhack/pull/1938 because... reasons.

only half implements https://github.com/DFHack/dfhack/issues/876 - i have zero idea about how to go about designating the largest / oldest / trees that won't grow anymore, so if anyone has any ideas on that, please let me know! - but the first part, only designating the amount of trees required to get to max_logs, is here and worked in my testing seven months ago.

Edit from myk002: Fixes #876 