### PR TITLE
Allow symlinked dfhack-run on linux

### DIFF
--- a/package/linux/dfhack-run
+++ b/package/linux/dfhack-run
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DF_DIR=$(dirname "$0")
+DF_DIR=$(dirname "$(readlink -f "$0")")
 cd "${DF_DIR}"
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"./hack/libs":"./hack"


### PR DESCRIPTION
This is useful for symlinking this script somewhere on your $PATH, and having it work without having to find the correct directory.