### PR TITLE
Make OverlayWidget inherit from Panel and allow overlays to be perma-enabled

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -50,6 +50,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``gui.View``: ``visible`` and ``active`` can now be functions that return a boolean
 - ``widgets.Panel``: new attributes to control window dragging and resizing with mouse or keyboard
 - ``widgets.Window``: Panel subclass with attributes preset for top-level windows
+- `overlay`: ``OverlayWidget`` now inherits from ``Panel`` instead of ``Widget`` to get all the frame and mouse integration goodies
 
 ## Internals
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4154,6 +4154,8 @@ Base of all the widgets. Inherits from View and has the following attributes:
 
   The pen to fill the outer frame with. Defaults to no fill.
 
+.. _panel:
+
 Panel class
 -----------
 

--- a/docs/dev/overlay-dev-guide.rst
+++ b/docs/dev/overlay-dev-guide.rst
@@ -38,7 +38,7 @@ Overlay widget API
 ------------------
 
 Overlay widgets are Lua classes that inherit from ``overlay.OverlayWidget``
-(which itself inherits from `widgets.Widget <widget>`). The regular
+(which itself inherits from `widgets.Panel <panel>`). The regular
 ``onInput(keys)``, ``onRenderFrame(dc, frame_rect)``, and ``onRenderBody(dc)``
 functions work as normal, and they are called when the viewscreen that the
 widget is associated with does its usual input and render processing. The widget
@@ -125,6 +125,10 @@ The ``overlay.OverlayWidget`` superclass defines the following class attributes:
     not annoy the player. Set to 0 to be called at the maximum rate. Be aware
     that running more often than you really need to will impact game FPS,
     especially if your widget can run while the game is unpaused.
+- ``always_enabled`` (default: ``false``)
+    Set this to ``true`` if you don't want to let the user disable the widget.
+    This is useful for widgets that are controlled purely through their
+    triggers. See `gui/pathable` for an example.
 
 Registering a widget with the overlay framework
 ***********************************************

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -177,6 +177,7 @@ end
 
 local function do_disable(args, quiet)
     local disable_fn = function(name, db_entry)
+        if db_entry.widget.always_enabled then return end
         overlay_config[name].enabled = false
         if db_entry.widget.hotspot then
             active_hotspot_widgets[name] = nil
@@ -244,7 +245,7 @@ local function load_widget(name, widget_class)
     local config = overlay_config[name]
     config.pos = sanitize_pos(config.pos or widget.default_pos)
     widget.frame = make_frame(config.pos, widget.frame)
-    if config.enabled then
+    if config.enabled or widget.always_enabled then
         do_enable(name, true, true)
     else
         config.enabled = false
@@ -461,7 +462,7 @@ end
 -- OverlayWidget (base class of all overlay widgets) --
 -- ------------------------------------------------- --
 
-OverlayWidget = defclass(OverlayWidget, widgets.Widget)
+OverlayWidget = defclass(OverlayWidget, widgets.Panel)
 OverlayWidget.ATTRS{
     name=DEFAULT_NIL, -- this is set by the framework to the widget name
     default_pos={x=DEFAULT_X_POS, y=DEFAULT_Y_POS}, -- 1-based widget screen pos
@@ -469,6 +470,7 @@ OverlayWidget.ATTRS{
     hotspot=false, -- whether to call overlay_onupdate on all screens
     viewscreens={}, -- override with associated viewscreen or list of viewscrens
     overlay_onupdate_max_freq_seconds=5, -- throttle calls to overlay_onupdate
+    always_enabled=false, -- for overlays that should never be disabled
 }
 
 function OverlayWidget:init()


### PR DESCRIPTION
We've been adding a lot of cool functionality to Panel, which OverlayWidgets have not been able to access since they inherit from Widget, not Panel. This PR shifts the inheritance to Panel so OverlayWidgets can be dragged, resized, and framed.

Also, allow overlay widgets to mark themselves as `always_enabled` if they want to control their own enablement via the overlay trigger mechanism. This will be used for the new `gui/pathable`.