### PR TITLE
migrate usage of set-output (required by github)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       id: env_setup
       run: |
         DF_VERSION="$(sh ci/get-df-version.sh)"
-        echo "::set-output name=df_version::${DF_VERSION}"
+        echo "df_version=${DF_VERSION}" >> $GITHUB_OUTPUT
         echo "DF_VERSION=${DF_VERSION}" >> $GITHUB_ENV
         echo "DF_FOLDER=${HOME}/DF/${DF_VERSION}/df_linux" >> $GITHUB_ENV
         echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,12 @@ jobs:
         echo "DF_FOLDER=${HOME}/DF/${DF_VERSION}/df_linux" >> $GITHUB_ENV
         echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
     - name: Fetch DF cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/DF
         key: dfcache-${{ steps.env_setup.outputs.df_version }}-${{ hashFiles('ci/download-df.sh') }}
     - name: Fetch ccache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ccache-v2-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.ref_name }}-${{ github.sha }}


### PR DESCRIPTION
as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/