### PR TITLE
add a default overlay config with standard widgets

### DIFF
--- a/dfhack-config/overlay.json
+++ b/dfhack-config/overlay.json
@@ -1,0 +1,14 @@
+{
+	"dwarfmonitor.date": {
+		"enabled": true
+	},
+	"dwarfmonitor.misery": {
+		"enabled": true
+	},
+	"dwarfmonitor.weather": {
+		"enabled": true
+	},
+	"hotkeys.menu": {
+		"enabled": true
+	}
+}


### PR DESCRIPTION
#2339

the default config does not include positions so we'll use the default positions from the widgets themselves. This makes the default config agnostic to default position changes (though we might want to include a versioning scheme in the future so that saved positions can get reset if the DF UI changes and the default positions need to be adjusted)