### PR TITLE
Update init files

### DIFF
--- a/data/examples/init/onMapLoad_dreamfort.init
+++ b/data/examples/init/onMapLoad_dreamfort.init
@@ -24,12 +24,6 @@ repeat -name autoMilkCreature -time 14 -timeUnits days -command [ workorder "{\"
 # Fulfill high-volume orders before slower once-daily orders
 repeat -name orders-sort -time 1 -timeUnits days -command [ orders sort ]
 
-# Reduce performance impact of temperature changes
-tweak fast-heat 100
-
-# Add a hotkey to the job menu to allow boosting the priority of the job
-tweak do-job-now
-
 # Don't let caravans bring barrels of blood and other useless liquids
 fix/blood-del
 

--- a/data/examples/init/onMapLoad_dreamfort.init
+++ b/data/examples/init/onMapLoad_dreamfort.init
@@ -3,29 +3,37 @@
 # configuration here is useful for any fort! Feed free to edit or override
 # to your liking.
 
-# Disallow cooking of otherwise useful item types
-on-new-fortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk; ban-cooking booze
-
 # Uncomment this next line if you want buildingplan (and quickfort) to use only
-# blocks for construction. If you do uncomment, be sure to bring some blocks
-# with you for starting workshops!
+# blocks (not bars or logs) for constructions and workshops. If you do
+# uncomment, be sure to bring some blocks with you for starting workshops!
 #on-new-fortress buildingplan set boulders false; buildingplan set logs false
 
+# Disable cooking of useful item types when you start a new fortress.
+on-new-fortress ban-cooking tallow; ban-cooking honey; ban-cooking oil; ban-cooking seeds; ban-cooking brew; ban-cooking fruit; ban-cooking mill; ban-cooking thread; ban-cooking milk; ban-cooking booze
+
+# Show a warning dialog when units are starving
 repeat -name warn-starving -time 10 -timeUnits days -command [ warn-starving ]
-repeat -name burial -time 7 -timeUnits days -command [ burial -pets ]
+
+# Force dwarves to drop tattered clothing instead of clinging to the scraps
 repeat -name cleanowned -time 1 -timeUnits months -command [ cleanowned X ]
-repeat -name clean -time 1 -timeUnits months -command [ clean all ]
-repeat -name feeding-timers -time 1 -timeUnits months -command [ fix/feeding-timers ]
-repeat -name stuckdoors -time 1 -timeUnits months -command [ fix/stuckdoors ]
+
+# Automatically enqueue orders to shear and milk animals
 repeat -name autoShearCreature -time 14 -timeUnits days -command [ workorder ShearCreature ]
 repeat -name autoMilkCreature -time 14 -timeUnits days -command [ workorder "{\"job\":\"MilkCreature\",\"item_conditions\":[{\"condition\":\"AtLeast\",\"value\":2,\"flags\":[\"empty\"],\"item_type\":\"BUCKET\"}]}" ]
+
+# Fulfill high-volume orders before slower once-daily orders
 repeat -name orders-sort -time 1 -timeUnits days -command [ orders sort ]
 
+# Reduce performance impact of temperature changes
 tweak fast-heat 100
-tweak do-job-now
-fix/blood-del enable
 
-# manages crop assignment for farm plots
+# Add a hotkey to the job menu to allow boosting the priority of the job
+tweak do-job-now
+
+# Don't let caravans bring barrels of blood and other useless liquids
+fix/blood-del
+
+# Manages crop assignment for farm plots
 enable autofarm
 autofarm default 30
 autofarm threshold 150 GRASS_TAIL_PIG
@@ -37,7 +45,8 @@ enable automelt
 enable tailor
 tailor enable
 
-# auto-assigns nesting birds to nestbox zones
+# auto-assigns nesting birds to nestbox zones and protects fertile eggs from
+# being cooked/eaten
 enable zone nestboxes
 autonestbox start
 
@@ -77,7 +86,7 @@ on-new-fortress autobutcher target 50 50 14 2 BIRD_GOOSE
 on-new-fortress autobutcher target 2 2 4 2 ALPACA SHEEP LLAMA
 # pigs give milk and meat and are zero-maintenance.
 on-new-fortress autobutcher target 5 5 6 2 PIG
-# generally unprofitable animals
+# butcher all unprofitable animals
 on-new-fortress autobutcher target 0 0 0 0 HORSE YAK DONKEY WATER_BUFFALO GOAT CAVY BIRD_DUCK BIRD_GUINEAFOWL
 # start it up!
 on-new-fortress autobutcher start; autobutcher watch all; autobutcher autowatch

--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -155,9 +155,6 @@ keybinding add Alt-W@dfhack/lua/status_overlay "gui/workflow status"
 # autobutcher front-end
 keybinding add Shift-B@pet/List/Unit "gui/autobutcher"
 
-# assign weapon racks to squads so that they can be used
-keybinding add P@dwarfmode/QueryBuilding/Some/Weaponrack gui/assign-rack
-
 # view pathable tiles from active cursor
 keybinding add Alt-Shift-P@dwarfmode/LookAround gui/pathable
 
@@ -186,9 +183,6 @@ tweak military-stable-assign
 # in same list, color units already assigned to squads in brown & green
 tweak military-color-assigned
 
-# remove inverse dependency of squad training speed on unit list size and use more sparring
-# tweak military-training
-
 # make crafted cloth items wear out with time like in old versions (bug 6003)
 tweak craft-age-wear
 
@@ -215,12 +209,14 @@ tweak block-labors              # Prevents labors that can't be used from being 
 tweak burrow-name-cancel
 tweak cage-butcher
 tweak civ-view-agreement
+tweak do-job-now
 tweak eggs-fertile
 tweak fps-min
 tweak hide-priority
 tweak kitchen-prefs-all
 tweak kitchen-prefs-empty
 tweak max-wheelbarrow
+tweak partial-items
 tweak shift-8-scroll
 tweak stone-status-all
 tweak title-start-rename
@@ -289,5 +285,6 @@ gui/load-screen enable
 # Extra DFHack command files #
 ##############################
 
-# Run commands in this file when a world loads
-sc-script add SC_WORLD_LOADED onLoad.init-example
+# Create a file named "onLoad.init" to run commands when a world is loaded
+# and/or create a file named "onMapLoad.init" to run commands when a map is
+# loaded. See the hack/examples/init/ directory for useful pre-made init files.

--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -34,6 +34,9 @@ keybinding add Ctrl-K autodump-destroy-item
 # quicksave, only in main dwarfmode screen and menu page
 keybinding add Ctrl-Alt-S@dwarfmode/Default quicksave
 
+# gui/quickfort script - apply pre-made blueprints to the map
+keybinding add Ctrl-Shift-Q@dwarfmode gui/quickfort
+
 # gui/rename script - rename units and buildings
 keybinding add Ctrl-Shift-N gui/rename
 keybinding add Ctrl-Shift-T "gui/rename unit-profession"

--- a/dfhack.init-example
+++ b/dfhack.init-example
@@ -207,6 +207,9 @@ tweak hotkey-clear
 # Allows lowercase letters in embark profile names, and allows exiting the name prompt without saving
 tweak embark-profile-name
 
+# Reduce performance impact of temperature changes
+tweak fast-heat 100
+
 # Misc. UI tweaks
 tweak block-labors              # Prevents labors that can't be used from being toggled
 tweak burrow-name-cancel

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `blueprint`: ``track`` phase renamed to ``carve``. carved fortifications and (optionally) engravings are now captured in blueprints
 - `tweak` stable-cursor: Keep the cursor stable even when the viewport moves a small amount
 - `cursecheck`: Added a new parameter, ``ids``, to print creature and race IDs of the cursed creature.
+- Include recently-added tweaks in example dfhack.init file, clean up dreamfort onMapLoad.init file
 
 ## Documentation
 - Add more examples to the plugin skeleton files so they are more informative for a newbie

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -461,7 +461,7 @@ endif()
 install(FILES xml/symbols.xml
     DESTINATION ${DFHACK_DATA_DESTINATION})
 # install the example autoexec file
-install(FILES ../dfhack.init-example ../onLoad.init-example
+install(FILES ../dfhack.init-example
     DESTINATION ${DFHACK_BINARY_DESTINATION})
 
 install(TARGETS dfhack-run dfhack-client binpatch

--- a/onLoad.init-example
+++ b/onLoad.init-example
@@ -1,1 +1,0 @@
-repeat -name warn-starving -time 10 -timeUnits days -command [ warn-starving ]


### PR DESCRIPTION
Update the default init files with the following changes:

**dfhack.init-example**
- add `gui/quickfort` keybinding (is Ctrl-Shift-Q a good choice?)
- remove keybinding for obsolete `gui/assign-rack`
- remove reference to obsolete `tweak military-training`
- add `tweak do-job-now`
- add `tweak partial-items`
- add `tweak fast-heat 100`
- replaced the `sc-script` example with documentation on how to name files so they load automatically without needing to use `sc-script`

**onLoad.init-example**
- removed (replaced with documentation added to `dfhack.init-example`)

**data/examples/init/onMapLoad_dreamfort.init**
- added more documentation, removed "cheaty" commands and commands now moved to `dfhack.init-example`

Should anything in `onMapLoad_dreamfort.init` be moved to a more "default" file?