### PR TITLE
namespace the ccache key with the repo and branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.sha }}
+        key: ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
+          ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}
           ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}
     - name: Download DF
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}-${{ github.sha }}
+        key: ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
-          ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}
+          ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.ref_name }}
           ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}
     - name: Download DF
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,10 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}-${{ github.sha }}
+        key: ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
-          ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}
-          ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}
+          ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.repository_owner }}-${{ github.ref_name }}
+          ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}
     - name: Download DF
       run: |
         sh ci/download-df.sh


### PR DESCRIPTION
as discussed on discord

this builds on https://github.com/DFHack/dfhack/commit/46f80bed3daeb105e6350a6ef12854447c245663 by adding the repo owner and branch name to the key. this allows the ccache that we build on to be the one most relevant to the branch.