### PR TITLE
[widgets.Scrollbar] support click and drag

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,6 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `digtype`: new ``-z`` option for digtype to restrict designations to the current z-level and down
 - UX: List widgets now have mouse-interactive scrollbars
 - UX: You can now hold down the mouse button on a scrollbar to make it scroll multiple times.
+- UX: You can now drag the scrollbar to scroll to a specific spot
 
 ## Documentation
 


### PR DESCRIPTION
Fixes #2312

This PR implements dragging scrollbars so you can scroll to a specific spot in the text/list.

It simulates up/down scroll events depending on where the cursor is in relation to the spot on the scrollbar where you started dragging. Moving the mouse quickly sends "large" scroll events and moving slowly sends "small" scroll events.