### PR TITLE
Confirmation dialog for removing manager orders

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``widgets.CycleHotkeyLabel``: allow initial option values to be specified as an index instead of an option value
 
 ## Misc Improvements
+- `confirm`: added a confirmation dialog for removing manager orders
 - `dfhack-examples-guide`: refine food preparation orders and fix conditions for making jugs and pots in the ``basic`` manager orders
 
 ## Documentation

--- a/plugins/confirm.cpp
+++ b/plugins/confirm.cpp
@@ -482,7 +482,7 @@ DEFINE_CONFIRMATION(note_delete,        viewscreen_dwarfmodest);
 DEFINE_CONFIRMATION(route_delete,       viewscreen_dwarfmodest);
 DEFINE_CONFIRMATION(location_retire,    viewscreen_locationsst);
 DEFINE_CONFIRMATION(convict,            viewscreen_justicest);
-DEFINE_CONFIRMATION(order_delete,       viewscreen_jobmanagementst);
+DEFINE_CONFIRMATION(order_remove,       viewscreen_jobmanagementst);
 
 DFhackCExport command_result plugin_init (color_ostream &out, vector <PluginCommand> &commands)
 {

--- a/plugins/confirm.cpp
+++ b/plugins/confirm.cpp
@@ -18,6 +18,7 @@
 #include "df/general_ref.h"
 #include "df/general_ref_contained_in_itemst.h"
 #include "df/viewscreen_dwarfmodest.h"
+#include "df/viewscreen_jobmanagementst.h"
 #include "df/viewscreen_justicest.h"
 #include "df/viewscreen_layer_militaryst.h"
 #include "df/viewscreen_locationsst.h"
@@ -481,7 +482,7 @@ DEFINE_CONFIRMATION(note_delete,        viewscreen_dwarfmodest);
 DEFINE_CONFIRMATION(route_delete,       viewscreen_dwarfmodest);
 DEFINE_CONFIRMATION(location_retire,    viewscreen_locationsst);
 DEFINE_CONFIRMATION(convict,            viewscreen_justicest);
-DEFINE_CONFIRMATION(order_delete,       viewscreen_manager_ordersst);
+DEFINE_CONFIRMATION(order_delete,       viewscreen_jobmanagementst);
 
 DFhackCExport command_result plugin_init (color_ostream &out, vector <PluginCommand> &commands)
 {

--- a/plugins/confirm.cpp
+++ b/plugins/confirm.cpp
@@ -481,6 +481,7 @@ DEFINE_CONFIRMATION(note_delete,        viewscreen_dwarfmodest);
 DEFINE_CONFIRMATION(route_delete,       viewscreen_dwarfmodest);
 DEFINE_CONFIRMATION(location_retire,    viewscreen_locationsst);
 DEFINE_CONFIRMATION(convict,            viewscreen_justicest);
+DEFINE_CONFIRMATION(order_delete,       viewscreen_manager_ordersst);
 
 DFhackCExport command_result plugin_init (color_ostream &out, vector <PluginCommand> &commands)
 {

--- a/plugins/lua/confirm.lua
+++ b/plugins/lua/confirm.lua
@@ -219,6 +219,14 @@ function convict.get_message()
         "This action is irreversible."
 end
 
+order_delete = defconf('order-delete')
+function order_delete.intercept_key(key)
+    return key == keys.D_MANAGER_REMOVE_ORDER and
+        screen.page == screen._type.T_page.ManagerOrders
+end
+order_delete.title = "Remove manager order"
+order_delete.message = "Are you sure you want to remove this order?"
+
 -- End of confirmation definitions
 
 function check()

--- a/plugins/lua/confirm.lua
+++ b/plugins/lua/confirm.lua
@@ -224,8 +224,8 @@ function order_remove.intercept_key(key)
     return key == keys.MANAGER_REMOVE and
         not screen.in_max_workshops
 end
-order_delete.title = "Remove manager order"
-order_delete.message = "Are you sure you want to remove this order?"
+order_remove.title = "Remove manager order"
+order_remove.message = "Are you sure you want to remove this order?"
 
 -- End of confirmation definitions
 

--- a/plugins/lua/confirm.lua
+++ b/plugins/lua/confirm.lua
@@ -219,10 +219,10 @@ function convict.get_message()
         "This action is irreversible."
 end
 
-order_delete = defconf('order-delete')
-function order_delete.intercept_key(key)
-    return key == keys.D_MANAGER_REMOVE_ORDER and
-        screen.page == screen._type.T_page.ManagerOrders
+order_remove = defconf('order-remove')
+function order_remove.intercept_key(key)
+    return key == keys.MANAGER_REMOVE and
+        not screen.in_max_workshops
 end
 order_delete.title = "Remove manager order"
 order_delete.message = "Are you sure you want to remove this order?"


### PR DESCRIPTION
Fixes #2155

Working on "pausing" functionality for the confirm plugin in a separate PR.