### PR TITLE
Add case_sensitive attr to FilteredList

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 - `overlay`: overlay widgets can now specify focus paths for the viewscreens they attach to so they only appear in specific contexts. see `overlay-dev-guide` for details.
 - ``widgets.CycleHotkeyLabel``: Added ``key_back`` optional parameter to cycle backwards.
+- ``widgets.FilteredList``: Added ``case_sensitive`` optional paramter to determine if filtering is case sensitive.
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4958,6 +4958,7 @@ construction that allows filtering the list by subwords of its items.
 In addition to passing through all attributes supported by List, it
 supports:
 
+:case_sensitive: If true, matching is case sensitive. Defaults to true.
 :edit_pen: If specified, used instead of ``cursor_pen`` for the edit field.
 :edit_below: If true, the edit field is placed below the list instead of above.
 :edit_key: If specified, the edit field is disabled until this key is pressed.

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1866,6 +1866,7 @@ end
 FilteredList = defclass(FilteredList, Widget)
 
 FilteredList.ATTRS {
+    case_sensitive = true,
     edit_below = false,
     edit_key = DEFAULT_NIL,
     edit_ignore_keys = DEFAULT_NIL,
@@ -2026,11 +2027,17 @@ function FilteredList:setFilter(filter, pos)
                 -- start matches at non-space or non-punctuation. this allows
                 -- punctuation itself to be matched if that is useful (e.g.
                 -- filenames or parameter names)
-                if key ~= '' and
+                if key ~= '' then
+                    if self.case_sensitive and
                         not search_key:match('%f[^%p\x00]'..key) and
                         not search_key:match('%f[^%s\x00]'..key) then
-                    ok = false
-                    break
+                            ok = false
+                            break
+                    elseif not string.lower(search_key):match('%f[^%p\x00]'..string.lower(key)) and
+                        not string.lower(search_key):match('%f[^%s\x00]'..string.lower(key)) then
+                            ok = false
+                            break
+                    end
                 end
             end
             if ok then

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -2028,13 +2028,13 @@ function FilteredList:setFilter(filter, pos)
                 -- punctuation itself to be matched if that is useful (e.g.
                 -- filenames or parameter names)
                 if key ~= '' then
-                    if self.case_sensitive and
-                        not search_key:match('%f[^%p\x00]'..key) and
+                    if not self.case_sensitive then
+                        search_key = string.lower(search_key)
+                        key = string.lower(key)
+                    end
+
+                    if not search_key:match('%f[^%p\x00]'..key) and
                         not search_key:match('%f[^%s\x00]'..key) then
-                            ok = false
-                            break
-                    elseif not string.lower(search_key):match('%f[^%p\x00]'..string.lower(key)) and
-                        not string.lower(search_key):match('%f[^%s\x00]'..string.lower(key)) then
                             ok = false
                             break
                     end


### PR DESCRIPTION
Add a `case_sensitive` attr to `FilteredList` to allow for case insensitive matching. Defaults to `true` so that existing `FilteredList`s keep the same behavior.