### PR TITLE
codegen: stub for std::map

### DIFF
--- a/plugins/ruby/codegen.pl
+++ b/plugins/ruby/codegen.pl
@@ -784,6 +784,14 @@ sub sizeof {
             } else {
                 print "sizeof stl-deque on $os\n";
             }
+        } elsif ($subtype eq 'stl-map') {
+            if ($os eq 'linux') {
+                return ($arch == 64) ? 48 : 24;
+            } elsif ($os eq 'windows') {
+                return ($arch == 64) ? 16 : 8;
+            } else {
+                print "sizeof stl-map on $os\n";
+            }
         } elsif ($subtype eq 'df-linked-list') {
             return 3 * $SIZEOF_PTR;
         } elsif ($subtype eq 'df-flagarray') {

--- a/plugins/ruby/ruby-autogen-defs.rb
+++ b/plugins/ruby/ruby-autogen-defs.rb
@@ -103,6 +103,9 @@ module DFHack
                 def stl_deque(tglen)
                     StlDeque.new(tglen, yield)
                 end
+                def stl_map
+                    StlMap.new
+                end
 
                 def df_flagarray(indexenum=nil)
                     DfFlagarray.new(indexenum)
@@ -707,6 +710,10 @@ module DFHack
             # XXX DF uses stl::deque<some_struct>, so to have a C binding we'd need to single-case every
             # possible struct size, like for StlVector. Just ignore it for now, deques are rare enough.
             def inspect ; "#<StlDeque>" ; end
+        end
+        class StlMap < MemStruct
+            # stub, similar to StlDeque
+            def inspect ; "#<StlMap>" ; end
         end
 
         class DfFlagarray < MemStruct


### PR DESCRIPTION
Fixes https://github.com/DFHack/df-structures/issues/498
Required by https://github.com/DFHack/df-structures/pull/500

Deliberately targeting v0.47.05 first since this was tested there (and fixes an alignment issue)