### PR TITLE
Include proper name for library/military_include_artifact_materials

### DIFF
--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -117,7 +117,7 @@ Make sure you have a lot of fuel (or magma forges and furnaces) before you turn
 
 This file should only be imported, of course, if you need to equip a military.
 
-:source:`library/military <data/orders/military_include_artifact_materials.json>`
+:source:`library/military_include_artifact_materials <data/orders/military_include_artifact_materials.json>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As above, but this collection will also allow creation of platinum blunt weapons.

--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -118,7 +118,7 @@ Make sure you have a lot of fuel (or magma forges and furnaces) before you turn
 This file should only be imported, of course, if you need to equip a military.
 
 :source:`library/military_include_artifact_materials <data/orders/military_include_artifact_materials.json>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As above, but this collection will also allow creation of platinum blunt weapons.
 Normally these are only created by artifact moods, work orders can't be created


### PR DESCRIPTION
Fix documentation to show proper filename for library/military_include_artifact_materials