### PR TITLE
autofarm: insert missing output flushes

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,6 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `tiletypes`: no longer resets dig priority to the default when updating other properties of a tile
 - `automaterial`: fix rendering errors with box boundary markers
 - `autolabor` & `autohauler`: properly handle jobs 241, 242, and 243
+- `autofarm`: add missing output flushes
 - Core: fix the segmentation fault with the REPORT event in EventManager
 - Core: fix the new JOB_STARTED event only sending each event once, to the first handler listed
 

--- a/plugins/autofarm.cpp
+++ b/plugins/autofarm.cpp
@@ -317,6 +317,8 @@ public:
         {
             set_farms(out, plants[ff.first], ff.second);
         }
+
+        out << std::flush;
     }
 
     void status(color_ostream& out)
@@ -336,6 +338,8 @@ public:
             out << plant->id << " limit " << getThreshold(th.first) << " current 0" << '\n';
         }
         out << "Default: " << defaultThreshold << '\n';
+
+        out << std::flush;
     }
 };
 
@@ -409,7 +413,7 @@ static command_result setThresholds(color_ostream& out, std::vector<std::string>
         }
         if (!ok)
         {
-            out << "Cannot find plant with id " << id << '\n';
+            out << "Cannot find plant with id " << id << '\n' << std::flush;
             return CR_WRONG_USAGE;
         }
     }


### PR DESCRIPTION
insert calls to std::flush as appropriate

fixes #2365