### PR TITLE
[tweak] fast-trade: Fix Shift+UP to select current item

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `autofarm` removed restriction on only planting 'discovered' plants
 - `luasocket` (and others): return correct status code when closing socket connections
+- `tweak` fast-trade: Shift+Up now behaves the same as Shift+Down: toggle the current item, then move to the previous line
 
 ## Misc Improvements
 - `dig-now`: handle fortification carving

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,7 +41,6 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `autofarm` removed restriction on only planting 'discovered' plants
 - `luasocket` (and others): return correct status code when closing socket connections
-- `tweak` fast-trade: Shift+Up now behaves the same as Shift+Down: toggle the current item, then move to the previous line
 
 ## Misc Improvements
 - `dig-now`: handle fortification carving
@@ -58,6 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autochop`: preferably designate larger trees over smaller ones
 - `blueprint`: ``track`` phase renamed to ``carve``. carved fortifications and (optionally) engravings are now captured in blueprints
 - `tweak` stable-cursor: Keep the cursor stable even when the viewport moves a small amount
+- `tweak` fast-trade: Shift+Up now behaves the same as Shift+Down: toggle the current item, then move to the previous line
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/plugins/tweak/tweaks/fast-trade.h
+++ b/plugins/tweak/tweaks/fast-trade.h
@@ -1,59 +1,44 @@
 using namespace std;
 
+static df::interface_key fast_trade_move_key(const set<df::interface_key> *input)
+{
+    return input->count(interface_key::CURSOR_DOWN_FAST)
+         ? interface_key::STANDARDSCROLL_DOWN
+         : input->count(interface_key::CURSOR_UP_FAST)
+         ? interface_key::STANDARDSCROLL_UP
+         : interface_key::NONE;
+}
+
+#define DEFINE_FAST_TRADE_INTERPOSE(is_trading)                             \
+    DEFINE_VMETHOD_INTERPOSE(void, feed, (set<df::interface_key> *input))   \
+    {                                                                       \
+        df::interface_key move_key;                                         \
+        if ((is_trading) && (move_key = fast_trade_move_key(input)))        \
+        {                                                                   \
+            set<df::interface_key> tmp;                                     \
+            tmp.insert(interface_key::SELECT);                              \
+            INTERPOSE_NEXT(feed)(&tmp);                                     \
+                                                                            \
+            tmp.clear();                                                    \
+            tmp.insert(move_key);                                           \
+            INTERPOSE_NEXT(feed)(&tmp);                                     \
+        }                                                                   \
+        else                                                                \
+            INTERPOSE_NEXT(feed)(input);                                    \
+    }
+
+
 struct fast_trade_assign_hook : df::viewscreen_layer_assigntradest {
     typedef df::viewscreen_layer_assigntradest interpose_base;
 
-    DEFINE_VMETHOD_INTERPOSE(void, feed, (set<df::interface_key> *input))
-    {
-        if (layer_objects[1]->active && input->count(interface_key::CURSOR_DOWN_FAST))
-        {
-            set<df::interface_key> tmp; tmp.insert(interface_key::SELECT);
-            INTERPOSE_NEXT(feed)(&tmp);
-            tmp.clear(); tmp.insert(interface_key::STANDARDSCROLL_DOWN);
-            INTERPOSE_NEXT(feed)(&tmp);
-        }
-        else if (layer_objects[1]->active && input->count(interface_key::CURSOR_UP_FAST))
-        {
-            set<df::interface_key> tmp; tmp.insert(interface_key::STANDARDSCROLL_UP);
-            INTERPOSE_NEXT(feed)(&tmp);
-            tmp.clear(); tmp.insert(interface_key::SELECT);
-            INTERPOSE_NEXT(feed)(&tmp);
-        }
-        else
-            INTERPOSE_NEXT(feed)(input);
-    }
+    DEFINE_FAST_TRADE_INTERPOSE(layer_objects[1]->active)
 };
 
 IMPLEMENT_VMETHOD_INTERPOSE(fast_trade_assign_hook, feed);
 
 struct fast_trade_select_hook : df::viewscreen_tradegoodsst {
     typedef df::viewscreen_tradegoodsst interpose_base;
-
-    DEFINE_VMETHOD_INTERPOSE(void, feed, (set<df::interface_key> *input))
-    {
-        if (!(is_unloading || !has_traders || in_edit_count)
-            && input->count(interface_key::CURSOR_DOWN_FAST))
-        {
-            set<df::interface_key> tmp; tmp.insert(interface_key::SELECT);
-            INTERPOSE_NEXT(feed)(&tmp);
-            if (in_edit_count)
-                INTERPOSE_NEXT(feed)(&tmp);
-            tmp.clear(); tmp.insert(interface_key::STANDARDSCROLL_DOWN);
-            INTERPOSE_NEXT(feed)(&tmp);
-        }
-        else if (!(is_unloading || !has_traders || in_edit_count)
-            && input->count(interface_key::CURSOR_UP_FAST))
-        {
-            set<df::interface_key> tmp; tmp.insert(interface_key::STANDARDSCROLL_UP);
-            INTERPOSE_NEXT(feed)(&tmp);
-            tmp.clear(); tmp.insert(interface_key::SELECT);
-            INTERPOSE_NEXT(feed)(&tmp);
-            if (in_edit_count)
-                INTERPOSE_NEXT(feed)(&tmp);
-        }
-        else
-            INTERPOSE_NEXT(feed)(input);
-    }
+    DEFINE_FAST_TRADE_INTERPOSE(has_traders && !is_unloading && !in_edit_count)
 };
 
 IMPLEMENT_VMETHOD_INTERPOSE(fast_trade_select_hook, feed);

--- a/plugins/tweak/tweaks/fast-trade.h
+++ b/plugins/tweak/tweaks/fast-trade.h
@@ -2,14 +2,15 @@ using namespace std;
 
 static df::interface_key fast_trade_move_key(const set<df::interface_key> *input)
 {
-    return input->count(interface_key::CURSOR_DOWN_FAST)
-         ? interface_key::STANDARDSCROLL_DOWN
-         : input->count(interface_key::CURSOR_UP_FAST)
-         ? interface_key::STANDARDSCROLL_UP
-         : interface_key::NONE;
+    if (input->count(interface_key::CURSOR_DOWN_FAST))
+        return interface_key::STANDARDSCROLL_DOWN;
+    else if (input->count(interface_key::CURSOR_UP_FAST))
+        return interface_key::STANDARDSCROLL_UP;
+    else
+        return interface_key::NONE;
 }
 
-#define DEFINE_FAST_TRADE_INTERPOSE(is_trading)                             \
+#define DEFINE_FAST_TRADE_INTERPOSE(is_trading, need_extra_select)          \
     DEFINE_VMETHOD_INTERPOSE(void, feed, (set<df::interface_key> *input))   \
     {                                                                       \
         df::interface_key move_key;                                         \
@@ -18,6 +19,8 @@ static df::interface_key fast_trade_move_key(const set<df::interface_key> *input
             set<df::interface_key> tmp;                                     \
             tmp.insert(interface_key::SELECT);                              \
             INTERPOSE_NEXT(feed)(&tmp);                                     \
+            if (need_extra_select)                                          \
+                INTERPOSE_NEXT(feed)(&tmp);                                 \
                                                                             \
             tmp.clear();                                                    \
             tmp.insert(move_key);                                           \
@@ -31,14 +34,14 @@ static df::interface_key fast_trade_move_key(const set<df::interface_key> *input
 struct fast_trade_assign_hook : df::viewscreen_layer_assigntradest {
     typedef df::viewscreen_layer_assigntradest interpose_base;
 
-    DEFINE_FAST_TRADE_INTERPOSE(layer_objects[1]->active)
+    DEFINE_FAST_TRADE_INTERPOSE(layer_objects[1]->active, false)
 };
 
 IMPLEMENT_VMETHOD_INTERPOSE(fast_trade_assign_hook, feed);
 
 struct fast_trade_select_hook : df::viewscreen_tradegoodsst {
     typedef df::viewscreen_tradegoodsst interpose_base;
-    DEFINE_FAST_TRADE_INTERPOSE(has_traders && !is_unloading && !in_edit_count)
+    DEFINE_FAST_TRADE_INTERPOSE(has_traders && !is_unloading && !in_edit_count, in_edit_count)
 };
 
 IMPLEMENT_VMETHOD_INTERPOSE(fast_trade_select_hook, feed);


### PR DESCRIPTION
The DOWN and UP keys should both work the same way: toggle the item on
the *current* line, then move the cursor (down or up) to the next item.

While here, since the logic is the same when moving goods to the depot
and during the trade, it is cleaner to pull it out into a common
definition.