### PR TITLE
Remove silver crossbow work-order from library/military

### DIFF
--- a/data/orders/military.json
+++ b/data/orders/military.json
@@ -1142,42 +1142,6 @@
 		"amount_left" : 1,
 		"amount_total" : 1,
 		"frequency" : "Daily",
-		"id" : 64,
-		"is_active" : false,
-		"is_validated" : false,
-		"item_conditions" : 
-		[
-			{
-				"condition" : "AtLeast",
-				"item_type" : "BAR",
-				"material" : "INORGANIC:SILVER",
-				"value" : 20
-			},
-			{
-				"condition" : "AtLeast",
-				"item_type" : "BAR",
-				"material" : "COAL",
-				"value" : 100
-			},
-			{
-				"condition" : "AtMost",
-				"flags" : 
-				[
-					"metal"
-				],
-				"item_subtype" : "ITEM_WEAPON_CROSSBOW",
-				"item_type" : "WEAPON",
-				"value" : 10
-			}
-		],
-		"item_subtype" : "ITEM_WEAPON_CROSSBOW",
-		"job" : "MakeWeapon",
-		"material" : "INORGANIC:SILVER"
-	},
-	{
-		"amount_left" : 1,
-		"amount_total" : 1,
-		"frequency" : "Daily",
 		"id" : 37,
 		"is_active" : false,
 		"is_validated" : false,

--- a/data/orders/military.json
+++ b/data/orders/military.json
@@ -1620,12 +1620,6 @@
 				"item_type" : "WEAPON",
 				"material" : "INORGANIC:STEEL",
 				"value" : 10
-			},
-			{
-				"condition" : "LessThan",
-				"item_type" : "BAR",
-				"material" : "INORGANIC:SILVER",
-				"value" : 5
 			}
 		],
 		"item_subtype" : "ITEM_WEAPON_CROSSBOW",
@@ -2320,12 +2314,6 @@
 				"item_type" : "BAR",
 				"material" : "INORGANIC:STEEL",
 				"value" : 30
-			},
-			{
-				"condition" : "LessThan",
-				"item_type" : "BAR",
-				"material" : "INORGANIC:SILVER",
-				"value" : 5
 			},
 			{
 				"condition" : "AtMost",
@@ -3031,12 +3019,6 @@
 				"item_type" : "BAR",
 				"material" : "INORGANIC:STEEL",
 				"value" : 30
-			},
-			{
-				"condition" : "LessThan",
-				"item_type" : "BAR",
-				"material" : "INORGANIC:SILVER",
-				"value" : 5
 			},
 			{
 				"condition" : "AtMost",
@@ -3819,12 +3801,6 @@
 				"item_type" : "BAR",
 				"material" : "INORGANIC:STEEL",
 				"value" : 30
-			},
-			{
-				"condition" : "LessThan",
-				"item_type" : "BAR",
-				"material" : "INORGANIC:SILVER",
-				"value" : 5
 			},
 			{
 				"condition" : "AtMost",
@@ -4697,12 +4673,6 @@
 				"item_type" : "BAR",
 				"material" : "INORGANIC:STEEL",
 				"value" : 30
-			},
-			{
-				"condition" : "LessThan",
-				"item_type" : "BAR",
-				"material" : "INORGANIC:SILVER",
-				"value" : 5
 			},
 			{
 				"condition" : "AtMost",

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `clean`: new hotkey for `spotclean`: Ctrl-C
 - `autobutcher`: changed defaults from 5 females / 1 male to 4 females / 2 males so a single unfortunate accident doesn't leave players without a mating pair
 - `autobutcher`: now immediately loads races available at game start into the watchlist
+- `orders`: recipe for silver crossbows removed from ``library/military`` as it is not a vanilla recipe, but is available in ``library/military_include_artifact_materials``
 
 ## Documentation
 


### PR DESCRIPTION
It is not possible to create a work-order for making silver crossbows, so the silver crossbow recipe belongs in the alternative military library with other artifact/non-craftable weapon recipes.

It's already present in the library/military_include_artifact_materials work-orders, so it simply needed removal from the vanilla library/military orders.