### PR TITLE
Move generally useful string functions from uicommon to MiscUtils

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -70,6 +70,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## API
 - Constructions module: added ``insert()`` to insert constructions into the game's sorted list.
+- MiscUtils: moved the following string transformation functions from ``uicommon.h``: ``int_to_string``, ``ltrim``, ``rtrim``, and ``trim``
 
 ## Lua
 - ``widgets.Scrollbar``: new scrollbar widget that can be paired with an associated scrollable widget. Integrated with ``widgets.Label`` and ``widgets.List``.

--- a/library/ColorText.cpp
+++ b/library/ColorText.cpp
@@ -52,6 +52,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #include <sstream>
 
+using namespace std;
 using namespace DFHack;
 
 #include "tinythread.h"

--- a/library/RemoteServer.cpp
+++ b/library/RemoteServer.cpp
@@ -61,6 +61,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "json/json.h"
 
+using namespace std;
 using namespace DFHack;
 
 using dfproto::CoreTextNotification;

--- a/library/VTableInterpose.cpp
+++ b/library/VTableInterpose.cpp
@@ -36,6 +36,7 @@ distribution.
 
 #include "MiscUtils.h"
 
+using namespace std;
 using namespace DFHack;
 
 /*

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -24,6 +24,7 @@ distribution.
 
 #pragma once
 #include "Export.h"
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 #include <climits>
@@ -32,10 +33,6 @@ distribution.
 #include <sstream>
 #include <cstdio>
 #include <memory>
-
-using std::ostream;
-using std::stringstream;
-using std::endl;
 
 #if defined(_MSC_VER)
     #define DFHACK_FUNCTION_SIG __FUNCSIG__
@@ -83,9 +80,9 @@ using std::make_unique;
 }
 
 template <typename T>
-void print_bits ( T val, ostream& out )
+void print_bits ( T val, std::ostream& out )
 {
-    stringstream strs;
+    std::stringstream strs;
     T n_bits = sizeof ( val ) * CHAR_BIT;
     int cnt;
     for ( unsigned i = 0; i < n_bits; ++i )
@@ -93,24 +90,24 @@ void print_bits ( T val, ostream& out )
         cnt = i/10;
         strs << cnt << " ";
     }
-    strs << endl;
+    strs << std::endl;
     for ( unsigned i = 0; i < n_bits; ++i )
     {
         cnt = i%10;
         strs << cnt << " ";
     }
-    strs << endl;
+    strs << std::endl;
     for ( unsigned i = 0; i < n_bits; ++i )
     {
         strs << "--";
     }
-    strs << endl;
+    strs << std::endl;
     for ( unsigned i = 0; i < n_bits; ++i )
     {
         strs<< !!( val & 1 ) << " ";
         val >>= 1;
     }
-    strs << endl;
+    strs << std::endl;
     out << strs.str();
 }
 
@@ -388,6 +385,30 @@ DFHACK_EXPORT std::string join_strings(const std::string &separator, const std::
 DFHACK_EXPORT std::string toUpper(const std::string &str);
 DFHACK_EXPORT std::string toLower(const std::string &str);
 DFHACK_EXPORT std::string to_search_normalized(const std::string &str);
+
+static inline std::string int_to_string(const int n)
+{
+    std::ostringstream ss;
+    ss << n;
+    return ss.str();
+}
+
+// trim from start
+static inline std::string &ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char x){ return !std::isspace(x); }));
+    return s;
+}
+
+// trim from end
+static inline std::string &rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](char x){ return !std::isspace(x); }).base(), s.end());
+    return s;
+}
+
+// trim from both ends
+static inline std::string &trim(std::string &s) {
+    return ltrim(rtrim(s));
+}
 
 enum word_wrap_whitespace_mode {
     WSMODE_KEEP_ALL,

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -27,6 +27,7 @@ distribution.
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
+#include <cctype>
 #include <climits>
 #include <stdint.h>
 #include <vector>

--- a/plugins/autobutcher.cpp
+++ b/plugins/autobutcher.cpp
@@ -24,6 +24,7 @@
 #include "modules/Units.h"
 #include "modules/World.h"
 
+using std::endl;
 using std::string;
 using std::unordered_map;
 using std::unordered_set;
@@ -808,7 +809,7 @@ static void autobutcher_cycle(color_ostream &out) {
     for (auto w : watched_races) {
         int slaughter_count = w.second->ProcessUnits();
         if (slaughter_count) {
-            stringstream ss;
+            std::stringstream ss;
             ss << slaughter_count;
             string announce = Units::getRaceNamePluralById(w.first) + " marked for slaughter: " + ss.str();
             DEBUG(cycle,out).print("%s\n", announce.c_str());

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -23,6 +23,8 @@
 #include "df/creature_raw.h"
 #include "df/world.h"
 
+using std::endl;
+
 using namespace DFHack;
 using namespace DFHack::Items;
 using namespace DFHack::Units;
@@ -80,7 +82,7 @@ struct ClothingRequirement
 
     std::string Serialize()
     {
-        stringstream stream;
+        std::stringstream stream;
         stream << ENUM_KEY_STR(job_type, jobType) << " ";
         stream << ENUM_KEY_STR(item_type,itemType) << " ";
         stream << item_subtype << " ";
@@ -91,7 +93,7 @@ struct ClothingRequirement
 
     void Deserialize(std::string s)
     {
-        stringstream stream(s);
+        std::stringstream stream(s);
         std::string loadedJob;
         stream >> loadedJob;
         FOR_ENUM_ITEMS(job_type, job)
@@ -138,7 +140,7 @@ struct ClothingRequirement
 
     std::string ToReadableLabel()
     {
-        stringstream stream;
+        std::stringstream stream;
         stream << bitfield_to_string(material_category) << " ";
         std::string adjective = "";
         std::string name = "";

--- a/plugins/autonestbox.cpp
+++ b/plugins/autonestbox.cpp
@@ -200,7 +200,7 @@ static command_result df_autonestbox(color_ostream &out, vector<string> &paramet
         autonestbox_cycle(out);
     }
     else {
-        out << "autonestbox is " << (is_enabled ? "" : "not ") << "running" << endl;
+        out << "autonestbox is " << (is_enabled ? "" : "not ") << "running" << std::endl;
     }
     return CR_OK;
 }
@@ -377,11 +377,11 @@ static size_t assign_nestboxes(color_ostream &out) {
             did_complain = false;
         old_count = freeEgglayers;
         if (!did_complain) {
-            stringstream ss;
+            std::stringstream ss;
             ss << freeEgglayers;
             string announce = "Not enough free nestbox zones found! You need " + ss.str() + " more.";
             Gui::showAnnouncement(announce, 6, true);
-            out << announce << endl;
+            out << announce << std::endl;
             did_complain = true;
         }
     }
@@ -396,12 +396,12 @@ static void autonestbox_cycle(color_ostream &out) {
 
     size_t processed = assign_nestboxes(out);
     if (processed > 0) {
-        stringstream ss;
+        std::stringstream ss;
         ss << processed << " nestboxes were assigned.";
         string announce = ss.str();
         DEBUG(cycle,out).print("%s\n", announce.c_str());
         Gui::showAnnouncement(announce, 2, false);
-        out << announce << endl;
+        out << announce << std::endl;
         // can complain again
         // (might lead to spamming the same message twice, but catches the case
         // where for example 2 new egglayers hatched right after 2 zones were created and assigned)

--- a/plugins/createitem.cpp
+++ b/plugins/createitem.cpp
@@ -256,7 +256,7 @@ command_result df_createitem (color_ostream &out, vector <string> & parameters)
 
     if (parameters.size() == 3)
     {
-        stringstream ss(parameters[2]);
+        std::stringstream ss(parameters[2]);
         ss >> count;
         if (count < 1)
         {

--- a/plugins/devel/itemhacks.cpp
+++ b/plugins/devel/itemhacks.cpp
@@ -10,6 +10,7 @@
 
 using std::vector;
 using std::string;
+using std::endl;
 using namespace DFHack;
 
 //////////////////////

--- a/plugins/devel/kittens.cpp
+++ b/plugins/devel/kittens.cpp
@@ -28,6 +28,7 @@
 
 using std::vector;
 using std::string;
+using std::endl;
 using namespace DFHack;
 
 DFHACK_PLUGIN("kittens");

--- a/plugins/devel/tiles.cpp
+++ b/plugins/devel/tiles.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 using std::vector;
 using std::string;
+using std::endl;
 
 #include "Core.h"
 #include <Console.h>

--- a/plugins/fix-unit-occupancy.cpp
+++ b/plugins/fix-unit-occupancy.cpp
@@ -14,6 +14,7 @@
 #include "df/unit.h"
 #include "df/world.h"
 
+using std::endl;
 using namespace DFHack;
 
 DFHACK_PLUGIN("fix-unit-occupancy");

--- a/plugins/generated-creature-renamer.cpp
+++ b/plugins/generated-creature-renamer.cpp
@@ -13,6 +13,7 @@
 //#include "df/world.h"
 
 using namespace DFHack;
+using std::endl;
 
 DFHACK_PLUGIN("generated-creature-renamer");
 REQUIRE_GLOBAL(world);

--- a/plugins/uicommon.h
+++ b/plugins/uicommon.h
@@ -157,36 +157,12 @@ static inline void OutputToggleString(int &x, int &y, const char *text, df::inte
     OutputToggleString(x, y, text, DFHack::Screen::getKeyDisplay(hotkey).c_str(), state, newline, left_margin, color, hotkey_color, map);
 }
 
-inline string int_to_string(const int n)
-{
-    std::ostringstream ss;
-    ss << n;
-    return ss.str();
-}
-
 static inline void set_to_limit(int &value, const int maximum, const int min = 0)
 {
     if (value < min)
         value = min;
     else if (value > maximum)
         value = maximum;
-}
-
-// trim from start
-static inline std::string &ltrim(std::string &s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char x){ return !std::isspace(x); }));
-    return s;
-}
-
-// trim from end
-static inline std::string &rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](char x){ return !std::isspace(x); }).base(), s.end());
-    return s;
-}
-
-// trim from both ends
-static inline std::string &trim(std::string &s) {
-    return ltrim(rtrim(s));
 }
 
 inline void paint_text(const UIColor color, const int &x, const int &y, const std::string &text, const UIColor background = 0)


### PR DESCRIPTION
and get rid of some "using" statements in headers that were leaking into widespread cpp files.

This will also remove the need for twbt to cargo cult the `int_to_string` function.