### PR TITLE
[tweak/stable-cursor] Fix for when default menu is off

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `autofarm` removed restriction on only planting 'discovered' plants
 - `luasocket` (and others): return correct status code when closing socket connections
+- `tweak`: stable-cursor now works when the default menu is hidden
 
 ## Misc Improvements
 - `dig-now`: handle fortification carving

--- a/plugins/tweak/tweaks/stable-cursor.h
+++ b/plugins/tweak/tweaks/stable-cursor.h
@@ -38,9 +38,22 @@ struct stable_cursor_hook : df::viewscreen_dwarfmodest
         return ui_menu_width && (*ui_menu_width)[0] < (*ui_menu_width)[1];
     }
 
+    bool check_area()
+    {
+        return ui_menu_width && (*ui_menu_width)[1] == 2;
+    }
+
     DEFINE_VMETHOD_INTERPOSE(void, feed, (set<df::interface_key> *input))
     {
+        uint32_t mx, my, mz;
+        Maps::getTileSize(mx, my, mz);
+        df::coord map(mx, my, mz);
+
+        // Full window has a 1-cell border on each side
+        int16_t width = Screen::getWindowSize().x - 2;
+
         bool was_default = check_default();
+        //bool was_menu = check_menu();
         df::coord view = Gui::getViewportPos();
         df::coord cursor = Gui::getCursorPos();
 
@@ -48,29 +61,40 @@ struct stable_cursor_hook : df::viewscreen_dwarfmodest
 
         bool is_default = check_default();
         bool is_menu = check_menu();
+        //df::coord cur_view = Gui::getViewportPos();
         df::coord cur_cursor = Gui::getCursorPos();
 
         if (is_default && !was_default)
         {
             if (!is_menu)
             {
-                // The menu disappeared, but getViewportPos() does not
-                // report the new info yet, so we must predict where the
-                // view has shifted to
+                // Menu disappeared, reported view info is wrong
                 view.x -= std::min(menu_shift, view.x);
+
+                bool is_area = check_area();
+                if (is_area)
+                {
+                    width -= (Gui::AREA_MAP_WIDTH + 1);
+                }
+
+                // At the right edge of the map, it's always shifted
+                // over so the right side of the viewport is menu_shift
+                // tiles from the right edge of the map
+                view.x = std::min(view.x, static_cast<int16_t>(map.x - width - menu_shift));
             }
             last_view = view; last_cursor = cursor;
         }
-        else if (!is_default && was_default &&
-                 Gui::getViewportPos() == last_view &&
-                 last_cursor.isValid() && cur_cursor.isValid())
+        else if (!is_default && cur_cursor.isValid() && last_cursor.isValid())
         {
-            Gui::setCursorCoords(last_cursor.x, last_cursor.y, last_cursor.z);
-            Gui::refreshSidebar();
-        }
-        else if (!is_default && cur_cursor.isValid())
-        {
-            last_cursor = df::coord();
+            if (was_default && view == last_view)
+            {
+                Gui::setCursorCoords(last_cursor.x, last_cursor.y, last_cursor.z);
+                Gui::refreshSidebar();
+            }
+            else
+            {
+                last_cursor = df::coord();
+            }
         }
     }
 };


### PR DESCRIPTION
When the default menu is off, the viewport shifts by 16 (half the menu
width), but getViewportPos() does not report that until after the
interpose vmethod is over. So the view is always off by 16 in the x
direction.

The check_menu() function is a simplified version of what is in
Gui::getDwarfmodeViewDims().