### PR TITLE
Fix script-docs.py extension check

### DIFF
--- a/ci/script-docs.py
+++ b/ci/script-docs.py
@@ -81,11 +81,11 @@ def check_file(fname):
 def main():
     """Check that all DFHack scripts include documentation"""
     err = 0
-    exclude = set(['internal', 'test'])
+    exclude = {'.git', 'internal', 'test'}
     for root, dirs, files in os.walk(SCRIPT_PATH, topdown=True):
         dirs[:] = [d for d in dirs if d not in exclude]
         for f in files:
-            if f[-3:] in {'.rb', 'lua'}:
+            if f.split('.')[-1] in {'rb', 'lua'}:
                 err += check_file(join(root, f))
     return err
 


### PR DESCRIPTION
The check previously matched any filename ending in `lua`, not `.lua`. This
caused failures in my fork because I had a branch ending in `-lua`, which
created a file of that name in `.git/refs` that was not a valid Lua script.

For extra good measure, anything under `.git` is ignored now as well.

(Fun fact: this dates back to the script's original implementation in #713)