### PR TITLE
Solve the inception problem: prevent screens (e.g. gui/launcher) from hanging when they attempt to dismiss and show themselves simultaneously

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - Fix issues with clicks "passing through" some DFHack window elements, like scrollbars
+-@ ``Screen``: allow `gui/launcher` and `gui/quickcmd` to launch themselves without hanging the game
 
 ## Misc Improvements
 - A new cross-compile build script was added for building the Windows files from a Linux Docker builder (see the Compile instructions in the docs)

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -318,9 +318,10 @@ namespace DFHack
 
             static const int RESTORE_AT_TOP = 0x1;
         private:
-            void extract(df::viewscreen*);
-            void merge(df::viewscreen*);
+            void extract();
+            void merge();
             df::viewscreen* screen;
+            df::viewscreen* prev_parent;
             int flags;
         };
     }


### PR DESCRIPTION
Fixes #2740

Guard against multi-insertion in Screen::Hide