### PR TITLE
Render tile textures if specified in the pen

### DIFF
--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -11,7 +11,7 @@ USE_GRAPHICS = dscreen.inGraphicsMode()
 
 local to_pen = dfhack.pen.parse
 
-CLEAR_PEN = to_pen{ch=32,fg=0,bg=0}
+CLEAR_PEN = to_pen{tile=909, ch=32, fg=0, bg=0}
 
 local FAKE_INPUT_KEYS = {
     _MOUSE_L = true,
@@ -693,17 +693,17 @@ BOUNDARY_FRAME = {
 }
 
 GREY_LINE_FRAME = {
-    frame_pen = to_pen{ ch = 206, fg = COLOR_GREY, bg = COLOR_BLACK },
-    t_frame_pen = to_pen{ tile=902, ch = 205, fg = COLOR_GREY, bg = COLOR_BLACK },
-    l_frame_pen = to_pen{ tile=908, ch = 186, fg = COLOR_GREY, bg = COLOR_BLACK },
-    b_frame_pen = to_pen{ tile=916, ch = 205, fg = COLOR_GREY, bg = COLOR_BLACK },
-    r_frame_pen = to_pen{ tile=910, ch = 186, fg = COLOR_GREY, bg = COLOR_BLACK },
-    lt_frame_pen = to_pen{ tile=901, ch = 201, fg = COLOR_GREY, bg = COLOR_BLACK },
-    lb_frame_pen = to_pen{ tile=915, ch = 200, fg = COLOR_GREY, bg = COLOR_BLACK },
-    rt_frame_pen = to_pen{ tile=903, ch = 187, fg = COLOR_GREY, bg = COLOR_BLACK },
-    rb_frame_pen = to_pen{ tile=917, ch = 188, fg = COLOR_GREY, bg = COLOR_BLACK },
-    title_pen = to_pen{ fg = COLOR_BLACK, bg = COLOR_GREY },
-    signature_pen = to_pen{ fg = COLOR_GREY, bg = COLOR_BLACK },
+    frame_pen = to_pen{ ch=206, fg=COLOR_GREY, bg=COLOR_BLACK },
+    t_frame_pen = to_pen{ tile=902, ch=205, fg=COLOR_GREY, bg=COLOR_BLACK },
+    l_frame_pen = to_pen{ tile=908, ch=186, fg=COLOR_GREY, bg=COLOR_BLACK },
+    b_frame_pen = to_pen{ tile=916, ch=205, fg=COLOR_GREY, bg=COLOR_BLACK },
+    r_frame_pen = to_pen{ tile=910, ch=186, fg=COLOR_GREY, bg=COLOR_BLACK },
+    lt_frame_pen = to_pen{ tile=901, ch=201, fg=COLOR_GREY, bg=COLOR_BLACK },
+    lb_frame_pen = to_pen{ tile=915, ch=200, fg=COLOR_GREY, bg=COLOR_BLACK },
+    rt_frame_pen = to_pen{ tile=903, ch=187, fg=COLOR_GREY, bg=COLOR_BLACK },
+    rb_frame_pen = to_pen{ tile=917, ch=188, fg=COLOR_GREY, bg=COLOR_BLACK },
+    title_pen = to_pen{ fg=COLOR_BLACK, bg=COLOR_GREY },
+    signature_pen = to_pen{ fg=COLOR_GREY, bg=COLOR_BLACK },
 }
 
 function paint_frame(dc,rect,style,title)

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -694,12 +694,14 @@ BOUNDARY_FRAME = {
 
 GREY_LINE_FRAME = {
     frame_pen = to_pen{ ch = 206, fg = COLOR_GREY, bg = COLOR_BLACK },
-    h_frame_pen = to_pen{ ch = 205, fg = COLOR_GREY, bg = COLOR_BLACK },
-    v_frame_pen = to_pen{ ch = 186, fg = COLOR_GREY, bg = COLOR_BLACK },
-    lt_frame_pen = to_pen{ ch = 201, fg = COLOR_GREY, bg = COLOR_BLACK },
-    lb_frame_pen = to_pen{ ch = 200, fg = COLOR_GREY, bg = COLOR_BLACK },
-    rt_frame_pen = to_pen{ ch = 187, fg = COLOR_GREY, bg = COLOR_BLACK },
-    rb_frame_pen = to_pen{ ch = 188, fg = COLOR_GREY, bg = COLOR_BLACK },
+    t_frame_pen = to_pen{ tile=902, ch = 205, fg = COLOR_GREY, bg = COLOR_BLACK },
+    l_frame_pen = to_pen{ tile=908, ch = 186, fg = COLOR_GREY, bg = COLOR_BLACK },
+    b_frame_pen = to_pen{ tile=916, ch = 205, fg = COLOR_GREY, bg = COLOR_BLACK },
+    r_frame_pen = to_pen{ tile=910, ch = 186, fg = COLOR_GREY, bg = COLOR_BLACK },
+    lt_frame_pen = to_pen{ tile=901, ch = 201, fg = COLOR_GREY, bg = COLOR_BLACK },
+    lb_frame_pen = to_pen{ tile=915, ch = 200, fg = COLOR_GREY, bg = COLOR_BLACK },
+    rt_frame_pen = to_pen{ tile=903, ch = 187, fg = COLOR_GREY, bg = COLOR_BLACK },
+    rb_frame_pen = to_pen{ tile=917, ch = 188, fg = COLOR_GREY, bg = COLOR_BLACK },
     title_pen = to_pen{ fg = COLOR_BLACK, bg = COLOR_GREY },
     signature_pen = to_pen{ fg = COLOR_GREY, bg = COLOR_BLACK },
 }

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -624,6 +624,7 @@ function Screen:renderParent()
     else
         dscreen.clear()
     end
+    df.global.gps.force_full_display_count = 1
 end
 
 function Screen:sendInputToParent(...)

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -117,31 +117,36 @@ bool Screen::inGraphicsMode()
 
 static bool doSetTile_default(const Pen &pen, int x, int y, bool map)
 {
-    if (x < 0 || x >= gps->dimx || y < 0 || y >= gps->dimy)
+    size_t index = (x * gps->dimy) + y;
+    uint8_t *screen = &gps->screen[index * 8];
+
+    if (screen > gps->screen_limit)
         return false;
 
     if (map) {
+
         //gps->main_viewport->screentexpos_interface
         return true;
     }
 
-    size_t index = (x * gps->dimy) + y;
-
-    uint8_t *screen = &gps->screen[index * 8];
     long *texpos = &gps->screentexpos[index];
+    long *texpos_lower = &gps->screentexpos_lower[index];
     uint32_t *flag = &gps->screentexpos_flag[index];
 
     *screen = 0;
     *texpos = 0;
+    *texpos_lower = 0;
     *flag = 4; // remove SCREENTEXPOS_FLAG_ANCHOR_SUBORDINATE
 
     if (gps->top_in_use) {
         screen = &gps->screen_top[index * 8];
         texpos = &gps->screentexpos_top[index];
+        texpos_lower = &gps->screentexpos_top_lower[index];
         flag = &gps->screentexpos_top_flag[index];
 
         *screen = 0;
         *texpos = 0;
+        *texpos_lower = 0;
         *flag = 4; // remove SCREENTEXPOS_FLAG_ANCHOR_SUBORDINATE
     }
 
@@ -154,6 +159,7 @@ static bool doSetTile_default(const Pen &pen, int x, int y, bool map)
         *texpos = pen.tile;
     } else {
         screen[0] = uint8_t(pen.ch);
+        *texpos_lower = 909;
     }
 
     // note that pen.bold currently (50.04) has no representation in the DF data


### PR DESCRIPTION
and clean up more conflicts with other rendering layers.

The anchor layer still gives us trouble. it will overwrite us unless we cover the upper left tile of the anchor graphic, and then the entire anchor graphic will disappear. not ideal, but it's a start