### PR TITLE
Fix dig plugin and enable building it

### DIFF
--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -9,7 +9,6 @@
 #include "Console.h"
 #include "Export.h"
 #include "PluginManager.h"
-#include "uicommon.h"
 
 #include "modules/Gui.h"
 #include "modules/MapCache.h"
@@ -213,7 +212,7 @@ bool lineY (MapExtras::MapCache & MCache,
 
 int32_t parse_priority(color_ostream &out, vector<string> &parameters)
 {
-    int32_t default_priority = game->designation.priority;
+    int32_t default_priority = game->main_interface.designation.priority;
 
     for (auto it = parameters.begin(); it != parameters.end(); ++it)
     {


### PR DESCRIPTION
Found that the only compiler errors were cause by an (apparently unused) header include and a single other line that apparently just needed to be updated because some structures change.

I tested all the types of dig* commands and it seems to work fine. I also confirmed that the line of code changed is correctly setting the default priority to 4000.

I'd like to try creating a GUI for dig to allow mouse based circle/ellipses/etc... drawing and also adding a WxH label and maybe even X/Y guidelines to the designation to make creating symmetrical designations easier, but this is a good first step.