### PR TITLE
Support backtick as a keybinding

### DIFF
--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -224,7 +224,8 @@ To set keybindings, use the built-in ``keybinding`` command. Like any other
 command it can be used at any time from the console, but bindings are not
 remembered between runs of the game unless re-created in `dfhack.init`.
 
-Currently, any combinations of Ctrl/Alt/Shift with A-Z, 0-9, or F1-F12 are supported.
+Currently, any combinations of Ctrl/Alt/Shift with A-Z, 0-9, F1-F12 or \`
+are supported.
 
 Possible ways to call the command:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - Init scripts: ``dfhack.init`` and other init scripts have moved to ``dfhack-config/init/``. If you have customized your ``dfhack.init`` file and want to keep your changes, please move the part that you have customized to the new location at ``dfhack-config/init/dfhack.init``. If you do not have changes that you want to keep, do not copy anything, and the new defaults will be used automatically.
+- `keybinding`: support backquote (``\```) as a hotkey
 - `manipulator`: add a library of useful default professions
 - `manipulator`: move professions configuration from ``professions/`` to ``dfhack-config/professions/`` to keep it together with other dfhack configuration. If you have saved professions that you would like to keep, please manually move them to the new folder.
 - ``materials.ItemTraitsDialog``: added a default ``on_select``-handler which toggles the traits.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,7 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - Init scripts: ``dfhack.init`` and other init scripts have moved to ``dfhack-config/init/``. If you have customized your ``dfhack.init`` file and want to keep your changes, please move the part that you have customized to the new location at ``dfhack-config/init/dfhack.init``. If you do not have changes that you want to keep, do not copy anything, and the new defaults will be used automatically.
-- `keybinding`: support backquote (``\```) as a hotkey
+- `keybinding`: support backquote (\`) as a hotkey
 - `manipulator`: add a library of useful default professions
 - `manipulator`: move professions configuration from ``professions/`` to ``dfhack-config/professions/`` to keep it together with other dfhack configuration. If you have saved professions that you would like to keep, please manually move them to the new folder.
 - ``materials.ItemTraitsDialog``: added a default ``on_select``-handler which toggles the traits.

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2611,6 +2611,9 @@ static bool parseKeySpec(std::string keyspec, int *psym, int *pmod, std::string 
     if (keyspec.size() == 1 && keyspec[0] >= 'A' && keyspec[0] <= 'Z') {
         *psym = SDL::K_a + (keyspec[0]-'A');
         return true;
+    } else if (keyspec.size() == 1 && keyspec[0] == '`') {
+        *psym = SDL::K_BACKQUOTE;
+        return true;
     } else if (keyspec.size() == 1 && keyspec[0] >= '0' && keyspec[0] <= '9') {
         *psym = SDL::K_0 + (keyspec[0]-'0');
         return true;

--- a/plugins/hotkeys.cpp
+++ b/plugins/hotkeys.cpp
@@ -44,6 +44,7 @@ static void find_active_keybindings(df::viewscreen *screen)
     sorted_keys.clear();
 
     vector<string> valid_keys;
+
     for (char c = 'A'; c <= 'Z'; c++)
     {
         valid_keys.push_back(string(&c, 1));
@@ -53,6 +54,8 @@ static void find_active_keybindings(df::viewscreen *screen)
     {
         valid_keys.push_back("F" + int_to_string(i));
     }
+
+    valid_keys.push_back("`");
 
     auto current_focus = Gui::getFocusString(screen);
     for (int shifted = 0; shifted < 2; shifted++)


### PR DESCRIPTION
In preparation for binding to `gui/launcher` once it is merged.