### PR TITLE
Reduce the size of the overlay button

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -51,6 +51,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - UX: List widgets now have mouse-interactive scrollbars
 - UX: You can now hold down the mouse button on a scrollbar to make it scroll multiple times.
 - UX: You can now drag the scrollbar to scroll to a specific spot
+- `overlay`: reduce the size of the "DFHack Launcher" button
 - Constructions module: ``findAtTile`` now uses a binary search intead of a linear search.
 
 ## Documentation

--- a/plugins/overlay.cpp
+++ b/plugins/overlay.cpp
@@ -99,7 +99,7 @@ namespace DFHack {
     DBG_DECLARE(overlay, log, DebugCategory::LINFO);
 }
 
-static const std::string button_text = "[ DFHack Launcher ]";
+static const std::string button_text = "[ DFHack ]";
 static bool clicked = false;
 
 static bool handle_click() {


### PR DESCRIPTION
Change text from "[ DFHack Launcher ]" to just "[ DFHack ]" so it doesn't take up so much space.