### PR TITLE
use extlinks where appropriate in docs

### DIFF
--- a/docs/guides/examples-guide.rst
+++ b/docs/guides/examples-guide.rst
@@ -91,8 +91,8 @@ order to save resources. It handles:
 - adamantine processing
 - item melting
 
-Orders are missing for plaster powder until DF `bug 11803
-<https://www.bay12games.com/dwarves/mantisbt/view.php?id=11803>`_ is fixed.
+Orders are missing for plaster powder until DF :bug:`bug 11803 <11803>` is
+fixed.
 
 :source:`military.json <data/examples/orders/military.json>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guides/quickfort-library-guide.rst
+++ b/docs/guides/quickfort-library-guide.rst
@@ -49,9 +49,8 @@ and a convenient `checklist
 <https://docs.google.com/spreadsheets/d/13PVZ2h3Mm3x_G1OXQvwKd7oIR2lK4A1Ahf6Om1kFigw/edit#gid=1459509569>`__
 from which you can copy the ``quickfort`` commands.
 
-If you like, you can download a fully built Dreamfort-based fort from `dffd
-<https://dffd.bay12games.com/file.php?id=15434>`__, load it, and explore it
-interactively.
+If you like, you can download a fully built Dreamfort-based fort from
+:dffd:`dffd <15434>`, load it, and explore it interactively.
 
 Visual overview
 ```````````````

--- a/docs/guides/quickfort-user-guide.rst
+++ b/docs/guides/quickfort-user-guide.rst
@@ -1462,8 +1462,7 @@ parts that might not be obvious just from looking at them.
 If you haven't built Dreamfort before, maybe try an embark in a flat area and
 take it for a spin! It will help put the following sections in context. There is
 also a pre-built Dreamfort available for download on
-`dffd <https://dffd.bay12games.com/file.php?id=15434>`__ if you just want an
-interactive reference.
+:dffd:`dffd <15434>` if you just want an interactive reference.
 
 Dreamfort organization and packaging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I apparently wasn't aware of extlinks when I wrote some documentation. Easy fix.