### PR TITLE
fix render errors with automaterial box boundaries

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `gui/create-item`: prevent materials list filter from intercepting sublist hotkeys
 - `tiletypes`: no longer resets dig priority to the default when updating other properties of a tile
+- `automaterial`: fix rendering errors with box boundary markers
 
 ## Misc Improvements
 - `blueprint`: new ``--smooth`` option for recording all smoothed floors and walls instead of just the ones that require smoothing for later carving


### PR DESCRIPTION
during box select, automaterial doesn't detect when the characters it is trying to draw are off the map, allowing them to be rendered over the main window frame and sidebar text.

This issue was already fixed in the Lua code, but most plugins do not use the lua code to render, unfortunately.