### PR TITLE
fix crash in buildingplan

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - `automaterial`: fix the cursor jumping up a z level when clicking quickly after box select
+- `buildingplan`: fix crash when canceling out of placement of a building with plan mode enabled and subsequently attempting to place a building that does not have plan mode enabled and that has no pertinent materials available
 - `gui/create-item`: prevent materials list filter from intercepting sublist hotkeys
 - `mousequery`: fix the cursor jumping up z levels sometimes when using TWBT
 - `tiletypes`: no longer resets dig priority to the default when updating other properties of a tile

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -734,6 +734,8 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
 
     DEFINE_VMETHOD_INTERPOSE(void, render, ())
     {
+        initStatics();
+
         bool plannable = isInPlannedBuildingPlacementMode();
         if (plannable && is_planmode_enabled(key))
         {
@@ -758,8 +760,6 @@ struct buildingplan_place_hook : public df::viewscreen_dwarfmodest
 
         if (!plannable)
             return;
-
-        initStatics();
 
         auto dims = Gui::getDwarfmodeViewDims();
         int left_margin = dims.menu_x1 + 1;


### PR DESCRIPTION
Fixes #2441 
Fixes #2358 

when a player cancels out of placing a building type with plan mode enabled and then immediately switches to placing a different building type where plan mode is not enabled, the placement errors array would be erroneously cleared and allow placement of the building. this would cause DF to crash if there were no materials available to build the building with.