### PR TITLE
modify seedwatch all to actually watch all seeds

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -51,6 +51,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``materials.ItemTraitsDialog``: added a default ``on_select``-handler which toggles the traits.
 - `orders`: added useful library of manager orders. see them with ``orders list`` and import them with, for example, ``orders import library/basic``
 - `prospect`: add new ``--show`` option to give the player control over which report sections are shown. e.g. ``prospect all --show ores`` will just show information on ores.
+- `seedwatch`: ``seedwatch all`` now adds all plants with seeds to the watchlist, not just the "basic" crops.
 
 ## Documentation
 

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -132,7 +132,9 @@ command_result df_seedwatch(color_ostream &out, vector<string>& parameters)
     map<string, int32_t> plantIDs;
     for(size_t i = 0; i < world->raws.plants.all.size(); ++i)
     {
-        plantIDs[world->raws.plants.all[i]->id] = i;
+        auto & plant = world->raws.plants.all[i];
+        if (plant->material_defs.type[plant_material_def::seed] != -1)
+            plantIDs[plant->id] = i;
     }
 
     t_gamemodes gm;
@@ -226,10 +228,8 @@ command_result df_seedwatch(color_ostream &out, vector<string>& parameters)
         if(limit < 0) limit = 0;
         if(parameters[0] == "all")
         {
-            for(auto i = abbreviations.begin(); i != abbreviations.end(); ++i)
-            {
-                if(plantIDs.count(i->second) > 0) Kitchen::setLimit(plantIDs[i->second], limit);
-            }
+            for(auto & entry : plantIDs)
+                Kitchen::setLimit(entry.second, limit);
         }
         else
         {


### PR DESCRIPTION
Fixes #1941 
This PR makes two changes:
- The internal map of plant id -> plant index now only contains plants that have seeds. This will allow us to print an error message instead of succeeding but performing no useful action when a plant ID is passed to the API that doesn't have seeds.
- When `seedwatch all` is called, we iterate over our map and set targets for all plants that have seeds, instead of just the ones in the hardcoded abbreviation list.

No doc updates in this PR since the docs have been rewritten in the docs branch and we don't need to cause conflicts.