### PR TITLE
implement Screen::paintTile for both modes and readTile for graphics mode

### DIFF
--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -150,6 +150,7 @@ static bool doSetTile_default(const Pen &pen, int x, int y, bool map)
     *screen = 0;
     *texpos = 0;
     *texpos_lower = 0;
+    gps->screentexpos_anchored[index] = 0;
     // keep SCREENTEXPOS_FLAG_ANCHOR_SUBORDINATE so occluded anchored textures
     // don't appear corrupted
     *flag &= 4;
@@ -163,6 +164,7 @@ static bool doSetTile_default(const Pen &pen, int x, int y, bool map)
         *screen = 0;
         *texpos = 0;
         *texpos_lower = 0;
+        gps->screentexpos_top_anchored[index] = 0;
         *flag &= 4; // keep SCREENTEXPOS_FLAG_ANCHOR_SUBORDINATE
     }
 


### PR DESCRIPTION
There are a *lot* of textures that might be shown in graphics mode, but readTile can only return one. I decided to return the first tile found when scanning in this order:

screentexpos (unit), screentexpos_item, screentexpos_building_one, screentexpos_background_two, screentexpos_background

From examining several tiles with `devel/inspect-screen`, these seem to be the interesting ones. We could certainly extend the search list more in the future if we find we're missing something, though.

Also, the screen is specified in RGB values, but our pens use 16-bit color codes. I translate to the old codes if the color is a perfect match, but otherwise I just return 0 for the color. We could potentially improve on this by finding the *closest* color, if we need to.