### PR TITLE
tombstone devel/unforbidall script

### DIFF
--- a/docs/Removed.rst
+++ b/docs/Removed.rst
@@ -10,6 +10,14 @@ work (e.g. links from the `changelog`).
   :local:
   :depth: 1
 
+.. _devel/unforbidall:
+
+devel/unforbidall
+=================
+
+Replaced by the `unforbid` script. Run ``unforbid all --quiet`` to match the
+behavior of the original ``devel/unforbidall`` script.
+
 .. _digfort:
 
 digfort


### PR DESCRIPTION
ref: DFHack/scripts#382

This PR should be merged before the stroke of midnight so the docs don't suddenly become unbuildable when the automated submodule update happens.