### PR TITLE
default unset `frame_inset` values to 0

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -3689,6 +3689,8 @@ Base of all the widgets. Inherits from View and has the following attributes:
   :x: left/right margin, if ``l`` and/or ``r`` are omitted.
   :y: top/bottom margin, if ``t`` and/or ``b`` are omitted.
 
+  Omitted fields are interpreted as having the value of 0.
+
 * ``frame_background = pen``
 
   The pen to fill the outer frame with. Defaults to no fill.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -80,6 +80,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``widgets.Panel``: if ``autoarrange_subviews`` is set, ``Panel``\s will now automatically lay out widgets vertically according to their current height.  This allows you to have widgets dynamically change height or become visible/hidden and you don't have to worry about recalculating frame layouts
 - ``widgets.ResizingPanel``: new ``Panel`` subclass that automatically recalculates it's own frame height based on the size, position, and visibility of its subviews
 - ``safe_index`` now properly handles lua sparse tables that are indexed by numbers
+- ``widgets``: unset values in ``frame_inset``-table default to ``0``
 
 # 0.47.05-r4
 

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -99,8 +99,8 @@ end
 local function parse_inset(inset)
     local l,r,t,b
     if type(inset) == 'table' then
-        l,r = inset.l or inset.x, inset.r or inset.x
-        t,b = inset.t or inset.y, inset.b or inset.y
+        l,r = inset.l or inset.x or 0, inset.r or inset.x or 0
+        t,b = inset.t or inset.y or 0, inset.b or inset.y or 0
     else
         l = inset or 0
         t,r,b = l,l,l


### PR DESCRIPTION
This change allows writing `frame_inset = {r=1}` instead of `frame_inset = {l=0, r=1, t=0, b=0}`