### PR TITLE
[cleanowned] don't print out how many items there are in the world

### DIFF
--- a/plugins/cleanowned.cpp
+++ b/plugins/cleanowned.cpp
@@ -74,8 +74,6 @@ command_result df_cleanowned (color_ostream &out, vector <string> & parameters)
         return CR_FAILURE;
     }
 
-    out.print("Found total %zd items.\n", world->items.all.size());
-
     for (std::size_t i=0; i < world->items.all.size(); i++)
     {
         df::item * item = world->items.all[i];


### PR DESCRIPTION
it prints out the size of items.all. but why? it appears to just be console spam