### PR TITLE
getBiomeType naming, docs, expose to lua

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1779,6 +1779,10 @@ Maps module
 
   Returns the biome info struct for the given global map region.
 
+  ``dfhack.maps.getBiomeType(region_coord2d)`` or ``getBiomeType(x,y)``
+
+  Returns the biome_type for the given global map region.
+
 * ``dfhack.maps.enableBlockUpdates(block[,flow,temperature])``
 
   Enables updates for liquid flow or temperature, unless already active.
@@ -1798,7 +1802,7 @@ Maps module
 
 * ``dfhack.maps.getTileBiomeRgn(coords)``, or ``getTileBiomeRgn(x,y,z)``
 
-  Returns *x, y* for use with ``getRegionBiome``.
+  Returns *x, y* for use with ``getRegionBiome`` and ``getBiomeType``.
 
 * ``dfhack.maps.getPlantAtTile(pos)``, or ``getPlantAtTile(x,y,z)``
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2131,6 +2131,13 @@ static int maps_getPlantAtTile(lua_State *L)
     return 1;
 }
 
+static int maps_getBiomeType(lua_State *L)
+{
+    auto pos = CheckCoordXY(L, 1, true);
+    lua_pushinteger(L, Maps::getBiomeType(pos.x, pos.y));
+    return 1;
+}
+
 static const luaL_Reg dfhack_maps_funcs[] = {
     { "isValidTilePos", maps_isValidTilePos },
     { "isTileVisible", maps_isTileVisible },
@@ -2141,6 +2148,7 @@ static const luaL_Reg dfhack_maps_funcs[] = {
     { "getRegionBiome", maps_getRegionBiome },
     { "getTileBiomeRgn", maps_getTileBiomeRgn },
     { "getPlantAtTile", maps_getPlantAtTile },
+    { "getBiomeType", maps_getBiomeType },
     { NULL, NULL }
 };
 

--- a/library/include/modules/Maps.h
+++ b/library/include/modules/Maps.h
@@ -349,8 +349,8 @@ extern DFHACK_EXPORT df::plant *getPlantAtTile(int32_t x, int32_t y, int32_t z);
 
 inline df::plant *getPlantAtTile(df::coord pos) { return getPlantAtTile(pos.x, pos.y, pos.z); }
 
-DFHACK_EXPORT df::enums::biome_type::biome_type GetBiomeType(int world_coord_x, int world_coord_y);
-DFHACK_EXPORT df::enums::biome_type::biome_type GetBiomeTypeWithRef(int world_coord_x, int world_coord_y, int world_ref_y_coord);
+DFHACK_EXPORT df::enums::biome_type::biome_type getBiomeType(int world_coord_x, int world_coord_y);
+DFHACK_EXPORT df::enums::biome_type::biome_type getBiomeTypeWithRef(int world_coord_x, int world_coord_y, int world_ref_y_coord);
 
 }
 

--- a/library/modules/Maps.cpp
+++ b/library/modules/Maps.cpp
@@ -987,7 +987,7 @@ Return the biome type, given a position coordinate expressed in world_tiles
 The world ref coordinates are used for tropicality determination and may refer
 to a tile neighboring the "official" one.
 *****************************************************************************/
-df::enums::biome_type::biome_type Maps::GetBiomeTypeWithRef(int world_coord_x,
+df::enums::biome_type::biome_type Maps::getBiomeTypeWithRef(int world_coord_x,
     int world_coord_y,
     int world_ref_coord_y
 )
@@ -1186,7 +1186,7 @@ df::enums::biome_type::biome_type Maps::GetBiomeTypeWithRef(int world_coord_x,
 Module main function.
 Return the biome type, given a position coordinate expressed in world_tiles
 *****************************************************************************/
-df::enums::biome_type::biome_type Maps::GetBiomeType(int world_coord_x, int world_coord_y)
+df::enums::biome_type::biome_type Maps::getBiomeType(int world_coord_x, int world_coord_y)
 {
-    return Maps::GetBiomeTypeWithRef(world_coord_x, world_coord_y, world_coord_y);
+    return Maps::getBiomeTypeWithRef(world_coord_x, world_coord_y, world_coord_y);
 }

--- a/plugins/autofarm.cpp
+++ b/plugins/autofarm.cpp
@@ -315,7 +315,7 @@ public:
                     biome = biome_type::SUBTERRANEAN_WATER;
                 else {
                     df::coord2d region(Maps::getTileBiomeRgn(df::coord(bb->centerx, bb->centery, bb->z)));
-                    biome = Maps::GetBiomeType(region.x, region.y);
+                    biome = Maps::getBiomeType(region.x, region.y);
                 }
                 farms[biome].push_back(farm);
             }

--- a/plugins/embark-assistant/survey.cpp
+++ b/plugins/embark-assistant/survey.cpp
@@ -790,7 +790,7 @@ void embark_assist::survey::high_level_world_survey(embark_assist::defs::geo_dat
                     offset_count++;
 
                     results.biome_index[l] = world_data->region_map[adjusted.x][adjusted.y].region_id;
-                    results.biome[l] = DFHack::Maps::GetBiomeTypeWithRef(adjusted.x, adjusted.y, k);
+                    results.biome[l] = DFHack::Maps::getBiomeTypeWithRef(adjusted.x, adjusted.y, k);
                     temperature = world_data->region_map[adjusted.x][adjusted.y].temperature;
                     negative = temperature < 0;
 


### PR DESCRIPTION
This exposes getBiomeType to lua as its useful for farms and fixes the naming scheme. While I'm here, I fixed getBiomeTypeWithRef for consistency