### PR TITLE
Ensure init script file run order is consistent

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -46,6 +46,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autofarm`: add missing output flushes
 - Core: fix the segmentation fault with the REPORT event in EventManager
 - Core: fix the new JOB_STARTED event only sending each event once, to the first handler listed
+- Core: ensure ``foo.init`` always runs before ``foo.*.init`` (e.g.  ``dfhack.init`` should always run before ``dfhack.something.init``)
 
 ## Misc Improvements
 - `blueprint`: new ``--smooth`` option for recording all smoothed floors and walls instead of just the ones that require smoothing for later carving

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2000,15 +2000,21 @@ void getFilesWithPrefixAndSuffix(const std::string& folder, const std::string& p
 }
 
 size_t loadScriptFiles(Core* core, color_ostream& out, const vector<std::string>& prefix, const std::string& folder) {
-    vector<std::string> scriptFiles;
+    static const string suffix = ".init";
+    vector<string> scriptFiles;
     for ( size_t a = 0; a < prefix.size(); a++ ) {
         getFilesWithPrefixAndSuffix(folder, prefix[a], ".init", scriptFiles);
     }
-    std::sort(scriptFiles.begin(), scriptFiles.end());
+    std::sort(scriptFiles.begin(), scriptFiles.end(),
+              [&](const string &a, const string &b) {
+        string a_base = a.substr(0, a.size() - suffix.size());
+        string b_base = b.substr(0, b.size() - suffix.size());
+        return a_base < b_base;
+    });
     size_t result = 0;
     for ( size_t a = 0; a < scriptFiles.size(); a++ ) {
         result++;
-        std::string path = "";
+        string path = "";
         if (folder != ".")
             path = folder + "/";
         core->loadScriptFile(out, path + scriptFiles[a], false);


### PR DESCRIPTION
Fixes #2324

ensure ``foo.init`` always runs before ``foo.*.init`` (e.g.  ``dfhack.init`` should always run before ``dfhack.something.init``)