### PR TITLE
set-df-path: accept path on command line

### DIFF
--- a/build/win32/set_df_path.vbs
+++ b/build/win32/set_df_path.vbs
@@ -2,11 +2,18 @@ Option Explicit
 
 Const BIF_returnonlyfsdirs   = &H0001
 
-Dim wsh, objDlg, objF, fso, spoFile
-Set objDlg = WScript.CreateObject("Shell.Application")
-Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs)
+Dim wsh, objDlg, objF, fso, spoFile, args
 
 Set fso = CreateObject("Scripting.FileSystemObject")
+
+set args = Wscript.Arguments
+if args.count > 0 Then
+    Set ObjF = fso.GetFolder(args.Item(0))
+else
+    Set objDlg = WScript.CreateObject("Shell.Application")
+    Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs).Self
+end if
+
 If fso.FileExists("DF_PATH.txt") Then
     fso.DeleteFile "DF_PATH.txt", True
 End If
@@ -14,7 +21,7 @@ End If
 If IsValue(objF) Then
     If InStr(1, TypeName(objF), "Folder") > 0 Then
         Set spoFile = fso.CreateTextFile("DF_PATH.txt", True)
-        spoFile.WriteLine(objF.Self.Path)
+        spoFile.WriteLine(objF.Path)
     End If
 End If
 

--- a/build/win32/set_df_path.vbs
+++ b/build/win32/set_df_path.vbs
@@ -11,7 +11,10 @@ if args.count > 0 Then
     Set ObjF = fso.GetFolder(args.Item(0))
 else
     Set objDlg = WScript.CreateObject("Shell.Application")
-    Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs).Self
+    Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs)
+    if IsValue(objF) Then
+        set ObjF = objF.self
+    end if
 end if
 
 If fso.FileExists("DF_PATH.txt") Then

--- a/build/win64/set_df_path.vbs
+++ b/build/win64/set_df_path.vbs
@@ -2,11 +2,18 @@ Option Explicit
 
 Const BIF_returnonlyfsdirs   = &H0001
 
-Dim wsh, objDlg, objF, fso, spoFile
-Set objDlg = WScript.CreateObject("Shell.Application")
-Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs)
+Dim wsh, objDlg, objF, fso, spoFile, args
 
 Set fso = CreateObject("Scripting.FileSystemObject")
+
+set args = Wscript.Arguments
+if args.count > 0 Then
+    Set ObjF = fso.GetFolder(args.Item(0))
+else
+    Set objDlg = WScript.CreateObject("Shell.Application")
+    Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs).Self
+end if
+
 If fso.FileExists("DF_PATH.txt") Then
     fso.DeleteFile "DF_PATH.txt", True
 End If
@@ -14,7 +21,7 @@ End If
 If IsValue(objF) Then
     If InStr(1, TypeName(objF), "Folder") > 0 Then
         Set spoFile = fso.CreateTextFile("DF_PATH.txt", True)
-        spoFile.WriteLine(objF.Self.Path)
+        spoFile.WriteLine(objF.Path)
     End If
 End If
 

--- a/build/win64/set_df_path.vbs
+++ b/build/win64/set_df_path.vbs
@@ -11,7 +11,10 @@ if args.count > 0 Then
     Set ObjF = fso.GetFolder(args.Item(0))
 else
     Set objDlg = WScript.CreateObject("Shell.Application")
-    Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs).Self
+    Set objF = objDlg.BrowseForFolder (&H0,"Select your DF folder", BIF_returnonlyfsdirs)
+    if IsValue(objF) Then
+        set ObjF = objF.self
+    end if
 end if
 
 If fso.FileExists("DF_PATH.txt") Then


### PR DESCRIPTION
This enables specifying the pathname on the command line for `set_df_path.vbs`, which is a longstanding pet peeve of mine