### PR TITLE
Allow widgets.List to report hover target and respond to shift-click

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -4322,8 +4322,8 @@ It has the following attributes:
             with an empty list.
 :on_submit: Enter key or mouse click callback; if specified, the list reacts to the
             key/click and calls the callback as ``on_submit(index,choice)``.
-:on_submit2: Shift-Enter key callback; if specified, the list reacts to the key
-             and calls it as ``on_submit2(index,choice)``.
+:on_submit2: Shift-Enter key or shift-mouse click callback; if specified, the list
+             reacts to the key/click and calls it as ``on_submit2(index,choice)``.
 :row_height: Height of every row in text lines.
 :icon_width: If not *nil*, the specified number of character columns
              are reserved to the left of the list item for the icons.
@@ -4359,6 +4359,11 @@ The list supports the following methods:
 * ``list:getSelected()``
 
   Returns the selected *index, choice*, or nothing if the list is empty.
+
+* ``list:getIdxUnderMouse()``
+
+  Returns the index of the list item under the mouse cursor, or nothing if the
+  list is empty or the mouse is not over a list item.
 
 * ``list:getContentWidth()``
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -73,6 +73,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - ``widgets.Scrollbar``: new scrollbar widget that can be paired with an associated scrollable widget. Integrated with ``widgets.Label`` and ``widgets.List``.
+- ``widgets.List``: new ``getIdxUnderMouse()`` function for detecting the list index under the active mouse cursor
+- ``widgets.List``: shift-clicking now triggers the ``submit2`` attribute function if it is defined
 - ``dfhack.constructions.findAtTile()``: exposed preexisting function to Lua.
 - ``dfhack.constructions.insert()``: exposed new function to Lua.
 - ``widgets.EditField`` now allows other widgets to process characters that the ``on_char`` callback rejects.

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1252,7 +1252,11 @@ function List:onInput(keys)
         local idx = self:getIdxUnderMouse()
         if idx then
             self:setSelected(idx)
-            self:submit()
+            if dfhack.internal.getModifiers().shift then
+                self:submit2()
+            else
+                self:submit()
+            end
             return true
         end
     else

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -444,7 +444,9 @@ local BAR_BG_CHAR = string.char(179)
 
 function Scrollbar:onRenderBody(dc)
     -- don't draw if all elements are visible
-    if not scrollbar_is_visible(self) then return end
+    if not scrollbar_is_visible(self) then
+        return
+    end
     -- render up arrow if we're not at the top
     dc:seek(0, 0):char(
         self.top_elem == 1 and NO_ARROW_CHAR or UP_ARROW_CHAR, self.fg, self.bg)
@@ -1216,6 +1218,14 @@ function List:onRenderBody(dc)
     end
 end
 
+function List:getIdxUnderMouse()
+    local _,mouse_y = self:getMousePos()
+    if mouse_y and #self.choices > 0 and
+            mouse_y < (#self.choices-self.page_top+1) * self.row_height then
+        return self.page_top + math.floor(mouse_y/self.row_height)
+    end
+end
+
 function List:submit()
     if self.on_submit and #self.choices > 0 then
         self.on_submit(self:getSelected())
@@ -1239,10 +1249,8 @@ function List:onInput(keys)
         self:submit2()
         return true
     elseif keys._MOUSE_L then
-        local _, mouse_y = self:getMousePos()
-        if mouse_y and #self.choices > 0 and
-                mouse_y < (#self.choices-self.page_top+1) * self.row_height then
-            local idx = self.page_top + math.floor(mouse_y/self.row_height)
+        local idx = self:getIdxUnderMouse()
+        if idx then
             self:setSelected(idx)
             self:submit()
             return true


### PR DESCRIPTION
- `widgets.List`: new `getIdxUnderMouse()` function for detecting the list index under the active mouse cursor
- `widgets.List`: shift-clicking now triggers the `submit2` attribute function if it is defined

both items will be used by the upcoming overlay menu widget.