### PR TITLE
[blueprint] add option to capture smoothed tiles

### DIFF
--- a/docs/plugins/blueprint.rst
+++ b/docs/plugins/blueprint.rst
@@ -103,6 +103,10 @@ Options
     to surround the parameter string in double quotes:
     ``"-s10,10,central stairs"`` or ``--playback-start "10,10,central stairs"``
     or ``"--playback-start=10,10,central stairs"``.
+``--smooth``
+    Record all smooth tiles in the ``smooth`` phase. If this parameter is not
+    specified, only tiles that will later be carved into fortifications or
+    engraved will be smoothed.
 ``-t``, ``--splitby <strategy>``
     Split blueprints into multiple files. See the `Splitting output into
     multiple files`_ section below for details. If not specified, defaults to

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -3,37 +3,6 @@ local _ENV = mkmodule('plugins.blueprint')
 local argparse = require('argparse')
 local utils = require('utils')
 
--- the info here is very basic and minimal, so hopefully we won't need to change
--- it when features are added and the full blueprint docs in Plugins.rst are
--- updated.
-local help_text = [=[
-
-blueprint
-=========
-
-Records the structure of a portion of your fortress in quickfort blueprints.
-
-Usage:
-
-    blueprint <width> <height> [<depth>] [<name> [<phases>]] [<options>]
-    blueprint gui [<name> [<phases>]] [<options>]
-
-Examples:
-
-blueprint gui
-    Runs gui/blueprint, the interactive blueprint frontend, where all
-    configuration can be set visually and interactively.
-
-blueprint 30 40 bedrooms
-    Generates blueprints for an area 30 tiles wide by 40 tiles tall, starting
-    from the active cursor on the current z-level. Output files are written to
-    the "blueprints" directory.
-
-See the online DFHack documentation for more examples and details.
-]=]
-
-function print_help() print(help_text) end
-
 local valid_phase_list = {
     'dig',
     'carve',

--- a/plugins/lua/blueprint.lua
+++ b/plugins/lua/blueprint.lua
@@ -123,6 +123,7 @@ local function process_args(opts, args)
             {'h', 'help', handler=function() opts.help = true end},
             {'s', 'playback-start', hasArg=true,
              handler=function(optarg) parse_start(opts, optarg) end},
+            {nil, 'smooth', handler=function() opts.smooth = true end},
             {'t', 'splitby', hasArg=true,
              handler=function(optarg) parse_split_strategy(opts, optarg) end},
         })

--- a/test/plugins/blueprint.lua
+++ b/test/plugins/blueprint.lua
@@ -36,6 +36,12 @@ function test.parse_gui_commandline()
                     opts)
 
     opts = {}
+    b.parse_gui_commandline(opts, {'--smooth'})
+    expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
+                     name='blueprint', smooth=true,},
+                    opts)
+
+    opts = {}
     b.parse_gui_commandline(opts, {'--engrave'})
     expect.table_eq({auto_phase=true, format='minimal', split_strategy='none',
                      name='blueprint', engrave=true,},


### PR DESCRIPTION
#2306

Before, `blueprint` would only generate smooth designations for tiles if they are later to be carved into fortifications or engraved. This was done so the user wouldn't be forced to take the time to smooth all the tiles before progressing to the next stage, even if the final area would be smoothed. Smoothing is often done as a final step when the player isn't under so much time pressure to get the level functional. This option allows the user to capture all smooth tiles if they want to.

also get rid of in-plugin help text. we should be displaying the full rendered help text instead.