### PR TITLE
autolabor/autohauler: add labor entries for 241-243

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `mousequery`: fix the cursor jumping up z levels sometimes when using TWBT
 - `tiletypes`: no longer resets dig priority to the default when updating other properties of a tile
 - `automaterial`: fix rendering errors with box boundary markers
+- `autolabor` & `autohauler`: properly handle jobs 241, 242, and 243
 - Core: fix the segmentation fault with the REPORT event in EventManager
 - Core: fix the new JOB_STARTED event only sending each event once, to the first handler listed
 

--- a/plugins/autohauler.cpp
+++ b/plugins/autohauler.cpp
@@ -407,6 +407,9 @@ static const dwarf_state dwarf_states[] = {
     BUSY  /* MakeBracelet */,
     BUSY  /* MakeGem */,
     BUSY  /* PutItemOnDisplay */,
+    OTHER /* unk_fake_no_job */,
+    OTHER /* InterrogateSubject */,
+    OTHER /* unk_fake_no_activity */,
 };
 
 // Mode assigned to labors. Either it's a hauling job, or it's not.

--- a/plugins/autolabor.cpp
+++ b/plugins/autolabor.cpp
@@ -375,6 +375,9 @@ static const dwarf_state dwarf_states[] = {
     BUSY /* MakeBracelet */,
     BUSY /* MakeGem */,
     BUSY /* PutItemOnDisplay */,
+    OTHER /* unk_fake_no_job */,
+    OTHER /* InterrogateSubject */,
+    OTHER /* unk_fake_no_activity */,
 };
 
 struct labor_info


### PR DESCRIPTION
add missing entries for jobs 241, 242, and 243

this was fixed in labormanager in PR #1566 (see #1561) but was never addressed in autolabor or autohauler

should close #1994