### PR TITLE
[ls] better formatting for tags output

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 
 ## Misc Improvements
+- `ls`: indent tag listings and wrap them in the right column for better readability
 
 ## Documentation
 

--- a/library/lua/helpdb.lua
+++ b/library/lua/helpdb.lua
@@ -726,13 +726,15 @@ end
 local function list_entries(skip_tags, include, exclude)
     local entries = search_entries(include, exclude)
     for _,entry in ipairs(entries) do
-        print_columns(entry, get_entry_short_help(entry))
+        local short_help = get_entry_short_help(entry)
         if not skip_tags then
             local tags = set_to_sorted_list(get_entry_tags(entry))
             if #tags > 0 then
-                print(('    tags: %s'):format(table.concat(tags, ', ')))
+                local taglist = table.concat(tags, ', ')
+                short_help = short_help .. NEWLINE .. 'tags: ' .. taglist
             end
         end
+        print_columns(entry, short_help)
     end
     if #entries == 0 then
         print('No matches.')

--- a/test/library/helpdb.lua
+++ b/test/library/helpdb.lua
@@ -637,7 +637,7 @@ function test.ls()
         expect.eq(5, mock_print.call_count)
         expect.eq('inscript_docs        in-file short description for inscript_docs.',
             mock_print.call_args[1][1])
-        expect.eq('    tags: map', mock_print.call_args[2][1])
+        expect.eq('                      tags: map', mock_print.call_args[2][1])
         expect.eq('nodoc_command        cpp description.',
             mock_print.call_args[3][1])
         expect.eq('nodocs_samename      Nodocs samename.',
@@ -652,15 +652,15 @@ function test.ls()
         expect.eq(6, mock_print.call_count)
         expect.eq('bindboxers           Bind your boxers.',
             mock_print.call_args[1][1])
-        expect.eq('    tags: armok, fort, units',
+        expect.eq('                      tags: armok, fort, units',
             mock_print.call_args[2][1])
         expect.eq('boxbinders           Box your binders.',
             mock_print.call_args[3][1])
-        expect.eq('    tags: armok, fort, units',
+        expect.eq('                      tags: armok, fort, units',
             mock_print.call_args[4][1])
         expect.eq('samename             Samename.',
             mock_print.call_args[5][1])
-        expect.eq('    tags: armok, fort, units',
+        expect.eq('                      tags: armok, fort, units',
             mock_print.call_args[6][1])
     end)
 


### PR DESCRIPTION
make the tags part of the right column so the left column is easier to read and the tags are also properly wrapped. before:
```
[DFHack]# ls gm
gui/gm-editor        Inspect and edit DF game data.
    tags: animals, armok, buildings, dfhack, inspection, items, jobs, map, plants, stockpiles, units, workorders
gui/gm-unit          Inspect and edit unit attributes.
    tags: animals, armok, dfhack, inspection, units
```
after:
```
[DFHack]# ls gm
gui/gm-editor        Inspect and edit DF game data.
                      tags: animals, armok, buildings, dfhack, inspection,
                      items, jobs, map, plants, stockpiles, units, workorders
gui/gm-unit          Inspect and edit unit attributes.
                      tags: animals, armok, dfhack, inspection, units
```