### PR TITLE
make tree compatible with new msvc compiler in cross compilation env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 
 if(WIN32)
     if((NOT MSVC) OR (MSVC_VERSION LESS 1930) OR (MSVC_VERSION GREATER 1934))
-        message(SEND_ERROR "MSVC 2015 or 2017 is required")
+        message(SEND_ERROR "MSVC 2022 is required")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(UNIX)
 endif()
 
 if(WIN32)
-    if((NOT MSVC) OR (MSVC_VERSION LESS 1900) OR (MSVC_VERSION GREATER 1919))
+    if((NOT MSVC) OR (MSVC_VERSION LESS 1930) OR (MSVC_VERSION GREATER 1934))
         message(SEND_ERROR "MSVC 2015 or 2017 is required")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,10 @@ endif()
 
 # Automatically detect architecture based on Visual Studio generator
 if(MSVC AND NOT DEFINED DFHACK_BUILD_ARCH)
-    if(${CMAKE_GENERATOR} MATCHES "Win64")
-        set(DFHACK_BUILD_ARCH "64")
-    else()
+    if ((${CMAKE_GENERATOR} MATCHES "Win32") OR (${CMAKE_GENERATOR} MATCHES "x86"))
         set(DFHACK_BUILD_ARCH "32")
+    else()
+        set(DFHACK_BUILD_ARCH "64")
     endif()
 else()
     set(DFHACK_BUILD_ARCH "64" CACHE STRING "Architecture to build ('32' or '64')")

--- a/depends/protobuf/CMakeLists.txt
+++ b/depends/protobuf/CMakeLists.txt
@@ -149,7 +149,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -Wno-unused-local-typedefs -Wno-misleading-indentation -Wno-class-memaccess -Wno-sign-compare")
 elseif(MSVC)
     # Disable warnings for integer conversion to smaller type
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4273")
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -159,15 +159,11 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Protobuf shared libraries
 
-add_library(protobuf SHARED ${LIBPROTOBUF_FULL_SRCS} ${LIBPROTOBUF_FULL_HDRS})
-ide_folder(protobuf "Depends")
 add_library(protobuf-lite SHARED ${LIBPROTOBUF_LITE_SRCS} ${LIBPROTOBUF_LITE_HDRS})
 ide_folder(protobuf-lite "Depends")
 
-set_target_properties(protobuf PROPERTIES COMPILE_DEFINITIONS LIBPROTOBUF_EXPORTS)
 set_target_properties(protobuf-lite PROPERTIES COMPILE_DEFINITIONS LIBPROTOBUF_EXPORTS)
 
-target_link_libraries(protobuf ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
 target_link_libraries(protobuf-lite ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
 
 install(TARGETS protobuf-lite
@@ -175,6 +171,11 @@ install(TARGETS protobuf-lite
     RUNTIME DESTINATION ${DFHACK_LIBRARY_DESTINATION})
 
 if(NOT CMAKE_CROSSCOMPILING)
+    add_library(protobuf SHARED ${LIBPROTOBUF_FULL_SRCS} ${LIBPROTOBUF_FULL_HDRS})
+    ide_folder(protobuf "Depends")
+    set_target_properties(protobuf PROPERTIES COMPILE_DEFINITIONS LIBPROTOBUF_EXPORTS)
+    target_link_libraries(protobuf ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+
     # Protobuf compiler shared library
 
     add_library(protoc SHARED ${LIBPROTOC_SRCS} ${LIBPROTOC_HDRS})

--- a/depends/protobuf/google/protobuf/stubs/hash.h
+++ b/depends/protobuf/google/protobuf/stubs/hash.h
@@ -104,7 +104,14 @@
 // And.. they are moved back to stdext in MSVC 2013 (haven't checked 2012). That
 // said, use unordered_map for MSVC 2010 and beyond is our safest bet.
 #elif defined(_MSC_VER)
-# if _MSC_VER >= 1600  // Since Visual Studio 2010
+# if _MSC_VER >= 1900 // Since Visual Studio 2019
+#  define GOOGLE_PROTOBUF_HASH_NAMESPACE std
+#  include <unordered_map>
+#  define GOOGLE_PROTOBUF_HASH_MAP_CLASS unordered_map
+#  include <unordered_set>
+#  define GOOGLE_PROTOBUF_HASH_SET_CLASS unordered_set
+
+# elif _MSC_VER >= 1600  // Since Visual Studio 2010
 #  define GOOGLE_PROTOBUF_HAS_CXX11_HASH
 #  define GOOGLE_PROTOBUF_HASH_COMPARE std::hash_compare
 # elif _MSC_VER >= 1500  // Since Visual Studio 2008
@@ -233,7 +240,7 @@ namespace google {
       HashFcn hash_function() const { return HashFcn(); }
     };
 
-#elif defined(_MSC_VER) && !defined(_STLPORT_VERSION)
+#elif defined(_MSC_VER) && _MSC_VER < 1900 && !defined(_STLPORT_VERSION)
 
     template <typename Key>
     struct hash : public GOOGLE_PROTOBUF_HASH_COMPARE<Key> {


### PR DESCRIPTION
This PR will likely prevent us from building with old msvc, but we need these changes for the updated compiler used in our buildmaster build env (which is also required for DF 50 compatibility). if we need to do another 0.47.05 release, it will have to be done on top of the v0.47.05 branch.