### PR TITLE
GitHub Actions: Upgrade newest matrix entry to Ubuntu 22.04, GCC 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,8 @@ jobs:
           -DBUILD_SIZECHECK:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_STONESENSE:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SUPPORTED:BOOL=1 \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DCMAKE_INSTALL_PREFIX="$DF_FOLDER"
     - name: Build DFHack
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,6 @@ jobs:
         - default
         include:
         - os: ubuntu-22.04
-          gcc: 11
-          plugins: all
-        - os: ubuntu-22.04
           gcc: 12
           plugins: all
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         echo "::set-output name=df_version::${DF_VERSION}"
         echo "DF_VERSION=${DF_VERSION}" >> $GITHUB_ENV
         echo "DF_FOLDER=${HOME}/DF/${DF_VERSION}/df_linux" >> $GITHUB_ENV
+        echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
     - name: Fetch DF cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
     - name: Build DFHack
       run: |
         ninja -C build-ci install
+        ccache --show-stats
     - name: Run tests
       id: run_tests
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,11 @@ jobs:
         plugins:
         - default
         include:
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           gcc: 11
+          plugins: all
+        - os: ubuntu-22.04
+          gcc: 12
           plugins: all
     steps:
     - name: Set up Python 3


### PR DESCRIPTION
Pending #2182

Worth noting that Ubuntu 22.04 comes with GCC 11.2, as opposed to the previous 11.1, and runs into the error resolved in https://github.com/DFHack/dfhack/pull/2182/files#diff-b79c29d99dee0213b3e1fdb5b09641f0300949a0257ea3635a856dcf97b01149R514. I kept GCC 11 in the matrix for comparison, but plan to remove it before merging.
