### PR TITLE
allow tile in Label tokens to be either pen or id

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -68,6 +68,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `helpdb`: changed from auto-refreshing every 60 seconds to only refreshing on explicit call to ``helpdb.refresh()``. docs very rarely change during a play session, and the automatic database refreshes were slowing down the startup of `gui/launcher`
 - ``widgets.Label``: ``label.scroll()`` now understands ``home`` and ``end`` keywords for scrolling to the top or bottom
 - ``dfhack.units.getCitizens()``: gets a list of citizens
+- ``Label``: token ``tile`` properties can now be either pens or numeric texture ids
 
 ## Removed
 - `autohauler`: no plans to port to v50, as it just doesn't make sense with the new work detail system

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4658,7 +4658,8 @@ containing newlines, or a table with the following possible fields:
 
 * ``token.tile = pen``
 
-  Specifies a pen to paint as one tile before the main part of the token.
+  Specifies a pen or texture index to paint as one tile before the main part of
+  the token.
 
 * ``token.width = ...``
 

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1110,7 +1110,9 @@ function render_text(obj,dc,x0,y0,pen,dpen,disabled)
             if token.tile then
                 x = x + 1
                 if dc then
-                    dc:tile(nil, token.tile)
+                    local tile_pen = tonumber(token.tile) and
+                            to_pen{tile=token.tile} or token.tile
+                    dc:char(nil, token.tile)
                     if token.width then
                         dc:advance(token.width-1)
                     end

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1112,7 +1112,7 @@ function render_text(obj,dc,x0,y0,pen,dpen,disabled)
                 if dc then
                     local tile_pen = tonumber(token.tile) and
                             to_pen{tile=token.tile} or token.tile
-                    dc:char(nil, token.tile)
+                    dc:char(nil, tile_pen)
                     if token.width then
                         dc:advance(token.width-1)
                     end


### PR DESCRIPTION
I changed this a while back due to a misunderstanding. This PR undoes the change to fix the old (and correctly documented) behavior, but makes it ok to do what I mistakenly thought you could/should do (i.e. pass a texture id directly)