### PR TITLE
[ls] add --exclude option

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -3150,8 +3150,8 @@ Each entry has several properties associated with it:
   alphabetized by their last path component, with populated path components
   coming before null path components (e.g. ``autobutcher`` will immediately
   follow ``gui/autobutcher``).
-  The optional ``include`` and ``exclude`` filter params are maps with the
-  following elements:
+  The optional ``include`` and ``exclude`` filter params are maps (or lists of
+  maps) with the following elements:
 
   :str:   if a string, filters by the given substring. if a table of strings,
           includes entry names that match any of the given substrings.
@@ -3159,6 +3159,13 @@ Each entry has several properties associated with it:
           includes entries that match any of the given tags.
   :entry_type: if a string, matches entries of the given type. if a table of
           strings, includes entries that match any of the given types.
+
+  Elements in a map are ANDed together (e.g. if both ``str`` and ``tag`` are
+  specified, the match is on any of the ``str`` elements AND any of the ``tag``
+  elements).
+
+  If lists of filters are passed instead of a single map, the maps are ORed
+  (that is, the match succeeds if any of the filters match).
 
   If ``include`` is ``nil`` or empty, then all entries are included. If
   ``exclude`` is ``nil`` or empty, then no entries are filtered out.

--- a/docs/builtins/ls.rst
+++ b/docs/builtins/ls.rst
@@ -40,3 +40,5 @@ Options
     Don't print out the tags associated with each command.
 ``--dev``
     Include commands intended for developers and modders.
+``--exclude <string>[,<string>...]``
+    Exclude commands that match any of the given strings.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -39,6 +39,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `ls`: indent tag listings and wrap them in the right column for better readability
+- `ls`: new ``--exclude`` option for hiding matched scripts from the output.  this can be especially useful for modders who don't want their mod scripts to be included in ``ls`` output.
 
 ## Documentation
 


### PR DESCRIPTION
Fixes #2309 
With this change, @Rumrusher (and others) should be able to exclude messy mod script directories from `ls` output.