### PR TITLE
Adding cprobe capability to cursecheck

### DIFF
--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -182,8 +182,7 @@ Options:
 
 :detail:      Print full name, date of birth, date of curse and some status
               info (some vampires might use fake identities in-game, though).
-:cprobe:      Print some information from creature probe plugin, displaying
-              the creature and race IDs.
+:ids:         Print the creature and race IDs.
 :nick:        Set the type of curse as nickname (does not always show up
               in-game, some vamps don't like nicknames).
 :all:         Include dead and passive cursed creatures (can result in a quite

--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -182,6 +182,8 @@ Options:
 
 :detail:      Print full name, date of birth, date of curse and some status
               info (some vampires might use fake identities in-game, though).
+:cprobe:      Print some information from creature probe plugin, displaying
+              the creature and race IDs.
 :nick:        Set the type of curse as nickname (does not always show up
               in-game, some vamps don't like nicknames).
 :all:         Include dead and passive cursed creatures (can result in a quite

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,7 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autochop`: preferably designate larger trees over smaller ones
 - `blueprint`: ``track`` phase renamed to ``carve``. carved fortifications and (optionally) engravings are now captured in blueprints
 - `tweak` stable-cursor: Keep the cursor stable even when the viewport moves a small amount
-- `cursecheck`: Added a new parameter, `ids`, to print creature and race IDs of the cursed creature.
+- `cursecheck`: Added a new parameter, ``ids``, to print creature and race IDs of the cursed creature.
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,7 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autochop`: preferably designate larger trees over smaller ones
 - `blueprint`: ``track`` phase renamed to ``carve``. carved fortifications and (optionally) engravings are now captured in blueprints
 - `tweak` stable-cursor: Keep the cursor stable even when the viewport moves a small amount
-- `cursecheck`: Added a new parameter, `ids`, to print create and race IDs of the cursed creature.
+- `cursecheck`: Added a new parameter, `ids`, to print creature and race IDs of the cursed creature.
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autochop`: preferably designate larger trees over smaller ones
 - `blueprint`: ``track`` phase renamed to ``carve``. carved fortifications and (optionally) engravings are now captured in blueprints
 - `tweak` stable-cursor: Keep the cursor stable even when the viewport moves a small amount
+- `cursecheck`: Added a new parameter, `ids`, to print create and race IDs of the cursed creature.
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/plugins/cursecheck.cpp
+++ b/plugins/cursecheck.cpp
@@ -146,6 +146,7 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
     Gui::getCursorCoords(cursorX,cursorY,cursorZ);
 
     bool giveDetails = false;
+    bool giveCProbe = false;
     bool giveNick = false;
     bool ignoreDead = true;
     bool verbose = false;
@@ -162,6 +163,7 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
                         "  By default dead and passive creatures (aka really dead) are ignored.\n"
                         "Options:\n"
                         "  detail  - show details (name and age shown ingame might differ)\n"
+                        "  cprobe  - add creature probe output to show creature and race IDs\n"
                         "  nick    - try to set cursetype as nickname (does not always work)\n"
                         "  all     - include dead and passive creatures\n"
                         "  verbose - show all curse tags (if you really want to know it all)\n"
@@ -170,6 +172,8 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
         }
         if(parameters[i] == "detail")
             giveDetails = true;
+        if(parameters[i] == "cprobe")
+            giveCProbe = true;
         if(parameters[i] == "nick")
             giveNick = true;
         if(parameters[i] == "all")
@@ -268,6 +272,11 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
                         << bitfield_to_string(unit->curse.add_tags1) << endl
                         << bitfield_to_string(unit->curse.add_tags2) << endl;
                 }
+            }
+
+            if (giveCProbe)
+            {
+                out.print("Creature %d, race %d (%x)\n", unit->id, unit->race, unit->race);
             }
         }
     }

--- a/plugins/cursecheck.cpp
+++ b/plugins/cursecheck.cpp
@@ -146,7 +146,7 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
     Gui::getCursorCoords(cursorX,cursorY,cursorZ);
 
     bool giveDetails = false;
-    bool giveCProbe = false;
+    bool giveUnitID = false;
     bool giveNick = false;
     bool ignoreDead = true;
     bool verbose = false;
@@ -163,7 +163,7 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
                         "  By default dead and passive creatures (aka really dead) are ignored.\n"
                         "Options:\n"
                         "  detail  - show details (name and age shown ingame might differ)\n"
-                        "  cprobe  - add creature probe output to show creature and race IDs\n"
+                        "  ids     - add creature and race IDs to be show on the  output\n"
                         "  nick    - try to set cursetype as nickname (does not always work)\n"
                         "  all     - include dead and passive creatures\n"
                         "  verbose - show all curse tags (if you really want to know it all)\n"
@@ -172,8 +172,8 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
         }
         if(parameters[i] == "detail")
             giveDetails = true;
-        if(parameters[i] == "cprobe")
-            giveCProbe = true;
+        if(parameters[i] == "ids")
+            giveUnitID = true;
         if(parameters[i] == "nick")
             giveNick = true;
         if(parameters[i] == "all")
@@ -274,7 +274,7 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
                 }
             }
 
-            if (giveCProbe)
+            if (giveUnitID)
             {
                 out.print("Creature %d, race %d (%x)\n", unit->id, unit->race, unit->race);
             }


### PR DESCRIPTION
This PR Closes #2087.

I added a new parameter `cprobe` to display part of cprobe output for the unit being evaluated by cursecheck. 

Also, added this parameter to the `help` and to the documentation.
Would appreciate feedback on those description texts.

Thanks in advance.