### PR TITLE
Add robots.txt to our HTML docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -256,6 +256,10 @@ html_favicon = 'docs/styles/dfhack-icon.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['docs/styles']
 
+# A list of paths that contain extra files not directly related to the
+# documentation.
+html_extra_path = ['robots.txt']
+
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
     '**': [

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+
+Allow: /en/stable/
+
+Sitemap: https://docs.dfhack.org/sitemap.xml


### PR DESCRIPTION
Fixes #2368

Google search does not grok our docs well. It often returns results for outdated versions. ReadTheDocs has an autogenerated robots.txt file we can use, but if we want to hide old DFHack docs from the crawler, we also hide it from the UI (in the flyout menu where doc readers can select the version of the docs they're reading). Therefore, it seems like the best idea to just create a custom robots.txt file to deploy to our docs site that only allows indexing of the `stable` docs. The other versions will still be there, they just won't show up in google search results.

Our generated sitemap.xml *does* appear to correctly give priority to `stable`, but it's easy to see that old docs still seem to outrank current docs in real search results. We may need a custom sitemap.xml as well, but let's see if just replacing robots.txt is enough first.

The robots.txt file in this PR won't take effect on docs.dfhack.org until it's deployed in the "stable" branch.