### PR TITLE
[gui/create-item] Fix hotkeys getting swallowed by the list filter

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `gui/create-item`: prevent materials list filter from intercepting sublist hotkeys
 - `tiletypes`: no longer resets dig priority to the default when updating other properties of a tile
 
 ## Misc Improvements

--- a/library/lua/gui/materials.lua
+++ b/library/lua/gui/materials.lua
@@ -56,6 +56,8 @@ function MaterialDialog:init(info)
             frame = { l = 0, r = 0, t = 4, b = 2 },
             icon_width = 2,
             on_submit = self:callback('onSubmitItem'),
+            edit_ignore_keys={'CUSTOM_SHIFT_I', 'CUSTOM_SHIFT_C',
+                              'CUSTOM_SHIFT_P'},
         },
         widgets.Label{
             text = { {

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1192,7 +1192,7 @@ function List:onRenderBody(dc)
 
         if obj.key then
             local keystr = gui.getKeyDisplay(obj.key)
-            ip = ip-2-#keystr
+            ip = ip-3-#keystr
             dc:seek(ip,y):pen(self.text_pen)
             dc:string('('):string(keystr,COLOR_LIGHTGREEN):string(')')
         end


### PR DESCRIPTION
Fixes #2327

fixed by ignoring just the hotkeys. we could have added the plumbing to ignore all capital letters, but that didn't seem necessary.

Also fix an off-by-one alignment error for hotkey hints in the scrollable list.