### PR TITLE
Always build stonesense

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           -DBUILD_DEV_PLUGINS:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SIZECHECK:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SKELETON:BOOL=${{ matrix.plugins == 'all' }} \
-          -DBUILD_STONESENSE:BOOL=1 \
+          -DBUILD_STONESENSE:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SUPPORTED:BOOL=1 \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -145,7 +145,7 @@ jobs:
       - name: Cross-compile win64 artifacts
         run: |
           cd build
-          bash -x build-win64-from-linux.sh
+          env EXTRA_CMAKE_ARGS="-DBUILD_STONESENSE:BOOL=1" bash -x build-win64-from-linux.sh
       - name: Format artifact name
         id: artifactname
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           -DBUILD_DEV_PLUGINS:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SIZECHECK:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SKELETON:BOOL=${{ matrix.plugins == 'all' }} \
-          -DBUILD_STONESENSE:BOOL=${{ matrix.plugins == 'all' }} \
+          -DBUILD_STONESENSE:BOOL=1 \
           -DBUILD_SUPPORTED:BOOL=1 \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/build/build-win64-from-linux.sh
+++ b/build/build-win64-from-linux.sh
@@ -43,7 +43,7 @@ if ! docker run --rm -i -v "$srcdir":/src -v "$srcdir/build/win64-cross/":/src/b
     -e CCACHE_DIR=/src/build/ccache \
     --name dfhack-win \
     ghcr.io/dfhack/build-env:msvc \
-    bash -c "cd /src/build && dfhack-configure windows 64 Release -DCMAKE_INSTALL_PREFIX=/src/build/output cmake .. -DBUILD_DOCS=1 && dfhack-make -j$jobs install" \
+    bash -c "cd /src/build && dfhack-configure windows 64 Release -DCMAKE_INSTALL_PREFIX=/src/build/output cmake .. -DBUILD_DOCS=1 ${EXTRA_CMAKE_ARGS} && dfhack-make -j$jobs install" \
     ; then
     echo
     echo "Build failed"


### PR DESCRIPTION
Stonesense was not being built by github actions for steam v50 builds. Thus not matching release.