### PR TITLE
prevent "offset" tiles from occluding DFHack-drawn tiles

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1014,10 +1014,12 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, v
     else if (first == "fpause")
     {
         World::SetPauseState(true);
+/* TODO: understand how this changes for v50
         if (auto scr = Gui::getViewscreenByType<df::viewscreen_new_regionst>())
         {
             scr->worldgen_paused = true;
         }
+*/
         con.print("The game was forced to pause!\n");
     }
     else if (first == "cls" || first == "clear")


### PR DESCRIPTION
It's not good that we have to do this. This has the nasty effect of making the full screen element disappear if we cover even a single tile of it. For example, the entire minimap will disappear if we cover a corner.

This also doesn't seem to work properly for very large offset tile groups, such as the logos on the title screen. They don't appear to have all their tiles tagged with their id. the dinosaur, for example, only has the upper left 5x5 tiles marked, yet the image extends far beyond that range.

I'm beginning to think that maybe we *should* render straight to the SDL surface and bypass all this nonsense.