### PR TITLE
Handle punctuation in FilteredList filter matching

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -69,6 +69,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Added functions reverse-engineered from ambushing unit code: ``Units::isHidden``, ``Units::isFortControlled``, ``Units::getOuterContainerRef``, ``Items::getOuterContainerRef``
 
 ## Lua
+- ``widgets.FilteredList`` now allows all punctuation to be typed into the filter and can match search keys that start with punctuation.
 - Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
 - ``dwarfmode.enterSidebarMode()``: passing ``df.ui_sidebar_mode.DesignateMine`` now always results in you entering ``DesignateMine`` mode and not ``DesignateChopTrees``, even when you looking at the surface where the default designation mode is ``DesignateChopTrees``
 

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -814,8 +814,13 @@ function FilteredList:setFilter(filter, pos)
             local ok = true
             local search_key = v.search_key or v.text
             for _,key in ipairs(tokens) do
+                key = key:escape()
+                -- start matches at non-space or non-punctuation. this allows
+                -- punctuation itself to be matched if that is useful (e.g.
+                -- filenames or parameter names)
                 if key ~= '' and
-                        not string.match(search_key, '%f[^%s%p\x00]'..key) then
+                        not search_key:match('%f[^%p\x00]'..key) and
+                        not search_key:match('%f[^%s\x00]'..key) then
                     ok = false
                     break
                 end
@@ -839,15 +844,7 @@ function FilteredList:onFilterChange(text)
     self:setFilter(text)
 end
 
-local bad_chars = {
-    ['%'] = true, ['.'] = true, ['+'] = true, ['*'] = true,
-    ['['] = true, [']'] = true, ['('] = true, [')'] = true,
-}
-
 function FilteredList:onFilterChar(char, text)
-    if bad_chars[char] then
-        return false
-    end
     if char == ' ' then
         return string.match(text, '%S$')
     end


### PR DESCRIPTION
Allows punctuation to be typed into a filter and allows the filter to match keys with punctuation.

This came up in the quickfort GUI redesign. I couldn't match labels that users would naturally type in starting with a `/`. I also couldn't match a `-n` if they copied the text from the `quickfort list` output.

This PR extends the FilteredList implementation by allowing punctuation to be used just like any other key.