### PR TITLE
explicitly declare namespaces and proto versions

### DIFF
--- a/library/proto/Basic.proto
+++ b/library/proto/Basic.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package dfproto;
 
 option optimize_for = LITE_RUNTIME;

--- a/library/proto/BasicApi.proto
+++ b/library/proto/BasicApi.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package dfproto;
 
 option optimize_for = LITE_RUNTIME;

--- a/library/proto/CoreProtocol.proto
+++ b/library/proto/CoreProtocol.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package dfproto;
 
 option optimize_for = LITE_RUNTIME;

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -708,8 +708,8 @@ static void create_boulders(color_ostream &out,
 
         size_t remaining_items = coords.size();
         while (remaining_items > 0) {
-            int16_t batch_size = min(remaining_items,
-                                     static_cast<size_t>(INT16_MAX));
+            int16_t batch_size = std::min(remaining_items,
+                                          static_cast<size_t>(INT16_MAX));
             prod->count = batch_size;
             remaining_items -= batch_size;
             prod->produce(unit, &out_products, &out_items, &in_reag, &in_items,
@@ -725,7 +725,7 @@ static void create_boulders(color_ostream &out,
                          material.toString().c_str(),
                          ENUM_KEY_STR(item_type, prod->item_type).c_str(),
                          coords.size(), num_items);
-            num_items = min(num_items, entry.second.size());
+            num_items = std::min(num_items, entry.second.size());
         }
 
         for (size_t i = 0; i < num_items; ++i) {

--- a/plugins/proto/AdventureControl.proto
+++ b/plugins/proto/AdventureControl.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 //Attempts to provide a complete framework for reading everything from a fortress needed for vizualization
 package AdventureControl;
 

--- a/plugins/proto/DwarfControl.proto
+++ b/plugins/proto/DwarfControl.proto
@@ -1,5 +1,6 @@
-//Attempts to provide a complete framework for reading everything from a fortress needed for vizualization
 syntax = "proto2";
+
+//Attempts to provide a complete framework for reading everything from a fortress needed for vizualization
 package DwarfControl;
 
 option optimize_for = LITE_RUNTIME;

--- a/plugins/proto/ItemdefInstrument.proto
+++ b/plugins/proto/ItemdefInstrument.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 //Attempts to provide a complete framework for reading everything from a fortress needed for vizualization
 package ItemdefInstrument;
 

--- a/plugins/proto/RemoteFortressReader.proto
+++ b/plugins/proto/RemoteFortressReader.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 //Attempts to provide a complete framework for reading everything from a fortress needed for vizualization
 package RemoteFortressReader;
 

--- a/plugins/proto/isoworldremote.proto
+++ b/plugins/proto/isoworldremote.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 //Describes a very basic material structure for the map embark
 package isoworldremote;
 

--- a/plugins/proto/rename.proto
+++ b/plugins/proto/rename.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package dfproto;
 
 option optimize_for = LITE_RUNTIME;

--- a/plugins/proto/ui_sidebar_mode.proto
+++ b/plugins/proto/ui_sidebar_mode.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 //Attempts to provide a complete framework for reading everything from a fortress needed for vizualization
 package proto.enums.ui_sidebar_mode;
 

--- a/plugins/stockpiles/StockpileSerializer.cpp
+++ b/plugins/stockpiles/StockpileSerializer.cpp
@@ -33,6 +33,9 @@
 #include <fstream>
 
 using std::endl;
+using std::string;
+using std::vector;
+
 using namespace DFHack;
 using namespace df::enums;
 using namespace google::protobuf;

--- a/plugins/stockpiles/proto/stockpiles.proto
+++ b/plugins/stockpiles/proto/stockpiles.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package dfstockpiles;
 
 option optimize_for = LITE_RUNTIME;


### PR DESCRIPTION
These are the salvageable parts from the aborted protobuf upgrade. It's not much.

proto files are explicitly declared as proto2. this was the default, but if we ever try to upgrade in the future, this will save us compatibility warnings.

a few places where we were using std identifiers without using the `std::` prefix have been cleaned up.