### PR TITLE
automatically manage sidebar modes in MenuOverlay

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -3370,7 +3370,10 @@ It adds the following methods:
 
   Adds the screen to the display stack with the given screen as the parent;
   if parent is not specified, places this one one topmost. Before calling
-  ``dfhack.screen.show``, calls ``self:onAboutToShow(parent)``.
+  ``dfhack.screen.show``, calls ``self:onAboutToShow(parent)``. Note that
+  ``onAboutToShow()`` can dismiss active screens, and therefore change the
+  potential parent. If parent is not specified, this function will re-detect the
+  current topmost window after ``self:onAboutToShow(parent)`` returns.
 
 * ``screen:onAboutToShow(parent)`` *(for overriding)*
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -70,6 +70,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
+- ``dwarfmode.MenuOverlay``: if ``sidebar_mode`` attribute is set, automatically manage entering a specific sidebar mode on show and restoring the previous sidebar mode on dismiss
 - ``dwarfmode.enterSidebarMode()``: passing ``df.ui_sidebar_mode.DesignateMine`` now always results in you entering ``DesignateMine`` mode and not ``DesignateChopTrees``, even when you looking at the surface where the default designation mode is ``DesignateChopTrees``
 
 # 0.47.05-r4

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -537,8 +537,11 @@ function Screen:show(parent)
     if self._native then
         error("This screen is already on display")
     end
+    self:onAboutToShow(parent or dfhack.gui.getCurViewscreen(true))
+
+    -- if we're autodetecting the parent, refresh the parent handle in case the
+    -- original parent has been dismissed by onAboutToShow()'s actions
     parent = parent or dfhack.gui.getCurViewscreen(true)
-    self:onAboutToShow(parent)
     if not dscreen.show(self, parent.child) then
         error('Could not show screen')
     end

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -426,8 +426,6 @@ function DwarfOverlay:simulateCursorMovement(keys, anchor)
 end
 
 function DwarfOverlay:onAboutToShow(parent)
-    DwarfOverlay.super.onAboutToShow(self, parent)
-
     if not df.viewscreen_dwarfmodest:is_instance(parent) then
         error("This screen requires the main dwarfmode view")
     end
@@ -451,30 +449,26 @@ end
 
 function MenuOverlay:onAboutToShow(parent)
     if not dfhack.isMapLoaded() then
-        qerror('Please load a fortress map.')
+        -- sidebar menus are only valid when a fort map is loaded
+        error('A fortress map must be loaded.')
     end
-
-    self.saved_sidebar_mode = df.global.ui.main.mode
-    -- what mode should we restore when this window is dismissed? ideally, we'd
-    -- restore the mode that the user has set, but we should fall back to
-    -- restoring the default mode if either of the following conditions are
-    -- true:
-    -- 1) enterSidebarMode doesn't support getting back into the current mode
-    -- 2) a dfhack viewscreen is currently visible. in this case, we can't trust
-    --    that the current sidebar mode was set by the user. it could just be a
-    --    MenuOverlay subclass that is currently being shown that has set the
-    --    sidebar mode for its own purposes.
-    if not SIDEBAR_MODE_KEYS[self.saved_sidebar_mode]
-            or dfhack.gui.getCurFocus(true):find('^dfhack/') then
-        self.saved_sidebar_mode = df.ui_sidebar_mode.Default
-    end
-    enterSidebarMode(df.ui_sidebar_mode.Default)
-
-    -- refresh parent since the original parent may have just been dismissed
-    parent = dfhack.gui.getCurViewscreen(true)
-    MenuOverlay.super.onAboutToShow(self, parent)
 
     if self.sidebar_mode then
+        self.saved_sidebar_mode = df.global.ui.main.mode
+        -- what mode should we restore when this window is dismissed? ideally, we'd
+        -- restore the mode that the user has set, but we should fall back to
+        -- restoring the default mode if either of the following conditions are
+        -- true:
+        -- 1) enterSidebarMode doesn't support getting back into the current mode
+        -- 2) a dfhack viewscreen is currently visible. in this case, we can't trust
+        --    that the current sidebar mode was set by the user. it could just be a
+        --    MenuOverlay subclass that is currently being shown that has set the
+        --    sidebar mode for its own purposes.
+        if not SIDEBAR_MODE_KEYS[self.saved_sidebar_mode]
+                or dfhack.gui.getCurFocus(true):find('^dfhack/') then
+            self.saved_sidebar_mode = df.ui_sidebar_mode.Default
+        end
+
         enterSidebarMode(self.sidebar_mode)
     end
 
@@ -485,9 +479,6 @@ function MenuOverlay:onAboutToShow(parent)
 end
 
 function MenuOverlay:onDismiss()
-    -- we have to check that saved_sidebar_mode is set because a subclass may
-    -- have overridden our onAboutToShow() method without calling
-    -- <class>.super.onAboutToShow(self, parent)
     if self.saved_sidebar_mode then
         enterSidebarMode(self.saved_sidebar_mode)
     end

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -455,10 +455,17 @@ function MenuOverlay:onAboutToShow(parent)
     end
 
     self.saved_sidebar_mode = df.global.ui.main.mode
-    -- if we can't get back to the saved sidebar mode via enterSidebarMode
-    -- then fall back to the default mode
-    if dfhack.gui.getCurFocus(true):find('^dfhack/')
-            or not SIDEBAR_MODE_KEYS[self.saved_sidebar_mode] then
+    -- what mode should we restore when this window is dismissed? ideally, we'd
+    -- restore the mode that the user has set, but we should fall back to
+    -- restoring the default mode if either of the following conditions are
+    -- true:
+    -- 1) enterSidebarMode doesn't support getting back into the current mode
+    -- 2) a dfhack viewscreen is currently visible. in this case, we can't trust
+    --    that the current sidebar mode was set by the user. it could just be a
+    --    MenuOverlay subclass that is currently being shown that has set the
+    --    sidebar mode for its own purposes.
+    if not SIDEBAR_MODE_KEYS[self.saved_sidebar_mode]
+            or dfhack.gui.getCurFocus(true):find('^dfhack/') then
         self.saved_sidebar_mode = df.ui_sidebar_mode.Default
     end
     enterSidebarMode(df.ui_sidebar_mode.Default)

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -470,7 +470,7 @@ function MenuOverlay:onAboutToShow(parent)
     end
     enterSidebarMode(df.ui_sidebar_mode.Default)
 
-    -- refresh parent since the original parent may have been dismissed
+    -- refresh parent since the original parent may have just been dismissed
     parent = dfhack.gui.getCurViewscreen(true)
     MenuOverlay.super.onAboutToShow(self, parent)
 
@@ -485,6 +485,9 @@ function MenuOverlay:onAboutToShow(parent)
 end
 
 function MenuOverlay:onDismiss()
+    -- we have to check that saved_sidebar_mode is set because a subclass may
+    -- have overridden our onAboutToShow() method without calling
+    -- <class>.super.onAboutToShow(self, parent)
     if self.saved_sidebar_mode then
         enterSidebarMode(self.saved_sidebar_mode)
     end


### PR DESCRIPTION
Refactor sidebar mode management code from `gui/blueprint` (and the new `gui/quickfort` that isn't merged yet) into the common library class.

Modifies the low-level `Screen:show()` function to handle `onAboutToShow()` dismissing a window. This allows a `MenuOverlay` subclass to reinvoke itself (or get run twice by the user) without having to manually track whether it already has a window shown so it can dismiss it before showing the new one. `gui/blueprint` does this, and now all that code can be removed.

There are many subclasses of MenuOverlay that can take advantage of the new code. I'll migrate them after this change is approved and merged.