### PR TITLE
autofarm: fix repetition in status output

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `autofarm`: don't duplicate status line entries for crops with no current supply
 - `orders`: allow the orders library to be listed and imported properly (if you previously copied the orders library into your ``dfhack-config/orders`` directory to work around this bug, you can remove those files now)
 
 ## Misc Improvements

--- a/plugins/autofarm.cpp
+++ b/plugins/autofarm.cpp
@@ -332,6 +332,7 @@ public:
     void status(color_ostream& out)
     {
         out << "Autofarm is " << (enabled ? "Active." : "Stopped.") << '\n';
+
         for (auto& lc : lastCounts)
         {
             auto plant = world->raws.plants.all[lc.first];
@@ -340,7 +341,7 @@ public:
 
         for (auto& th : thresholds)
         {
-            if (lastCounts[th.first] > 0)
+            if (lastCounts.find(th.first) != lastCounts.end())
                 continue;
             auto plant = world->raws.plants.all[th.first];
             out << plant->id << " limit " << getThreshold(th.first) << " current 0" << '\n';

--- a/plugins/autofarm.cpp
+++ b/plugins/autofarm.cpp
@@ -341,7 +341,7 @@ public:
 
         for (auto& th : thresholds)
         {
-            if (lastCounts.find(th.first) != lastCounts.end())
+            if (lastCounts.count(th.first) > 0)
                 continue;
             auto plant = world->raws.plants.all[th.first];
             out << plant->id << " limit " << getThreshold(th.first) << " current 0" << '\n';


### PR DESCRIPTION
because C++ std::map is not the same as a ruby table

should close #2656 