### PR TITLE
Add Github Actions build of win64 artifacts, and update compile instructions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,14 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Fetch ccache
+        uses: actions/cache@v3
+        with:
+          path: build/win64-cross/ccache
+          key: ccache-win64-cross-msvc-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-win64-cross-msvc-${{ github.ref_name }}
+            ccache-win64-cross-msvc
       - name: Cross-compile win64 artifacts
         run: |
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Format artifact name
         id: artifactname
         run: |
-          echo name=$(date +%Y%m%d)-$(git rev-parse --short $GITHUB_REF) >> $GITHUB_OUTPUT
+          echo name=$(date +%Y%m%d)-$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
       - name: Upload win64 artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,29 @@ jobs:
       run: |
         rm -rf "$DF_FOLDER"
 
+  build-cross-win64:
+    name: Build MSVC win64
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone DFHack
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Cross-compile win64 artifacts
+        run: |
+          cd build
+          bash -x build-win64-from-linux.sh
+      - name: Format artifact name
+        id: artifactname
+        run: |
+          echo name=$(date +%Y%m%d)-$(git rev-parse --short $GITHUB_REF) >> $GITHUB_OUTPUT
+      - name: Upload win64 artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dfhack-win64-build-${{ steps.artifactname.outputs.name }}
+          path: build/win64-cross/output/*
+
   docs:
     runs-on: ubuntu-18.04
     steps:

--- a/build/build-win64-from-linux.sh
+++ b/build/build-win64-from-linux.sh
@@ -13,6 +13,7 @@ builder_uid=$(id -u)
 
 mkdir -p win64-cross
 mkdir -p win64-cross/output
+mkdir -p win64-cross/ccache
 
 # Check for sudo; we want to use the real user
 if [[ $(id -u) -eq 0 ]]; then
@@ -39,6 +40,7 @@ fi
 # the Dockerfile
 if ! docker run --rm -i -v "$srcdir":/src -v "$srcdir/build/win64-cross/":/src/build  \
     -e BUILDER_UID=$builder_uid \
+    -e CCACHE_DIR=/src/build/ccache \
     --name dfhack-win \
     ghcr.io/dfhack/build-env:msvc \
     bash -c "cd /src/build && dfhack-configure windows 64 Release -DCMAKE_INSTALL_PREFIX=/src/build/output cmake .. -DBUILD_DOCS=1 && dfhack-make -j$jobs install" \

--- a/build/build-win64-from-linux.sh
+++ b/build/build-win64-from-linux.sh
@@ -37,10 +37,11 @@ fi
 #
 # NOTE: win64-cross is mounted in /src/build due to the hardcoded `cmake ..` in
 # the Dockerfile
-if ! docker run --rm -it -v "$srcdir":/src -v "$srcdir/build/win64-cross/":/src/build  \
+if ! docker run --rm -i -v "$srcdir":/src -v "$srcdir/build/win64-cross/":/src/build  \
     -e BUILDER_UID=$builder_uid \
     --name dfhack-win \
-    dfhack-build-msvc bash -c "cd /src/build && dfhack-configure windows 64 Release -DCMAKE_INSTALL_PREFIX=/src/build/output cmake .. -DBUILD_DOCS=1 && dfhack-make -j$jobs install" \
+    ghcr.io/dfhack/build-env:msvc \
+    bash -c "cd /src/build && dfhack-configure windows 64 Release -DCMAKE_INSTALL_PREFIX=/src/build/output cmake .. -DBUILD_DOCS=1 && dfhack-make -j$jobs install" \
     ; then
     echo
     echo "Build failed"

--- a/docs/dev/compile/Compile.rst
+++ b/docs/dev/compile/Compile.rst
@@ -296,18 +296,13 @@ on a Linux host system.
   :local:
   :depth: 1
 
-Step 1: prepare a docker image
-------------------------------
+Step 1: prepare a build container
+---------------------------------
 
 On your Linux host, install and run the docker daemon and then run these commands::
 
     xhost +local:root
-    git clone https://github.com/BenLubar/build-env.git
-    cd build-env/msvc
-    docker build .
-    docker image ls
-    IMAGE_ID=<your image id>
-    docker run -it --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --volume=/tmp/.X11-unix:/tmp/.X11-unix --user buildmaster --name dfhack-win $IMAGE_ID
+    docker run -it --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --volume=/tmp/.X11-unix:/tmp/.X11-unix --user buildmaster --name dfhack-win ghcr.io/dfhack/build-env:msvc
 
 The ``xhost`` command and ``--env`` parameters are there so you can eventually
 run Dwarf Fortress from the container and have it display on your host.
@@ -380,19 +375,7 @@ existing Steam installation on Linux.
   :local:
   :depth: 1
 
-Step 1: Build the MSVC builder image
-------------------------------------
-
-It'll be called ``dfhack-build-msvc:latest`` after it's done building::
-
-   git clone https://github.com/BenLubar/build-env.git
-   cd build-env/msvc
-   docker build -t dfhack-build-msvc .
-
-The docker build takes a while, but only needs to be done once, unless the build
-environment changes.
-
-Step 2: Get dfhack, and run the build script
+Step 1: Get dfhack, and run the build script
 --------------------------------------------
 
 Check out ``dfhack`` into another directory, and run the build script::
@@ -412,7 +395,7 @@ rather than directly::
 
   sudo ./build-win64-from-linux.sh
 
-Step 3: install dfhack to your Steam DF install
+Step 2: install dfhack to your Steam DF install
 -----------------------------------------------
 As the script will tell you, you can then copy the files into your DF folder::
 


### PR DESCRIPTION
Thanks to @BenLubar for setting up the official build images on ghcr.io, we can now have automated win64 builds without requiring a win64 builder.

This updates the build to now generate Windows artifacts (for Steam users) for every single PR and commit. See here (scroll down):

https://github.com/kelvie/dfhack/actions/runs/4002114641

One side effect this will have is that the build now takes 20 minutes, as the new bottleneck is this new cross-win64 build, and this may be an issue with e.g. PRs that should be quick.

I haven't tried getting `cccache` working, though I don't think this will help the worst case PRs anyway.