### PR TITLE
Command prompt wrap

### DIFF
--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -168,32 +168,58 @@ std::string to_search_normalized(const std::string &str)
     return result;
 }
 
-bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t line_length)
+
+bool word_wrap(std::vector<std::string> *out, const std::string &str,
+               size_t line_length, bool collapse_whitespace)
 {
-    out->clear();
-    std::istringstream input(str);
-    std::string out_line;
-    std::string word;
-    if (input >> word)
+    if (line_length == 0)
+        line_length = SIZE_MAX;
+
+    std::string line;
+    size_t break_pos = 0;
+
+    for (auto &c : str)
     {
-        out_line += word;
-        // size_t remaining = line_length - std::min(line_length, word.length());
-        while (input >> word)
+        if (c == '\n')
         {
-            if (out_line.length() + word.length() + 1 <= line_length)
+            out->push_back(line);
+            line.clear();
+            break_pos = 0;
+            continue;
+        }
+
+        if (isspace(c))
+        {
+            if (break_pos == line.length() && collapse_whitespace)
+                continue;
+
+            line.push_back(collapse_whitespace ? ' ' : c);
+            break_pos = line.length();
+        }
+        else {
+            line.push_back(c);
+        }
+
+        if (line.length() > line_length)
+        {
+            if (break_pos > 0)
             {
-                out_line += ' ';
-                out_line += word;
+                // Break before last space, and skip that space
+                out->push_back(line.substr(0, break_pos - 1));
             }
             else
             {
-                out->push_back(out_line);
-                out_line = word;
+                // Single word is too long, just break it
+                out->push_back(line.substr(0, line_length));
+                break_pos = line_length;
             }
+            line = line.substr(break_pos);
+            break_pos = 0;
         }
-        if (out_line.length())
-            out->push_back(out_line);
     }
+    if (line.length())
+        out->push_back(line);
+
     return true;
 }
 

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -391,7 +391,8 @@ DFHACK_EXPORT std::string to_search_normalized(const std::string &str);
 
 DFHACK_EXPORT bool word_wrap(std::vector<std::string> *out,
                              const std::string &str,
-                             size_t line_length = 80);
+                             size_t line_length = 80,
+                             bool collapse_whitespace = false);
 
 inline bool bits_match(unsigned required, unsigned ok, unsigned mask)
 {

--- a/plugins/command-prompt.cpp
+++ b/plugins/command-prompt.cpp
@@ -1,23 +1,23 @@
-//command-prompt a one line command entry at the top of the screen for quick commands
+// command-prompt: A one-line command entry at the top of the screen for quick commands
 
 #include "Core.h"
+#include <ColorText.h>
 #include <Console.h>
 #include <Export.h>
 #include <PluginManager.h>
-#include <ColorText.h>
 
-#include <modules/Screen.h>
 #include <modules/Gui.h>
+#include <modules/Screen.h>
 
-#include <set>
 #include <list>
+#include <set>
 #include <utility>
 #include <vector>
 
+#include "df/enabler.h"
+#include "df/graphic.h"
 #include "df/interface_key.h"
 #include "df/ui.h"
-#include "df/graphic.h"
-#include "df/enabler.h"
 
 using namespace DFHack;
 using namespace df::enums;
@@ -36,8 +36,10 @@ class prompt_ostream:public buffered_color_ostream
     protected:
         void flush_proxy();
     public:
-        prompt_ostream(viewscreen_commandpromptst* parent):parent_(parent){}
-        bool empty(){return buffer.empty();}
+        prompt_ostream(viewscreen_commandpromptst* parent)
+            : parent_(parent)
+        {}
+        bool empty() { return buffer.empty(); }
 };
 class viewscreen_commandpromptst : public dfhack_viewscreen {
 public:
@@ -48,7 +50,7 @@ public:
     }
 
     void render();
-    void help() { }
+    void help() {}
     int8_t movies_okay() { return 0; }
 
     df::unit* getSelectedUnit() { return Gui::getAnyUnit(parent); }
@@ -57,10 +59,11 @@ public:
     df::plant* getSelectedPlant() { return Gui::getAnyPlant(parent); }
 
     std::string getFocusString() { return "commandprompt"; }
-    viewscreen_commandpromptst(std::string entry):submitted(false), is_response(false)
+    viewscreen_commandpromptst(std::string entry)
+        : submitted(false), is_response(false)
     {
-        show_fps=gps->display_frames;
-        gps->display_frames=0;
+        show_fps = gps->display_frames;
+        gps->display_frames = 0;
         cursor_pos = entry.size();
         frame = 0;
         history_idx = command_history.size();
@@ -76,7 +79,7 @@ public:
     }
     ~viewscreen_commandpromptst()
     {
-        gps->display_frames=show_fps;
+        gps->display_frames = show_fps;
     }
 
     void add_response(color_value v, std::string s)
@@ -125,7 +128,7 @@ public:
     }
 
 protected:
-    std::list<std::pair<color_value,std::string> > responses;
+    std::list<std::pair<color_value, std::string> > responses;
     int cursor_pos;
     int history_idx;
     bool submitted;
@@ -138,8 +141,8 @@ void prompt_ostream::flush_proxy()
 {
     if (buffer.empty())
         return;
-    for(auto it=buffer.begin();it!=buffer.end();it++)
-        parent_->add_response(it->first,it->second);
+    for(auto it = buffer.begin(); it != buffer.end(); it++)
+        parent_->add_response(it->first, it->second);
     buffer.clear();
 }
 void viewscreen_commandpromptst::render()
@@ -154,25 +157,26 @@ void viewscreen_commandpromptst::render()
 
     auto dim = Screen::getWindowSize();
     parent->render();
-    if(is_response)
+    if (is_response)
     {
-        auto it=responses.begin();
-        for(int i=0;i<dim.y && it!=responses.end();i++,it++)
+        auto it = responses.begin();
+        for (int i = 0; i < dim.y && it != responses.end(); i++, it++)
         {
-            Screen::fillRect(Screen::Pen(' ', 7, 0),0,i,dim.x,i);
-            std::string cur_line=it->second;
-            Screen::paintString(Screen::Pen(' ',it->first,0),0,i,cur_line.substr(0,cur_line.size()-1));
+            Screen::fillRect(Screen::Pen(' ', 7, 0), 0, i, dim.x, i);
+            std::string cur_line = it->second;
+            Screen::paintString(Screen::Pen(' ', it->first, 0), 0, i,
+                    cur_line.substr(0, cur_line.size() - 1));
         }
     }
     else
     {
         std::string entry = get_entry();
-        Screen::fillRect(Screen::Pen(' ', 7, 0),0,0,dim.x,0);
-        Screen::paintString(Screen::Pen(' ', 7, 0), 0, 0,"[DFHack]#");
+        Screen::fillRect(Screen::Pen(' ', 7, 0), 0, 0, dim.x, 0);
+        Screen::paintString(Screen::Pen(' ', 7, 0), 0, 0, "[DFHack]#");
         std::string cursor = (frame < enabler->gfps / 2) ? "_" : " ";
-        if(cursor_pos < (dim.x - 10))
+        if (cursor_pos < dim.x - 10)
         {
-            Screen::paintString(Screen::Pen(' ', 7, 0), 10,0 , entry);
+            Screen::paintString(Screen::Pen(' ', 7, 0), 10, 0, entry);
             if (int16_t(entry.size()) > dim.x - 10)
                 Screen::paintTile(Screen::Pen('\032', 7, 0), dim.x - 1, 0);
             if (cursor != " ")
@@ -191,12 +195,12 @@ void viewscreen_commandpromptst::render()
 void viewscreen_commandpromptst::submit()
 {
     CoreSuspendClaimer suspend;
-    if(is_response)
+    if (is_response)
     {
         Screen::dismiss(this);
         return;
     }
-    if(submitted)
+    if (submitted)
         return;
     submitted = true;
     prompt_ostream out(this);
@@ -204,11 +208,11 @@ void viewscreen_commandpromptst::submit()
         Screen::Hide hide_guard(this, Screen::Hide::RESTORE_AT_TOP);
         Core::getInstance().runCommand(out, get_entry());
     }
-    if(out.empty() && responses.empty())
+    if (out.empty() && responses.empty())
         Screen::dismiss(this);
     else
     {
-        is_response=true;
+        is_response = true;
     }
 }
 void viewscreen_commandpromptst::feed(std::set<df::interface_key> *events)
@@ -240,14 +244,14 @@ void viewscreen_commandpromptst::feed(std::set<df::interface_key> *events)
     for (auto it = events->begin(); it != events->end(); ++it)
     {
         auto key = *it;
-        if (key==interface_key::STRING_A000) //delete?
+        if (key == interface_key::STRING_A000) //delete?
         {
-            if(entry.size() && cursor_pos > 0)
+            if (entry.size() && cursor_pos > 0)
             {
                 entry.erase(cursor_pos - 1, 1);
                 cursor_pos--;
             }
-            if(size_t(cursor_pos) > entry.size())
+            if (size_t(cursor_pos) > entry.size())
                 cursor_pos = entry.size();
             continue;
         }
@@ -261,34 +265,34 @@ void viewscreen_commandpromptst::feed(std::set<df::interface_key> *events)
         }
     }
     // Prevent number keys from moving cursor
-    if(events->count(interface_key::CURSOR_RIGHT))
+    if (events->count(interface_key::CURSOR_RIGHT))
     {
         cursor_pos++;
         if (size_t(cursor_pos) > entry.size())
             cursor_pos = entry.size();
     }
-    else if(events->count(interface_key::CURSOR_LEFT))
+    else if (events->count(interface_key::CURSOR_LEFT))
     {
         cursor_pos--;
         if (cursor_pos < 0) cursor_pos = 0;
     }
-    else if(events->count(interface_key::CURSOR_RIGHT_FAST))
+    else if (events->count(interface_key::CURSOR_RIGHT_FAST))
     {
         forward_word();
     }
-    else if(events->count(interface_key::CURSOR_LEFT_FAST))
+    else if (events->count(interface_key::CURSOR_LEFT_FAST))
     {
         back_word();
     }
-    else if(events->count(interface_key::CUSTOM_CTRL_A))
+    else if (events->count(interface_key::CUSTOM_CTRL_A))
     {
         cursor_pos = 0;
     }
-    else if(events->count(interface_key::CUSTOM_CTRL_E))
+    else if (events->count(interface_key::CUSTOM_CTRL_E))
     {
         cursor_pos = entry.size();
     }
-    else if(events->count(interface_key::CURSOR_UP))
+    else if (events->count(interface_key::CURSOR_UP))
     {
         history_idx--;
         if (history_idx < 0)
@@ -296,7 +300,7 @@ void viewscreen_commandpromptst::feed(std::set<df::interface_key> *events)
         entry = get_entry();
         cursor_pos = entry.size();
     }
-    else if(events->count(interface_key::CURSOR_DOWN))
+    else if (events->count(interface_key::CURSOR_DOWN))
     {
         if (size_t(history_idx) < command_history.size() - 1)
         {
@@ -321,8 +325,8 @@ command_result show_prompt(color_ostream &out, std::vector <std::string> & param
         return CR_OK;
     }
     std::string params;
-    for(size_t i=0;i<parameters.size();i++)
-        params+=parameters[i]+" ";
+    for(size_t i = 0; i < parameters.size(); i++)
+        params += parameters[i] + " ";
     Screen::show(dts::make_unique<viewscreen_commandpromptst>(params), plugin_self);
     return CR_OK;
 }
@@ -330,21 +334,23 @@ bool hotkey_allow_all(df::viewscreen *top)
 {
     return true;
 }
-DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
+DFhackCExport command_result plugin_init(color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
-        "command-prompt","Shows a command prompt on window.",show_prompt,hotkey_allow_all,
-        "command-prompt [entry] - shows a cmd prompt in df window. Entry is used for default prefix (e.g. ':lua')"
+                "command-prompt", "Shows a command prompt on window.",
+                show_prompt, hotkey_allow_all,
+                "command-prompt [entry] - shows a cmd prompt in df window."
+                " Entry is used for default prefix (e.g. ':lua')"
         ));
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_onstatechange (color_ostream &out, state_change_event e)
+DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_change_event e)
 {
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_shutdown ( color_ostream &out )
+DFhackCExport command_result plugin_shutdown(color_ostream &out)
 {
     return CR_OK;
 }

--- a/plugins/command-prompt.cpp
+++ b/plugins/command-prompt.cpp
@@ -4,6 +4,7 @@
 #include <ColorText.h>
 #include <Console.h>
 #include <Export.h>
+#include <MiscUtils.h>
 #include <PluginManager.h>
 
 #include <modules/Gui.h>
@@ -11,6 +12,7 @@
 
 #include <list>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -159,13 +161,18 @@ void viewscreen_commandpromptst::render()
     parent->render();
     if (is_response)
     {
-        auto it = responses.begin();
-        for (int i = 0; i < dim.y && it != responses.end(); i++, it++)
+        int y = 0;
+        for (auto &response : responses)
         {
-            Screen::fillRect(Screen::Pen(' ', 7, 0), 0, i, dim.x, i);
-            std::string cur_line = it->second;
-            Screen::paintString(Screen::Pen(' ', it->first, 0), 0, i,
-                    cur_line.substr(0, cur_line.size() - 1));
+            std::vector<std::string> lines;
+            word_wrap(&lines, response.second, dim.x);
+            for (auto &line : lines)
+            {
+                Screen::fillRect(Screen::Pen(' ', 7, 0), 0, y, dim.x, y);
+                Screen::paintString(Screen::Pen(' ', response.first, 0), 0, y, line);
+                if (++y >= dim.y)
+                    return;
+            }
         }
     }
     else


### PR DESCRIPTION
Adding word wrapping to the command-prompt responses is simple. But we want to preserve whitespace, which our existing `word_wrap()` (both C++ and Lua) don't do. So here's an upgrade.

Now that word wrapping is in place, it really cries out for scrolling the results up and down. That can be done in a separate PR, though.

Closes #2079

Tests for word_wrap(), to be added once unit testing for C++ is sorted:

```cpp
#include "Internal.h"
#include "MiscUtils.h"

#include <iostream>
#include <string>
using namespace std;

bool compare_result(const vector<string> &expect, const vector<string> &result)
{
    if (result == expect)
    {
        return true;
    }
    else
    {
        auto e = expect.begin();
        auto r = result.begin();
        cout << "# " << setw(20) << left << "Expected" << " " << left << "Got\n";
        while (e < expect.end() || r < result.end())
        {
            cout
                << "# "
                << setw(20) << left << ":" + (e < expect.end() ? *e++ : "") + ":"
                << " "
                << setw(20) << left << ":" + (r < result.end() ? *r++ : "") + ":"
                << "\n";
        }
        return false;
    }
}

int main()
{
    const int plan = 14;

    int test_num = 0;
    int fails = 0;
#define TEST_WORDWRAP(label, args, expect) \
    { \
        ++test_num; \
        vector<string> RESULT; \
        word_wrap args; \
        bool ok = compare_result(expect, RESULT); \
        cout << setw(6) << left << (ok ? "ok" : "not ok") \
                << " " << setw(5) << test_num << " - " << label \
                << "\n"; \
    }

    cout << "1.." << plan << "\n";

    TEST_WORDWRAP("Short line, no wrap", (&RESULT, "12345", 15), vector<string>({"12345"}));

    TEST_WORDWRAP("One long word, wrap", (&RESULT, "12345", 3), vector<string>({"123", "45"}));

    TEST_WORDWRAP("Lines preserved", (&RESULT, "123\n45\n", 15), vector<string>({"123", "45"}));

    TEST_WORDWRAP("Internal spaces per line", (&RESULT, "123  ab cde\n45 x  y   z\n", 15), vector<string>({"123  ab cde", "45 x  y   z"}));

    TEST_WORDWRAP("Internal spaces collapsed", (&RESULT, "123  ab cde\n45 x  y   z\n", 15, true), vector<string>({"123 ab cde", "45 x y z"}));

    TEST_WORDWRAP("Trailing spaces", (&RESULT, "123 \n456  \n789   \n", 15), vector<string>({"123 ", "456  ", "789   "}));

    TEST_WORDWRAP("Trailing spaces collapsed", (&RESULT, "123 \n456  \n789   \n", 15, true), vector<string>({"123 ", "456 ", "789 "}));

    TEST_WORDWRAP("Initial spaces", (&RESULT, " 123\n  456\n   789\n", 15), vector<string>({" 123", "  456", "   789"}));

    TEST_WORDWRAP("Initial spaces collapsed", (&RESULT, " 123\n  456\n   789\n", 15, true), vector<string>({"123", "456", "789"}));

    TEST_WORDWRAP("Basic wrap", (&RESULT, "this is a long line that will wrap, and it has normal spaces in it", 15), vector<string>({"this is a long", "line that will", "wrap, and it", "has normal", "spaces in it"}));

    TEST_WORDWRAP("Wrap with internal spaces", (&RESULT, "this  is a   long line    that     will  wrap,   and    it has   extra   spaces in   it", 15), vector<string>({"this  is a  ", "long line   ", "that     will ", "wrap,   and   ", "it has   extra ", " spaces in   it"}));

    TEST_WORDWRAP("Wrap with internal spaces collapsed", (&RESULT, "this  is a   long line    that     will  wrap,   and    it has   extra   spaces in   it", 15, true), vector<string>({"this is a long", "line that will", "wrap, and it", "has extra", "spaces in it"}));

    TEST_WORDWRAP("One long word, initial spaces, wrap", (&RESULT, "   12345   ", 3), vector<string>({"  ", "123", "45 ", " "}));

    TEST_WORDWRAP("One long word, initial spaces, wrap, collapse", (&RESULT, "   12345   ", 3, true), vector<string>({"123", "45 "}));

    return fails == 0 ? 0 : 1;
}
```