### PR TITLE
tailor: increased check frequency

### DIFF
--- a/plugins/tailor.cpp
+++ b/plugins/tailor.cpp
@@ -582,7 +582,7 @@ public:
 
 static std::unique_ptr<Tailor> tailor_instance;
 
-#define DELTA_TICKS 600
+#define DELTA_TICKS 50
 
 DFhackCExport command_result plugin_onupdate(color_ostream& out)
 {


### PR DESCRIPTION
i think the previous window of 600 ticks was allowing it to miss bookkeeper runs, causing tailor to run less often than intended

reducing to 50 to reduce the chances of this happening