### PR TITLE
[widgets.Label] show full scrollbars instead of just scroll icons

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -4046,6 +4046,11 @@ It has the following attributes:
 :scrollbar_fg: Specifies the pen for the scroll icons and the active part of the bar. Default is ``COLOR_LIGHTGREEN`` (the same as the native DF help screens).
 :scrollbar_bg: Specifies the pen for the background part of the scrollbar. Default is ``COLOR_CYAN`` (the same as the native DF help screens).
 
+If the scrollbar is shown, it will react to mouse clicks on the scrollbar itself.
+Clicking on the arrows at the top or the bottom will scroll by one line, and
+clicking on the unfilled portion of the scrollbar will scroll by a half page in
+that direction.
+
 The text itself is represented as a complex structure, and passed
 to the object via the ``text`` argument of the constructor, or via
 the ``setText`` method, as one of:

--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -4039,13 +4039,12 @@ It has the following attributes:
     keys to the number of lines to scroll as positive or negative integers or one of the keywords
     supported by the ``scroll`` method. The default is up/down arrows scrolling by one line and page
     up/down scrolling by one page.
-:show_scroll_icons: Controls scroll icons' behaviour: ``false`` for no icons, ``'right'`` or ``'left'`` for
+:show_scrollbar: Controls scrollbar display: ``false`` for no scrollbar, ``'right'`` or ``'left'`` for
     icons next to the text in an additional column (``frame_inset`` is adjusted to have ``.r`` or ``.l`` greater than ``0``),
     ``nil`` same as ``'right'`` but changes ``frame_inset`` only if a scroll icon is actually necessary
     (if ``getTextHeight()`` is greater than ``frame_body.height``). Default is ``nil``.
-:up_arrow_icon: The symbol for scroll up arrow. Default is ``string.char(24)`` (``↑``).
-:down_arrow_icon: The symbol for scroll down arrow. Default is ``string.char(25)`` (``↓``).
-:scroll_icon_pen: Specifies the pen for scroll icons. Default is ``COLOR_LIGHTCYAN``.
+:scrollbar_fg: Specifies the pen for the scroll icons and the active part of the bar. Default is ``COLOR_LIGHTGREEN`` (the same as the native DF help screens).
+:scrollbar_bg: Specifies the pen for the background part of the scrollbar. Default is ``COLOR_CYAN`` (the same as the native DF help screens).
 
 The text itself is represented as a complex structure, and passed
 to the object via the ``text`` argument of the constructor, or via

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `seedwatch`: ``seedwatch all`` now adds all plants with seeds to the watchlist, not just the "basic" crops.
 - UX: You can now move the cursor around in DFHack text fields in ``gui/`` scripts (e.g. `gui/blueprint`, `gui/quickfort`, or `gui/gm-editor`). You can move the cursor by clicking where you want it to go with the mouse or using the Left/Right arrow keys.  Ctrl+Left/Right will move one word at a time, and Alt+Left/Right will move to the beginning/end of the text.
 - UX: You can now click on the hotkey hint text in many ``gui/`` script windows to activate the hotkey, like a button. Not all scripts have been updated to use the clickable widget yet, but you can try it in `gui/blueprint` or `gui/quickfort`.
+- UX: Label widget scroll icons are replaced with scrollbars that represent the percentage of text on the screen and move with the position of the visible text, just like web browser scrollbars.
 - `quickfort`: `Dreamfort <quickfort-blueprint-guide>` blueprint set improvements: set traffic designations to encourage dwarves to eat cooked food instead of raw ingredients
 
 ## Documentation

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -599,8 +599,8 @@ local function get_scrollbar_pos_and_height(label)
     local scrollbar_body_height = label.frame_body.height - 2
     local displayed_lines = last_visible_line - first_visible_line
 
-    local height = math.min(scrollbar_body_height - 1,
-        math.ceil((displayed_lines-1) * scrollbar_body_height / text_height))
+    local height = math.floor(((displayed_lines-1) * scrollbar_body_height) /
+                              text_height)
 
     local max_pos = scrollbar_body_height - height
     local pos = math.ceil(((first_visible_line-1) * max_pos) /
@@ -683,7 +683,6 @@ end
 
 function Label:onRenderFrame(dc, rect)
     if self._show_scrollbar
-    and self:getTextHeight() > self.frame_body.height
     then
         local x = self._show_scrollbar == 'left'
                 and self.frame_body.x1-dc.x1-1

--- a/test/library/gui/widgets.Label.lua
+++ b/test/library/gui/widgets.Label.lua
@@ -29,7 +29,7 @@ function test.correct_frame_body_with_scroll_icons()
     end
 
     local o = fs{}
-    expect.eq(o.subviews.text.frame_body.width, 9, "Label's frame_body.x2 and .width should be one smaller because of show_scroll_icons.")
+    expect.eq(o.subviews.text.frame_body.width, 9, "Label's frame_body.x2 and .width should be one smaller because of show_scrollbar.")
 end
 
 function test.correct_frame_body_with_few_text_lines()
@@ -50,10 +50,10 @@ function test.correct_frame_body_with_few_text_lines()
     end
 
     local o = fs{}
-    expect.eq(o.subviews.text.frame_body.width, 10, "Label's frame_body.x2 and .width should not change with show_scroll_icons = false.")
+    expect.eq(o.subviews.text.frame_body.width, 10, "Label's frame_body.x2 and .width should not change with show_scrollbar = false.")
 end
 
-function test.correct_frame_body_without_show_scroll_icons()
+function test.correct_frame_body_without_show_scrollbar()
     local t = {}
     for i = 1, 12 do
         t[#t+1] = tostring(i)
@@ -66,13 +66,13 @@ function test.correct_frame_body_without_show_scroll_icons()
                 view_id = 'text',
                 frame_inset = 0,
                 text = t,
-                show_scroll_icons = false,
+                show_scrollbar = false,
             },
         }
     end
 
     local o = fs{}
-    expect.eq(o.subviews.text.frame_body.width, 10, "Label's frame_body.x2 and .width should not change with show_scroll_icons = false.")
+    expect.eq(o.subviews.text.frame_body.width, 10, "Label's frame_body.x2 and .width should not change with show_scrollbar = false.")
 end
 
 function test.scroll()


### PR DESCRIPTION
Based on the appearance of the native DF help screen scrollbars.

Screenshot of text at top of screen:
![image](https://user-images.githubusercontent.com/977482/189557507-71fb2901-bf19-4122-a0ab-cfee344a03c0.png)

Screenshot of somewhere in the middle of the text; note that the size of the scrollbar increases because of the shorter total text size for this tool:
![image](https://user-images.githubusercontent.com/977482/189557665-50587d5d-5ecf-475c-9745-0105ff045d09.png)