### PR TITLE
make the materials dialog filter lcase only

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -4382,7 +4382,8 @@ supports:
 :edit_pen: If specified, used instead of ``cursor_pen`` for the edit field.
 :edit_below: If true, the edit field is placed below the list instead of above.
 :edit_key: If specified, the edit field is disabled until this key is pressed.
-:edit_ignore_keys: If specified, must be a list of key names that the filter edit field should ignore.
+:edit_ignore_keys: If specified, will be passed to the filter edit field as its ``ignore_keys`` attribute.
+:edit_on_char: If specified, will be passed to the filter edit field as its ``on_char`` attribute.
 :not_found_label: Specifies the text of the label shown when no items match the filter.
 
 The list choices may include the following attributes:

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``widgets.Scrollbar``: new scrollbar widget that can be paired with an associated scrollable widget. Integrated with ``widgets.Label`` and ``widgets.List``.
 - ``dfhack.constructions.findAtTile()``: exposed preexisting function to Lua.
 - ``dfhack.constructions.insert()``: exposed new function to Lua.
+- ``widgets.EditField`` now allows other widgets to process characters that the ``on_char`` callback rejects.
 
 # 0.47.05-r7
 

--- a/library/lua/gui/materials.lua
+++ b/library/lua/gui/materials.lua
@@ -56,8 +56,7 @@ function MaterialDialog:init(info)
             frame = { l = 0, r = 0, t = 4, b = 2 },
             icon_width = 2,
             on_submit = self:callback('onSubmitItem'),
-            edit_ignore_keys={'CUSTOM_SHIFT_I', 'CUSTOM_SHIFT_C',
-                              'CUSTOM_SHIFT_P'},
+            edit_on_char=function(c) return c:match('%l') end,
         },
         widgets.Label{
             text = { {

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -326,6 +326,8 @@ function EditField:onInput(keys)
             if not self.on_char or self.on_char(cv, old) then
                 self:setText(old:sub(1,self.cursor-1)..cv..old:sub(self.cursor),
                              self.cursor + 1)
+            elseif self.on_char then
+                return self.modal
             end
         end
         if self.on_change and self.text ~= old then
@@ -1274,14 +1276,22 @@ FilteredList.ATTRS {
     edit_below = false,
     edit_key = DEFAULT_NIL,
     edit_ignore_keys = DEFAULT_NIL,
+    edit_on_char = DEFAULT_NIL,
 }
 
 function FilteredList:init(info)
+    local on_char = self:callback('onFilterChar')
+    if self.edit_on_char then
+        on_char = function(c, text)
+            return self.edit_on_char(c, text) and self:onFilterChar(c, text)
+        end
+    end
+
     self.edit = EditField{
         text_pen = info.edit_pen or info.cursor_pen,
         frame = { l = info.icon_width, t = 0, h = 1 },
         on_change = self:callback('onFilterChange'),
-        on_char = self:callback('onFilterChar'),
+        on_char = on_char,
         key = self.edit_key,
         ignore_keys = self.edit_ignore_keys,
     }


### PR DESCRIPTION
this allows the capital letter hotkeys to be processed by the list widget without the special-casing of the ignore_keys attribute.

#2327 
This improves the solution merged in #2348