### PR TITLE
[Gui] add "anywhere" keybinding guard

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -70,6 +70,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `spectate`: improved documentation of features and functionality
 
 ## API
+- ``Gui::anywhere_hotkey``: for plugin commands bound to keybindings that can be invoked on any screen
 - ``Lua::PushInterfaceKeys()``: transforms viewscreen ``feed()`` keys into something that can be interpreted by lua-based widgets
 - ``Lua::Push()``: now handles maps with otherwise supported keys and values
 - Constructions module: added ``insert()`` to insert constructions into the game's sorted list.

--- a/library/include/PluginManager.h
+++ b/library/include/PluginManager.h
@@ -301,6 +301,7 @@ namespace DFHack
     {
         // Predefined hotkey guards
         DFHACK_EXPORT bool default_hotkey(df::viewscreen *);
+        DFHACK_EXPORT bool anywhere_hotkey(df::viewscreen *);
         DFHACK_EXPORT bool dwarfmode_hotkey(df::viewscreen *);
         DFHACK_EXPORT bool cursor_hotkey(df::viewscreen *);
     }

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -630,6 +630,10 @@ bool Gui::default_hotkey(df::viewscreen *top)
     return false;
 }
 
+bool Gui::anywhere_hotkey(df::viewscreen *) {
+    return true;
+}
+
 bool Gui::dwarfmode_hotkey(df::viewscreen *top)
 {
     // Require the main dwarf mode screen

--- a/plugins/command-prompt.cpp
+++ b/plugins/command-prompt.cpp
@@ -337,17 +337,14 @@ command_result show_prompt(color_ostream &out, std::vector <std::string> & param
     Screen::show(dts::make_unique<viewscreen_commandpromptst>(params), plugin_self);
     return CR_OK;
 }
-bool hotkey_allow_all(df::viewscreen *top)
-{
-    return true;
-}
+
 DFhackCExport command_result plugin_init(color_ostream &out, std::vector <PluginCommand> &commands)
 {
     commands.push_back(PluginCommand(
                 "command-prompt",
                 "Allows you to run a DFHack command from in-game.",
                 show_prompt,
-                hotkey_allow_all));
+                Gui::anywhere_hotkey));
     return CR_OK;
 }
 


### PR DESCRIPTION
I am somewhat surprised that we don't have this already. command-prompt implemented its own, which I ported.

This ultra-permissive hotkey guard will be used by the `overlay` and `hotkeys` commands.