### PR TITLE
Allow lua scripts to access a commandline history without a terminal

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -524,6 +524,20 @@ Input & Output
   lock. Using an explicit ``dfhack.with_suspend`` will prevent
   this, forcing the function to block on input with lock held.
 
+* ``dfhack.getCommandHistory(history_id, history_filename)``
+
+  Returns the list of strings in the specified history. Intended to be used by
+  GUI scripts that don't have access to a console and so can't use
+  ``dfhack.lineedit``. The ``history_id`` parameter is some unique string that
+  the script uses to identify its command history, such as the script's name. If
+  this is the first time the history with the given ``history_id`` is being
+  accessed, it is initialized from the given file.
+
+* ``dfhack.addCommandToHistory(history_id, history_filename, command)``
+
+  Adds a command to the specified history and saves the updated history to the
+  specified file.
+
 * ``dfhack.interpreter([prompt[,history_filename[,env]]])``
 
   Starts an interactive lua interpreter, using the specified prompt
@@ -837,6 +851,7 @@ can be omitted.
 * ``dfhack.getGitXmlExpectedCommit()``
 * ``dfhack.gitXmlMatch()``
 * ``dfhack.isRelease()``
+* ``dfhack.isPrerelease()``
 
   Return information about the DFHack build in use.
 
@@ -889,7 +904,6 @@ can be omitted.
   When printing CP437-encoded text to the console (for example, names returned
   from ``dfhack.TranslateName()``), use ``print(dfhack.df2console(text))`` to
   ensure proper display on all platforms.
-
 
 * ``dfhack.utf2df(string)``
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``Gui::getSelectedItem()``, ``Gui::getAnyItem()``: added support for the artifacts screen
 
 ## Lua
+- History: added ``dfhack.getCommandHistory(history_id, history_filename)`` and ``dfhack.addCommandToHistory(history_id, history_filename, command)`` so gui scripts can access a commandline history without requiring a terminal.
 - ``tile-material``: fix the order of declarations. The ``GetTileMat`` function now returns the material as intended (always returned nil before). Also changed the license info, with permission of the original author.
 - ``widgets.EditField``: new ``onsubmit2`` callback attribute is called when the user hits Shift-Enter.
 - ``widgets.EditField``: new function: ``setCursor(position)`` sets the input cursor.

--- a/library/include/Console.h
+++ b/library/include/Console.h
@@ -32,6 +32,7 @@ distribution.
 #include <assert.h>
 #include <iostream>
 #include <string>
+#include <vector>
 namespace tthread
 {
     class mutex;
@@ -113,6 +114,12 @@ namespace  DFHack
         void remove( void )
         {
             history.pop_front();
+        }
+        /// adds the current list of entries to the given vector
+        void getEntries(std::vector<std::string> &entries)
+        {
+            for (auto &entry : history)
+                entries.push_back(entry);
         }
     private:
         std::size_t capacity;


### PR DESCRIPTION
Create a persistent CommandHistory repository that can be used from Lua. It is a direct access to the history and does not require `lineedit`, so it does not require that the script have access to the terminal.

The only consumer of this interface right now will be `gui/launcher` in DFHack/scripts#413