### PR TITLE
remove compatibility with msvc express

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,14 +132,8 @@ endif()
 find_package(Perl REQUIRED)
 
 # set up folder structures for IDE solutions
-# MSVC Express won't load solutions that use this. It also doesn't include MFC supported
-# Check for MFC!
-find_package(MFC QUIET)
-if(MFC_FOUND OR (NOT MSVC))
-    option(CMAKE_USE_FOLDERS "Enable folder grouping of projects in IDEs." ON)
-else()
-    option(CMAKE_USE_FOLDERS "Enable folder grouping of projects in IDEs." OFF)
-endif()
+# checking for msvc express is meaningless now, all available editions of msvc support folder groupings
+option(CMAKE_USE_FOLDERS "Enable folder grouping of projects in IDEs." ON)
 
 if(CMAKE_USE_FOLDERS)
     set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
this removes cmakefile code to detect msvc express, which did not support folder grouping in projects, because we only support vs 2022 on windows anyway, all available editions of vs 2022 support folder grouping in projects, and msvc express itself was discontinued with vs 2019