### PR TITLE
Make mouse button event behavior conform to docs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -114,6 +114,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``widgets.EditField`` now allows other widgets to process characters that the ``on_char`` callback rejects.
 - ``gui.Screen.show()`` now returns ``self`` as a convenience
 - ``gui.View.getMousePos()`` now takes an optional ``ViewRect`` parameter in case the caller wants to get the mouse pos relative to a rect that is not the frame_body (such as the frame_rect)
+- Lua mouse events now conform to documented behavior in `lua-api` -- ``_MOUSE_L_DOWN`` will be sent exactly once per mouse click and ``_MOUSE_L`` will be sent repeatedly as long as the button is held down. Similarly for right mouse button events.
 
 ## Internals
 - MSVC warning level upped to /W3, and /WX added to make warnings cause compilations to fail.

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -156,21 +156,21 @@ void DFHack::Lua::PushInterfaceKeys(lua_State *L,
     if (df::global::enabler) {
         if (df::global::enabler->mouse_lbut_down) {
             lua_pushboolean(L, true);
-            lua_setfield(L, -2, "_MOUSE_L");
+            lua_setfield(L, -2, "_MOUSE_L_DOWN");
         }
         if (df::global::enabler->mouse_rbut_down) {
             lua_pushboolean(L, true);
-            lua_setfield(L, -2, "_MOUSE_R");
+            lua_setfield(L, -2, "_MOUSE_R_DOWN");
         }
         if (df::global::enabler->mouse_lbut) {
             lua_pushboolean(L, true);
-            lua_setfield(L, -2, "_MOUSE_L_DOWN");
-            df::global::enabler->mouse_lbut = 0;
+            lua_setfield(L, -2, "_MOUSE_L");
+            df::global::enabler->mouse_lbut_down = 0;
         }
         if (df::global::enabler->mouse_rbut) {
             lua_pushboolean(L, true);
-            lua_setfield(L, -2, "_MOUSE_R_DOWN");
-            df::global::enabler->mouse_rbut = 0;
+            lua_setfield(L, -2, "_MOUSE_R");
+            df::global::enabler->mouse_rbut_down = 0;
         }
     }
 }

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -334,7 +334,7 @@ function EditField:onInput(keys)
     elseif keys._MOUSE_L then
         local mouse_x, mouse_y = self:getMousePos()
         if mouse_x then
-            self:setCursor(self.start_pos + mouse_x - self.text_offset)
+            self:setCursor(self.start_pos + mouse_x - (self.text_offset or 0))
             return true
         end
     elseif keys._STRING then

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -334,7 +334,7 @@ function EditField:onInput(keys)
     elseif keys._MOUSE_L then
         local mouse_x, mouse_y = self:getMousePos()
         if mouse_x then
-            self:setCursor(self.start_pos + mouse_x)
+            self:setCursor(self.start_pos + mouse_x - self.text_offset)
             return true
         end
     elseif keys._STRING then
@@ -496,7 +496,7 @@ function Scrollbar:onRenderBody(dc)
     if self.is_dragging then
         scrollbar_do_drag(self)
     end
-    if df.global.enabler.mouse_lbut_down == 0 then
+    if df.global.enabler.mouse_lbut == 0 then
         self.last_scroll_ms = 0
         self.is_dragging = false
         self.scroll_spec = nil
@@ -928,7 +928,7 @@ end
 function HotkeyLabel:onInput(keys)
     if HotkeyLabel.super.onInput(self, keys) then
         return true
-    elseif keys._MOUSE_L and self:getMousePos() then
+    elseif keys._MOUSE_L_DOWN and self:getMousePos() then
         self.on_activate()
         return true
     end
@@ -1009,7 +1009,7 @@ end
 function CycleHotkeyLabel:onInput(keys)
     if CycleHotkeyLabel.super.onInput(self, keys) then
         return true
-    elseif keys._MOUSE_L and self:getMousePos() then
+    elseif keys._MOUSE_L_DOWN and self:getMousePos() then
         self:cycle()
         return true
     end
@@ -1274,7 +1274,7 @@ function List:onInput(keys)
     elseif self.on_submit2 and keys.SEC_SELECT then
         self:submit2()
         return true
-    elseif keys._MOUSE_L then
+    elseif keys._MOUSE_L_DOWN then
         local idx = self:getIdxUnderMouse()
         if idx then
             self:setSelected(idx)

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -207,7 +207,7 @@ function MenuScreen:onInput(keys)
     elseif keys.STANDARDSCROLL_RIGHT then
         self:onSubmit2(self.subviews.list:getSelected())
         return true
-    elseif keys._MOUSE_L then
+    elseif keys._MOUSE_L_DOWN then
         local list = self.subviews.list
         local x = list:getMousePos()
         if x == 0 then -- clicked on icon

--- a/test/library/gui/widgets.EditField.lua
+++ b/test/library/gui/widgets.EditField.lua
@@ -40,17 +40,17 @@ function test.editfield_click()
     expect.eq(5, e.cursor)
 
     mock.patch(e, 'getMousePos', mock.func(0), function()
-            e:onInput{_MOUSE_L_DOWN=true}
+            e:onInput{_MOUSE_L=true}
             expect.eq(1, e.cursor)
         end)
 
     mock.patch(e, 'getMousePos', mock.func(20), function()
-            e:onInput{_MOUSE_L_DOWN=true}
+            e:onInput{_MOUSE_L=true}
             expect.eq(5, e.cursor, 'should only seek to end of text')
         end)
 
     mock.patch(e, 'getMousePos', mock.func(2), function()
-            e:onInput{_MOUSE_L_DOWN=true}
+            e:onInput{_MOUSE_L=true}
             expect.eq(3, e.cursor)
         end)
 end

--- a/test/library/gui/widgets.EditField.lua
+++ b/test/library/gui/widgets.EditField.lua
@@ -40,17 +40,17 @@ function test.editfield_click()
     expect.eq(5, e.cursor)
 
     mock.patch(e, 'getMousePos', mock.func(0), function()
-            e:onInput{_MOUSE_L=true}
+            e:onInput{_MOUSE_L_DOWN=true}
             expect.eq(1, e.cursor)
         end)
 
     mock.patch(e, 'getMousePos', mock.func(20), function()
-            e:onInput{_MOUSE_L=true}
+            e:onInput{_MOUSE_L_DOWN=true}
             expect.eq(5, e.cursor, 'should only seek to end of text')
         end)
 
     mock.patch(e, 'getMousePos', mock.func(2), function()
-            e:onInput{_MOUSE_L=true}
+            e:onInput{_MOUSE_L_DOWN=true}
             expect.eq(3, e.cursor)
         end)
 end

--- a/test/library/gui/widgets.lua
+++ b/test/library/gui/widgets.lua
@@ -5,7 +5,7 @@ function test.hotkeylabel_click()
     local l = widgets.HotkeyLabel{key='SELECT', on_activate=func}
 
     mock.patch(l, 'getMousePos', mock.func(0), function()
-            l:onInput{_MOUSE_L=true}
+            l:onInput{_MOUSE_L_DOWN=true}
             expect.eq(1, func.call_count)
         end)
 end
@@ -31,7 +31,7 @@ function test.togglehotkeylabel_click()
     local l = widgets.ToggleHotkeyLabel{}
     expect.true_(l:getOptionValue())
     mock.patch(l, 'getMousePos', mock.func(0), function()
-            l:onInput{_MOUSE_L=true}
+            l:onInput{_MOUSE_L_DOWN=true}
             expect.false_(l:getOptionValue())
         end)
 end


### PR DESCRIPTION
before, when a mouse button was held down, we'd send a single _MOUSE_L and _MOUSE_L_DOWN event and that's it. now we properly send a single _MOUSE_L_DOWN event and _MOUSE_L events for as long as the button is held down. similar for the right mouse button

This PR fixes core behavior and updates lua library code to handle the newly correct behavior.