### PR TITLE
clear out obsolete area map and menu logic from the Gui module

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -45,6 +45,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - added DFHack architecture diagrams to the dev intro
 
 ## API
+- ``Gui::getDwarfmodeDims``: now only returns map viewport dimensions; menu dimensions are obsolete
 
 ## Lua
 - ``gui.View``: ``visible`` and ``active`` can now be functions that return a boolean

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1011,7 +1011,7 @@ Fortress mode
 
 * ``dfhack.gui.getDwarfmodeViewDims()``
 
-  Returns dimensions of the main fortress mode screen. See ``getPanelLayout()``
+  Returns dimensions of the displayed map viewport. See ``getPanelLayout()``
   in the ``gui.dwarfmode`` module for a more Lua-friendly version.
 
 * ``dfhack.gui.resetDwarfmodeView([pause])``

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1436,17 +1436,8 @@ static int gui_getDwarfmodeViewDims(lua_State *state)
     lua_newtable(state);
     Lua::TableInsert(state, "map_x1", dims.map_x1);
     Lua::TableInsert(state, "map_x2", dims.map_x2);
-    Lua::TableInsert(state, "menu_x1", dims.menu_x1);
-    Lua::TableInsert(state, "menu_x2", dims.menu_x2);
-    Lua::TableInsert(state, "area_x1", dims.area_x1);
-    Lua::TableInsert(state, "area_x2", dims.area_x2);
-    Lua::TableInsert(state, "y1", dims.y1);
-    Lua::TableInsert(state, "y2", dims.y2);
     Lua::TableInsert(state, "map_y1", dims.map_y1);
     Lua::TableInsert(state, "map_y2", dims.map_y2);
-    Lua::TableInsert(state, "menu_on", dims.menu_on);
-    Lua::TableInsert(state, "area_on", dims.area_on);
-    Lua::TableInsert(state, "menu_forced", dims.menu_forced);
     return 1;
 }
 

--- a/library/include/modules/Gui.h
+++ b/library/include/modules/Gui.h
@@ -143,13 +143,10 @@ namespace DFHack
         static const int MENU_WIDTH = 30;
 
         struct DwarfmodeDims {
-            int map_x1, map_x2, menu_x1, menu_x2, area_x1, area_x2;
-            int y1, y2;
+            int map_x1, map_x2;
             int map_y1, map_y2;
-            bool menu_on, area_on, menu_forced;
 
             rect2d map() { return mkrect_xy(map_x1, map_y1, map_x2, map_y2); }
-            rect2d menu() { return mkrect_xy(menu_x1, y1, menu_x2, y2); }
         };
 
         DFHACK_EXPORT DwarfmodeDims getDwarfmodeViewDims();
@@ -197,18 +194,6 @@ namespace DFHack
 
         /// get the size of the window buffer
         DFHACK_EXPORT bool getWindowSize(int32_t & width, int32_t & height);
-
-        /**
-         *Menu width:
-         *3:3 - menu and area map closed
-         *2:3 - menu open single width
-         *1:3 - menu open double width
-         *1:2 - menu and area map open
-         *2:2 - area map open
-         */
-
-        DFHACK_EXPORT bool getMenuWidth(uint8_t & menu_width, uint8_t & area_map_width);
-        DFHACK_EXPORT bool setMenuWidth(const uint8_t menu_width, const uint8_t area_map_width);
 
         namespace Hooks {
             GUI_HOOK_DECLARE(depth_at, int, (int32_t x, int32_t y));

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -71,30 +71,9 @@ end
 
 function getPanelLayout()
     local dims = dfhack.gui.getDwarfmodeViewDims()
-    local area_pos = df.global.ui_menu_width[1]
-    local menu_pos = df.global.ui_menu_width[0]
-
-    if dims.menu_forced then
-        menu_pos = area_pos - 1
-    end
-
-    local rv = {
-        menu_pos = menu_pos,
-        area_pos = area_pos,
-        map = gui.mkdims_xy(dims.map_x1, dims.map_y1, dims.map_x2, dims.map_y2),
+    return {
+        map=gui.mkdims_xy(dims.map_x1, dims.map_y1, dims.map_x2, dims.map_y2),
     }
-
-    if dims.menu_forced then
-        rv.menu_forced = true
-    end
-    if dims.menu_on then
-        rv.menu = gui.mkdims_xy(dims.menu_x1, dims.y1, dims.menu_x2, dims.y2)
-    end
-    if dims.area_on then
-        rv.area_map = gui.mkdims_xy(dims.area_x1, dims.y1, dims.area_x2, dims.y2)
-    end
-
-    return rv
 end
 
 function getCursorPos()

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -1919,47 +1919,14 @@ Gui::DwarfmodeDims getDwarfmodeViewDims_default()
 {
     Gui::DwarfmodeDims dims;
 
-    auto ws = Screen::getWindowSize();
-    dims.y1 = 1;
-    dims.y2 = ws.y-2;
+    bool use_graphics = Screen::inGraphicsMode();
+    auto dimx = use_graphics ? gps->main_viewport->dim_x : gps->dimx;
+    auto dimy = use_graphics ? gps->main_viewport->dim_y : gps->dimy;
 
-    dims.map_x1 = 1;
-    dims.map_x2 = ws.x-2;
-    dims.map_y1 = dims.y1;
-    dims.map_y2 = dims.y2;
-
-    dims.area_x1 = dims.area_x2 = dims.menu_x1 = dims.menu_x2 = -1;
-    dims.menu_forced = false;
-
-    int menu_pos = (ui_menu_width ? (*ui_menu_width)[0] : 2);
-    int area_pos = (ui_menu_width ? (*ui_menu_width)[1] : 3);
-
-    if (ui && ui->main.mode != ui_sidebar_mode::Default && ui->main.mode != ui_sidebar_mode::ArenaWeather && menu_pos >= area_pos)
-    {
-        dims.menu_forced = true;
-        menu_pos = area_pos-1;
-    }
-
-    dims.area_on = (area_pos < 3);
-    dims.menu_on = (menu_pos < area_pos);
-
-    if (dims.menu_on)
-    {
-        dims.menu_x2 = ws.x - 2;
-        dims.menu_x1 = dims.menu_x2 - Gui::MENU_WIDTH + 1;
-        if (menu_pos == 1)
-            dims.menu_x1 -= Gui::AREA_MAP_WIDTH + 1;
-        dims.map_x2 = dims.menu_x1 - 2;
-    }
-    if (dims.area_on)
-    {
-        dims.area_x2 = ws.x-2;
-        dims.area_x1 = dims.area_x2 - Gui::AREA_MAP_WIDTH + 1;
-        if (dims.menu_on)
-            dims.menu_x2 = dims.area_x1 - 2;
-        else
-            dims.map_x2 = dims.area_x1 - 2;
-    }
+    dims.map_x1 = 0;
+    dims.map_x2 = dimx - 1;
+    dims.map_y1 = 0;
+    dims.map_y2 = dimy - 1;
 
     return dims;
 }
@@ -2198,18 +2165,4 @@ bool Gui::getWindowSize (int32_t &width, int32_t &height)
         height = 25;
         return false;
     }
-}
-
-bool Gui::getMenuWidth(uint8_t &menu_width, uint8_t &area_map_width)
-{
-    menu_width = (*ui_menu_width)[0];
-    area_map_width = (*ui_menu_width)[1];
-    return true;
-}
-
-bool Gui::setMenuWidth(const uint8_t menu_width, const uint8_t area_map_width)
-{
-    (*ui_menu_width)[0] = menu_width;
-    (*ui_menu_width)[1] = area_map_width;
-    return true;
 }


### PR DESCRIPTION
in particular, return the correct map dimensions in getDwarfmodeDims()