### PR TITLE
Remove os.execute and io.popen

### DIFF
--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -1896,9 +1896,17 @@ lua_State *DFHack::Lua::Open(color_ostream &out, lua_State *state)
     luaL_setfuncs(state, dfhack_coro_funcs, 0);
     lua_pop(state, 1);
 
+    // replace some io functions
+    lua_getglobal(state, "io");
+    lua_pushnil(state);
+    lua_setfield(state, -2, "popen");
+    lua_pop(state, 1);
+    
     // replace some os functions
     lua_getglobal(state, "os");
     luaL_setfuncs(state, dfhack_os_funcs, 0);
+    lua_pushnil(state);
+    lua_setfield(state, -2, "execute");
     lua_pop(state, 1);
 
     // split the global environment

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -1901,7 +1901,7 @@ lua_State *DFHack::Lua::Open(color_ostream &out, lua_State *state)
     lua_pushnil(state);
     lua_setfield(state, -2, "popen");
     lua_pop(state, 1);
-    
+
     // replace some os functions
     lua_getglobal(state, "os");
     luaL_setfuncs(state, dfhack_os_funcs, 0);


### PR DESCRIPTION
I don't think anyone uses these functions currently and they're often removed from any program that has Lua scripting available.