### PR TITLE
Allow overlay widgets to set their default enabled state

### DIFF
--- a/data/dfhack-config/overlay.json
+++ b/data/dfhack-config/overlay.json
@@ -1,8 +1,0 @@
-{
-	"hotkeys.menu": {
-		"enabled": true
-	},
-	"unsuspend.overlay": {
-		"enabled": true
-	}
-}

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -45,6 +45,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `orders`: orders plugin functionality is now offered via an overlay widget when the manager orders screen is open
 - `gui/quickcmd`: now has it's own global keybinding for your convenience: Ctrl-Shift-A
 - Many DFHack windows can now be unfocused by clicking somewhere not over the tool window. This has the same effect as pinning previously did, but without the extra clicking.
+- `overlay`: overlay widgets can now specify a default enabled state if they are not already set in the player's overlay config file
 
 ## Documentation
 

--- a/docs/dev/overlay-dev-guide.rst
+++ b/docs/dev/overlay-dev-guide.rst
@@ -96,6 +96,9 @@ The ``overlay.OverlayWidget`` superclass defines the following class attributes:
     mean for the position. Players can change the widget position at any time
     via the `overlay position <overlay>` command, so don't assume that your
     widget will always be at the default position.
+- ``default_enabled`` (default: ``false``)
+    Override this attribute if the overlay should be enabled by default if it
+    does not already have a state stored in ``dfhack-config/overlay.json``.
 - ``viewscreens`` (default: ``{}``)
     The list of viewscreens that this widget should be associated with. When
     one of these viewscreens is on top of the viewscreen stack, your widget's

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -12,6 +12,7 @@ local widgets = require('gui.widgets')
 HotspotMenuWidget = defclass(HotspotMenuWidget, overlay.OverlayWidget)
 HotspotMenuWidget.ATTRS{
     default_pos={x=2,y=2},
+    default_enabled=true,
     hotspot=true,
     viewscreens='all',
     overlay_onupdate_max_freq_seconds=0,

--- a/plugins/lua/orders.lua
+++ b/plugins/lua/orders.lua
@@ -48,6 +48,7 @@ end
 OrdersOverlay = defclass(OrdersOverlay, overlay.OverlayWidget)
 OrdersOverlay.ATTRS{
     default_pos={x=53,y=-6},
+    default_enabled=true,
     viewscreens='dwarfmode',
     frame={w=30, h=4},
     frame_style=gui.MEDIUM_FRAME,

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -249,6 +249,9 @@ local function load_widget(name, widget_class)
     }
     if not overlay_config[name] then overlay_config[name] = {} end
     local config = overlay_config[name]
+    if config.enabled == nil then
+        config.enabled = widget.default_enabled
+    end
     config.pos = sanitize_pos(config.pos or widget.default_pos)
     widget.frame = make_frame(config.pos, widget.frame)
     if config.enabled then
@@ -487,6 +490,7 @@ OverlayWidget = defclass(OverlayWidget, widgets.Panel)
 OverlayWidget.ATTRS{
     name=DEFAULT_NIL, -- this is set by the framework to the widget name
     default_pos={x=DEFAULT_X_POS, y=DEFAULT_Y_POS}, -- 1-based widget screen pos
+    default_enabled=false, -- initial enabled state if not in config
     overlay_only=false, -- true if there is no widget to reposition
     hotspot=false, -- whether to call overlay_onupdate on all screens
     viewscreens={}, -- override with associated viewscreen or list of viewscrens


### PR DESCRIPTION
and make relevant library widgets enabled by default
and remove the default overlay.json config file