### PR TITLE
[tiletypes] don't overwrite dig priority by accident

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `tiletypes`: no longer resets dig priority to the default when updating other properties of a tile
 
 ## Misc Improvements
 - `blueprint`: new ``--smooth`` option for recording all smoothed floors and walls instead of just the ones that require smoothing for later carving

--- a/library/include/modules/MapCache.h
+++ b/library/include/modules/MapCache.h
@@ -267,7 +267,7 @@ public:
     {
         return index_tile(designation,p);
     }
-    bool setDesignationAt(df::coord2d p, df::tile_designation des, int32_t priority = 4000)
+    bool setDesignationAt(df::coord2d p, df::tile_designation des, int32_t priority = 0)
     {
         if(!valid) return false;
         dirty_designations = true;
@@ -276,6 +276,12 @@ public:
         index_tile(designation,p) = des;
         if((des.bits.dig || des.bits.smooth) && block) {
             block->flags.bits.designated = true;
+            // if priority is not specified, keep the existing priority if it
+            // is set. otherwise default to 4000.
+            if (priority <= 0)
+                priority = priorityAt(p);
+            if (priority <= 0)
+                priority = 4000;
             setPriorityAt(p, priority);
         }
         return true;
@@ -554,8 +560,8 @@ class DFHACK_EXPORT MapCache
         Block * b= BlockAtTile(tilecoord);
         return b ? b->DesignationAt(tilecoord) : df::tile_designation();
     }
-    // priority is optional, only set if >= 0
-    bool setDesignationAt (DFCoord tilecoord, df::tile_designation des, int32_t priority = 4000)
+    // if priority is 0, it is kept unchanged if previously set, otherwise 4000
+    bool setDesignationAt (DFCoord tilecoord, df::tile_designation des, int32_t priority = 0)
     {
         if (Block *b = BlockAtTile(tilecoord))
         {

--- a/library/modules/MapCache.cpp
+++ b/library/modules/MapCache.cpp
@@ -303,7 +303,7 @@ int32_t MapExtras::Block::priorityAt(df::coord2d pos)
 
 bool MapExtras::Block::setPriorityAt(df::coord2d pos, int32_t priority)
 {
-    if (!block || priority < 0)
+    if (!block || priority <= 0)
         return false;
 
     auto event = getPriorityEvent(block, true);


### PR DESCRIPTION
Fixes #2342

Many callers of `MapCache::setDesignationAt()` simply didn't bother with the optional `priority` parameter. This PR changes the default value of the `priority` param so that by default we will keep the previous value instead of overwrite it. This fixes behavior of all callers, not just tiletypes. Tiletypes was just the one I happened to notice when I filed the bug.