### PR TITLE
[widgets.Panel] support frames around panel widgets

### DIFF
--- a/docs/Lua API.rst
+++ b/docs/Lua API.rst
@@ -3946,7 +3946,7 @@ Base of all the widgets. Inherits from View and has the following attributes:
 Panel class
 -----------
 
-Inherits from Widget, and intended for grouping a number of subviews.
+Inherits from Widget, and intended for framing and/or grouping subviews.
 
 Has attributes:
 
@@ -3967,6 +3967,13 @@ Has attributes:
   between subviews. This allows you to have widgets dynamically change
   height or become visible/hidden and you don't have to worry about
   recalculating subview positions.
+
+* ``frame_style``, ``frame_title`` (default: nil)
+  If defined, a frame will be drawn around the panel and subviews will be inset
+  by 1. The attributes are identical to what is defined in the
+  `FramedScreen class`_. When using the predefined frame styles in the ``gui``
+  module, remember to ``require`` the gui module and prefix the identifier with
+  ``gui.``, e.g. ``gui.GREY_LINE_FRAME``.
 
 ResizingPanel class
 -------------------

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -75,6 +75,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``widgets.Scrollbar``: new scrollbar widget that can be paired with an associated scrollable widget. Integrated with ``widgets.Label`` and ``widgets.List``.
 - ``dfhack.constructions.findAtTile()``: exposed preexisting function to Lua.
 - ``dfhack.constructions.insert()``: exposed new function to Lua.
+- ``widgets.Panel``: new ``frame_style`` and ``frame_title`` attributes for drawing frames around groups of widgets
 - ``widgets.EditField`` now allows other widgets to process characters that the ``on_char`` callback rejects.
 
 # 0.47.05-r7


### PR DESCRIPTION
Reuse FramedScreen frame-drawing logic to allow panels to draw their own frames. This functionality will be used in the new overlay menu widget.