### PR TITLE
ensure ListBoxes always have enough height

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -69,6 +69,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Added functions reverse-engineered from ambushing unit code: ``Units::isHidden``, ``Units::isFortControlled``, ``Units::getOuterContainerRef``, ``Items::getOuterContainerRef``
 
 ## Lua
+- ``widgets.ListBox``: minimum height of dialog is now calculated correctly when there are no items in the list (e.g. when a filter doesn't match anything)
 - Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
 - ``dwarfmode.enterSidebarMode()``: passing ``df.ui_sidebar_mode.DesignateMine`` now always results in you entering ``DesignateMine`` mode and not ``DesignateChopTrees``, even when you looking at the surface where the default designation mode is ``DesignateChopTrees``
 

--- a/library/lua/gui/dialogs.lua
+++ b/library/lua/gui/dialogs.lua
@@ -215,7 +215,7 @@ function ListBox:getWantedFrameSize()
     local mw, mh = ListBox.super.getWantedFrameSize(self)
     local list = self.subviews.list
     list.frame.t = mh+1
-    return math.max(mw, list:getContentWidth()), mh+3+math.min(20,list:getContentHeight())
+    return math.max(mw, list:getContentWidth()), mh+3+math.min(18,list:getContentHeight())
 end
 
 function ListBox:onInput(keys)

--- a/library/lua/gui/dialogs.lua
+++ b/library/lua/gui/dialogs.lua
@@ -212,10 +212,10 @@ function ListBox:onRenderFrame(dc,rect)
 end
 
 function ListBox:getWantedFrameSize()
-    local mw, mh = InputBox.super.getWantedFrameSize(self)
+    local mw, mh = ListBox.super.getWantedFrameSize(self)
     local list = self.subviews.list
     list.frame.t = mh+1
-    return math.max(mw, list:getContentWidth()), mh+1+math.min(20,list:getContentHeight())
+    return math.max(mw, list:getContentWidth()), mh+3+math.min(20,list:getContentHeight())
 end
 
 function ListBox:onInput(keys)


### PR DESCRIPTION
Currently, if a filtered ListBox has a filter that doesn't match any items, it will shrink the dialog box so small that users won't be able to see the message that says that nothing matches the filter.

This PR modifies the minimum dialog box height to take the error message into account.

There appeared to be a typo in the call to `super`. The wrong class name was used. This apparently gave the same result as the correct class name, so that wasn't much of an issue. I fixed it anyway, though.