### PR TITLE
Implements plugin: channel-safely v1.1.1b

### DIFF
--- a/plugins/channel-safely/include/inlines.h
+++ b/plugins/channel-safely/include/inlines.h
@@ -53,7 +53,7 @@ inline bool is_dig_designation(const df::tile_designation &designation) {
 }
 
 inline bool is_channel_designation(const df::tile_designation &designation) {
-    return designation.bits.dig != df::tile_dig_designation::Channel;
+    return designation.bits.dig == df::tile_dig_designation::Channel;
 }
 
 inline bool is_safe_fall(const df::coord &map_pos) {


### PR DESCRIPTION
Found a critical typo for an inline check. The check is not used heavily, so the broken behaviour will have been confined to a few niche edge cases.