### PR TITLE
Cleanup: GHA: use declarative env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,9 +143,11 @@ jobs:
             ccache-win64-cross-msvc-${{ github.ref_name }}
             ccache-win64-cross-msvc
       - name: Cross-compile win64 artifacts
+        env:
+          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1'
         run: |
           cd build
-          env CMAKE_EXTRA_ARGS=-DBUILD_STONESENSE:BOOL=1 bash -x build-win64-from-linux.sh
+          bash -x build-win64-from-linux.sh
       - name: Format artifact name
         id: artifactname
         run: |


### PR DESCRIPTION
Rather than calling `env` as part of the commandline.

Checked the zip created on my fork for stonesense, and it's there.