### PR TITLE
add const & to Push overloads; remove circular def

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -478,7 +478,7 @@ static void OpenPersistent(lua_State *state)
 
 static int DFHACK_MATINFO_TOKEN = 0;
 
-void Lua::Push(lua_State *state, MaterialInfo &info)
+void Lua::Push(lua_State *state, const MaterialInfo &info)
 {
     if (!info.isValid())
     {

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -101,7 +101,7 @@ void DFHack::Lua::Push(lua_State *state, const Units::NoblePosition &pos)
     lua_setfield(state, -2, "position");
 }
 
-void DFHack::Lua::Push(lua_State *state, df::coord pos)
+void DFHack::Lua::Push(lua_State *state, const df::coord &pos)
 {
     lua_createtable(state, 0, 3);
     lua_pushinteger(state, pos.x);
@@ -112,7 +112,7 @@ void DFHack::Lua::Push(lua_State *state, df::coord pos)
     lua_setfield(state, -2, "z");
 }
 
-void DFHack::Lua::Push(lua_State *state, df::coord2d pos)
+void DFHack::Lua::Push(lua_State *state, const df::coord2d &pos)
 {
     lua_createtable(state, 0, 2);
     lua_pushinteger(state, pos.x);
@@ -191,7 +191,7 @@ void DFHack::Lua::PushInterfaceKeys(lua_State *L,
     }
 }
 
-int DFHack::Lua::PushPosXYZ(lua_State *state, df::coord pos)
+int DFHack::Lua::PushPosXYZ(lua_State *state, const df::coord &pos)
 {
     if (!pos.isValid())
     {
@@ -207,7 +207,7 @@ int DFHack::Lua::PushPosXYZ(lua_State *state, df::coord pos)
     }
 }
 
-int DFHack::Lua::PushPosXY(lua_State *state, df::coord2d pos)
+int DFHack::Lua::PushPosXY(lua_State *state, const df::coord2d &pos)
 {
     if (!pos.isValid())
     {

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -325,10 +325,10 @@ namespace DFHack {namespace Lua {
     inline void Push(lua_State *state, const std::string &str) {
         lua_pushlstring(state, str.data(), str.size());
     }
-    DFHACK_EXPORT void Push(lua_State *state, df::coord obj);
-    DFHACK_EXPORT void Push(lua_State *state, df::coord2d obj);
+    DFHACK_EXPORT void Push(lua_State *state, const df::coord &obj);
+    DFHACK_EXPORT void Push(lua_State *state, const df::coord2d &obj);
     void Push(lua_State *state, const Units::NoblePosition &pos);
-    DFHACK_EXPORT void Push(lua_State *state, MaterialInfo &info);
+    DFHACK_EXPORT void Push(lua_State *state, const MaterialInfo &info);
     DFHACK_EXPORT void Push(lua_State *state, const Screen::Pen &info);
     template<class T> inline void Push(lua_State *state, T *ptr) {
         PushDFObject(state, ptr);
@@ -361,29 +361,34 @@ namespace DFHack {namespace Lua {
 
     DFHACK_EXPORT void GetVector(lua_State *state, std::vector<std::string> &pvec);
 
-    DFHACK_EXPORT int PushPosXYZ(lua_State *state, df::coord pos);
-    DFHACK_EXPORT int PushPosXY(lua_State *state, df::coord2d pos);
-
-    template <typename T_Key, typename T_Value>
-    inline void TableInsert(lua_State *state, T_Key key, T_Value value)
-    {
-        Lua::Push(state, key);
-        Lua::Push(state, value);
-        lua_settable(state, -3);
-    }
+    DFHACK_EXPORT int PushPosXYZ(lua_State *state, const df::coord &pos);
+    DFHACK_EXPORT int PushPosXY(lua_State *state, const df::coord2d &pos);
 
     template<typename T_Key, typename T_Value>
     void Push(lua_State *L, const std::map<T_Key, T_Value> &pmap) {
         lua_createtable(L, 0, pmap.size());
-        for (auto &entry : pmap)
-            TableInsert(L, entry.first, entry.second);
+        for (auto &entry : pmap) {
+            Lua::Push(L, entry.first);
+            Lua::Push(L, entry.second);
+            lua_settable(L, -3);
+        }
     }
 
     template<typename T_Key, typename T_Value>
     void Push(lua_State *L, const std::unordered_map<T_Key, T_Value> &pmap) {
         lua_createtable(L, 0, pmap.size());
-        for (auto &entry : pmap)
-            TableInsert(L, entry.first, entry.second);
+        for (auto &entry : pmap) {
+            Lua::Push(L, entry.first);
+            Lua::Push(L, entry.second);
+            lua_settable(L, -3);
+        }
+    }
+
+    template <typename T_Key, typename T_Value>
+    inline void TableInsert(lua_State *state, const T_Key &key, const T_Value &value) {
+        Lua::Push(state, key);
+        Lua::Push(state, value);
+        lua_settable(state, -3);
     }
 
     DFHACK_EXPORT void CheckPen(lua_State *L, Screen::Pen *pen, int index, bool allow_nil = false, bool allow_color = true);


### PR DESCRIPTION
the circular template expansion went unnoticed before since we've never tried to Push a map of maps. Now that we are (to solve the Lua stack smashing problem in #2848), gcc doesn't like it. msvc seems ok with it, but it's still something we should fix.