### PR TITLE
No platinum weapons

### DIFF
--- a/data/orders/military_include_artifact_materials.json
+++ b/data/orders/military_include_artifact_materials.json
@@ -1070,11 +1070,116 @@
 		"amount_left" : 1,
 		"amount_total" : 1,
 		"frequency" : "Daily",
+		"id" : 31,
+		"is_active" : false,
+		"is_validated" : false,
+		"item_conditions" : 
+		[
+			{
+				"condition" : "AtLeast",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
+			{
+				"condition" : "AtLeast",
+				"item_type" : "BAR",
+				"material" : "COAL",
+				"value" : 100
+			},
+			{
+				"condition" : "AtMost",
+				"item_subtype" : "ITEM_WEAPON_MACE",
+				"item_type" : "WEAPON",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 10
+			}
+		],
+		"item_subtype" : "ITEM_WEAPON_MACE",
+		"job" : "MakeWeapon",
+		"material" : "INORGANIC:PLATINUM"
+	},
+	{
+		"amount_left" : 1,
+		"amount_total" : 1,
+		"frequency" : "Daily",
+		"id" : 32,
+		"is_active" : false,
+		"is_validated" : false,
+		"item_conditions" : 
+		[
+			{
+				"condition" : "AtLeast",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
+			{
+				"condition" : "AtLeast",
+				"item_type" : "BAR",
+				"material" : "COAL",
+				"value" : 100
+			},
+			{
+				"condition" : "AtMost",
+				"item_subtype" : "ITEM_WEAPON_HAMMER_WAR",
+				"item_type" : "WEAPON",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 10
+			}
+		],
+		"item_subtype" : "ITEM_WEAPON_HAMMER_WAR",
+		"job" : "MakeWeapon",
+		"material" : "INORGANIC:PLATINUM"
+	},
+	{
+		"amount_left" : 1,
+		"amount_total" : 1,
+		"frequency" : "Daily",
+		"id" : 64,
+		"is_active" : false,
+		"is_validated" : false,
+		"item_conditions" : 
+		[
+			{
+				"condition" : "AtLeast",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 20
+			},
+			{
+				"condition" : "AtLeast",
+				"item_type" : "BAR",
+				"material" : "COAL",
+				"value" : 100
+			},
+			{
+				"condition" : "AtMost",
+				"item_subtype" : "ITEM_WEAPON_CROSSBOW",
+				"item_type" : "WEAPON",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 10
+			}
+		],
+		"item_subtype" : "ITEM_WEAPON_CROSSBOW",
+		"job" : "MakeWeapon",
+		"material" : "INORGANIC:PLATINUM"
+	},
+	{
+		"amount_left" : 1,
+		"amount_total" : 1,
+		"frequency" : "Daily",
 		"id" : 35,
 		"is_active" : false,
 		"is_validated" : false,
 		"item_conditions" : 
 		[
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
 			{
 				"condition" : "AtLeast",
 				"item_type" : "BAR",
@@ -1111,6 +1216,12 @@
 		"is_validated" : false,
 		"item_conditions" : 
 		[
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
 			{
 				"condition" : "AtLeast",
 				"item_type" : "BAR",
@@ -1158,6 +1269,12 @@
 				"item_type" : "BAR",
 				"material" : "COAL",
 				"value" : 100
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
 			},
 			{
 				"condition" : "AtMost",
@@ -1447,6 +1564,12 @@
 				"value" : 5
 			},
 			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
+			{
 				"condition" : "AtMost",
 				"item_subtype" : "ITEM_WEAPON_MACE",
 				"item_type" : "WEAPON",
@@ -1483,6 +1606,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -1656,6 +1785,12 @@
 				"item_type" : "WEAPON",
 				"material" : "INORGANIC:STEEL",
 				"value" : 10
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
 			},
 			{
 				"condition" : "LessThan",
@@ -2064,6 +2199,12 @@
 				"value" : 5
 			},
 			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
+			{
 				"condition" : "AtMost",
 				"flags" : 
 				[
@@ -2115,6 +2256,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -2361,6 +2508,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -2784,6 +2937,12 @@
 				"material" : "INORGANIC:SILVER",
 				"value" : 5
 			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			}
 		],
 		"item_subtype" : "ITEM_WEAPON_MACE",
 		"job" : "MakeWeapon",
@@ -2826,6 +2985,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -3072,6 +3237,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -3527,6 +3698,12 @@
 				"value" : 5
 			},
 			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
+			{
 				"condition" : "AtMost",
 				"flags" : 
 				[
@@ -3584,6 +3761,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -3860,6 +4043,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -4369,6 +4558,12 @@
 				"value" : 5
 			},
 			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
+				"value" : 5
+			},
+			{
 				"condition" : "AtMost",
 				"flags" : 
 				[
@@ -4432,6 +4627,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{
@@ -4738,6 +4939,12 @@
 				"condition" : "LessThan",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:SILVER",
+				"value" : 5
+			},
+			{
+				"condition" : "LessThan",
+				"item_type" : "BAR",
+				"material" : "INORGANIC:PLATINUM",
 				"value" : 5
 			},
 			{

--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -106,7 +106,7 @@ produces weapons and armor:
 - smelting for platinum, silver, steel, bronze, bismuth bronze, and copper (and
   their dependencies)
 - bronze/bismuth bronze/copper bolts
-- platinum/silver/steel/iron/bismuth bronze/bronze/copper weapons and armor,
+- silver/steel/iron/bismuth bronze/bronze/copper weapons and armor,
   with checks to ensure only the best available materials are being used
 
 If you set a stockpile to take weapons and armor of less than masterwork quality
@@ -116,6 +116,16 @@ Make sure you have a lot of fuel (or magma forges and furnaces) before you turn
 ``automelt`` on, though!
 
 This file should only be imported, of course, if you need to equip a military.
+
+:source:`library/military <data/orders/military_include_artifact_materials.json>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As above, but this collection will also allow creation of platinum blunt weapons.
+Normally these are only created by artifact moods, work orders can't be created 
+manually for them.
+
+- platinum/silver/steel/iron/bismuth bronze/bronze/copper weapons and armor,
+  with checks to ensure only the best available materials are being used
 
 :source:`library/smelting <data/orders/smelting.json>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -121,7 +121,7 @@ This file should only be imported, of course, if you need to equip a military.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As above, but this collection will also allow creation of platinum blunt weapons.
-Normally these are only created by artifact moods, work orders can't be created 
+Normally these are only created by artifact moods, work orders can't be created
 manually for them.
 
 - platinum/silver/steel/iron/bismuth bronze/bronze/copper weapons and armor,

--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -118,7 +118,7 @@ Make sure you have a lot of fuel (or magma forges and furnaces) before you turn
 This file should only be imported, of course, if you need to equip a military.
 
 :source:`library/military <data/orders/military_include_artifact_materials.json>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As above, but this collection will also allow creation of platinum blunt weapons.
 Normally these are only created by artifact moods, work orders can't be created


### PR DESCRIPTION
Fixes #2718

Remove the creation of platinum weapons from military.json since they are normally only produced by strange moods and can't be crafted normally.  Retain the original code as data/orders/military_include_artifact_materials.json