### PR TITLE
reset the saved frame counter on new world

### DIFF
--- a/plugins/autobutcher.cpp
+++ b/plugins/autobutcher.cpp
@@ -122,6 +122,7 @@ DFhackCExport command_result plugin_shutdown (color_ostream &out) {
 }
 
 DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid()) {

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -158,6 +158,7 @@ DFhackCExport command_result plugin_shutdown (color_ostream &out) {
 }
 
 DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid()) {

--- a/plugins/automelt.cpp
+++ b/plugins/automelt.cpp
@@ -167,6 +167,7 @@ DFhackCExport command_result plugin_shutdown(color_ostream &out)
 
 DFhackCExport command_result plugin_load_data(color_ostream &out)
 {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid())

--- a/plugins/autonestbox.cpp
+++ b/plugins/autonestbox.cpp
@@ -96,6 +96,7 @@ DFhackCExport command_result plugin_enable(color_ostream &out, bool enable) {
 }
 
 DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid()) {

--- a/plugins/autoslab.cpp
+++ b/plugins/autoslab.cpp
@@ -107,6 +107,7 @@ DFhackCExport command_result plugin_shutdown(color_ostream &out)
 
 DFhackCExport command_result plugin_load_data(color_ostream &out)
 {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid())

--- a/plugins/buildingplan.cpp
+++ b/plugins/buildingplan.cpp
@@ -162,6 +162,7 @@ DFhackCExport command_result plugin_shutdown (color_ostream &out) {
 }
 
 DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid()) {

--- a/plugins/examples/persistent_per_save_example.cpp
+++ b/plugins/examples/persistent_per_save_example.cpp
@@ -103,6 +103,7 @@ DFhackCExport command_result plugin_shutdown (color_ostream &out) {
 }
 
 DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid()) {

--- a/plugins/nestboxes.cpp
+++ b/plugins/nestboxes.cpp
@@ -85,6 +85,7 @@ DFhackCExport command_result plugin_shutdown (color_ostream &out) {
 }
 
 DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    cycle_timestamp = 0;
     config = World::GetPersistentData(CONFIG_KEY);
 
     if (!config.isValid()) {

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -165,6 +165,8 @@ DFhackCExport command_result plugin_shutdown (color_ostream &out) {
 }
 
 DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    cycle_timestamp = 0;
+
     world_plant_ids.clear();
     for (size_t i = 0; i < world->raws.plants.all.size(); ++i) {
         auto & plant = world->raws.plants.all[i];


### PR DESCRIPTION
this allows the plugins to function normally even after one world is exited and a different world with a lower frame counter is loaded