### PR TITLE
More civzone <-> building work, add removing zones with associated squads support

### DIFF
--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -167,8 +167,8 @@ int linear_index(const std::vector<CT*> &vec, FT CT::*field, FT key)
     return -1;
 }
 
-template <typename CT, typename FT>
-int binsearch_index(const std::vector<CT*> &vec, FT CT::*field, FT key, bool exact = true)
+template <typename CT, typename FT, typename MT>
+int binsearch_index(const std::vector<CT*> &vec, FT MT::*field, FT key, bool exact = true)
 {
     // Returns the index of the value >= the key
     int min = -1, max = (int)vec.size();
@@ -245,8 +245,8 @@ unsigned insert_into_vector(std::vector<FT> &vec, FT key, bool *inserted = NULL)
     return pos;
 }
 
-template<typename CT, typename FT>
-unsigned insert_into_vector(std::vector<CT*> &vec, FT CT::*field, CT *obj, bool *inserted = NULL)
+template<typename CT, typename FT, typename MT>
+unsigned insert_into_vector(std::vector<CT*> &vec, FT MT::*field, CT *obj, bool *inserted = NULL)
 {
     unsigned pos = (unsigned)binsearch_index(vec, field, obj->*field, false);
     bool to_ins = (pos >= vec.size() || vec[pos] != obj);

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -186,7 +186,7 @@ static void zone_into_building_unidir(df::building* bld, df::building_civzonest*
             return;
     }
 
-    insert_into_vector<df::building_civzonest>(bld->relations, &df::building_civzonest::id, zone);
+    insert_into_vector(bld->relations, &df::building_civzonest::id, zone);
 }
 
 static bool is_suitable_building_for_zoning(df::building* bld)
@@ -1344,7 +1344,7 @@ static void delete_civzone_squad_links(df::building* bld)
         //if this is null, something has gone just *terribly* wrong
         if (squad)
         {
-            for (int i=0; i < squad->rooms.size(); i++)
+            for (int i=0; i < (int)squad->rooms.size(); i++)
             {
                 if (squad->rooms[i]->building_id == bld->id)
                 {

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -1344,14 +1344,13 @@ static void delete_civzone_squad_links(df::building* bld)
         //if this is null, something has gone just *terribly* wrong
         if (squad)
         {
-            for (int i=0; i < (int)squad->rooms.size(); i++)
+            for (int i=(int)squad->rooms.size() - 1; i >= 0; i--)
             {
                 if (squad->rooms[i]->building_id == bld->id)
                 {
                     auto room = squad->rooms[i];
                     squad->rooms.erase(squad->rooms.begin() + i);
                     delete room;
-                    i--;
                 }
             }
         }

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -186,7 +186,7 @@ static void zone_into_building_unidir(df::building* bld, df::building_civzonest*
             return;
     }
 
-    insert_into_vector(bld->relations, &df::building::id, (df::building*)zone);
+    insert_into_vector<df::building_civzonest>(bld->relations, &df::building_civzonest::id, zone);
 }
 
 static bool is_suitable_building_for_zoning(df::building* bld)

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -1357,17 +1357,20 @@ static void delete_civzone_squad_links(df::building_civzonest* zone)
 //do not use anything that touches anything other than the pointer value
 //this means also that if dwarf fortress reuses a memory allocation, we will end up with duplicates
 //this vector is also not sorted by id
+//it also turns out that multiple units eg (solely?) spouses can point to one room
 static void delete_assigned_unit_links(df::building_civzonest* zone)
 {
-    if (zone->assigned_unit_id == -1)
-        return;
+    //not clear if this is always true
+    /*if (zone->assigned_unit_id == -1)
+        return;*/
 
-    df::unit* unit = zone->assigned_unit;
-
-    for (int i=(int)unit->owned_buildings.size() - 1; i >= 0; i--)
+    for (df::unit* unit : world->units.active)
     {
-        if (unit->owned_buildings[i] == zone)
-            unit->owned_buildings.erase(unit->owned_buildings.begin() + i);
+        for (int i=(int)unit->owned_buildings.size() - 1; i >= 0; i--)
+        {
+            if (unit->owned_buildings[i] == zone)
+                unit->owned_buildings.erase(unit->owned_buildings.begin() + i);
+        }
     }
 }
 


### PR DESCRIPTION
This addresses the style changes, as well as implementing support for removing zones which have ever had a squad assigned to them. The removal of zones from squads is conservative, and handles duplicates if they arise - though I haven't seen it

It *is* worth noting that I discovered surprisingly that there isn't a 1:1 mapping between the zone's room-squad vector, and the squad's room-zone vector. A zone remembers any squads ever associated with it, whereas squads proactively clean up their zone associations

Additionally, given some of the suspicion about vanilla bugs in this kind of bidirectional mapping, I'm not sure how generally conservative the civzone changes want to be. At the moment I've taken the approach generally of df-is-not-to-be-trusted, which is somewhat borne out by some suspicious bug reports

Updating miscutils was necessary to get it to work with derived types in insert_with_vector (eg `insert_with_vector(bld->relations, &df::building_civzonest::id, zone)`), as df::building_civzonest::id is actually technically of type (int32_t df::building*). There don't seem to be that many users of it, but I thought it might be useful and it cleans up this case

I've been bashing on this and the previous PR a lot locally as I use them for drawing zones in the UI rework, and haven't noticed any issues so far which is good