### PR TITLE
[autobutcher] tweak defaults, load initial races immediately

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `automelt`: is now more resistent to savegame corruption
+- `autobutcher`: changed defaults from 5 females / 1 male to 4 females / 2 males so a single unfortunate accident doesn't leave players without a mating pair
+- `autobutcher`: now immediately loads races available at game start into the watchlist
 
 ## Documentation
 

--- a/docs/plugins/autobutcher.rst
+++ b/docs/plugins/autobutcher.rst
@@ -18,8 +18,8 @@ watch list. Units will be ignored if they are:
 Creatures who will not reproduce (because they're not interested in the
 opposite sex or have been gelded) will be butchered before those who will.
 Older adults and younger children will be butchered first if the population
-is above the target (defaults are: 1 male kid, 5 female kids, 1 male adult,
-5 female adults). Note that you may need to set a target above 1 to have a
+is above the target (defaults are: 2 male kids, 4 female kids, 2 male adults,
+4 female adults). Note that you may need to set a target above 1 to have a
 reliable breeding population due to asexuality etc. See `fix-ster` if this is a
 problem.
 
@@ -34,7 +34,7 @@ Usage
 ``autobutcher autowatch``
     Automatically add all new races (animals you buy from merchants, tame
     yourself, or get from migrants) to the watch list using the default target
-    counts.
+    counts. This option is enabled by default.
 ``autobutcher noautowatch``
     Stop auto-adding new races to the watch list.
 ``autobutcher target <fk> <mk> <fa> <ma> all|new|<race> [<race> ...]``
@@ -108,4 +108,3 @@ fortress::
     autobutcher target 2 2 4 2 ALPACA SHEEP LLAMA
     autobutcher target 5 5 6 2 PIG
     autobutcher target 0 0 0 0 new
-    autobutcher autowatch

--- a/plugins/autobutcher.cpp
+++ b/plugins/autobutcher.cpp
@@ -107,6 +107,8 @@ DFhackCExport command_result plugin_enable(color_ostream &out, bool enable) {
         DEBUG(status,out).print("%s from the API; persisting\n",
                                 is_enabled ? "enabled" : "disabled");
         set_config_bool(CONFIG_IS_ENABLED, is_enabled);
+        if (enable)
+            autobutcher_cycle(out);
     } else {
         DEBUG(status,out).print("%s from the API, but already %s; no action\n",
                                 is_enabled ? "enabled" : "disabled",
@@ -130,11 +132,11 @@ DFhackCExport command_result plugin_load_data (color_ostream &out) {
         config = World::AddPersistentData(CONFIG_KEY);
         set_config_bool(CONFIG_IS_ENABLED, is_enabled);
         set_config_val(CONFIG_CYCLE_TICKS, 6000);
-        set_config_bool(CONFIG_AUTOWATCH, false);
-        set_config_val(CONFIG_DEFAULT_FK, 5);
-        set_config_val(CONFIG_DEFAULT_MK, 1);
-        set_config_val(CONFIG_DEFAULT_FA, 5);
-        set_config_val(CONFIG_DEFAULT_MA, 1);
+        set_config_bool(CONFIG_AUTOWATCH, true);
+        set_config_val(CONFIG_DEFAULT_FK, 4);
+        set_config_val(CONFIG_DEFAULT_MK, 2);
+        set_config_val(CONFIG_DEFAULT_FA, 4);
+        set_config_val(CONFIG_DEFAULT_MA, 2);
     }
 
     // we have to copy our enabled flag into the global plugin variable, but


### PR DESCRIPTION
Fixes #2651

solves issue where initial races aren't configurable until tick 6000