### PR TITLE
Make View:getMousePos() and Screen:show() a bit more flexible

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -3707,10 +3707,11 @@ The class has the following methods:
 
   Returns the dimensions of the ``frame_body`` rectangle.
 
-* ``view:getMousePos()``
+* ``view:getMousePos([view_rect])``
 
-  Returns the mouse *x,y* in coordinates local to the ``frame_body``
-  rectangle if it is within its clip area, or nothing otherwise.
+  Returns the mouse *x,y* in coordinates local to the given ViewRect (or
+  ``frame_body`` if no ViewRect is passed) if it is within its clip area,
+  or nothing otherwise.
 
 * ``view:updateLayout([parent_rect])``
 
@@ -3829,7 +3830,9 @@ It adds the following methods:
   ``dfhack.screen.show``, calls ``self:onAboutToShow(parent)``. Note that
   ``onAboutToShow()`` can dismiss active screens, and therefore change the
   potential parent. If parent is not specified, this function will re-detect the
-  current topmost window after ``self:onAboutToShow(parent)`` returns.
+  current topmost window after ``self:onAboutToShow(parent)`` returns. This
+  function returns ``self`` as a convenience so you can write such code as
+  ``local view = MyScreen{params=val}:show()``.
 
 * ``screen:onAboutToShow(parent)`` *(for overriding)*
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -76,6 +76,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``dfhack.constructions.findAtTile()``: exposed preexisting function to Lua.
 - ``dfhack.constructions.insert()``: exposed new function to Lua.
 - ``widgets.EditField`` now allows other widgets to process characters that the ``on_char`` callback rejects.
+- ``gui.Screen.show()`` now returns ``self`` as a convenience
+- ``gui.View.getMousePos()`` now takes an optional ``ViewRect`` parameter in case the caller wants to get the mouse pos relative to a rect that is not the frame_body (such as the frame_rect)
 
 # 0.47.05-r7
 

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -641,6 +641,7 @@ function Screen:show(parent)
     if not dscreen.show(self, parent.child) then
         error('Could not show screen')
     end
+    return self
 end
 
 function Screen:onAboutToShow(parent)

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -473,8 +473,8 @@ function View:getWindowSize()
     return rect.width, rect.height
 end
 
-function View:getMousePos()
-    local rect = self.frame_body
+function View:getMousePos(view_rect)
+    local rect = view_rect or self.frame_body
     local x,y = dscreen.getMousePos()
     if rect and rect:inClipGlobalXY(x,y) then
         return rect:localXY(x,y)


### PR DESCRIPTION
- allow View:getMousePos() to use a given ViewRect as its frame of reference (before, it only could use self.frame_body, but this made getting the mouse position relative to the frame itself difficult. this capability will be used in the upcoming overlay menu widget
- return self from Screen:show() so we can get the screen instance after calling `show()`. before, code had to get the reference and then call show() on the next line, which is just a waste of space.