### PR TITLE
add ResizingPanel class and autolayout for Panels

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -3705,6 +3705,23 @@ Has attributes:
 
   Called from ``onRenderBody``.
 
+* ``autoarrange_subviews = bool`` (default: false)
+* ``autoarrange_gap = int`` (default: 0)
+
+  If ``autoarrange_subviews`` is set to ``true``, the Panel will
+  automatically handle subview layout. Subviews are laid out vertically
+  according to their current height, with ``autoarrange_gap`` empty lines
+  between subviews. This allows you to have widgets dynamically change
+  height or become visible/hidden and you don't have to worry about
+  recalculating subview positions.
+
+ResizingPanel class
+-------------------
+
+Subclass of Panel; automatically adjusts its own frame height according to
+the size, position, and visibility of its subviews. Pairs nicely with a
+parent Panel that has ``autoarrange_subviews`` enabled.
+
 Pages class
 -----------
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -74,6 +74,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
 - ``dwarfmode.enterSidebarMode()``: passing ``df.ui_sidebar_mode.DesignateMine`` now always results in you entering ``DesignateMine`` mode and not ``DesignateChopTrees``, even when you looking at the surface where the default designation mode is ``DesignateChopTrees``
 - New string class function: ``string:escape_pattern()`` escapes regex special characters within a string
+- ``widgets.Panel``: if ``autoarrange_subviews`` is set, ``Panel``s will now automatically lay out widgets vertically according to their current height.  This allows you to have widgets dynamically change height or become visible/hidden and you don't have to worry about recalculating frame layouts
+- ``widgets.ResizingPanel``: new ``Panel`` subclass that automatically recalculates it's own frame height based on the size, position, and visibility of its subviews
 
 # 0.47.05-r4
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -74,7 +74,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
 - ``dwarfmode.enterSidebarMode()``: passing ``df.ui_sidebar_mode.DesignateMine`` now always results in you entering ``DesignateMine`` mode and not ``DesignateChopTrees``, even when you looking at the surface where the default designation mode is ``DesignateChopTrees``
 - New string class function: ``string:escape_pattern()`` escapes regex special characters within a string
-- ``widgets.Panel``: if ``autoarrange_subviews`` is set, ``Panel``s will now automatically lay out widgets vertically according to their current height.  This allows you to have widgets dynamically change height or become visible/hidden and you don't have to worry about recalculating frame layouts
+- ``widgets.Panel``: if ``autoarrange_subviews`` is set, ``Panel``\s will now automatically lay out widgets vertically according to their current height.  This allows you to have widgets dynamically change height or become visible/hidden and you don't have to worry about recalculating frame layouts
 - ``widgets.ResizingPanel``: new ``Panel`` subclass that automatically recalculates it's own frame height based on the size, position, and visibility of its subviews
 
 # 0.47.05-r4


### PR DESCRIPTION
- `widgets.Panel`: if `autoarrange_subviews` is set, `Panel`s will now automatically lay out widgets vertically according to their current height.  This allows you to have widgets dynamically change height or become visible/hidden and you don't have to worry about recalculating frame layouts
- `widgets.ResizingPanel`: new `Panel` subclass that automatically recalculates it's own frame height based on the size, position, and visibility of its subviews

These are refactored from the current `gui/blueprint` implementation for reuse in `gui/quickfort` and to be made available to other scripts