### PR TITLE
Support resizing for DFHack Panel widgets

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -48,6 +48,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 - ``gui.View``: ``visible`` and ``active`` can now be functions that return a boolean
 - ``widgets.Panel``: new attributes to control window dragging and resizing with mouse or keyboard
+- ``widgets.Window``: Panel subclass with attributes preset for top-level windows
 
 ## Internals
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,7 +47,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - ``gui.View``: ``visible`` and ``active`` can now be functions that return a boolean
-- ``widgets.Panel``: new attributes to control window dragging with mouse or keyboard
+- ``widgets.Panel``: new attributes to control window dragging and resizing with mouse or keyboard
 
 ## Internals
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4182,8 +4182,27 @@ Has attributes:
   ``true`` if the drag was "successful" (i.e. not canceled) and ``false``
   otherwise. Dragging can be canceled by right clicking while dragging with the
   mouse, hitting :kbd:`Esc` (while dragging with the mouse or keyboard), or by
-  calling ``Panel:setCursorMoveEnabled(false)`` (while dragging with the
+  calling ``Panel:setKeyboaredDragEnabled(false)`` (while dragging with the
   keyboard).
+
+* ``resizable = bool`` (default: ``false``)
+* ``resize_anchors = {}`` (default: ``{t=false, l=true, r=true, b=true}``
+* ``resize_min = {}`` (default: w and h from the ``frame``, or ``{w=5, h=5}``)
+* ``on_resize_begin = function()`` (default: ``nil``)
+* ``on_resize_end = function(bool)`` (default: ``nil``)
+
+  If ``resizable`` is set to ``true``, then the player can click the mouse on
+  any edge specified in ``resize_anchors`` and drag the border to resize the
+  window. If two adjacent edges are enabled as anchors, then the tile where they
+  meet can be used to resize both edges at the same time. The minimum dimensions
+  specified in ``resize_min`` (or inherited from ``frame`` are respected when
+  resizing. The panel is also prevented from resizing beyond the boundaries of
+  its parent. When the player clicks on a valid anchor, ``on_resize_begin()`` is
+  called. The boolean passed to the ``on_resize_end`` callback will be ``true``
+  if the drag was "successful" (i.e. not canceled) and ``false`` otherwise.
+  Dragging can be canceled by right clicking while resizing with the mouse,
+  hitting :kbd:`Esc` (while resizing with the mouse or keyboard), or by calling
+  ``Panel:setKeyboardResizeEnabled(false)`` (while resizing with the keyboard).
 
 * ``autoarrange_subviews = bool`` (default: ``false``)
 * ``autoarrange_gap = int`` (default: ``0``)
@@ -4207,8 +4226,8 @@ Has functions:
 
 * ``panel:setKeyboardDragEnabled(bool)``
 
-  If called with something truthy and the panel is not already in keyboard drag
-  mode, then any current drag operations are halted where they are (not
+  If called with ``true`` and the panel is not already in keyboard drag mode,
+  then any current drag or resize operations are halted where they are (not
   canceled), the panel siezes input focus (see `View class`_ above for
   information on the DFHack focus subsystem), and further keyboard cursor keys
   move the window as if it were being dragged. Shift-cursor keys move by larger
@@ -4216,12 +4235,24 @@ Has functions:
   cancel. If dragging is canceled, then the window is moved back to its original
   position.
 
+* ``panel:setKeyboardResizeEnabled(bool)``
+
+  If called with ``true`` and the panel is not already in keyboard resize mode,
+  then any current drag or resize operations are halted where they are (not
+  canceled), the panel siezes input focus (see `View class`_ above for
+  information on the DFHack focus subsystem), and further keyboard cursor keys
+  resize the window as if it were being dragged from the lower right corner. If
+  neither the bottom or right edge is a valid anchor, an appropriate corner will
+  be chosen. Shift-cursor keys move by larger amounts. Hit :kbd:`Enter` to
+  commit the new window size or :kbd:`Esc` to cancel. If resizing is canceled,
+  then the window size from before the resize operation is restored.
+
 ResizingPanel class
 -------------------
 
-Subclass of Panel; automatically adjusts its own frame height according to
-the size, position, and visibility of its subviews. Pairs nicely with a
-parent Panel that has ``autoarrange_subviews`` enabled.
+Subclass of Panel; automatically adjusts its own frame height and width to the
+minimum required to show its subviews. Pairs nicely with a parent Panel that has
+``autoarrange_subviews`` enabled.
 
 Pages class
 -----------

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4247,6 +4247,20 @@ Has functions:
   commit the new window size or :kbd:`Esc` to cancel. If resizing is canceled,
   then the window size from before the resize operation is restored.
 
+Double clicking:
+
+If the panel is resizable and the user double-clicks on the top edge (the frame
+title, if the panel has a frame), then the panel will jump to its maximum size.
+If the panel has already been maximized in this fashion, then it will jump to
+its minimum size. Both jumps respect the resizable edges defined by the
+``resize_anchors`` attribute.
+
+The time duration that a double click can span is defined by the global variable
+``DOUBLE_CLICK_MS``. The default value is ``500`` and can be changed by the end
+user with a command like::
+
+  :lua require('gui.widgets').DOUBLE_CLICK_MS=1000
+
 Window class
 ------------
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4247,6 +4247,12 @@ Has functions:
   commit the new window size or :kbd:`Esc` to cancel. If resizing is canceled,
   then the window size from before the resize operation is restored.
 
+Window class
+------------
+
+Subclass of Panel; sets Panel attributes to useful defaults for a top-level
+framed, draggable window.
+
 ResizingPanel class
 -------------------
 

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -704,8 +704,9 @@ GREY_LINE_FRAME = {
     signature_pen = to_pen{ fg = COLOR_DARKGREY, bg = COLOR_BLACK },
 }
 
-function paint_frame(x1,y1,x2,y2,style,title)
+function paint_frame(dc,rect,style,title)
     local pen = style.frame_pen
+    local x1,y1,x2,y2 = dc.x1+rect.x1, dc.y1+rect.y1, dc.x1+rect.x2, dc.y1+rect.y2
     dscreen.paintTile(style.lt_frame_pen or pen, x1, y1)
     dscreen.paintTile(style.rt_frame_pen or pen, x2, y1)
     dscreen.paintTile(style.lb_frame_pen or pen, x1, y2)
@@ -750,16 +751,13 @@ function FramedScreen:computeFrame(parent_rect)
 end
 
 function FramedScreen:onRenderFrame(dc, rect)
-    local x1,y1,x2,y2 = rect.x1, rect.y1, rect.x2, rect.y2
-
     if rect.wgap <= 0 and rect.hgap <= 0 then
         dc:clear()
     else
         self:renderParent()
         dc:fill(rect, self.frame_background)
     end
-
-    paint_frame(x1,y1,x2,y2,self.frame_style,self.frame_title)
+    paint_frame(dc,rect,self.frame_style,self.frame_title)
 end
 
 return _ENV

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -420,8 +420,7 @@ end
 function Panel:onRenderFrame(dc, rect)
     Panel.super.onRenderFrame(self, dc, rect)
     if not self.frame_style then return end
-    local x1,y1,x2,y2 = rect.x1, rect.y1, rect.x2, rect.y2
-    gui.paint_frame(x1, y1, x2, y2, self.frame_style, self.frame_title)
+    gui.paint_frame(dc, rect, self.frame_style, self.frame_title)
     if self.kbd_get_pos then
         local pos = self.kbd_get_pos()
         local pen = dfhack.pen.parse{fg=COLOR_GREEN, bg=COLOR_BLACK}
@@ -432,6 +431,19 @@ function Panel:onRenderFrame(dc, rect)
         Panel_end_drag(self, nil, true)
     end
 end
+
+------------
+-- Window --
+------------
+
+Window = defclass(Window, Panel)
+
+Window.ATTRS {
+    frame_style = gui.GREY_LINE_FRAME,
+    frame_background = gui.CLEAR_PEN,
+    frame_inset = 1,
+    draggable = true,
+}
 
 -------------------
 -- ResizingPanel --


### PR DESCRIPTION
Fixes #2497

If resizing is enabled for a panel, it can be clicked and stretched around within its parent bounds (which could be the whole screen). Keyboard resizing is supported, though the hotkey to initiate keyboard resizing is left up to the containing Screen.