### PR TITLE
[gui/cp437-table] add global keybinding for the on-screen keyboard

### DIFF
--- a/data/init/dfhack.keybindings.init
+++ b/data/init/dfhack.keybindings.init
@@ -4,9 +4,9 @@
 # defaults when you update DFHack. Instead, add your configuration to
 # dfhack-config/init/dfhack.init
 
-##############################
-# Generic dwarfmode bindings #
-##############################
+###################
+# Global bindings #
+###################
 
 # the GUI command launcher (two bindings since some keyboards don't have `)
 keybinding add ` gui/launcher
@@ -15,6 +15,13 @@ keybinding add Ctrl-Shift-D gui/launcher
 # show all current key bindings
 keybinding add Ctrl-F1 hotkeys
 keybinding add Alt-F1 hotkeys
+
+# on-screen keyboard
+keybinding add Ctrl-Shift-K gui/cp437-table
+
+##############################
+# Generic dwarfmode bindings #
+##############################
 
 # toggle the display of water level as 1-7 tiles
 keybinding add Ctrl-W twaterlvl

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -53,6 +53,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - UX: You can now drag the scrollbar to scroll to a specific spot
 - `overlay`: reduce the size of the "DFHack Launcher" button
 - Constructions module: ``findAtTile`` now uses a binary search intead of a linear search.
+- `gui/cp437-table`: new global keybinding for the clickable on-screen keyboard for players with keyboard layouts that prevent them from using certain keys: Ctrl-Shift-K
 
 ## Documentation
 


### PR DESCRIPTION
Fixes #2341

so players with keyboard layouts that prevent them from sending certain keys (e.g. German QWERTZ keyboards and square brackets) can write DFHack commandlines that include those characters.