### PR TITLE
update behavior of hotspot menu

### DIFF
--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -725,6 +725,7 @@ function ZScreen:onInput(keys)
     if ZScreen.super.onInput(self, keys) then
         -- ensure underlying DF screens don't also react to handled clicks
         if keys._MOUSE_L_DOWN then
+            -- note we can't clear mouse_lbut here. otherwise we break dragging,
             df.global.enabler.mouse_lbut_down = 0
         end
         if keys._MOUSE_R_DOWN then

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -43,7 +43,12 @@ end
 
 local function triggered_screen_has_lock()
     if not trigger_lock_holder_screen then return false end
-    if trigger_lock_holder_screen:isActive() then return true end
+    if trigger_lock_holder_screen:isActive() then
+        if trigger_lock_holder_screen.raise then
+            trigger_lock_holder_screen:raise()
+        end
+        return true
+    end
     return register_trigger_lock_screen(nil, nil)
 end
 
@@ -429,9 +434,8 @@ local function _update_viewscreen_widgets(vs_name, vs, now_ms)
     return now_ms
 end
 
--- not subject to trigger lock since these widgets are already filtered by
--- viewscreen
 function update_viewscreen_widgets(vs_name, vs)
+    if triggered_screen_has_lock() then return end
     local now_ms = _update_viewscreen_widgets(vs_name, vs, nil)
     _update_viewscreen_widgets('all', vs, now_ms)
 end


### PR DESCRIPTION
- disappears on click outside its borders
- disappears on r-click
- mouse over the help panel counts as "over the menu" (so the menu doesn't close if the player moves the mouse to the help text)
- menu panels appear next to the logo hotspot instead of over it, allowing players to avoid clicking on the wrong item if they intend to click on the logo