### PR TITLE
Zone <-> building interactions

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1998,6 +1998,11 @@ Low-level building creation functions:
   Destroys the building, or queues a deconstruction job.
   Returns *true* if the building was destroyed and deallocated immediately.
 
+* ``dfhack.buildings.notifyCivzoneModified(building)``
+
+  Rebuilds the civzone <-> overlapping building association mapping.
+  Call after changing extents or modifying size in some fashion
+
 * ``dfhack.buildings.markedForRemoval(building)``
 
   Returns *true* if the building is marked for removal (with :kbd:`x`), *false*

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2239,6 +2239,7 @@ static const LuaWrapper::FunctionReg dfhack_buildings_module[] = {
     WRAPM(Buildings, constructWithItems),
     WRAPM(Buildings, constructWithFilters),
     WRAPM(Buildings, deconstruct),
+    WRAPM(Buildings, notifyCivzoneModified),
     WRAPM(Buildings, markedForRemoval),
     WRAPM(Buildings, getRoomDescription),
     WRAPM(Buildings, isActivityZone),

--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -202,6 +202,11 @@ DFHACK_EXPORT bool deconstruct(df::building *bld);
  */
 DFHACK_EXPORT bool markedForRemoval(df::building *bld);
 
+/**
+ * Rebuilds a civzones building associations after it has been modified
+*/
+DFHACK_EXPORT void notifyCivzoneModified(df::building* bld);
+
 void updateBuildings(color_ostream& out, void* ptr);
 void clearBuildings(color_ostream& out);
 

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -102,7 +102,6 @@ struct CoordHash {
 };
 
 static unordered_map<df::coord, int32_t, CoordHash> locationToBuilding;
-static unordered_map<df::coord, vector<int32_t>, CoordHash> locationToCivzones;
 
 static df::building_extents_type *getExtentTile(df::building_extents &extent, df::coord2d tile)
 {
@@ -115,18 +114,36 @@ static df::building_extents_type *getExtentTile(df::building_extents &extent, df
     return &extent.extents[dx + dy*extent.width];
 }
 
+void add_building_to_all_zones(df::building* bld);
+
+static void buildings_fixzones()
+{
+    auto& vec = world->buildings.other[buildings_other_id::IN_PLAY];
+
+    bool changed = false;
+
+    for (size_t i = 0; i < vec.size(); i++)
+    {
+        df::building* bld = vec[i];
+
+        add_building_to_all_zones(bld);
+    }
+}
+
 /*
  * A monitor to work around this bug, in its application to buildings:
  *
  * http://www.bay12games.com/dwarves/mantisbt/view.php?id=1416
  */
 bool buildings_do_onupdate = false;
+static bool buildings_do_fixzones = false;
 
 void buildings_onStateChange(color_ostream &out, state_change_event event)
 {
     switch (event) {
     case SC_MAP_LOADED:
         buildings_do_onupdate = true;
+        buildings_do_fixzones = true;
         break;
     case SC_MAP_UNLOADED:
         buildings_do_onupdate = false;
@@ -138,6 +155,12 @@ void buildings_onStateChange(color_ostream &out, state_change_event event)
 
 void buildings_onUpdate(color_ostream &out)
 {
+    if (buildings_do_fixzones)
+    {
+        buildings_fixzones();
+        buildings_do_fixzones = false;
+    }
+
     buildings_do_onupdate = false;
 
     df::job_list_link *link = world->jobs.list.next;
@@ -164,6 +187,163 @@ void buildings_onUpdate(color_ostream &out)
             iref->role = df::job_item_ref::Hauled;
             iref->job_item_idx = -1;
         }
+    }
+}
+
+static void building_into_zone_unidir(df::building* bld, df::building_civzonest* zone)
+{
+    for (size_t bid = 0; bid < zone->contained_buildings.size(); bid++)
+    {
+        if (zone->contained_buildings[bid] == bld)
+            return;
+    }
+
+    zone->contained_buildings.push_back(bld);
+
+    std::sort(zone->contained_buildings.begin(), zone->contained_buildings.end(), [](df::building* b1, df::building* b2)
+    {
+        return b1->id < b2->id;
+    });
+}
+
+static void zone_into_building_unidir(df::building* bld, df::building_civzonest* zone)
+{
+    for (size_t bid = 0; bid < bld->relations.size(); bid++)
+    {
+        if (bld->relations[bid] == zone)
+            return;
+    }
+
+    bld->relations.push_back(zone);
+
+    std::sort(bld->relations.begin(), bld->relations.end(), [](df::building* b1, df::building* b2)
+    {
+        return b1->id < b2->id;
+    });
+}
+
+static void add_building_to_zone(df::building* bld, df::building_civzonest* zone)
+{
+    if (!bld->canBeRoom())
+        return;
+
+    building_into_zone_unidir(bld, zone);
+    zone_into_building_unidir(bld, zone);
+}
+
+static bool is_suitable_building_for_zoning(df::building* bld)
+{
+    return bld->canBeRoom();
+}
+
+static void add_building_to_all_zones(df::building* bld)
+{
+    if (!is_suitable_building_for_zoning(bld))
+        return;
+
+    df::coord coord(bld->centerx, bld->centery, bld->z);
+
+    std::vector<df::building_civzonest*> cv;
+    Buildings::findCivzonesAt(&cv, coord);
+
+    for (size_t i=0; i < cv.size(); i++)
+    {
+        add_building_to_zone(bld, cv[i]);
+    }
+}
+
+static void add_zone_to_all_buildings(df::building* zone_as_building)
+{
+    if (zone_as_building->getType() != building_type::Civzone)
+        return;
+
+    auto zone = strict_virtual_cast<df::building_civzonest>(zone_as_building);
+
+    if (zone == nullptr)
+        return;
+
+    auto& vec = world->buildings.other[buildings_other_id::IN_PLAY];
+
+    for (size_t i = 0; i < vec.size(); i++)
+    {
+        auto against = vec[i];
+
+        if (zone->z != against->z)
+            continue;
+
+        if (!is_suitable_building_for_zoning(against))
+            continue;
+
+        int32_t cx = against->centerx;
+        int32_t cy = against->centery;
+
+        df::coord2d coord(cx, cy);
+
+        //can a zone without extents exist?
+        if (zone->room.extents && zone->isExtentShaped())
+        {
+            auto etile = getExtentTile(zone->room, coord);
+            if (!etile || !*etile)
+                continue;
+
+            add_building_to_zone(against, zone);
+        }
+    }
+}
+
+static void remove_building_from_zone(df::building* bld, df::building_civzonest* zone)
+{
+    for (int bid = 0; bid < (int)zone->contained_buildings.size(); bid++)
+    {
+        if (zone->contained_buildings[bid] == bld)
+        {
+            zone->contained_buildings.erase(zone->contained_buildings.begin() + bid);
+            bid--;
+        }
+    }
+
+    for (int bid = 0; bid < (int)bld->relations.size(); bid++)
+    {
+        if (bld->relations[bid] == zone)
+        {
+            bld->relations.erase(bld->relations.begin() + bid);
+            bid--;
+        }
+    }
+}
+
+static void remove_building_from_all_zones(df::building* bld)
+{
+    df::coord coord(bld->centerx, bld->centery, bld->z);
+
+    std::vector<df::building_civzonest*> cv;
+    Buildings::findCivzonesAt(&cv, coord);
+
+    for (size_t i=0; i < cv.size(); i++)
+    {
+        remove_building_from_zone(bld, cv[i]);
+    }
+}
+
+static void remove_zone_from_all_buildings(df::building* zone_as_building)
+{
+    if (zone_as_building->getType() != building_type::Civzone)
+        return;
+
+    auto zone = strict_virtual_cast<df::building_civzonest>(zone_as_building);
+
+    if (zone == nullptr)
+        return;
+
+    auto& vec = world->buildings.other[buildings_other_id::IN_PLAY];
+
+    //this is a paranoid check and slower than it could be. Zones contain a list of children
+    //good for fixing potentially bad game states when deleting a zone
+    for (size_t i = 0; i < vec.size(); i++)
+    {
+        df::building* bld = vec[i];
+
+        remove_building_from_zone(bld, zone);
     }
 }
 
@@ -325,78 +505,30 @@ static void cacheBuilding(df::building *building, bool is_civzone) {
         for (int32_t y = p1.y; y <= p2.y; y++) {
             df::coord pt(x, y, building->z);
             if (Buildings::containsTile(building, pt, is_civzone)) {
-                if (is_civzone)
-                    locationToCivzones[pt].push_back(id);
-                else
+                if (!is_civzone)
                     locationToBuilding[pt] = id;
             }
         }
     }
 }
 
-static int32_t nextCivzone = 0;
-static void cacheNewCivzones() {
-    if (!world || !building_next_id)
-        return;
-
-    int32_t nextBuildingId = *building_next_id;
-    for (int32_t id = nextCivzone; id < nextBuildingId; ++id) {
-        auto &vec = world->buildings.other[buildings_other_id::ANY_ZONE];
-        int32_t idx = df::building::binsearch_index(vec, id);
-        if (idx > -1)
-            cacheBuilding(vec[idx], true);
-    }
-    nextCivzone = nextBuildingId;
-}
-
 bool Buildings::findCivzonesAt(std::vector<df::building_civzonest*> *pvec,
                                df::coord pos) {
     pvec->clear();
 
-    // Tiles have an occupancy->bits.building flag to quickly determine if it is
-    // covered by a buildling, but there is no such flag for civzones.
-    // Therefore, we need to make sure that our cache is authoratative.
-    // Otherwise, we would have to fall back to linearly scanning the list of
-    // all civzones on a cache miss.
-    //
-    // Since we guarantee our cache contains *at least* all tiles that are
-    // currently covered by civzones, we can conclude that if a tile is not in
-    // the cache, there is no civzone there. Civzones *can* be dynamically
-    // shrunk, so we still need to verify that civzones that once covered this
-    // tile continue to cover this tile.
-    cacheNewCivzones();
-
-    auto civzones_it = locationToCivzones.find(pos);
-    if (civzones_it == locationToCivzones.end())
-        return false;
-
-    set<int32_t> ids_to_remove;
-    auto &civzones = civzones_it->second;
-    for (int32_t id : civzones) {
-        int32_t idx = df::building::binsearch_index(
-                world->buildings.other[buildings_other_id::ANY_ZONE], id);
-        df::building_civzonest *civzone = NULL;
-        if (idx > -1)
-            civzone = world->buildings.other.ANY_ZONE[idx];
-        if (!civzone || civzone->z != pos.z ||
-                !containsTile(civzone, pos, true)) {
-            ids_to_remove.insert(id);
+    for (df::building_civzonest* zone : world->buildings.other.ACTIVITY_ZONE)
+    {
+        if (pos.z != zone->z)
             continue;
-        }
-        pvec->push_back(civzone);
-    }
 
-    // civzone no longer occupies this tile; update the cache
-    if (!ids_to_remove.empty()) {
-        for (auto it = civzones.begin(); it != civzones.end(); ) {
-            if (ids_to_remove.count(*it)) {
-                it = civzones.erase(it);
+        if (zone->room.extents && zone->isExtentShaped())
+        {
+            auto etile = getExtentTile(zone->room, pos);
+            if (!etile || !*etile)
                 continue;
-            }
-            ++it;
+
+            pvec->push_back(zone);
         }
-        if (civzones.empty())
-            locationToCivzones.erase(pos);
     }
 
     return !pvec->empty();
@@ -1053,7 +1185,6 @@ static int getMaxStockpileId()
     return max_id;
 }
 
-/* TODO: understand how this changes for v50
 static int getMaxCivzoneId()
 {
     auto &vec = world->buildings.other[buildings_other_id::ANY_ZONE];
@@ -1068,7 +1199,6 @@ static int getMaxCivzoneId()
 
     return max_id;
 }
-*/
 
 bool Buildings::constructAbstract(df::building *bld)
 {
@@ -1087,12 +1217,14 @@ bool Buildings::constructAbstract(df::building *bld)
                 stock->stockpile_number = getMaxStockpileId() + 1;
             break;
 
-/* TODO: understand how this changes for v50
         case building_type::Civzone:
             if (auto zone = strict_virtual_cast<df::building_civzonest>(bld))
+            {
                 zone->zone_num = getMaxCivzoneId() + 1;
+
+                add_zone_to_all_buildings(zone);
+            }
             break;
-*/
 
         default:
             break;
@@ -1186,6 +1318,8 @@ bool Buildings::constructWithItems(df::building *bld, std::vector<df::item*> ite
             bld->mat_index = items[i]->getMaterialIndex();
     }
 
+    add_building_to_all_zones(bld);
+
     createDesign(bld, rough);
     return true;
 }
@@ -1232,6 +1366,8 @@ bool Buildings::constructWithFilters(df::building *bld, std::vector<df::job_item
 
     buildings_do_onupdate = true;
 
+    add_building_to_all_zones(bld);
+
     createDesign(bld, rough);
     return true;
 }
@@ -1272,6 +1408,10 @@ bool Buildings::deconstruct(df::building *bld)
     // Don't clear arrows.
 
     bld->uncategorize();
+
+    remove_building_from_all_zones(bld);
+    remove_zone_from_all_buildings(bld);
+
     delete bld;
 
     if (world->selected_building == bld)
@@ -1314,8 +1454,6 @@ void Buildings::clearBuildings(color_ostream& out) {
     corner1.clear();
     corner2.clear();
     locationToBuilding.clear();
-    locationToCivzones.clear();
-    nextCivzone = 0;
 }
 
 void Buildings::updateBuildings(color_ostream&, void* ptr)

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -198,18 +198,18 @@ static void zone_into_building_unidir(df::building* bld, df::building_civzonest*
     });
 }
 
+static bool is_suitable_building_for_zoning(df::building* bld)
+{
+    return bld->canMakeRoom();
+}
+
 static void add_building_to_zone(df::building* bld, df::building_civzonest* zone)
 {
-    if (!bld->canBeRoom())
+    if (!is_suitable_building_for_zoning(bld))
         return;
 
     building_into_zone_unidir(bld, zone);
     zone_into_building_unidir(bld, zone);
-}
-
-static bool is_suitable_building_for_zoning(df::building* bld)
-{
-    return bld->canBeRoom();
 }
 
 static void add_building_to_all_zones(df::building* bld)


### PR DESCRIPTION
Brief outline of the way zones + buildings interact:

1. Zones have a contained_buildings vector which is a list of buildings that meet a particular criteria

2. Buildings have a relations vector, which appears to be a list of civzones that contain them

3. The criteria for a building being put into a zone appears to be building->canBeRoom()

When a building is placed in a zone (including abstractly), zone->contained_buildings adds the building, and the civzone is added to the building's relation. When the building is uninstalled, its relations vector is used by the game to remove the building from the civzone's contained_buildings list (quite sure on this point). When a civzone is deleted, its contained_buildings list is used to update the contained building's relations list when it is deleted and is removed from their relations list

Overlapping civzones do not touch this system. canBeRoom encompasses beds, doors, archery targets, chairs, tables, traction benches etc, but does not include eg workshops

What this PR adds:

1. When constructing a building via buildings.constructWithItems or buildings.constructWithFilters, it checks if building->canBeRoom() is true, and if yes it finds all overlapping civzones at its centre. It then inserts itself into the civzones list of `contained_buildings`, and inserts the civzone into its `relations` list

2. When destroying a building, if it is a civzone, it finds (the slow method, via a global lookup) all buildings that have that civzone in their relations lists, and then removes them

3. When destroying a building, if its not a civzone but *is* an abstract building that can be in a civzone (ie canBeRoom), it finds all civzones at the building's centre and updates the civzones contained list. This happens just before it is deleted

5. When making a civzone in constructAbstract, the overlapping buildings are found and its contained_buildings and the overlapping buildings' relations are updated

6. When loading a save, a fixup is applied in case we end up with buildings that should be in zones that are not

What this PR can't do easily:

1. When shrinking, expanding, or generally modifying a zone, the contained_buildings and relations vectors of objects needs to be modified. This means that there are some out of sync issues here - *probably* of the non crashing kind. Civzones as modified by a user need some sort of poke hook when you modify them to correct their internal state. Perhaps buildings.notifyCivzoneModified(zone)

What this PR could add now that I think about it after writing this wall of text

1. Fixing up buildings that shouldn't be in a zone on load. I'll add this, it'll completely rebuild the civzone <-> building relations system when you load a save which should ensure that any non serious mistakes above will be corrected on load

Terribly alarming things about this PR:

1. In the event that a zone's contained_buildings vector contains a building, but the building's relation vector doesn't contain the zone, the game will crash a lot when the building is uninstalled. This whole PR is a bit of a recipe for crashing if mistakes are made

2. This PR is very conservative in terms of assumptions it makes, because there are still some significant unknowns here. There are several things that need more concrete answers

Things that could do with answers:

1. Is a civzone's relations vector always empty

2. Does a buildings relations vector only ever contain civzones

3. Is canBeRoom() the correct indicator function for putting buildings into zones

4. Do the pointers in the relations and contained_buildings vectors need to be sorted by ID, or perhaps even by pointer value? If the latter, this PR is broken. Edit: It does actually look like they do need to be sorted by ID

5. Can buildings not strictly within a civzone legally end up in its contained_buildings list

I use this system and this PR for drawing zones in the ui replacement and today I'm going to be extensively bugtesting this, but some basic experimentation with previous crash cases seems to show that it works on some level. Given that there are some unanswered questions I thought this might be useful to open so people can see what's necessary here, and also to write this all down somewhere so I don't forget