### PR TITLE
allow frames to be drawn without the DFHack signature

### DIFF
--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -711,7 +711,9 @@ function paint_frame(x1,y1,x2,y2,style,title)
     dscreen.fillRect(style.b_frame_pen or style.h_frame_pen or pen,x1+1,y2,x2-1,y2)
     dscreen.fillRect(style.l_frame_pen or style.v_frame_pen or pen,x1,y1+1,x1,y2-1)
     dscreen.fillRect(style.r_frame_pen or style.v_frame_pen or pen,x2,y1+1,x2,y2-1)
-    dscreen.paintString(style.signature_pen or style.title_pen or pen,x2-7,y2,"DFHack")
+    if style.signature_pen ~= false then
+        dscreen.paintString(style.signature_pen or style.title_pen or pen,x2-7,y2,"DFHack")
+    end
 
     if title then
         local x = math.max(0,math.floor((x2-x1-3-#title)/2)) + x1


### PR DESCRIPTION
for panels that do not need to be individually identified as belonging to DFHack