### PR TITLE
Make screen elements clickable when using TWBT

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1523,6 +1523,12 @@ static int gui_getDwarfmodeViewDims(lua_State *state)
     return 1;
 }
 
+static int gui_getMousePos(lua_State *L)
+{
+    Lua::PushPosXYZ(L, Gui::getMousePos());
+    return 3;
+}
+
 static const LuaWrapper::FunctionReg dfhack_gui_module[] = {
     WRAPM(Gui, getCurViewscreen),
     WRAPM(Gui, getFocusString),
@@ -1555,6 +1561,7 @@ static const LuaWrapper::FunctionReg dfhack_gui_module[] = {
 
 static const luaL_Reg dfhack_gui_funcs[] = {
     { "getDwarfmodeViewDims", gui_getDwarfmodeViewDims },
+    { "getMousePos", gui_getMousePos },
     { NULL, NULL }
 };
 
@@ -2282,9 +2289,7 @@ static const LuaWrapper::FunctionReg dfhack_screen_module[] = {
 
 static int screen_getMousePos(lua_State *L)
 {
-    auto pos = Screen::getMousePos();
-    lua_pushinteger(L, pos.x);
-    lua_pushinteger(L, pos.y);
+    Lua::PushPosXY(L, Screen::getMousePos());
     return 2;
 }
 

--- a/library/include/modules/Gui.h
+++ b/library/include/modules/Gui.h
@@ -126,10 +126,11 @@ namespace DFHack
         DFHACK_EXPORT void showAutoAnnouncement(df::announcement_type type, df::coord pos, std::string message, int color = 7, bool bright = true, df::unit *unit1 = NULL, df::unit *unit2 = NULL);
 
         /*
-         * Cursor and window coords
+         * Cursor and window map coords
          */
         DFHACK_EXPORT df::coord getViewportPos();
         DFHACK_EXPORT df::coord getCursorPos();
+        DFHACK_EXPORT df::coord getMousePos();
 
         static const int AREA_MAP_WIDTH = 23;
         static const int MENU_WIDTH = 30;
@@ -161,8 +162,6 @@ namespace DFHack
 
         DFHACK_EXPORT bool getDesignationCoords (int32_t &x, int32_t &y, int32_t &z);
         DFHACK_EXPORT bool setDesignationCoords (const int32_t x, const int32_t y, const int32_t z);
-
-        DFHACK_EXPORT bool getMousePos (int32_t & x, int32_t & y);
 
         // The distance from the z-level of the tile at map coordinates (x, y) to the closest ground z-level below
         // Defaults to 0, unless overriden by plugins

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -104,7 +104,7 @@ function getCursorPos()
 end
 
 function setCursorPos(cursor)
-    df.global.cursor = cursor
+    df.global.cursor = copyall(cursor)
 end
 
 function clearCursorPos()

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -1831,17 +1831,16 @@ bool Gui::setDesignationCoords (const int32_t x, const int32_t y, const int32_t 
     return true;
 }
 
-bool Gui::getMousePos (int32_t & x, int32_t & y)
+// returns the map coordinates that the mouse cursor is over
+df::coord Gui::getMousePos()
 {
-    if (gps) {
-        x = gps->mouse_x;
-        y = gps->mouse_y;
+    df::coord pos;
+    if (gps && gps->mouse_x > -1) {
+        pos = getViewportPos();
+        pos.x += gps->mouse_x - 1;
+        pos.y += gps->mouse_y - 1;
     }
-    else {
-        x = -1;
-        y = -1;
-    }
-    return (x == -1) ? false : true;
+    return pos;
 }
 
 int getDepthAt_default (int32_t x, int32_t y)

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -31,6 +31,7 @@ distribution.
 #include <set>
 using namespace std;
 
+#include "modules/Renderer.h"
 #include "modules/Screen.h"
 #include "modules/GuiHooks.h"
 #include "MemAccess.h"
@@ -75,12 +76,14 @@ using std::string;
  * Screen painting API.
  */
 
+// returns text grid coordinates, even if the game map is scaled differently
 df::coord2d Screen::getMousePos()
 {
-    if (!gps || (enabler && !enabler->tracking_on))
+    int32_t x = Renderer::GET_MOUSE_COORDS_SENTINEL, y = (int32_t)true;
+    if (!enabler || !enabler->renderer->get_mouse_coords(&x, &y)) {
         return df::coord2d(-1, -1);
-
-    return df::coord2d(gps->mouse_x, gps->mouse_y);
+    }
+    return df::coord2d(x, y);
 }
 
 df::coord2d Screen::getWindowSize()
@@ -769,7 +772,7 @@ int dfhack_lua_viewscreen::do_input(lua_State *L)
         }
     }
 
-    if (enabler && enabler->tracking_on)
+    if (enabler)
     {
         if (enabler->mouse_lbut_down) {
             lua_pushboolean(L, true);

--- a/plugins/devel/kittens.cpp
+++ b/plugins/devel/kittens.cpp
@@ -135,13 +135,12 @@ DFhackCExport command_result plugin_onupdate ( color_ostream &out )
             last_designation[2] = desig_z;
             out.print("Designation: %d %d %d\n",desig_x, desig_y, desig_z);
         }
-        int mouse_x, mouse_y;
-        Gui::getMousePos(mouse_x,mouse_y);
-        if(mouse_x != last_mouse[0] || mouse_y != last_mouse[1])
+        df:coord mousePos = Gui::getMousePos();
+        if(mousePos.x != last_mouse[0] || mousePos.y != last_mouse[1])
         {
-            last_mouse[0] = mouse_x;
-            last_mouse[1] = mouse_y;
-            out.print("Mouse: %d %d\n",mouse_x, mouse_y);
+            last_mouse[0] = mousePos.x;
+            last_mouse[1] = mousePos.y;
+            out.print("Mouse: %d %d\n",mousePos.x, mousePos.y);
         }
     }
     return CR_OK;

--- a/plugins/mousequery.cpp
+++ b/plugins/mousequery.cpp
@@ -53,23 +53,11 @@ static enum { None, Left, Right } drag_mode;
 
 static df::coord get_mouse_pos(int32_t &mx, int32_t &my)
 {
-    df::coord pos;
-    pos.x = -30000;
+    df::coord pos = Gui::getMousePos();
+    pos.z -= Gui::getDepthAt(pos.x, pos.y);
 
-    if (!enabler->tracking_on)
-        return pos;
-
-    if (!Gui::getMousePos(mx, my))
-        return pos;
-
-    int32_t vx, vy, vz;
-    if (!Gui::getViewCoords(vx, vy, vz))
-        return pos;
-
-    pos.x = vx + mx - 1;
-    pos.y = vy + my - 1;
-    pos.z = vz - Gui::getDepthAt(mx, my);
-
+    mx = pos.x;
+    my = pos.y;
     return pos;
 }
 

--- a/plugins/overlay.cpp
+++ b/plugins/overlay.cpp
@@ -87,7 +87,7 @@
 #include "VTableInterpose.h"
 #include "uicommon.h"
 
-#include "modules/Renderer.h"
+#include "modules/Screen.h"
 
 using namespace DFHack;
 
@@ -104,16 +104,12 @@ static const std::string button_text = "[ DFHack Launcher ]";
 static bool clicked = false;
 
 static bool handle_click() {
-    int32_t x = Renderer::GET_MOUSE_COORDS_SENTINEL, y = (int32_t)true;
-    if (!enabler->mouse_lbut_down || clicked ||
-            !enabler->renderer->get_mouse_coords(&x, &y)) {
-        DEBUG(log).print(
-            "lbut_down=%s; clicked=%s; mouse_x=%d; mouse_y=%d\n",
-            enabler->mouse_lbut_down ? "true" : "false",
-            clicked ? "true" : "false", x, y);
+    if (!enabler->mouse_lbut_down || clicked) {
         return false;
     }
-    if (y == gps->dimy - 1 && x >= 1 && (size_t)x <= button_text.size()) {
+    df::coord2d pos = Screen::getMousePos();
+    DEBUG(log).print("clicked at screen coordinates (%d, %d)\n", pos.x, pos.y);
+    if (pos.y == gps->dimy - 1 && pos.x >= 1 && (size_t)pos.x <= button_text.size()) {
         clicked = true;
         Core::getInstance().setHotkeyCmd("gui/launcher");
         return true;


### PR DESCRIPTION
Makes the following changes:

- `Screen::getMousePos()` now always returns screen text grid coordinates, regardless of whether the cursor is over the map or not. This allows us to find the mouse cursor position in relation to displayed screens that may overlap the map. The upper left of the screen is 0, 0.
- The Screen module no longer looks at `enabler->tracking_on` to determine whether it should send button events to Lua `onInput` handlers. The value changes dynamically when using TWBT based on where the cursor is, so it is not a reliable signal. Instead, we just look at the button flags, which will always be false when the mouse is truly not supported.
- `Gui::getMousePos()` (which already existed, amusingly) now returns a `df::coord` of the *map* coordinates under the cursor. The upper left tile of the map is the coordinates of the viewport, including the z-level. If the cursor is not over the map, the upper left tile of the viewport is returned.

Requires a TWBT that includes thurin/df-twbt#7 in order to work with TWBT, of course. There should be no behavior changes for non-TWBT renderers.

I'm starting the PR now to solicit input, but there are still the following open tasks:

- The newly exposed `dfhack.gui.getMousePos()` needs docs
- `Gui::getMousePos()` will return coordinates off the visible map if the cursor is over the frame/sidebar and the renderer is not TWBT. I need to add a guard that prevents this in the non-TWBT case.

Also, scripts that get the map coordinates (`gui/quantum` and `gui/blueprint`) will need to be modified to use the new `dfhack.gui.getMousePos()`.