### PR TITLE
update the list of submodules to autoupdate

### DIFF
--- a/ci/update-submodules.manifest
+++ b/ci/update-submodules.manifest
@@ -1,7 +1,9 @@
 library/xml master
 scripts master
 plugins/stonesense master
+plugins/isoworld master
 depends/libzip dfhack
 depends/libexpat dfhack
 depends/xlsxio dfhack
 depends/luacov dfhack
+depends/jsoncpp dfhack


### PR DESCRIPTION
#2131 
move jsoncpp to reading from the new `dfhack` branch instead of master so we can fetch upstream into master without it automatically getting pulled into the main build

also autoupdate isoworld, which wasn't currently tracked.