### PR TITLE
add keybinding for gui/quickcmd

### DIFF
--- a/data/init/dfhack.keybindings.init
+++ b/data/init/dfhack.keybindings.init
@@ -19,6 +19,9 @@ keybinding add Ctrl-Shift-C hotkeys
 # on-screen keyboard
 keybinding add Ctrl-Shift-K gui/cp437-table
 
+# customizable quick command list
+keybinding add Ctrl-Shift-A gui/quickcmd
+
 # an in-game init file editor
 #keybinding add Alt-S@title|dwarfmode/Default|dungeonmode gui/settings-manager
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `hotkeys`: clicking on the DFHack logo no longer closes the popup menu
 - `gui/launcher`: sped up initialization time for faster load of the UI
 - `orders`: orders plugin functionality is now offered via an overlay widget when the manager orders screen is open
+- `gui/quickcmd`: now has it's own global keybinding for your convenience: Ctrl-Shift-A
 
 ## Documentation
 


### PR DESCRIPTION
global keybinding for gui/quickcmd: Ctrl-Shift-A

according to https://defkey.com/what-means/ctrl-shift-a it's not likely to conflict with any system hotkeys

Fixes #2697