### PR TITLE
Add a link to the rust library for interacting with the remote API

### DIFF
--- a/docs/Remote.rst
+++ b/docs/Remote.rst
@@ -79,6 +79,7 @@ from other (non-C++) languages, including:
 - `dfhack-client-qt <https://github.com/cvuchener/dfhack-client-qt>`_ for C++ with Qt
 - `dfhack-client-python <https://github.com/McArcady/dfhack-client-python>`_ for Python (adapted from :forums:`"Blendwarf" <178089>`)
 - `dfhack-client-java <https://github.com/McArcady/dfhack-client-java>`_ for Java
+- `dfhack-remote <https://github.com/plule/dfhack-remote>`_ for Rust
 
 
 Protocol description

--- a/docs/Remote.rst
+++ b/docs/Remote.rst
@@ -79,7 +79,7 @@ from other (non-C++) languages, including:
 - `dfhack-client-qt <https://github.com/cvuchener/dfhack-client-qt>`_ for C++ with Qt
 - `dfhack-client-python <https://github.com/McArcady/dfhack-client-python>`_ for Python (adapted from :forums:`"Blendwarf" <178089>`)
 - `dfhack-client-java <https://github.com/McArcady/dfhack-client-java>`_ for Java
-- `dfhack-remote <https://github.com/plule/dfhack-remote>`_ for Rust
+- `dfhack-remote <https://docs.rs/dfhack-remote/latest/dfhack_remote/index.html>`_ for Rust
 
 
 Protocol description

--- a/docs/Remote.rst
+++ b/docs/Remote.rst
@@ -75,11 +75,11 @@ from other (non-C++) languages, including:
 
 - `RemoteClientDF-Net <https://github.com/RosaryMala/RemoteClientDF-Net>`_ for C#
 - `dfhackrpc <https://github.com/BenLubar/dfhackrpc>`_ for Go
-- `dfhack-remote <https://github.com/alexchandel/dfhack-remote>`_ for JavaScript
+- `dfhack-remote <https://github.com/alexchandel/dfhack-remote>`__ for JavaScript
 - `dfhack-client-qt <https://github.com/cvuchener/dfhack-client-qt>`_ for C++ with Qt
 - `dfhack-client-python <https://github.com/McArcady/dfhack-client-python>`_ for Python (adapted from :forums:`"Blendwarf" <178089>`)
 - `dfhack-client-java <https://github.com/McArcady/dfhack-client-java>`_ for Java
-- `dfhack-remote <https://docs.rs/dfhack-remote/latest/dfhack_remote/index.html>`_ for Rust
+- `dfhack-remote <https://docs.rs/dfhack-remote/latest/dfhack_remote/index.html>`__ for Rust
 
 
 Protocol description

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -71,6 +71,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `confirm`: Correct the command name in the plugin help text
 - ``Quickfort Blueprint Editing Guide``: added screenshots to the Dreamfort case study and overall clarified text
 - Document DFHack `lua-string` (``startswith``, ``endswith``, ``split``, ``trim``, ``wrap``, and ``escape_pattern``).
+- Added a Rust client library to the `remote interface docs <remote-client-libs>`
 
 ## API
 - Added functions reverse-engineered from ambushing unit code: ``Units::isHidden``, ``Units::isFortControlled``, ``Units::getOuterContainerRef``, ``Items::getOuterContainerRef``


### PR DESCRIPTION
Add a link to https://docs.rs/dfhack-remote/latest/dfhack_remote/index.html, a library using the remote API for the rust programming language. Note: the github repo is https://github.com/plule/dfhack-remote if you prefer linking to it rather than docs.rs