### PR TITLE
let CycleHotkeyLabels take numeric initial_options

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Tweaks
 
 ## Fixes
+- ``widgets.CycleHotkeyLabel``: allow initial option values to be specified as an index instead of an option value
 
 ## Misc Improvements
 - `dfhack-examples-guide`: refine food preparation orders and fix conditions for making jugs and pots in the ``basic`` manager orders

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -638,6 +638,11 @@ function CycleHotkeyLabel:init()
         end
     end
     if not self.option_idx then
+        if self.options[self.initial_option] then
+            self.option_idx = self.initial_option
+        end
+    end
+    if not self.option_idx then
         error(('cannot find option with value or index: "%s"')
               :format(self.initial_option))
     end

--- a/test/library/gui/widgets.lua
+++ b/test/library/gui/widgets.lua
@@ -1,0 +1,18 @@
+local widgets = require('gui.widgets')
+
+function test.togglehotkeylabel()
+   local toggle = widgets.ToggleHotkeyLabel{}
+   expect.true_(toggle:getOptionValue())
+   toggle:cycle()
+   expect.false_(toggle:getOptionValue())
+   toggle:cycle()
+   expect.true_(toggle:getOptionValue())
+end
+
+function test.togglehotkeylabel_default_value()
+   local toggle = widgets.ToggleHotkeyLabel{initial_option=2}
+   expect.false_(toggle:getOptionValue())
+
+   toggle = widgets.ToggleHotkeyLabel{initial_option=false}
+   expect.false_(toggle:getOptionValue())
+end


### PR DESCRIPTION
even if all of the option values are non-numeric

Fixes #2158