### PR TITLE
Prepare for the hook API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ if(UNIX)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32 -march=i686")
     endif()
     string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    set(CMAKE_INSTALL_RPATH "hack")
 elseif(MSVC)
     # for msvc, tell it to always use 8-byte pointers to member functions to avoid confusion
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /vmg /vmm /MP")

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -96,6 +96,7 @@ endif()
 set(MAIN_SOURCES_WINDOWS
     ${CONSOLE_SOURCES}
     Hooks-windows.cpp
+    Hooks.cpp
     PlugLoad-windows.cpp
     Process-windows.cpp
 )
@@ -374,6 +375,8 @@ if(WIN32)
 else()
     set_target_properties(dfhack PROPERTIES COMPILE_FLAGS "-include Export.h" )
     set_target_properties(dfhack-client PROPERTIES COMPILE_FLAGS "-include Export.h" )
+    add_library(dfhooks SHARED Hooks.cpp)
+    target_link_libraries(dfhooks dfhack)
 endif()
 
 # effectively disables debug builds...
@@ -422,6 +425,9 @@ if(UNIX)
         install(PROGRAMS ${dfhack_SOURCE_DIR}/package/linux/dfhack-run
             DESTINATION .)
     endif()
+    install(TARGETS dfhooks
+        LIBRARY DESTINATION .
+        RUNTIME DESTINATION .)
 else()
     # On windows, copy the renamed SDL so DF can still run.
     install(PROGRAMS ${dfhack_SOURCE_DIR}/package/windows/win${DFHACK_BUILD_ARCH}/SDLreal.dll

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1483,10 +1483,12 @@ bool Core::Init()
         // Don't do this on Linux because it will break PRINT_MODE:TEXT
         // this is handled as appropriate in Console-posix.cpp
         fprintf(stdout, "dfhack: redirecting stdout to stdout.log (again)\n");
-        freopen("stdout.log", "w", stdout);
+        if (!freopen("stdout.log", "w", stdout))
+            cerr << "Could not redirect stdout to stdout.log" << endl;
     #endif
     fprintf(stderr, "dfhack: redirecting stderr to stderr.log\n");
-    freopen("stderr.log", "w", stderr);
+    if (!freopen("stderr.log", "w", stderr))
+        cerr << "Could not redirect stderr to stderr.log" << endl;
 
     Filesystem::init();
 

--- a/library/Hooks-darwin.cpp
+++ b/library/Hooks-darwin.cpp
@@ -279,9 +279,8 @@ DFhackCExport int DFH_SDL_Init(uint32_t flags)
 {
     // reroute stderr
     fprintf(stderr,"dfhack: attempting to hook in\n");
-    freopen("stderr.log", "w", stderr);
     // we don't reroute stdout until  we figure out if this should be done at all
-    // See: Console-linux.cpp
+    // See: Console-posix.cpp
 
     // find real functions
     fprintf(stderr,"dfhack: saving real SDL functions\n");

--- a/library/Hooks-linux.cpp
+++ b/library/Hooks-linux.cpp
@@ -117,12 +117,6 @@ DFhackCExport int wgetch(WINDOW *win)
 static int (*_SDL_Init)(uint32_t flags) = 0;
 DFhackCExport int SDL_Init(uint32_t flags)
 {
-    // reroute stderr
-    if (!freopen("stderr.log", "w", stderr))
-        fprintf(stderr, "dfhack: failed to reroute stderr\n");
-    // we don't reroute stdout until  we figure out if this should be done at all
-    // See: Console-linux.cpp
-
     // find real functions
     _SDL_Init = (int (*)( uint32_t )) dlsym(RTLD_NEXT, "SDL_Init");
     _SDL_Quit = (void (*)( void )) dlsym(RTLD_NEXT, "SDL_Quit");

--- a/library/Hooks.cpp
+++ b/library/Hooks.cpp
@@ -1,0 +1,33 @@
+#include "Core.h"
+#include "Export.h"
+
+// called before main event loop starts
+DFhackCExport void dfhooks_init() {
+    DFHack::Core::getInstance().Init();
+}
+
+// called after main event loops exits
+DFhackCExport void dfhooks_shutdown() {
+    DFHack::Core::getInstance().Shutdown();
+}
+
+// called in the main event loop
+DFhackCExport void dfhooks_update() {
+    DFHack::Core::getInstance().Update();
+}
+
+// called just before adding the macro recording/playback overlay
+DFhackCExport void dfhooks_prerender() {
+    // TODO: render overlay widgets that are not attached to a viewscreen
+}
+
+// called for each SDL event, if true is returned, then the event has been
+// consumed and further processing shouldn't happen
+DFhackCExport bool dfhooks_sdl_event(SDL::Event* event) {
+    return DFHack::Core::getInstance().DFH_SDL_Event(event);
+}
+// called for each utf-8 char read from the ncurses input
+// key is positive for ncurses keys and negative for everything else
+DFhackCExport bool dfhooks_ncurses_key(int key) {
+    return DFHack::Core::getInstance().DFH_ncurses_key(key);
+}

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -121,6 +121,12 @@ namespace DFHack
         friend int  ::SDL_Init(uint32_t flags);
         friend int  ::wgetch(WINDOW * w);
 #endif
+        friend void ::dfhooks_init();
+        friend void ::dfhooks_shutdown();
+        friend void ::dfhooks_update();
+        friend void ::dfhooks_prerender();
+        friend bool ::dfhooks_sdl_event(SDL::Event* event);
+        friend bool ::dfhooks_ncurses_key(int key);
     public:
         /// Get the single Core instance or make one.
         static Core& getInstance()
@@ -202,8 +208,9 @@ namespace DFHack
         int Shutdown (void);
         int DFH_SDL_Event(SDL::Event* event);
         bool ncurses_wgetch(int in, int & out);
+        bool DFH_ncurses_key(int key);
 
-        void doUpdate(color_ostream &out, bool first_update);
+        void doUpdate(color_ostream &out);
         void onUpdate(color_ostream &out);
         void onStateChange(color_ostream &out, state_change_event event);
         void handleLoadAndUnloadScripts(color_ostream &out, state_change_event event);

--- a/library/include/Hooks.h
+++ b/library/include/Hooks.h
@@ -74,3 +74,11 @@ DFhackCExport void * SDL_GetVideoSurface(void);
 
 DFhackCExport int SDL_SemWait(vPtr sem);
 DFhackCExport int SDL_SemPost(vPtr sem);
+
+// new Hooks API
+DFhackCExport void dfhooks_init();
+DFhackCExport void dfhooks_shutdown();
+DFhackCExport void dfhooks_update();
+DFhackCExport void dfhooks_prerender();
+DFhackCExport bool dfhooks_sdl_event(SDL::Event* event);
+DFhackCExport bool dfhooks_ncurses_key(int key);


### PR DESCRIPTION
as per the files in the new DFHack/hooks repo. Note that this API does not break our current injection strategy. Once we have a version that uses this new API, we can turn down the SDL-related injection code.

This PR builds a stub shared object for Linux and OSX and installs it in the main DF dir (where the dfhooks API knows to look for it). That stub calls into hack/dfhack.(so|dylib).

For Windows, where all the dlls are in the main DF directory anyway, there isn't much reason to have an additional stub, so the hooks are baked directly into the dfhack library, and we can just change from building the library as SDL.dll to dfhooks.dll.