### PR TITLE
handle number-indexed lua maps in safe_index

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -74,6 +74,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Lua wrappers for functions reverse-engineered from ambushing unit code: ``isHidden(unit)``, ``isFortControlled(unit)``, ``getOuterContainerRef(unit)``, ``getOuterContainerRef(item)``
 - ``dwarfmode.enterSidebarMode()``: passing ``df.ui_sidebar_mode.DesignateMine`` now always results in you entering ``DesignateMine`` mode and not ``DesignateChopTrees``, even when you looking at the surface where the default designation mode is ``DesignateChopTrees``
 - New string class function: ``string:escape_pattern()`` escapes regex special characters within a string
+- ``safe_index`` now properly handles lua sparse tables that are indexed by numbers
 
 # 0.47.05-r4
 

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -372,7 +372,9 @@ function safe_index(obj,idx,...)
     if obj == nil or idx == nil then
         return nil
     end
-    if type(idx) == 'number' and (idx < 0 or idx >= #obj) then
+    if type(idx) == 'number' and
+            type(obj) == 'userdata' and -- this check is only relevant for c++
+            (idx < 0 or idx >= #obj) then
         return nil
     end
     obj = obj[idx]


### PR DESCRIPTION
`safe_index` purports to make it safe to walk through a sequence of dereferences, but it fails to handle two cases:
1) the index is numeric and is the upper bound of a lua list
2) the index is numeric and is the index into a sparse lua map

the first issue occurs because `safe_index` assumes it is looking at a C++ vector when it gets numeric indices. in the case of C++, it correctly bails if index is < 0 or >= `#obj`.  however, for lua lists, this check doesn't make sense. first of all it's fine if you index to a location outside of the list (the next check will correctly return nil anyway). second, lua lists range from 1 to #, not 0 to # - 1.

The second issue occurs because to check the range of the list, it uses the `#` operator. this always returns 0 if the map is sparse and doesn't contain an element at `[1]`.

both issues can be fixed by only doing the range check if `type(obj)` is userdata.