### PR TITLE
supply default search key for tokenized text

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -115,7 +115,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``dfhack.constructions.findAtTile()``: exposed preexisting function to Lua.
 - ``dfhack.constructions.insert()``: exposed new function to Lua.
 - ``widgets.Panel``: new ``frame_style`` and ``frame_title`` attributes for drawing frames around groups of widgets
-- ``widgets.EditField`` now allows other widgets to process characters that the ``on_char`` callback rejects.
+- ``widgets.EditField``: now allows other widgets to process characters that the ``on_char`` callback rejects.
+- ``widgets.FilteredList``: now provides a useful default search key for list items made up of text tokens instead of plain text
 - ``gui.Screen.show()`` now returns ``self`` as a convenience
 - ``gui.View.getMousePos()`` now takes an optional ``ViewRect`` parameter in case the caller wants to get the mouse pos relative to a rect that is not the frame_body (such as the frame_rect)
 - Lua mouse events now conform to documented behavior in `lua-api` -- ``_MOUSE_L_DOWN`` will be sent exactly once per mouse click and ``_MOUSE_L`` will be sent repeatedly as long as the button is held down. Similarly for right mouse button events.

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1452,7 +1452,20 @@ function FilteredList:setFilter(filter, pos)
 
         for i,v in ipairs(self.choices) do
             local ok = true
-            local search_key = v.search_key or v.text
+            local search_key = v.search_key
+            if not search_key then
+                if type(v.text) ~= 'table' then
+                    search_key = v.text
+                else
+                    local texts = {}
+                    for _,token in ipairs(v.text) do
+                        table.insert(texts,
+                            type(token) == 'string' and token
+                                or getval(token.text) or '')
+                    end
+                    search_key = table.concat(texts, ' ')
+                end
+            end
             for _,key in ipairs(tokens) do
                 key = key:escape_pattern()
                 -- start matches at non-space or non-punctuation. this allows


### PR DESCRIPTION
Fixes #1912

if a FilteredList list item has no search key and consists of tokens instead of plain text, synthesize a search key by adding the texts from the constituent tokens