### PR TITLE
only do a full refresh when needed

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2366,12 +2366,6 @@ Supported callbacks and fields are:
   In order to make a dialog where portions of the parent viewscreen are still
   visible in the background, call ``screen:renderParent()``.
 
-  If artifacts are left on the parent even after this function is called, such
-  as when the window is dragged or is resized, any code can set
-  ``gui.Screen.request_full_screen_refresh`` to ``true``. Then when
-  ``screen.renderParent()`` is next called, it will do a full flush of the
-  graphics and clear the screen of artifacts.
-
 * ``function screen:onIdle()``
 
   Called every frame when the screen is on top of the stack.

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2366,6 +2366,12 @@ Supported callbacks and fields are:
   In order to make a dialog where portions of the parent viewscreen are still
   visible in the background, call ``screen:renderParent()``.
 
+  If artifacts are left on the parent even after this function is called, such
+  as when the window is dragged or is resized, any code can set
+  ``gui.Screen.request_full_screen_refresh`` to ``true``. Then when
+  ``screen.renderParent()`` is next called, it will do a full flush of the
+  graphics and clear the screen of artifacts.
+
 * ``function screen:onIdle()``
 
   Called every frame when the screen is on top of the stack.

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2363,7 +2363,14 @@ Supported callbacks and fields are:
   where the above painting functions work correctly.
 
   If omitted, the screen is cleared; otherwise it should do that itself.
-  In order to make a see-through dialog, call ``self._native.parent:render()``.
+  In order to make a dialog where portions of the parent viewscreen are still
+  visible in the background, call ``screen:renderParent()``.
+
+  If artifacts are left on the parent even after this function is called, such
+  as when the window is dragged or is resized, any code can set
+  ``gui.Screen.request_full_screen_refresh`` to ``true``. Then when
+  ``screen.renderParent()`` is next called, it will do a full flush of the
+  graphics and clear the screen of artifacts.
 
 * ``function screen:onIdle()``
 

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -661,6 +661,8 @@ function Screen:dismiss()
     if self._native then
         dscreen.dismiss(self)
     end
+    -- don't leave artifacts behind on the parent screen when we disappear
+    Screen.request_full_screen_refresh = true
 end
 
 function Screen:onDismiss()

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -597,7 +597,6 @@ end
 Screen = defclass(Screen, View)
 
 Screen.text_input_mode = false
-Screen.request_full_screen_refresh = false
 
 function Screen:postinit()
     self:onResize(dscreen.getWindowSize())
@@ -622,10 +621,6 @@ function Screen:renderParent()
         self._native.parent:render()
     else
         dscreen.clear()
-    end
-    if Screen.request_full_screen_refresh then
-        df.global.gps.force_full_display_count = 1
-        Screen.request_full_screen_refresh = false
     end
 end
 

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -597,6 +597,7 @@ end
 Screen = defclass(Screen, View)
 
 Screen.text_input_mode = false
+Screen.request_full_screen_refresh = false
 
 function Screen:postinit()
     self:onResize(dscreen.getWindowSize())
@@ -622,7 +623,10 @@ function Screen:renderParent()
     else
         dscreen.clear()
     end
-    df.global.gps.force_full_display_count = 1
+    if Screen.request_full_screen_refresh then
+        df.global.gps.force_full_display_count = 1
+        Screen.request_full_screen_refresh = false
+    end
 end
 
 function Screen:sendInputToParent(...)

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -597,6 +597,7 @@ end
 Screen = defclass(Screen, View)
 
 Screen.text_input_mode = false
+Screen.request_full_screen_refresh = false
 
 function Screen:postinit()
     self:onResize(dscreen.getWindowSize())
@@ -621,6 +622,10 @@ function Screen:renderParent()
         self._native.parent:render()
     else
         dscreen.clear()
+    end
+    if Screen.request_full_screen_refresh then
+        df.global.gps.force_full_display_count = 1
+        Screen.request_full_screen_refresh = false
     end
 end
 

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -487,6 +487,10 @@ Window.ATTRS {
     draggable = true,
 }
 
+function Window:postUpdateLayout()
+    gui.Screen.request_full_screen_refresh = true
+end
+
 -------------------
 -- ResizingPanel --
 -------------------

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -442,7 +442,7 @@ end
 -- adding gaps between widgets according to self.autoarrange_gap.
 function Panel:postUpdateLayout()
     -- don't leave artifacts behind on the parent screen when we move
-    gui.Screen.request_full_screen_refresh = true
+    self.request_full_screen_refresh = true
 
     if not self.autoarrange_subviews then return end
 
@@ -464,6 +464,10 @@ end
 
 function Panel:onRenderFrame(dc, rect)
     Panel.super.onRenderFrame(self, dc, rect)
+    if self.request_full_screen_refresh then
+        df.global.gps.force_full_display_count = 1
+        self.request_full_screen_refresh = false
+    end
     if not self.frame_style then return end
     gui.paint_frame(dc, rect, self.frame_style, self.frame_title)
     if self.kbd_get_pos then

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -441,6 +441,9 @@ end
 -- if self.autoarrange_subviews is true, lay out visible subviews vertically,
 -- adding gaps between widgets according to self.autoarrange_gap.
 function Panel:postUpdateLayout()
+    -- don't leave artifacts behind on the parent screen when we move
+    gui.Screen.request_full_screen_refresh = true
+
     if not self.autoarrange_subviews then return end
 
     local gap = self.autoarrange_gap
@@ -486,10 +489,6 @@ Window.ATTRS {
     frame_inset = 1,
     draggable = true,
 }
-
-function Window:postUpdateLayout()
-    gui.Screen.request_full_screen_refresh = true
-end
 
 -------------------
 -- ResizingPanel --

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -442,7 +442,7 @@ end
 -- adding gaps between widgets according to self.autoarrange_gap.
 function Panel:postUpdateLayout()
     -- don't leave artifacts behind on the parent screen when we move
-    self.request_full_screen_refresh = true
+    gui.Screen.request_full_screen_refresh = true
 
     if not self.autoarrange_subviews then return end
 
@@ -464,10 +464,6 @@ end
 
 function Panel:onRenderFrame(dc, rect)
     Panel.super.onRenderFrame(self, dc, rect)
-    if self.request_full_screen_refresh then
-        df.global.gps.force_full_display_count = 1
-        self.request_full_screen_refresh = false
-    end
     if not self.frame_style then return end
     gui.paint_frame(dc, rect, self.frame_style, self.frame_title)
     if self.kbd_get_pos then


### PR DESCRIPTION
this significantly reduces CPU utilization when DFHack-owned screens are visible.