### PR TITLE
don't cache dup civzones when scanning buildings

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `dig-now`: Fix direction of smoothed walls when adjacent to a door or floodgate
 - ``job.removeJob()``: ensure jobs are removed from the world list when they are canceled
 - `quickfort`: `Dreamfort <quickfort-blueprint-guide>` blueprint set: declare the hospital zone before building the coffer; otherwise DF fails to stock the hospital with materials
+- ``dfhack.buildings.findCivzonesAt``: no longer return duplicate civzones after loading a save with existing civzones
 
 ## Misc Improvements
 - Init scripts: ``dfhack.init`` and other init scripts have moved to ``dfhack-config/init/``. If you have customized your ``dfhack.init`` file and want to keep your changes, please move the part that you have customized to the new location at ``dfhack-config/init/dfhack.init``. If you do not have changes that you want to keep, do not copy anything, and the new defaults will be used automatically.

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -308,9 +308,8 @@ df::building *Buildings::findAtTile(df::coord pos)
 
 static unordered_map<int32_t, df::coord> corner1;
 static unordered_map<int32_t, df::coord> corner2;
-static void cacheBuilding(df::building *building) {
+static void cacheBuilding(df::building *building, bool is_civzone) {
     int32_t id = building->id;
-    bool is_civzone = !building->isSettingOccupancy();
     df::coord p1(min(building->x1, building->x2), min(building->y1,building->y2), building->z);
     df::coord p2(max(building->x1, building->x2), max(building->y1,building->y2), building->z);
 
@@ -344,7 +343,7 @@ static void cacheNewCivzones() {
         auto &vec = world->buildings.other[buildings_other_id::ANY_ZONE];
         int32_t idx = df::building::binsearch_index(vec, id);
         if (idx > -1)
-            cacheBuilding(vec[idx]);
+            cacheBuilding(vec[idx], true);
     }
     nextCivzone = nextBuildingId;
 }
@@ -1311,8 +1310,9 @@ void Buildings::updateBuildings(color_ostream&, void* ptr)
 
     if (building)
     {
-        if (!corner1.count(id))
-            cacheBuilding(building);
+        bool is_civzone = !building->isSettingOccupancy();
+        if (!corner1.count(id) && !is_civzone)
+            cacheBuilding(building, false);
     }
     else if (corner1.count(id))
     {


### PR DESCRIPTION
Fixes #2301

We keep state to make sure we don't scan civzones more than once, but we don't check that state for civzones when we're scanning all buildings in the buildings cache path.

This change make it so we don't scan for civzones in the general building pass. civzones are only updated when a lookup request for civzones is received.