### PR TITLE
remove unused always_enabled attribute for overlays

### DIFF
--- a/docs/dev/overlay-dev-guide.rst
+++ b/docs/dev/overlay-dev-guide.rst
@@ -125,10 +125,6 @@ The ``overlay.OverlayWidget`` superclass defines the following class attributes:
     not annoy the player. Set to 0 to be called at the maximum rate. Be aware
     that running more often than you really need to will impact game FPS,
     especially if your widget can run while the game is unpaused.
-- ``always_enabled`` (default: ``false``)
-    Set this to ``true`` if you don't want to let the user disable the widget.
-    This is useful for widgets that are controlled purely through their
-    triggers. See `gui/pathable` for an example.
 
 Registering a widget with the overlay framework
 ***********************************************

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -184,7 +184,6 @@ end
 
 local function do_disable(args, quiet)
     local disable_fn = function(name, db_entry)
-        if db_entry.widget.always_enabled then return end
         overlay_config[name].enabled = false
         if db_entry.widget.hotspot then
             active_hotspot_widgets[name] = nil
@@ -252,7 +251,7 @@ local function load_widget(name, widget_class)
     local config = overlay_config[name]
     config.pos = sanitize_pos(config.pos or widget.default_pos)
     widget.frame = make_frame(config.pos, widget.frame)
-    if config.enabled or widget.always_enabled then
+    if config.enabled then
         do_enable(name, true, true)
     else
         config.enabled = false
@@ -492,7 +491,6 @@ OverlayWidget.ATTRS{
     hotspot=false, -- whether to call overlay_onupdate on all screens
     viewscreens={}, -- override with associated viewscreen or list of viewscrens
     overlay_onupdate_max_freq_seconds=5, -- throttle calls to overlay_onupdate
-    always_enabled=false, -- for overlays that should never be disabled
 }
 
 function OverlayWidget:init()


### PR DESCRIPTION
it was made for gui/pathable, but that became a ZScreen this option made me uncomfortable for overlays. it didn't seem like the right user experience