### PR TITLE
increase min scrollbar height to 2 (from 1)

### DIFF
--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -808,7 +808,7 @@ local function scrollbar_get_max_pos_and_height(scrollbar)
     local frame_body = scrollbar.frame_body
     local scrollbar_body_height = (frame_body and frame_body.height or 3) - 2
 
-    local height = math.max(1, math.floor(
+    local height = math.max(2, math.floor(
         (math.min(scrollbar.elems_per_page, scrollbar.num_elems) * scrollbar_body_height) /
         scrollbar.num_elems))
 


### PR DESCRIPTION
rationale:
- vanilla scrollbars dont get shorter than 2.
- 2-tall 'bars are easier to click on than 1-tall 'bars.
- this avoids having to make short custom graphics for 1-tall tiles, which most of the time look terrible...

cons:
- short scrollbars are cool : (