### PR TITLE
[blueprint] capture carved fortifications and engravings

### DIFF
--- a/data/blueprints/library/test/ecosystem/golden/tracks-carve.csv
+++ b/data/blueprints/library/test/ecosystem/golden/tracks-carve.csv
@@ -1,4 +1,4 @@
-#dig label(track)
+#dig label(carve)
 trackSE,trackEW,trackEW,trackEW,trackSW
 trackNE,,,,trackNW
 #>

--- a/data/blueprints/library/test/ecosystem/in/basic-carve.csv
+++ b/data/blueprints/library/test/ecosystem/in/basic-carve.csv
@@ -1,4 +1,4 @@
-#dig label(track)
+#dig label(carve)
 ,,trackS
 ,,trackNS
 trackE,trackEW,trackNSEW,trackEW,trackW

--- a/data/blueprints/library/test/ecosystem/in/fortifications-carve.csv
+++ b/data/blueprints/library/test/ecosystem/in/fortifications-carve.csv
@@ -1,0 +1,4 @@
+#dig label(carve)
+,F
+F,,F
+,F

--- a/data/blueprints/library/test/ecosystem/in/fortifications-dig.csv
+++ b/data/blueprints/library/test/ecosystem/in/fortifications-dig.csv
@@ -1,0 +1,3 @@
+#dig label(dig)
+
+,d

--- a/data/blueprints/library/test/ecosystem/in/fortifications-smooth.csv
+++ b/data/blueprints/library/test/ecosystem/in/fortifications-smooth.csv
@@ -1,0 +1,4 @@
+#dig label(smooth)
+,s
+s,,s
+,s

--- a/data/blueprints/library/test/ecosystem/in/fortifications-spec.csv
+++ b/data/blueprints/library/test/ecosystem/in/fortifications-spec.csv
@@ -1,0 +1,4 @@
+#notes
+description=test carving fortifications
+width=3
+height=3

--- a/data/blueprints/library/test/ecosystem/in/tracks-carve.csv
+++ b/data/blueprints/library/test/ecosystem/in/tracks-carve.csv
@@ -1,4 +1,4 @@
-#dig label(track)
+#dig label(carve)
 T(5x2)
 ,,,,T(-5x-2)
 #>

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -55,6 +55,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `manipulator`: Tweak colors to make the cursor easier to locate
 - `autochop`: only designate the amount of trees required to reach ``max_logs``
 - `autochop`: preferably designate larger trees over smaller ones
+- `blueprint`: ``track`` phase renamed to ``carve``. carved fortifications and (optionally) engravings are now captured in blueprints
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -36,7 +36,7 @@ function print_help() print(help_text) end
 
 local valid_phase_list = {
     'dig',
-    'track',
+    'carve',
     'build',
     'place',
     'zone',
@@ -148,6 +148,7 @@ local function process_args(opts, args)
     local positionals = argparse.processArgsGetopt(args, {
             {'c', 'cursor', hasArg=true,
              handler=function(optarg) parse_cursor(opts, optarg) end},
+            {'e', 'engrave', handler=function() opts.engrave = true end},
             {'f', 'format', hasArg=true,
              handler=function(optarg) parse_format(opts, optarg) end},
             {'h', 'help', handler=function() opts.help = true end},

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -30,6 +30,18 @@ function test.parse_gui_commandline()
                     opts)
 
     opts = {}
+    b.parse_gui_commandline(opts, {'-e'})
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', engrave=true,},
+                    opts)
+
+    opts = {}
+    b.parse_gui_commandline(opts, {'--engrave'})
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', engrave=true,},
+                    opts)
+
+    opts = {}
     b.parse_gui_commandline(opts, {'-fminimal'})
     expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
                      name='blueprint'},


### PR DESCRIPTION
#1842

Fortifications and engravings were difficult to replicate in a blueprint because they need the surface to be smoothed before they can be designated. This required some reworking of the blueprint plugin:

- the `track` phase is renamed to `carve` and covers tracks, fortifications, and engravings
- a new `smooth` blueprint is created that smooths the tiles that will later hold fortifications and engravings
- a new commandline param (`--engrave`) that toggles whether engravings are captured. otherwise they are ignored and their tiles are not smoothed in the `smooth` blueprint

this PR also adds functional tests for fortifications (but not engravings since `dig-now` doesn't support engravings).

the `ecosystem` test harness was retooled slightly to play back the phases in a specific order, since we need to smooth before carving. before only the `dig` phase was guaranteed to go first, and all other phases were played back in map iteration order.