### PR TITLE
clean up default keybindings

### DIFF
--- a/data/init/dfhack.keybindings.init
+++ b/data/init/dfhack.keybindings.init
@@ -22,8 +22,7 @@ keybinding add Ctrl-Shift-P command-prompt
 keybinding add Ctrl-Shift-K gui/cp437-table
 
 # an in-game init file editor
-keybinding add Alt-S@title gui/settings-manager
-keybinding add Alt-S@dwarfmode/Default gui/settings-manager
+keybinding add Alt-S@title|dwarfmode/Default|dungeonmode gui/settings-manager
 
 
 ######################
@@ -34,20 +33,20 @@ keybinding add Alt-S@dwarfmode/Default gui/settings-manager
 keybinding add Ctrl-Alt-S@dwarfmode/Default quicksave
 
 # toggle the display of water level as 1-7 tiles
-keybinding add Ctrl-W twaterlvl
+keybinding add Ctrl-W@dwarfmode|dungeonmode twaterlvl
 
 # designate the whole vein for digging
-keybinding add Ctrl-V digv
-keybinding add Ctrl-Shift-V "digv x"
+keybinding add Ctrl-V@dwarfmode digv
+keybinding add Ctrl-Shift-V@dwarfmode "digv x"
 
 # clean the selected tile of blood etc
 keybinding add Ctrl-C spotclean
 
 # destroy the selected item
-keybinding add Ctrl-K autodump-destroy-item
+keybinding add Ctrl-K@dwarfmode autodump-destroy-item
 
 # destroy items designated for dump in the selected tile
-keybinding add Ctrl-Shift-K autodump-destroy-here
+keybinding add Ctrl-Shift-K@dwarfmode autodump-destroy-here
 
 # apply blueprints to the map (Alt-F for compatibility with LNP Quickfort)
 keybinding add Ctrl-Shift-Q@dwarfmode gui/quickfort
@@ -64,8 +63,7 @@ keybinding add Alt-Shift-I@dwarfmode/Zones "zone set"
 keybinding add Ctrl-Shift-Z@dwarfmode/Default "stocks show"
 
 # open an overview window summarising some stocks (dfstatus)
-keybinding add Ctrl-Shift-I@dwarfmode/Default gui/dfstatus
-keybinding add Ctrl-Shift-I@dfhack/lua/dfstatus gui/dfstatus
+keybinding add Ctrl-Shift-I@dwarfmode/Default|dfhack/lua/dfstatus gui/dfstatus
 
 # change quantity of manager orders
 keybinding add Alt-Q@jobmanagement/Main gui/manager-quantity
@@ -77,19 +75,19 @@ keybinding add Alt-R@jobmanagement/Main workorder-recheck
 keybinding add D@workquota_details gui/workorder-details
 
 # view combat reports for the selected unit/corpse/spatter
-keybinding add Ctrl-Shift-R view-unit-reports
+keybinding add Ctrl-Shift-R@dwarfmode|unit|unitlist|joblist|dungeon_monsterstatus|layer_unit_relationship|item|workshop_profile|layer_noblelist|locations|pets|layer_overall_health|textviewer|reportlist|announcelist|layer_military|layer_unit_health|customize_unit|buildinglist|workshop_profile view-unit-reports
 
 # view extra unit information
 keybinding add Alt-I@dwarfmode/ViewUnits|unitlist gui/unit-info-viewer
 
 # boost priority of jobs related to the selected entity
-keybinding add Alt-N do-job-now
+keybinding add Alt-N@dwarfmode|job|joblist|unit|unitlist|joblist|dungeon_monsterstatus|layer_unit_relationship|item|layer_noblelist|locations|pets|layer_overall_health|textviewer|reportlist|announcelist|layer_military|layer_unit_health|customize_unit|buildinglist|textviewer|item|layer_assigntrade|tradegoods|store|assign_display_item|treasurelist do-job-now
 
 # export a Dwarf's preferences screen in BBCode to post to a forum
-keybinding add Ctrl-Shift-F@dwarfmode forum-dwarves
+keybinding add Ctrl-Shift-F@textviewer forum-dwarves
 
 # q->stockpile - copy & paste stockpiles
-keybinding add Alt-P copystock
+keybinding add Alt-P@dwarfmode/QueryBuilding/Some/Stockpile copystock
 
 # q->stockpile - load and save stockpile settings out of game
 keybinding add Alt-L@dwarfmode/QueryBuilding/Some/Stockpile "gui/stockpiles -load"
@@ -155,8 +153,8 @@ keybinding add Shift-B@pet/List/Unit gui/autobutcher
 keybinding add Alt-Shift-P@dwarfmode/LookAround gui/pathable
 
 # gui/rename script - rename units and buildings
-keybinding add Ctrl-Shift-N gui/rename
-keybinding add Ctrl-Shift-T "gui/rename unit-profession"
+keybinding add Ctrl-Shift-N@dwarfmode|unit|unitlist|joblist|dungeon_monsterstatus|layer_unit_relationship|item|workshop_profile|layer_noblelist|locations|pets|layer_overall_health|textviewer|reportlist|announcelist|layer_military|layer_unit_health|customize_unit|buildinglist gui/rename
+keybinding add Ctrl-Shift-T@dwarfmode|unit|unitlist|joblist|dungeon_monsterstatus|layer_unit_relationship|item|workshop_profile|layer_noblelist|locations|pets|layer_overall_health|textviewer|reportlist|announcelist|layer_military|layer_unit_health|customize_unit "gui/rename unit-profession"
 
 
 #####################

--- a/data/init/dfhack.keybindings.init
+++ b/data/init/dfhack.keybindings.init
@@ -5,7 +5,7 @@
 # dfhack-config/init/dfhack.init
 
 ###################
-# Global bindings #
+# global bindings #
 ###################
 
 # the GUI command launcher (two bindings since some keyboards don't have `)
@@ -15,17 +15,26 @@ keybinding add Ctrl-Shift-D gui/launcher
 # show hotkey popup menu
 keybinding add Ctrl-Shift-C hotkeys
 
+# a dfhack prompt in df. Sublime text like.
+keybinding add Ctrl-Shift-P command-prompt
+
 # on-screen keyboard
 keybinding add Ctrl-Shift-K gui/cp437-table
 
-##############################
-# Generic dwarfmode bindings #
-##############################
+# an in-game init file editor
+keybinding add Alt-S@title gui/settings-manager
+keybinding add Alt-S@dwarfmode/Default gui/settings-manager
+
+
+######################
+# dwarfmode bindings #
+######################
+
+# quicksave, only in main dwarfmode screen and menu page
+keybinding add Ctrl-Alt-S@dwarfmode/Default quicksave
 
 # toggle the display of water level as 1-7 tiles
 keybinding add Ctrl-W twaterlvl
-
-# with cursor:
 
 # designate the whole vein for digging
 keybinding add Ctrl-V digv
@@ -34,43 +43,29 @@ keybinding add Ctrl-Shift-V "digv x"
 # clean the selected tile of blood etc
 keybinding add Ctrl-C spotclean
 
-# destroy items designated for dump in the selected tile
-keybinding add Ctrl-Shift-K autodump-destroy-here
-
-# set the zone or cage under the cursor as the default
-keybinding add Alt-Shift-I@dwarfmode/Zones "zone set"
-
-# with an item selected:
-
 # destroy the selected item
 keybinding add Ctrl-K autodump-destroy-item
 
-# scripts:
-
-# quicksave, only in main dwarfmode screen and menu page
-keybinding add Ctrl-Alt-S@dwarfmode/Default quicksave
+# destroy items designated for dump in the selected tile
+keybinding add Ctrl-Shift-K autodump-destroy-here
 
 # apply blueprints to the map (Alt-F for compatibility with LNP Quickfort)
 keybinding add Ctrl-Shift-Q@dwarfmode gui/quickfort
 keybinding add Alt-F@dwarfmode gui/quickfort
 
-# gui/rename script - rename units and buildings
-keybinding add Ctrl-Shift-N gui/rename
-keybinding add Ctrl-Shift-T "gui/rename unit-profession"
-
-# a dfhack prompt in df. Sublime text like.
-keybinding add Ctrl-Shift-P command-prompt
-
 # show information collected by dwarfmonitor
 keybinding add Alt-M@dwarfmode/Default "dwarfmonitor prefs"
 keybinding add Ctrl-F@dwarfmode/Default "dwarfmonitor stats"
 
-# export a Dwarf's preferences screen in BBCode to post to a forum
-keybinding add Ctrl-Shift-F@dwarfmode forum-dwarves
+# set the zone or cage under the cursor as the default
+keybinding add Alt-Shift-I@dwarfmode/Zones "zone set"
 
-# an in-game init file editor
-keybinding add Alt-S@title gui/settings-manager
-keybinding add Alt-S@dwarfmode/Default gui/settings-manager
+# Stocks plugin
+keybinding add Ctrl-Shift-Z@dwarfmode/Default "stocks show"
+
+# open an overview window summarising some stocks (dfstatus)
+keybinding add Ctrl-Shift-I@dwarfmode/Default gui/dfstatus
+keybinding add Ctrl-Shift-I@dfhack/lua/dfstatus gui/dfstatus
 
 # change quantity of manager orders
 keybinding add Alt-Q@jobmanagement/Main gui/manager-quantity
@@ -78,7 +73,7 @@ keybinding add Alt-Q@jobmanagement/Main gui/manager-quantity
 # re-check manager orders
 keybinding add Alt-R@jobmanagement/Main workorder-recheck
 
-# workorder detail configuration
+# set workorder item details (on workorder details screen press D again)
 keybinding add D@workquota_details gui/workorder-details
 
 # view combat reports for the selected unit/corpse/spatter
@@ -87,39 +82,11 @@ keybinding add Ctrl-Shift-R view-unit-reports
 # view extra unit information
 keybinding add Alt-I@dwarfmode/ViewUnits|unitlist gui/unit-info-viewer
 
-# set workorder item details (on workorder details screen press D again)
-keybinding add D@workquota_details gui/workorder-details
-
 # boost priority of jobs related to the selected entity
 keybinding add Alt-N do-job-now
 
-##############################
-# Generic adv mode bindings  #
-##############################
-
-keybinding add Ctrl-B@dungeonmode adv-bodyswap
-keybinding add Ctrl-Shift-B@dungeonmode "adv-bodyswap force"
-keybinding add Shift-O@dungeonmode gui/companion-order
-keybinding add Ctrl-T@dungeonmode gui/advfort
-keybinding add Ctrl-A@dungeonmode/ConversationSpeak adv-rumors
-
-##############################
-# Generic legends bindings   #
-##############################
-
-# export all information, or just the detailed maps (doesn't handle site maps)
-keybinding add Ctrl-A@legends "exportlegends all"
-
-#############################
-# Context-specific bindings #
-#############################
-
-# Stocks plugin
-keybinding add Ctrl-Shift-Z@dwarfmode/Default "stocks show"
-
-# open an overview window summarising some stocks (dfstatus)
-keybinding add Ctrl-Shift-I@dwarfmode/Default "gui/dfstatus"
-keybinding add Ctrl-Shift-I@dfhack/lua/dfstatus "gui/dfstatus"
+# export a Dwarf's preferences screen in BBCode to post to a forum
+keybinding add Ctrl-Shift-F@dwarfmode forum-dwarves
 
 # q->stockpile - copy & paste stockpiles
 keybinding add Alt-P copystock
@@ -182,7 +149,30 @@ keybinding add Alt-W@overallstatus "gui/workflow status"
 keybinding add Alt-W@dfhack/lua/status_overlay "gui/workflow status"
 
 # autobutcher front-end
-keybinding add Shift-B@pet/List/Unit "gui/autobutcher"
+keybinding add Shift-B@pet/List/Unit gui/autobutcher
 
 # view pathable tiles from active cursor
 keybinding add Alt-Shift-P@dwarfmode/LookAround gui/pathable
+
+# gui/rename script - rename units and buildings
+keybinding add Ctrl-Shift-N gui/rename
+keybinding add Ctrl-Shift-T "gui/rename unit-profession"
+
+
+#####################
+# adv mode bindings #
+#####################
+
+keybinding add Ctrl-A@dungeonmode/ConversationSpeak adv-rumors
+keybinding add Ctrl-B@dungeonmode adv-bodyswap
+keybinding add Ctrl-Shift-B@dungeonmode "adv-bodyswap force"
+keybinding add Shift-O@dungeonmode gui/companion-order
+keybinding add Ctrl-T@dungeonmode gui/advfort
+
+
+#########################
+# legends mode bindings #
+#########################
+
+# export all information, or just the detailed maps (doesn't handle site maps)
+keybinding add Ctrl-A@legends "exportlegends all"

--- a/docs/builtins/keybinding.rst
+++ b/docs/builtins/keybinding.rst
@@ -7,10 +7,10 @@ keybinding
 
 Like any other command, it can be used at any time from the console, but
 bindings are not remembered between runs of the game unless re-created in
-`dfhack.init`.
+:file:`dfhack-config/init/dfhack.init`.
 
-Hotkeys can be any combinations of Ctrl/Alt/Shift with A-Z, 0-9, F1-F12, or
-\` (the key below the :kbd:`Esc` key.
+Hotkeys can be any combinations of Ctrl/Alt/Shift with A-Z, 0-9, F1-F12, or `
+(the key below the :kbd:`Esc` key on most keyboards).
 
 Usage
 -----
@@ -21,16 +21,17 @@ Usage
     List bindings active for the key combination.
 ``keybinding clear <key> [<key>...]``
     Remove bindings for the specified keys.
-``keybinding add <key> "cmdline" ["cmdline"...]``
+``keybinding add <key> "<cmdline>" ["<cmdline>" ...]``
     Add bindings for the specified key.
-``keybinding set <key> "cmdline" ["cmdline"...]``
+``keybinding set <key> "<cmdline>" ["<cmdline>" ...]``
     Clear, and then add bindings for the specified key.
 
 The ``<key>`` parameter above has the following **case-sensitive** syntax::
 
     [Ctrl-][Alt-][Shift-]KEY[@context[|context...]]
 
-where the ``KEY`` part can be any recognized key and [] denote optional parts.
+where the ``KEY`` part can be any recognized key and :kbd:`[`:kbd:`]` denote
+optional parts.
 
 When multiple commands are bound to the same key combination, DFHack selects
 the first applicable one. Later ``add`` commands, and earlier entries within one
@@ -49,13 +50,18 @@ Multiple contexts can be specified by separating them with a pipe (``|``) - for
 example, ``@foo|bar|baz/foo`` would match anything under ``@foo``, ``@bar``, or
 ``@baz/foo``.
 
-Interactive commands like `liquids` cannot be used as hotkeys.
+Commands like `liquids` or `tiletypes` cannot be used as hotkeys since they
+require the console for interactive input.
 
 Examples
 --------
 
-``keybinding add Alt-F1 hotkeys``
-    Bind Alt-F1 to run the `hotkeys` command on any screen at any time.
+``keybinding add Ctrl-Shift-C hotkeys``
+    Bind Ctrl-Shift-C to run the `hotkeys` command on any screen at any time.
 ``keybinding add Alt-F@dwarfmode gui/quickfort``
     Bind Alt-F to run `gui/quickfort`, but only when on a screen that shows the
     main map.
+``keybinding add Ctrl-Shift-Z@dwarfmode/Default "stocks show"``
+    Bind Ctrl-Shift-Z to run `stocks show <stocks>`, but only when on the main
+    map in the default mode (that is, no special mode, like cursor look, is
+    enabled).


### PR DESCRIPTION
Fixes #2384

Go through the keybindings and scope them closer to their area of use so they don't clutter the hotkeys list unnecessarily
the better solution for many of these commands is hotkey guards, but we don't yet support hotkey guards for scripts

see the second commit for actual content changes. the first commit is just reformatting and reordering.