### PR TITLE
Adds ccache to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install \
+            ccache \
             libgtk2.0-0 \
             libncursesw5 \
             libsdl-image1.2-dev \
@@ -38,8 +39,7 @@ jobs:
             libxml-libxslt-perl \
             lua5.3 \
             ninja-build \
-            zlib1g-dev \
-            ccache
+            zlib1g-dev
         pip install 'sphinx<4.4.0'
     - name: Install GCC
       run: |
@@ -65,7 +65,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ${{ matrix.gcc }}
+        key: ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}
     - name: Download DF
       run: |
         sh ci/download-df.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,8 @@ jobs:
             libxml-libxslt-perl \
             lua5.3 \
             ninja-build \
-            zlib1g-dev
+            zlib1g-dev \
+            ccache
         pip install 'sphinx<4.4.0'
     - name: Install GCC
       run: |
@@ -60,6 +61,11 @@ jobs:
       with:
         path: ~/DF
         key: ${{ steps.env_setup.outputs.df_version }}
+    - name: Fetch ccache
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: ${{ matrix.gcc }}
     - name: Download DF
       run: |
         sh ci/download-df.sh


### PR DESCRIPTION
I tested on my fork with PR https://github.com/cppcooper/dfhack/pull/3

I added this commit and pushed, opened the PR, added a (temporary) document change commit and pushed. The second commit's build steps were seconds instead of minutes. So this works as far as I tested.