### PR TITLE
adjust to new directory layouts

### DIFF
--- a/ci/download-df.sh
+++ b/ci/download-df.sh
@@ -23,7 +23,7 @@ if ! test -f "$df_tardest"; then
         fi
     done <<URLS
     https://www.bay12games.com/dwarves/df_${minor}_${patch}_linux.tar.bz2
-    https://files.dfhack.org/DF/0.${minor}.${patch}/df_${minor}_${patch}_linux.tar.bz2
+    https://files.dfhack.org/DF/${minor}.${patch}/df_${minor}_${patch}_linux.tar.bz2
 URLS
     echo $df_tardest
     if ! test -f "$df_tardest"; then
@@ -42,11 +42,11 @@ URLS
 fi
 
 rm -rf df_linux
-mkdir -p df_linux/data/save
+mkdir -p df_linux/save
 
 echo Extracting
 tar xf "$df_tardest" --strip-components=1 -C df_linux
-tar xf "$save_tardest" -C df_linux/data/save
+tar xf "$save_tardest" -C df_linux/save
 echo Done
 
 ls -l

--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -216,10 +216,10 @@ after a modded save is unloaded.
 
 .. _other_init_files:
 
-raw/init.d/\*.lua
-.................
+init.d/\*.lua
+.............
 
-Any lua script named ``raw/init.d/*.lua``, in the save or main DF directory,
+Any lua script named ``init.d/*.lua``, in the save or main DF directory,
 will be run when any world or that save is loaded.
 
 

--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -144,11 +144,10 @@ savegave portability, mod merging, and general organization of init files,
 DFHack supports multiple init files both in the main DF directory and
 save-specific init files in the save folders.
 
-DFHack looks for init files in three places each time they could be run:
+DFHack looks for init files in two places each time they could be run:
 
-#. The :file:`dfhack-config/init` subdirectory in the main DF directory
-#. :file:`data/save/{world}/raw`, where ``{world}`` is the current save, and
-#. :file:`data/save/{world}/raw/objects`
+#. The :file:`dfhack-config/init` subdirectory in the main DF directory and
+#. :file:`save/{world}/init`, where ``{world}`` is the current save
 
 For each of those directories, all matching init files will be executed in
 alphabetical order.
@@ -156,7 +155,7 @@ alphabetical order.
 Before running matched init scripts in any of those locations, the
 :file:`dfhack-config/init/default.*` file that matches the event will be run to
 load DFHack defaults. Only the :file:`dfhack-config/init` directory is checked
-for this file, not any :file:`raw` directories. If you want DFHack to load
+for this file, not any :file:`save` directories. If you want DFHack to load
 without running any of its default configuration commands, edit the
 :file:`dfhack-config/init/default.*` files and comment out the commands you see
 there.
@@ -234,12 +233,11 @@ run. By default, the following folders are searched, in order (relative to the
 root DF folder):
 
 #. :file:`dfhack-config/scripts`
-#. :file:`data/save/{<region folder>}/raw/scripts` (only if a save is loaded)
-#. :file:`raw/scripts`
+#. :file:`save/{world}/scripts` (only if a save is loaded)
 #. :file:`hack/scripts`
 
 For example, if ``teleport`` is run, these folders are searched in order for
-``teleport.lua`` or ``teleport.rb``, and the first matching file is run.
+``teleport.lua``, and the first matching file is run.
 
 Script paths can be added by modifying :file:`dfhack-config/script-paths.txt`.
 Each line should start with one of these characters:

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Scrollable widgets now react to mouse wheel events when the mouse is over the widget
 - the ``dfhack-config/scripts/`` folder is now searched for scripts by default
 - `hotkeys`: overlay hotspot widget now shows the DFHack logo in graphics mode and "DFHack" in text mode
+- `script-paths`: removed "raw" directories from default script paths. now the default locations to search for scripts are ``dfhack-config/scripts``, ``save/*/scripts``, and ``hack/scripts``
+- ``init.d``: directories have moved from the ``raw`` subfolder (which no longer exists) to the root of the main DF folder or a savegame folder
 
 ## Documentation
 - `overlay-dev-guide`: added troubleshooting tips and common development workflows
@@ -68,8 +70,6 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``gui.View``: new function ``view:getMouseFramePos()`` for detecting whether the mouse is within (or over) the exterior frame of a view
 - ``gui.CLEAR_PEN``: now clears the background and foreground and writes to the background (before it would always write to the foreground)
 - ``gui.KEEP_LOWER_PEN``: a general use pen that writes associated tiles to the foreground while keeping the existing background
-
-## Internals
 
 ## Removed
 - ``fix-job-postings`` from the `workflow` plugin is now obsolete since affected savegames can no longer be loaded

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -5883,9 +5883,9 @@ all script modules.
 Save init script
 ================
 
-If a save directory contains a file called ``raw/init.lua``, it is
+If a save directory contains a file called ``init.lua``, it is
 automatically loaded and executed every time the save is loaded.
-The same applies to any files called ``raw/init.d/*.lua``. Every
+The same applies to any files called ``init.d/*.lua``. Every
 such script can define the following functions to be called by dfhack:
 
 * ``function onStateChange(op) ... end``

--- a/docs/guides/modding-guide.rst
+++ b/docs/guides/modding-guide.rst
@@ -358,7 +358,7 @@ names for the mod folders within it. In the example below, we'll use a mod ID of
 ``example-mod`` mod will be developed in the ``/path/to/mymods/example-mod/``
 directory and has a basic structure that looks like this::
 
-    raw/init.d/example-mod.lua
+    init.d/example-mod.lua
     raw/objects/...
     raw/scripts/example-mod.lua
     raw/scripts/example-mod/...
@@ -366,13 +366,13 @@ directory and has a basic structure that looks like this::
 
 Let's go through that line by line.
 
-* A short (one-line) script in ``raw/init.d/`` to initialise your
+* A short (one-line) script in ``init.d/`` to initialise your
   mod when a save is loaded.
 * Modifications to the game raws (potentially with custom raw tokens) go in
   ``raw/objects/``.
-* A control script in ``raw/scripts/`` that handles enabling and disabling your
+* A control script in ``scripts/`` that handles enabling and disabling your
   mod.
-* A subfolder for your mod under ``raw/scripts/`` will contain all the internal
+* A subfolder for your mod under ``scripts/`` will contain all the internal
   scripts and/or modules used by your mod.
 
 It is a good idea to use a version control system to organize changes to your
@@ -384,10 +384,10 @@ Unless you want to install your ``raw/`` folder into your DF game folder every
 time you make a change to your scripts, you should add your development scripts
 directory to your script paths in ``dfhack-config/script-paths.txt``::
 
-    +/path/to/mymods/example-mod/raw/scripts/
+    +/path/to/mymods/example-mod/scripts/
 
 Ok, you're all set up! Now, let's take a look at an example
-``raw/scripts/example-mod.lua`` file::
+``scripts/example-mod.lua`` file::
 
     -- main setup and teardown for example-mod
     -- this next line indicates that the script supports the "enable"
@@ -474,7 +474,7 @@ Ok, you're all set up! Now, let's take a look at an example
 
 You can call ``enable example-mod`` and ``disable example-mod`` yourself while
 developing, but for end users you can start your mod automatically from
-``raw/init.d/example-mod.lua``::
+``init.d/example-mod.lua``::
 
     dfhack.run_command('enable example-mod')
 

--- a/docs/guides/modding-guide.rst
+++ b/docs/guides/modding-guide.rst
@@ -61,8 +61,7 @@ be:
 
 1. ``own-scripts/``
 2. ``dfhack-config/scripts/``
-3. ``data/save/*/raw/scripts/``
-4. ``raw/scripts/``
+3. ``save/*/scripts/``
 5. ``hack/scripts/``
 
 The structure of the game

--- a/docs/guides/modding-guide.rst
+++ b/docs/guides/modding-guide.rst
@@ -62,7 +62,7 @@ be:
 1. ``own-scripts/``
 2. ``dfhack-config/scripts/``
 3. ``save/*/scripts/``
-5. ``hack/scripts/``
+4. ``hack/scripts/``
 
 The structure of the game
 -------------------------

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -472,9 +472,8 @@ void Core::getScriptPaths(std::vector<std::string> *dest)
     if (df::global::world && isWorldLoaded()) {
         string save = World::ReadWorldFolder();
         if (save.size())
-            dest->push_back(df_path + "/data/save/" + save + "/raw/scripts");
+            dest->push_back(df_path + "/save/" + save + "/scripts");
     }
-    dest->push_back(df_path + "/raw/scripts");
     dest->push_back(df_path + "/hack/scripts");
     for (auto it = script_paths[1].begin(); it != script_paths[1].end(); ++it)
         dest->push_back(*it);
@@ -2053,7 +2052,7 @@ void Core::handleLoadAndUnloadScripts(color_ostream& out, state_change_event eve
 
     if (!df::global::world)
         return;
-    std::string rawFolder = "data/save/" + (df::global::world->cur_savegame.save_dir) + "/raw/";
+    std::string rawFolder = "save/" + (df::global::world->cur_savegame.save_dir) + "/init";
 
     auto i = table.find(event);
     if ( i != table.end() ) {
@@ -2064,7 +2063,6 @@ void Core::handleLoadAndUnloadScripts(color_ostream& out, state_change_event eve
 
         loadScriptFiles(this, out, set, CONFIG_PATH + "init");
         loadScriptFiles(this, out, set, rawFolder);
-        loadScriptFiles(this, out, set, rawFolder + "objects/");
     }
 
     for (auto it = state_change_scripts.begin(); it != state_change_scripts.end(); ++it)
@@ -2125,7 +2123,7 @@ void Core::onStateChange(color_ostream &out, state_change_event event)
     case SC_MAP_UNLOADED:
         if (world && world->cur_savegame.save_dir.size())
         {
-            std::string save_dir = "data/save/" + world->cur_savegame.save_dir;
+            std::string save_dir = "save/" + world->cur_savegame.save_dir;
             std::string evtlogpath = save_dir + "/events-dfhack.log";
             std::ofstream evtlog;
             evtlog.open(evtlogpath, std::ios_base::app);  // append

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -905,14 +905,14 @@ if dfhack.is_core_context then
             local path = dfhack.getSavePath()
 
             if path and op == SC_WORLD_LOADED then
-                loadInitFile(path, path..'/raw/init.lua')
+                loadInitFile(path, path..'/init.lua')
 
-                local dirlist = dfhack.internal.getDir(path..'/raw/init.d/')
+                local dirlist = dfhack.internal.getDir(path..'/init.d/')
                 if dirlist then
                     table.sort(dirlist)
                     for i,name in ipairs(dirlist) do
                         if string.match(name,'%.lua$') then
-                            loadInitFile(path, path..'/raw/init.d/'..name)
+                            loadInitFile(path, path..'/init.d/'..name)
                         end
                     end
                 end

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -871,7 +871,7 @@ end
 
 function dfhack.getSavePath()
     if dfhack.isWorldLoaded() then
-        return dfhack.getDFPath() .. '/data/save/' .. df.global.world.cur_savegame.save_dir
+        return dfhack.getDFPath() .. '/save/' .. df.global.world.cur_savegame.save_dir
     end
 end
 

--- a/plugins/autogems.cpp
+++ b/plugins/autogems.cpp
@@ -299,7 +299,7 @@ IMPLEMENT_VMETHOD_INTERPOSE(autogem_hook, feed);
 IMPLEMENT_VMETHOD_INTERPOSE(autogem_hook, render);
 
 bool read_config(color_ostream &out) {
-    std::string path = "data/save/" + World::ReadWorldFolder() + "/autogems.json";
+    std::string path = "save/" + World::ReadWorldFolder() + "/autogems.json";
     if (!Filesystem::isfile(path)) {
         // no need to require the config file to exist
         return true;

--- a/plugins/rendermax/renderer_light.cpp
+++ b/plugins/rendermax/renderer_light.cpp
@@ -1171,11 +1171,11 @@ void lightingEngineViewscreen::loadSettings()
     std::string rawFolder;
     if(df::global::world->cur_savegame.save_dir!="")
     {
-        rawFolder= "data/save/" + (df::global::world->cur_savegame.save_dir) + "/raw/";
+        rawFolder= "save/" + (df::global::world->cur_savegame.save_dir) + "/";
     }
     else
     {
-        rawFolder= "raw/";
+        rawFolder= "dfhack-config/";
     }
     const std::string settingsfile=rawFolder+"rendermax.lua";
 

--- a/plugins/tweak/tweaks/title-start-rename.h
+++ b/plugins/tweak/tweaks/title-start-rename.h
@@ -17,7 +17,7 @@ struct title_start_rename_hook : df::viewscreen_titlest {
 
     inline std::string full_save_dir(const std::string &region_name)
     {
-        return std::string("data/save/") + region_name;
+        return std::string("save/") + region_name;
     }
 
     bool do_rename()


### PR DESCRIPTION
default script path has changed from:

#. :file:`dfhack-config/scripts`
#. :file:`data/save/{<region folder>}/raw/scripts` (only if a save is loaded)
#. :file:`raw/scripts`
#. :file:`hack/scripts`

to:

#. :file:`dfhack-config/scripts`
#. :file:`save/{world}/scripts` (only if a save is loaded)
#. :file:`hack/scripts`


likewise, init.d folders are now in the root dir or in the root of the savegame dir instead of in raw/init.d directories.