### PR TITLE
getplants fixes

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,7 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 -@ Fix issues with clicks "passing through" some DFHack window elements, like scrollbars
-- `plugin/getplants`: tree are now designated correctly
+- `getplants`: tree are now designated correctly
 
 ## Misc Improvements
 - A new cross-compile build script was added for building the Windows files from a Linux Docker builder (see the Compile instructions in the docs)
@@ -47,7 +47,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `gui/quickcmd`: now has it's own global keybinding for your convenience: Ctrl-Shift-A
 - Many DFHack windows can now be unfocused by clicking somewhere not over the tool window. This has the same effect as pinning previously did, but without the extra clicking.
 - `overlay`: overlay widgets can now specify a default enabled state if they are not already set in the player's overlay config file
-- `plugin/getplants`: ID values will now be accepted regardless of case
+- `getplants`: ID values will now be accepted regardless of case
 -@ New borders for DFHack tool windows -- tell us what you think!
 
 ## Documentation

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - Fix issues with clicks "passing through" some DFHack window elements, like scrollbars
+- `plugin/getplants`: tree are now designated correctly
 
 ## Misc Improvements
 - A new cross-compile build script was added for building the Windows files from a Linux Docker builder (see the Compile instructions in the docs)
@@ -46,6 +47,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `gui/quickcmd`: now has it's own global keybinding for your convenience: Ctrl-Shift-A
 - Many DFHack windows can now be unfocused by clicking somewhere not over the tool window. This has the same effect as pinning previously did, but without the extra clicking.
 - `overlay`: overlay widgets can now specify a default enabled state if they are not already set in the player's overlay config file
+- `plugin/getplants`: ID values will now be accepted regardless of case
 
 ## Documentation
 

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -322,9 +322,9 @@ bool designate(const df::plant *plant, bool farming) {
                     }
                 }
 
-                if ((!farming || seedSource) &&
-                    ripe(plant->pos.x, plant->pos.y, plant_raw->growths[i]->timing_1, plant_raw->growths[i]->timing_2) &&
-                    !picked(plant, i))
+                bool istree = (tileMaterial(Maps::getTileBlock(plant->pos)->tiletype[plant->pos.x % 16][plant->pos.y % 16]) == tiletype_material::TREE);
+                bool isripe = ripe(plant->pos.x, plant->pos.y, plant_raw->growths[i]->timing_1, plant_raw->growths[i]->timing_2);
+                if ((!farming || seedSource) && (istree || isripe) && !picked(plant, i))
                 {
                     return Designations::markPlant(plant);
                 }
@@ -429,7 +429,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
 //            plantSelections[i] = selectablePlant(out, plant, farming);
             plantSelections[i] = selectablePlant(plant, farming);
         }
-         else if (plantNames.find(plant->id) != plantNames.end())
+        else if (plantNames.find(plant->id) != plantNames.end())
         {
             plantNames.erase(plant->id);
 //            plantSelections[i] = selectablePlant(out, plant, farming);

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -7,6 +7,7 @@
 #include "PluginManager.h"
 #include "DataDefs.h"
 #include "TileTypes.h"
+#include "MiscUtils.h"
 
 #include "df/map_block.h"
 #include "df/map_block_column.h"
@@ -395,7 +396,7 @@ command_result df_getplants (color_ostream &out, vector <string> & parameters)
             }
         }
         else
-            plantNames.insert(parameters[i]);
+            plantNames.insert(toUpper(parameters[i]));
     }
     if (treesonly && shrubsonly)
     {


### PR DESCRIPTION
Hey, just some small first-timer fixing issues I found for the *getplants plugin*.

Fixes #1805 
ID parameters are now added to `plantNames` with a `toUppercase` call, so case doesn't matter for input.

Fixes #2043 
The `designate` call was returning *false* for all trees because the `ripe` check was failing.
My guess is that the trees either have a different lifetime or aren't ripe but it doesn't matter because they can still be chopped. I'm wasn't sure what the best way to fix this one was, so I added an `istree` check for the tile and now the check passes if `istree || isripe`.

I did some brief testing and it seems good.