### PR TITLE
Add "partial-items" tweak.

### DIFF
--- a/docs/Plugins.rst
+++ b/docs/Plugins.rst
@@ -159,6 +159,7 @@ Subcommands that persist until disabled or DF quits:
                         i.e. stop the rightmost list of the Positions page of the military
                         screen from constantly resetting to the top.
 :nestbox-color:         Fixes the color of built nestboxes
+:partial-items:         Displays percentages on partially-consumed items such as hospital cloth
 :reaction-gloves:       Fixes reactions to produce gloves in sets with correct handedness (:bug:`6273`)
 :shift-8-scroll:        Gives Shift-8 (or :kbd:`*`) priority when scrolling menus, instead of scrolling the map
 :stable-cursor:         Saves the exact cursor position between t/q/k/d/b/etc menus of fortress mode, if the

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Removed
 
+## New Tweaks
+- `tweak` partial-items: displays percentages on partially-consumed items such as hospital cloth
+
 ## Fixes
 - `autofarm` removed restriction on only planting 'discovered' plants
 - `luasocket` (and others): return correct status code when closing socket connections

--- a/plugins/tweak/tweak.cpp
+++ b/plugins/tweak/tweak.cpp
@@ -49,11 +49,14 @@
 #include "df/item_glovesst.h"
 #include "df/item_shoesst.h"
 #include "df/item_pantsst.h"
+#include "df/item_drinkst.h"
+#include "df/item_globst.h"
 #include "df/item_liquid_miscst.h"
 #include "df/item_powder_miscst.h"
 #include "df/item_barst.h"
 #include "df/item_threadst.h"
 #include "df/item_clothst.h"
+#include "df/item_sheetst.h"
 #include "df/spatter.h"
 #include "df/layer_object.h"
 #include "df/reaction.h"
@@ -68,6 +71,7 @@
 #include "df/job.h"
 #include "df/general_ref_building_holderst.h"
 #include "df/unit_health_info.h"
+#include "df/caste_body_info.h"
 #include "df/activity_entry.h"
 #include "df/activity_event_combat_trainingst.h"
 #include "df/activity_event_individual_skill_drillst.h"
@@ -101,14 +105,15 @@
 #include "tweaks/kitchen-prefs-empty.h"
 #include "tweaks/max-wheelbarrow.h"
 #include "tweaks/military-assign.h"
-#include "tweaks/pausing-fps-counter.h"
 #include "tweaks/nestbox-color.h"
+#include "tweaks/partial-items.h"
+#include "tweaks/pausing-fps-counter.h"
+#include "tweaks/reaction-gloves.h"
 #include "tweaks/shift-8-scroll.h"
 #include "tweaks/stable-cursor.h"
 #include "tweaks/stone-status-all.h"
 #include "tweaks/title-start-rename.h"
 #include "tweaks/tradereq-pet-gender.h"
-#include "tweaks/reaction-gloves.h"
 
 using std::set;
 using std::vector;
@@ -244,6 +249,8 @@ DFhackCExport command_result plugin_init (color_ostream &out, std::vector <Plugi
         "    Preserve list order and cursor position when assigning to squad,\n"
         "    i.e. stop the rightmost list of the Positions page of the military\n"
         "    screen from constantly jumping to the top.\n"
+        "  tweak partial-items [disable]\n"
+        "    Displays percentages on partially-consumed items such as hospital cloth\n"
         "  tweak pausing-fps-counter [disable]\n"
         "    Replace fortress mode FPS counter with one that stops counting \n"
         "    when paused.\n"
@@ -329,8 +336,19 @@ DFhackCExport command_result plugin_init (color_ostream &out, std::vector <Plugi
 
     TWEAK_HOOK("nestbox-color", nestbox_color_hook, drawBuilding);
 
+    TWEAK_HOOK("partial-items", partial_items_hook_bar, getItemDescription);
+    TWEAK_HOOK("partial-items", partial_items_hook_drink, getItemDescription);
+    TWEAK_HOOK("partial-items", partial_items_hook_glob, getItemDescription);
+    TWEAK_HOOK("partial-items", partial_items_hook_liquid_misc, getItemDescription);
+    TWEAK_HOOK("partial-items", partial_items_hook_powder_misc, getItemDescription);
+    TWEAK_HOOK("partial-items", partial_items_hook_cloth, getItemDescription);
+    TWEAK_HOOK("partial-items", partial_items_hook_sheet, getItemDescription);
+    TWEAK_HOOK("partial-items", partial_items_hook_thread, getItemDescription);
+
     TWEAK_HOOK("pausing-fps-counter", dwarfmode_pausing_fps_counter_hook, render);
     TWEAK_HOOK("pausing-fps-counter", title_pausing_fps_counter_hook, render);
+
+    TWEAK_HOOK("reaction-gloves", reaction_gloves_hook, produce);
 
     TWEAK_HOOK("shift-8-scroll", shift_8_scroll_hook, feed);
 
@@ -343,8 +361,6 @@ DFhackCExport command_result plugin_init (color_ostream &out, std::vector <Plugi
     TWEAK_HOOK("title-start-rename", title_start_rename_hook, render);
 
     TWEAK_HOOK("tradereq-pet-gender", pet_gender_hook, render);
-
-    TWEAK_HOOK("reaction-gloves", reaction_gloves_hook, produce);
 
     return CR_OK;
 }

--- a/plugins/tweak/tweaks/partial-items.h
+++ b/plugins/tweak/tweaks/partial-items.h
@@ -1,0 +1,23 @@
+// When displaying the names of partially-consumed items, show the percentage remaining
+// Potentially useful for revealing why random pieces of cloth or thread aren't suitable for jobs
+
+#define DEFINE_PARTIAL_ITEM_TWEAK(TYPE, DIM) \
+struct partial_items_hook_##TYPE : df::item_##TYPE##st { \
+    typedef df::item_##TYPE##st interpose_base; \
+    DEFINE_VMETHOD_INTERPOSE(void, getItemDescription, (std::string *str, int8_t plurality)) \
+    { \
+        INTERPOSE_NEXT(getItemDescription)(str, plurality); \
+        if (dimension != DIM) \
+            str->append(stl_sprintf(" (%i%%)", std::max(1, dimension * 100 / DIM))); \
+    } \
+}; \
+IMPLEMENT_VMETHOD_INTERPOSE(partial_items_hook_##TYPE, getItemDescription);
+
+DEFINE_PARTIAL_ITEM_TWEAK(bar, 150)
+DEFINE_PARTIAL_ITEM_TWEAK(drink, 150)
+DEFINE_PARTIAL_ITEM_TWEAK(glob, 150)
+DEFINE_PARTIAL_ITEM_TWEAK(liquid_misc, 150)
+DEFINE_PARTIAL_ITEM_TWEAK(powder_misc, 150)
+DEFINE_PARTIAL_ITEM_TWEAK(cloth, 10000)
+DEFINE_PARTIAL_ITEM_TWEAK(sheet, 10000)
+DEFINE_PARTIAL_ITEM_TWEAK(thread, 15000)


### PR DESCRIPTION
When active, the displayed names of partially-consumed items (e.g. hospital cloth) will display a percentage indicator at the end.

Because otherwise it's impossible to see why certain pieces of cloth or thread are being ignored for other jobs.