### PR TITLE
up MSVC warning level to /W3 /WX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(MSVC)
+    # increase warning level
+    add_definitions("/WX")
+    add_definitions("/W3")
+
     # disable C4819 code-page warning
     add_definitions("/wd4819")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(MSVC)
-    # increase warning level
+    # increase warning level and treat warnings as errors
     add_definitions("/WX")
     add_definitions("/W3")
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -111,7 +111,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``gui.Screen.show()`` now returns ``self`` as a convenience
 - ``gui.View.getMousePos()`` now takes an optional ``ViewRect`` parameter in case the caller wants to get the mouse pos relative to a rect that is not the frame_body (such as the frame_rect)
 
-## Build configuration
+## Internal
 - MSVC warning level upped to /W3, and /WX added to make warnings cause compilations to fail.
 
 # 0.47.05-r7

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -111,6 +111,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``gui.Screen.show()`` now returns ``self`` as a convenience
 - ``gui.View.getMousePos()`` now takes an optional ``ViewRect`` parameter in case the caller wants to get the mouse pos relative to a rect that is not the frame_body (such as the frame_rect)
 
+## Build configuration
+- MSVC warning level upped to /W3, and /WX added to make warnings cause compilations to fail.
+
 # 0.47.05-r7
 
 ## New Plugins

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -111,7 +111,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``gui.Screen.show()`` now returns ``self`` as a convenience
 - ``gui.View.getMousePos()`` now takes an optional ``ViewRect`` parameter in case the caller wants to get the mouse pos relative to a rect that is not the frame_body (such as the frame_rect)
 
-## Internal
+## Internals
 - MSVC warning level upped to /W3, and /WX added to make warnings cause compilations to fail.
 
 # 0.47.05-r7


### PR DESCRIPTION
This makes MSVC warn at a level comparable to what we use on gcc for Linux builds

This basically the same thing for MSVC that we did in #1958 for Linux