### PR TITLE
[automaterial] prevent z-level from changing after box select

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `automaterial`: fix the cursor jumping up a z level when clicking quickly after box select
 - `gui/create-item`: prevent materials list filter from intercepting sublist hotkeys
 - `tiletypes`: no longer resets dig priority to the default when updating other properties of a tile
 

--- a/plugins/automaterial.cpp
+++ b/plugins/automaterial.cpp
@@ -94,7 +94,7 @@ static bool show_box_selection = true;
 static bool hollow_selection = false;
 static deque<df::item*> box_select_materials;
 
-#define SELECTION_IGNORE_TICKS 10
+#define SELECTION_IGNORE_TICKS 1
 static int ignore_selection = SELECTION_IGNORE_TICKS;
 
 static map<int16_t, MaterialDescriptor> last_used_material;


### PR DESCRIPTION
Fixes #2274

If the player clicks the mouse within the SELECTION_IGNORE_TICKS window after finishing a selection, then the z-level changes. Reducing this window to the minimum prevents the issue from happening.

This does not address the root cause, but it does make the issue very unlikely to occur (at least with a human on the mouse).