### PR TITLE
MiscUtils word_wrap: Add option to trim only leading whitespace after wrapping

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,8 +47,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
-- ``word_wrap``: argument ``bool collapse_whitespace`` converted to enum ``word_wrap_wspace_mode mode``,
-  with valid modes ``WSMODE_KEEP_ALL``, ``WSMODE_COLLAPSE_ALL``, and ``WSMODE_TRIM_LEADING``.
+- ``word_wrap``: argument ``bool collapse_whitespace`` converted to enum ``word_wrap_wspace_mode mode``, with valid modes ``WSMODE_KEEP_ALL``, ``WSMODE_COLLAPSE_ALL``, and ``WSMODE_TRIM_LEADING``.
 
 ## Lua
 - ``widgets.HotkeyLabel``: the ``key_sep`` string is now configurable

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,7 +47,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
-- `word_wrap`: add ``trim_whitespace_after_newline`` option, which trims any whitespace at the beginning of a line after wrapping
+- ``word_wrap``: argument ``bool collapse_whitespace`` converted to enum ``word_wrap_wspace_mode mode``,
+  with valid modes ``WSMODE_KEEP_ALL``, ``WSMODE_COLLAPSE_ALL``, and ``WSMODE_TRIM_LEADING``.
 
 ## Lua
 - ``widgets.HotkeyLabel``: the ``key_sep`` string is now configurable

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,6 +47,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
+- `word_wrap`: add ``trim_whitespace_after_newline`` option, which trims any whitespace at the beginning of a line after wrapping
 
 ## Lua
 - ``widgets.HotkeyLabel``: the ``key_sep`` string is now configurable

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,7 +47,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
-- ``word_wrap``: argument ``bool collapse_whitespace`` converted to enum ``word_wrap_wspace_mode mode``, with valid modes ``WSMODE_KEEP_ALL``, ``WSMODE_COLLAPSE_ALL``, and ``WSMODE_TRIM_LEADING``.
+- ``word_wrap``: argument ``bool collapse_whitespace`` converted to enum ``word_wrap_whitespace_mode mode``, with valid modes ``WSMODE_KEEP_ALL``, ``WSMODE_COLLAPSE_ALL``, and ``WSMODE_TRIM_LEADING``.
 
 ## Lua
 - ``widgets.HotkeyLabel``: the ``key_sep`` string is now configurable

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -169,14 +169,15 @@ std::string to_search_normalized(const std::string &str)
 }
 
 
-bool word_wrap(std::vector<std::string> *out, const std::string &str,
-               size_t line_length, bool collapse_whitespace)
+bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t line_length,
+               bool collapse_whitespace, bool trim_whitespace_after_newline)
 {
     if (line_length == 0)
         line_length = SIZE_MAX;
 
     std::string line;
     size_t break_pos = 0;
+    bool ignore_whitespace = false;
 
     for (auto &c : str)
     {
@@ -185,12 +186,13 @@ bool word_wrap(std::vector<std::string> *out, const std::string &str,
             out->push_back(line);
             line.clear();
             break_pos = 0;
+            ignore_whitespace = trim_whitespace_after_newline;
             continue;
         }
 
         if (isspace(c))
         {
-            if (break_pos == line.length() && collapse_whitespace)
+            if (ignore_whitespace || break_pos == line.length() && collapse_whitespace)
                 continue;
 
             line.push_back(collapse_whitespace ? ' ' : c);
@@ -198,6 +200,7 @@ bool word_wrap(std::vector<std::string> *out, const std::string &str,
         }
         else {
             line.push_back(c);
+            ignore_whitespace = false;
         }
 
         if (line.length() > line_length)
@@ -215,6 +218,7 @@ bool word_wrap(std::vector<std::string> *out, const std::string &str,
             }
             line = line.substr(break_pos);
             break_pos = 0;
+            ignore_whitespace = trim_whitespace_after_newline;
         }
     }
     if (line.length())

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -168,9 +168,8 @@ std::string to_search_normalized(const std::string &str)
     return result;
 }
 
-
 bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t line_length,
-               bool collapse_whitespace, bool trim_whitespace_after_newline)
+               word_wrap_wspace_mode mode)
 {
     if (line_length == 0)
         line_length = SIZE_MAX;
@@ -186,19 +185,20 @@ bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t lin
             out->push_back(line);
             line.clear();
             break_pos = 0;
-            ignore_whitespace = trim_whitespace_after_newline;
+            ignore_whitespace = (mode == WSMODE_TRIM_LEADING);
             continue;
         }
 
         if (isspace(c))
         {
-            if (ignore_whitespace || (break_pos == line.length() && collapse_whitespace))
+            if (ignore_whitespace || (mode == WSMODE_COLLAPSE_ALL && break_pos == line.length()))
                 continue;
 
-            line.push_back(collapse_whitespace ? ' ' : c);
+            line.push_back((mode == WSMODE_COLLAPSE_ALL) ? ' ' : c);
             break_pos = line.length();
         }
-        else {
+        else
+        {
             line.push_back(c);
             ignore_whitespace = false;
         }
@@ -218,7 +218,7 @@ bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t lin
             }
             line = line.substr(break_pos);
             break_pos = 0;
-            ignore_whitespace = trim_whitespace_after_newline;
+            ignore_whitespace = (mode == WSMODE_TRIM_LEADING);
         }
     }
     if (line.length())

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -192,7 +192,7 @@ bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t lin
 
         if (isspace(c))
         {
-            if (ignore_whitespace || break_pos == line.length() && collapse_whitespace)
+            if (ignore_whitespace || (break_pos == line.length() && collapse_whitespace))
                 continue;
 
             line.push_back(collapse_whitespace ? ' ' : c);

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -169,7 +169,7 @@ std::string to_search_normalized(const std::string &str)
 }
 
 bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t line_length,
-               word_wrap_wspace_mode mode)
+               word_wrap_whitespace_mode mode)
 {
     if (line_length == 0)
         line_length = SIZE_MAX;

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -389,11 +389,16 @@ DFHACK_EXPORT std::string toUpper(const std::string &str);
 DFHACK_EXPORT std::string toLower(const std::string &str);
 DFHACK_EXPORT std::string to_search_normalized(const std::string &str);
 
+enum word_wrap_wspace_mode {
+    WSMODE_KEEP_ALL,
+    WSMODE_COLLAPSE_ALL,
+    WSMODE_TRIM_LEADING
+};
+
 DFHACK_EXPORT bool word_wrap(std::vector<std::string> *out,
                              const std::string &str,
                              size_t line_length = 80,
-                             bool collapse_whitespace = false,
-                             bool trim_whitespace_after_newline = false);
+                             word_wrap_wspace_mode mode = WSMODE_KEEP_ALL);
 
 inline bool bits_match(unsigned required, unsigned ok, unsigned mask)
 {

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -392,7 +392,8 @@ DFHACK_EXPORT std::string to_search_normalized(const std::string &str);
 DFHACK_EXPORT bool word_wrap(std::vector<std::string> *out,
                              const std::string &str,
                              size_t line_length = 80,
-                             bool collapse_whitespace = false);
+                             bool collapse_whitespace = false,
+                             bool trim_whitespace_after_newline = false);
 
 inline bool bits_match(unsigned required, unsigned ok, unsigned mask)
 {

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -389,7 +389,7 @@ DFHACK_EXPORT std::string toUpper(const std::string &str);
 DFHACK_EXPORT std::string toLower(const std::string &str);
 DFHACK_EXPORT std::string to_search_normalized(const std::string &str);
 
-enum word_wrap_wspace_mode {
+enum word_wrap_whitespace_mode {
     WSMODE_KEEP_ALL,
     WSMODE_COLLAPSE_ALL,
     WSMODE_TRIM_LEADING

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -398,7 +398,7 @@ enum word_wrap_whitespace_mode {
 DFHACK_EXPORT bool word_wrap(std::vector<std::string> *out,
                              const std::string &str,
                              size_t line_length = 80,
-                             word_wrap_wspace_mode mode = WSMODE_KEEP_ALL);
+                             word_wrap_whitespace_mode mode = WSMODE_KEEP_ALL);
 
 inline bool bits_match(unsigned required, unsigned ok, unsigned mask)
 {


### PR DESCRIPTION
Replace ``bool collapse_whitespace`` option with an enum. Options ``WSMODE_KEEP_ALL``, ``WSMODE_COLLAPSE_ALL``, and ``WSMODE_TRIM_LEADING``.

Related to https://github.com/DFHack/dfhack/pull/2113