### PR TITLE
framework for passthru, z-order swapping windows

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2456,6 +2456,17 @@ static int screen_findGraphicsTile(lua_State *L)
     }
 }
 
+static int screen_raise(lua_State *L) {
+    df::viewscreen *screen = dfhack_lua_viewscreen::get_pointer(L, 1, false);
+
+    // remove screen from the stack so it doesn't get returned as an output
+    lua_remove(L, 1);
+
+    Screen::raise(screen);
+
+    return 0;
+}
+
 static int screen_hideGuard(lua_State *L) {
     df::viewscreen *screen = dfhack_lua_viewscreen::get_pointer(L, 1, false);
     luaL_checktype(L, 2, LUA_TFUNCTION);
@@ -2574,6 +2585,7 @@ static const luaL_Reg dfhack_screen_funcs[] = {
     { "paintString", screen_paintString },
     { "fillRect", screen_fillRect },
     { "findGraphicsTile", screen_findGraphicsTile },
+    CWRAP(raise, screen_raise),
     CWRAP(hideGuard, screen_hideGuard),
     CWRAP(show, screen_show),
     CWRAP(dismiss, screen_dismiss),

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -131,6 +131,9 @@ void DFHack::Lua::GetVector(lua_State *state, std::vector<std::string> &pvec)
     }
 }
 
+static bool trigger_inhibit_l_down = false;
+static bool trigger_inhibit_r_down = false;
+static bool trigger_inhibit_m_down = false;
 static bool inhibit_l_down = false;
 static bool inhibit_r_down = false;
 static bool inhibit_m_down = false;
@@ -161,17 +164,17 @@ void DFHack::Lua::PushInterfaceKeys(lua_State *L,
         if (!inhibit_l_down && df::global::enabler->mouse_lbut_down) {
             lua_pushboolean(L, true);
             lua_setfield(L, -2, "_MOUSE_L_DOWN");
-            inhibit_l_down = true;
+            trigger_inhibit_l_down = true;
         }
         if (!inhibit_r_down && df::global::enabler->mouse_rbut_down) {
             lua_pushboolean(L, true);
             lua_setfield(L, -2, "_MOUSE_R_DOWN");
-            inhibit_r_down = true;
+            trigger_inhibit_r_down = true;
         }
         if (!inhibit_m_down && df::global::enabler->mouse_mbut_down) {
             lua_pushboolean(L, true);
             lua_setfield(L, -2, "_MOUSE_M_DOWN");
-            inhibit_m_down = true;
+            trigger_inhibit_m_down = true;
         }
         if (df::global::enabler->mouse_lbut) {
             lua_pushboolean(L, true);
@@ -2146,6 +2149,19 @@ void DFHack::Lua::Core::Reset(color_ostream &out, const char *where)
     {
         out.printerr("Common lua context stack top left at %d after %s.\n", top, where);
         lua_settop(State, 0);
+    }
+
+    if (trigger_inhibit_l_down) {
+        trigger_inhibit_l_down = false;
+        inhibit_l_down = true;
+    }
+    if (trigger_inhibit_r_down) {
+        trigger_inhibit_r_down = false;
+        inhibit_r_down = true;
+    }
+    if (trigger_inhibit_m_down) {
+        trigger_inhibit_m_down = false;
+        inhibit_m_down = true;
     }
 
     if (!df::global::enabler->mouse_lbut)

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -222,6 +222,7 @@ namespace DFHack
         DFHACK_EXPORT void dismiss(df::viewscreen *screen, bool to_first = false);
         DFHACK_EXPORT bool isDismissed(df::viewscreen *screen);
         DFHACK_EXPORT bool hasActiveScreens(Plugin *p);
+        DFHACK_EXPORT void raise(df::viewscreen *screen);
 
         /// Retrieve the string representation of the bound key.
         DFHACK_EXPORT std::string getKeyDisplay(df::interface_key key);

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -484,6 +484,10 @@ function View:getMousePos(view_rect)
     end
 end
 
+function View:getMouseFramePos()
+    return self:getMousePos(ViewRect{rect=self.frame_rect})
+end
+
 function View:computeFrame(parent_rect)
     return mkdims_wh(0,0,parent_rect.width,parent_rect.height)
 end
@@ -681,9 +685,67 @@ function Screen:onRender()
     self:render(Painter.new())
 end
 
-------------------------
+-----------------------------
+-- Z-order swapping screen --
+-----------------------------
+
+ZScreen = defclass(ZScreen, Screen)
+
+function ZScreen:onIdle()
+    if self._native and self._native.parent then
+        self._native.parent:logic()
+    end
+end
+
+function ZScreen:render(dc)
+    self:renderParent()
+    ZScreen.super.render(self, dc)
+end
+
+local function zscreen_is_top(self)
+    return dfhack.gui.getCurViewscreen(true) == self._native
+end
+
+function ZScreen:onInput(keys)
+    if not zscreen_is_top(self) then
+        if keys._MOUSE_L_DOWN and self:isMouseOver() then
+            self:raise()
+        else
+            self:sendInputToParent(keys)
+            return
+        end
+    end
+
+    if ZScreen.super.onInput(self, keys) then
+        return
+    end
+    if keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
+        self:dismiss()
+        return
+    end
+
+    if not keys._MOUSE_L or not self:isMouseOver() then
+        self:sendInputToParent(keys)
+    end
+end
+
+-- move this viewscreen to the top of the stack (if it's not there already)
+function ZScreen:raise()
+    if self:isDismissed() or zscreen_is_top(self) then
+        return
+    end
+    dscreen.raise(self)
+end
+
+-- subclasses should override this and return whether the mouse is over an
+-- owned screen element
+function ZScreen:isMouseOver()
+    return false
+end
+
+--------------------------
 -- Framed screen object --
-------------------------
+--------------------------
 
 -- Plain grey-colored frame.
 GREY_FRAME = {

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -87,7 +87,7 @@ Panel.ATTRS {
 
 function Panel:init(args)
     if not self.drag_anchors then
-        self.drag_anchors = {title=true, frame=false, body=false}
+        self.drag_anchors = {title=true, frame=false, body=true}
     end
     if not self.resize_anchors then
         self.resize_anchors = {t=false, l=true, r=true, b=true}
@@ -303,8 +303,7 @@ function Panel:onInput(keys)
         return true
     end
     if not keys._MOUSE_L_DOWN then return end
-    local rect = self.frame_rect
-    local x,y = self:getMousePos(gui.ViewRect{rect=rect})
+    local x,y = self:getMouseFramePos()
     if not x then return end
 
     if self.resizable and y == 0 then

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -502,6 +502,10 @@ bool Screen::hasActiveScreens(Plugin *plugin)
     return false;
 }
 
+void Screen::raise(df::viewscreen *screen) {
+    Hide swapper(screen, Screen::Hide::RESTORE_AT_TOP);
+}
+
 namespace DFHack { namespace Screen {
 
 Hide::Hide(df::viewscreen* screen, int flags) :


### PR DESCRIPTION
Provides a gui.ZScreen class that lua gui tools can inherit from instead of gui.Screen. It allows the parent viewscreen to receive events if the ZScreen subclass doesn't handle them. It also allows other ZScreen subclass screens to raise to the top if windows on those screens are clicked with the mouse. In addition to providing "real window system" behavior for DFHack windows, it also lets the player interact with the map while DFHack tool windows are being shown and lets the game progress while DFHack tools are up if the game is unpaused. Note that DFHack tools can still choose to inherit from gui.Screen if they want the previous "modal" behavior.

ZScreen subclasses should *not* override the `onInput()` function. Instead, they should delegate any input processing to contained widgets (including the main Window panel). This allows top-level input processing to be consistent across all ZScreens. namely:

- otherwise unhandled r-clicks or ESC keypresses close the ZScreen
- keyboard input is passed to the top ZScreen, and if it is unhandled, is sent directly to the first underlying non-ZScreen viewscreen (this is usually the DF viewscreen)
- left mouse clicks outside the ZScreen's window area are passed to the next viewscreen. if a lower ZScreen detects that the mouse click is within its window area, that ZScreen will be raised to be the top viewscreen and receives focus for further mouse and keyboard input 