### PR TITLE
reduce spurious warnings from libzip

### DIFF
--- a/depends/CMakeLists.txt
+++ b/depends/CMakeLists.txt
@@ -37,6 +37,7 @@ if(UNIX)
     set_target_properties(expat PROPERTIES COMPILE_FLAGS "-Wno-maybe-uninitialized")
 endif()
 
+set(CMAKE_REQUIRED_QUIET ON)
 set(LIBZIP_BUILD_DOC OFF CACHE BOOL "")
 set(LIBZIP_BUILD_EXAMPLES OFF CACHE BOOL "")
 set(LIBZIP_BUILD_REGRESS OFF CACHE BOOL "")


### PR DESCRIPTION
This should get rid of those silly `WARN: CHECK_STARTLooking for _snprintf` messages