### PR TITLE
Implements plugin: channel-safely v1.2.3

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -39,6 +39,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``Units::isFortControlled``: Account for agitated wildlife
 - Fix right click sometimes closing both a DFHack window and a vanilla panel
 - Fixed issue with scrollable lists having some data off-screen if they were scrolled before being made visible
+- `channel-safely`: fixed bug resulting in marker mode never being set for any designation
 
 ## Misc Improvements
 - `automelt`: is now more resistent to savegame corruption


### PR DESCRIPTION
- Revises a few log lines
- Adds d_assert macro to replace assert usage
  - provides a log line printed to the console to indicate d_assert failed in Release/Debug builds
  
This resolves #2818 (presumably)