### PR TITLE
[widgets.Scrollbar] hold down the mouse button to continue scrolling

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -4064,6 +4064,18 @@ direction. The amount of scrolling done in each case in determined by the
 associated widget, and after scrolling is complete, the associated widget must
 call ``scrollbar:update()`` with updated new display info.
 
+You can hold down the mouse button to scroll multiple times, just like in a
+normal browser scrollbar. The speed of scroll events when the mouse button is
+held down is controlled by two global variables:
+
+:``SCROLL_INITIAL_DELAY_MS``: The delay before the second scroll event.
+:``SCROLL_DELAY_MS``: The delay between further scroll events.
+
+The defaults are 300 and 20, respectively, but they can be overridden by the
+user in their :file:`dfhack-config/init/dfhack.init` file, for example::
+
+  :lua require('gui.widgets').SCROLL_DELAY_MS = 100
+
 Label class
 -----------
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `ls`: new ``--exclude`` option for hiding matched scripts from the output.  this can be especially useful for modders who don't want their mod scripts to be included in ``ls`` output.
 - `digtype`: new ``-z`` option for digtype to restrict designations to the current z-level and down
 - UX: List widgets now have mouse-interactive scrollbars
+- UX: You can now hold down the mouse button on a scrollbar to make it scroll multiple times.
 
 ## Documentation
 


### PR DESCRIPTION
This improves our emulation of scrollbars by allowing the mouse button to be held down to continue scrolling at a fast rate.

The rate is controlled by two user-overridable variables:
```
SCROLL_INITIAL_DELAY_MS = 300
SCROLL_DELAY_MS = 20
```

The user can set the values in `dfhack.init`, e.g. `require('gui.widgets').SCROLL_DELAY_MS = 100`

Some scrollbar implementations stop scrolling when the bar portion crosses where the mouse cursor is. Others continue scrolling in the same direction as long as the mouse cursor is held down, even if it passes the mouse cursor. I followed the latter example since it seemed to make more sense (and it also resulted in simpler code). It would not be hard to change this behavior if others have strong opinions, though.