### PR TITLE
Implements plugin: channel-safely v1.1b

### DIFF
--- a/plugins/channel-safely/include/channel-groups.h
+++ b/plugins/channel-safely/include/channel-groups.h
@@ -39,7 +39,7 @@ protected:
 public:
     explicit ChannelGroups(ChannelJobs &jobs) : jobs(jobs) { groups.reserve(200); }
     void scan_one(const df::coord &map_pos);
-    void scan();
+    void scan(bool full_scan = false);
     void clear();
     void remove(const df::coord &map_pos);
     Groups::const_iterator find(const df::coord &map_pos) const;

--- a/plugins/channel-safely/include/channel-manager.h
+++ b/plugins/channel-safely/include/channel-manager.h
@@ -23,7 +23,7 @@ public:
         return instance;
     }
 
-    void build_groups() { groups.scan(); debug(); }
+    void build_groups(bool full_scan = false) { groups.scan(full_scan); debug(); }
     void destroy_groups() { groups.clear(); debug(); }
     void manage_groups();
     void manage_group(const df::coord &map_pos, bool set_marker_mode = false, bool marker_mode = false);


### PR DESCRIPTION
Designations in marker mode don't flag their block(s) as having designations. The scan code attempts to avoid scanning every block in the map.

This combination of factors creates problems when, for example, loading a map where mega projects are in progress with many designations in marker mode as those designations won't get added to groups and thus cannot participate in checks.

To remedy this, I've removed the sometimes randomly checking a block anyways which still leads to strange behaviour and instead have added a `bool full_scan` parameter to function arguments to disable this optimization.. then made sure to build groups with that optimization disabled when first loading the map.