### PR TITLE
don't autorefresh the enableable tools list

### DIFF
--- a/library/lua/script-manager.lua
+++ b/library/lua/script-manager.lua
@@ -24,7 +24,7 @@ function foreach_module_script(cb)
     end
 end
 
-local enabled_map = {}
+local enabled_map = nil
 
 local function process_script(env_name, env)
     local global_name = 'isEnabled'
@@ -44,10 +44,14 @@ function reload()
     foreach_module_script(process_script)
 end
 
+local function ensure_loaded()
+    if not enabled_map then
+        reload()
+    end
+end
+
 function list()
-    -- call reload every time we list to make sure we get scripts that have
-    -- just been added
-    reload()
+    ensure_loaded()
     for name,fn in pairs(enabled_map) do
         print(('%21s  %-3s'):format(name..':', fn() and 'on' or 'off'))
     end


### PR DESCRIPTION
it just takes too long (>1s) to refresh every time. manual refresh with script_manager.reload() is still available for devs who need it

This change massively speeds up initial load and page changes in the (in-progress) `gui/control-panel`

Once we support workshop mod scripts, I expect we'll want to call `reload()` after we modify the script paths.