### PR TITLE
Get correct mouse button down behavior in Lua without overwriting enabler fields

### DIFF
--- a/data/init/dfhack.tools.init
+++ b/data/init/dfhack.tools.init
@@ -78,6 +78,9 @@
 # Display DFHack version on title screen
 #enable title-version
 
+# Allow DFHack tools to overlay functionality and information on the DF screen
+enable overlay
+
 # Dwarf Manipulator (simple in-game Dwarf Therapist replacement)
 #enable manipulator
 
@@ -89,7 +92,6 @@
 
 # Other interface improvement tools
 #enable \
-# overlay \
 # confirm \
 # dwarfmonitor \
 # mousequery \

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2392,13 +2392,13 @@ Supported callbacks and fields are:
   ``_STRING``
     Maps to an integer in range 0-255. Duplicates a separate "STRING_A???" code for convenience.
 
-  ``_MOUSE_L, _MOUSE_R``
-    If the left or right mouse button is being pressed.
+  ``_MOUSE_L, _MOUSE_R, _MOUSE_M``
+    If the left, right, and/or middle mouse button is being pressed.
 
-  ``_MOUSE_L_DOWN, _MOUSE_R_DOWN``
-    If the left or right mouse button was just pressed.
+  ``_MOUSE_L_DOWN, _MOUSE_R_DOWN, _MOUSE_M_DOWN``
+    If the left, right, and/or middle mouse button was just pressed.
 
-  If this method is omitted, the screen is dismissed on receival of the ``LEAVESCREEN`` key.
+  If this method is omitted, the screen is dismissed on reception of the ``LEAVESCREEN`` key.
 
 * ``function screen:onGetSelectedUnit()``
 * ``function screen:onGetSelectedItem()``

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -131,9 +131,13 @@ void DFHack::Lua::GetVector(lua_State *state, std::vector<std::string> &pvec)
     }
 }
 
+static bool inhibit_l_down = false;
+static bool inhibit_r_down = false;
+static bool inhibit_m_down = false;
+
 void DFHack::Lua::PushInterfaceKeys(lua_State *L,
                             const std::set<df::interface_key> &keys) {
-    lua_createtable(L, 0, keys.size() + 5);
+    lua_createtable(L, 0, keys.size() + 7);
 
     for (auto &key : keys)
     {
@@ -154,23 +158,32 @@ void DFHack::Lua::PushInterfaceKeys(lua_State *L,
     }
 
     if (df::global::enabler) {
-        if (df::global::enabler->mouse_lbut_down) {
+        if (!inhibit_l_down && df::global::enabler->mouse_lbut_down) {
             lua_pushboolean(L, true);
             lua_setfield(L, -2, "_MOUSE_L_DOWN");
+            inhibit_l_down = true;
         }
-        if (df::global::enabler->mouse_rbut_down) {
+        if (!inhibit_r_down && df::global::enabler->mouse_rbut_down) {
             lua_pushboolean(L, true);
             lua_setfield(L, -2, "_MOUSE_R_DOWN");
+            inhibit_r_down = true;
+        }
+        if (!inhibit_m_down && df::global::enabler->mouse_mbut_down) {
+            lua_pushboolean(L, true);
+            lua_setfield(L, -2, "_MOUSE_M_DOWN");
+            inhibit_m_down = true;
         }
         if (df::global::enabler->mouse_lbut) {
             lua_pushboolean(L, true);
             lua_setfield(L, -2, "_MOUSE_L");
-            df::global::enabler->mouse_lbut_down = 0;
         }
         if (df::global::enabler->mouse_rbut) {
             lua_pushboolean(L, true);
             lua_setfield(L, -2, "_MOUSE_R");
-            df::global::enabler->mouse_rbut_down = 0;
+        }
+        if (df::global::enabler->mouse_mbut) {
+            lua_pushboolean(L, true);
+            lua_setfield(L, -2, "_MOUSE_M");
         }
     }
 }
@@ -2134,4 +2147,11 @@ void DFHack::Lua::Core::Reset(color_ostream &out, const char *where)
         out.printerr("Common lua context stack top left at %d after %s.\n", top, where);
         lua_settop(State, 0);
     }
+
+    if (!df::global::enabler->mouse_lbut)
+        inhibit_l_down = false;
+    if (!df::global::enabler->mouse_rbut)
+        inhibit_r_down = false;
+    if (!df::global::enabler->mouse_mbut)
+        inhibit_m_down = false;
 }

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -14,8 +14,10 @@ CLEAR_PEN = to_pen{tile=909, ch=32, fg=0, bg=0}
 local FAKE_INPUT_KEYS = {
     _MOUSE_L = true,
     _MOUSE_R = true,
+    _MOUSE_M = true,
     _MOUSE_L_DOWN = true,
     _MOUSE_R_DOWN = true,
+    _MOUSE_M_DOWN = true,
     _STRING = true,
 }
 


### PR DESCRIPTION
DF does not clear the `enabler->mouse_lbut_down` after the first run through a viewscreen's `feed()` function. Since we guarantee to Lua scripts that only one `keys._MOUSE_L_DOWN` event will be sent per button press, we've been manually clearing the `enabler` state so `enabler->mouse_lbut_down` will be false for the next run through `DFHack::Lua::PushInterfaceKeys()`.

This method worked fine in the past since DF didn't do much with the mouse. Now that it does, writing to enabler has nasty side effects on DF.

For example, adding a `keys._MOUSE_M_DOWN` event to capture middle mouse button clicks to our code also required clearing the `enabler->mouse_mbut_down` state. This immediately broke map dragging with the middle mouse button.

This PR removes the code that modifies `enabler` state and instead adds "inhibitor" flags for each of the mouse buttons. The flags are set when a button click occurs (`enabler->mouse_xbut_down` becomes `true` from a `false` state) and are cleared in `onUpdate()` when the corresponding `enabler->mouse_xbut` value becomes `false` again.

This PR also add events and state tracking for the middle mouse button.