### PR TITLE
allow focus string generation to fall through unfocused ZScreens

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -974,10 +974,11 @@ Screens
   the specified type (e.g. ``df.viewscreen_titlest``), or ``nil`` if none match.
   If ``depth`` is not specified or is less than 1, all viewscreens are checked.
 
-* ``dfhack.gui.getDFViewscreen([skip_dismissed])``
+* ``dfhack.gui.getDFViewscreen([skip_dismissed[, viewscreen]])``
 
   Returns the topmost viewscreen not owned by DFHack. If ``skip_dismissed`` is
-  ``true``, ignores screens already marked to be removed.
+  ``true``, ignores screens already marked to be removed. If ``viewscreen`` is
+  specified, starts the scan at the given viewscreen.
 
 General-purpose selections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/library/include/modules/Gui.h
+++ b/library/include/modules/Gui.h
@@ -189,7 +189,7 @@ namespace DFHack
         DFHACK_EXPORT df::viewscreen *getViewscreenByIdentity(virtual_identity &id, int n = 1);
 
         /// Get the top-most underlying DF viewscreen (not owned by DFHack)
-        DFHACK_EXPORT df::viewscreen *getDFViewscreen(bool skip_dismissed = false);
+        DFHACK_EXPORT df::viewscreen *getDFViewscreen(bool skip_dismissed = false, df::viewscreen *top = NULL);
 
         /// Get the top-most viewscreen of the given type from the top `n` viewscreens (or all viewscreens if n < 1)
         /// returns NULL if none match

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -351,6 +351,7 @@ namespace DFHack
 
         virtual bool is_lua_screen() { return false; }
 
+        virtual bool isFocused() { return true; }
         virtual std::string getFocusString() = 0;
         virtual void onShow() {};
         virtual void onDismiss() {};
@@ -365,6 +366,7 @@ namespace DFHack
 
     class DFHACK_EXPORT dfhack_lua_viewscreen : public dfhack_viewscreen {
         std::string focus;
+        bool defocused = false;
 
         void update_focus(lua_State *L, int idx);
 
@@ -384,6 +386,7 @@ namespace DFHack
         static df::viewscreen *get_pointer(lua_State *L, int idx, bool make);
 
         virtual bool is_lua_screen() { return true; }
+        virtual bool isFocused() { return !defocused; }
         virtual std::string getFocusString() { return focus; }
 
         virtual void render();

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -865,6 +865,9 @@ void dfhack_lua_viewscreen::update_focus(lua_State *L, int idx)
     lua_getfield(L, idx, "allow_options");
     allow_options = lua_toboolean(L, -1);
     lua_pop(L, 1);
+    lua_getfield(L, idx, "defocused");
+    defocused = lua_toboolean(L, -1);
+    lua_pop(L, 1);
 
     lua_getfield(L, idx, "focus_path");
     auto str = lua_tostring(L, -1);
@@ -1081,6 +1084,7 @@ using df::identity_traits;
 #define CUR_STRUCT dfhack_viewscreen
 static const struct_field_info dfhack_viewscreen_fields[] = {
     { METHOD(OBJ_METHOD, is_lua_screen), 0, 0 },
+    { METHOD(OBJ_METHOD, isFocused), 0, 0 },
     { METHOD(OBJ_METHOD, getFocusString), 0, 0 },
     { METHOD(OBJ_METHOD, onShow), 0, 0 },
     { METHOD(OBJ_METHOD, onDismiss), 0, 0 },


### PR DESCRIPTION
next steps for the focus string update

this allows the focus strings from the underlying DF viewscreen to come through, even when there is an unfocused DFHack tool window on the stack. Note that *focused* DFHack tool windows will be reflected in the focus string and will (correctly) *not* let the hotkey guard to function.