### PR TITLE
Fix contributing broken hyperlink

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Thank you for your interest in contributing to DFHack! If you're reading this
 document, you're probably viewing it on GitHub. The DFHack docs are hosted
 on [ReadTheDocs](https://dfhack.readthedocs.io/) - in particular, contributing
-guidelines are [here](https://docs.dfhack.org/en/latest/docs/Contributing.html).
+guidelines are [here](https://docs.dfhack.org/en/stable/docs/dev/Contributing.html).
 Double-checking the style guidelines before submitting a pull request is
 always appreciated.


### PR DESCRIPTION
Link looped "too many redirects"