### PR TITLE
[nestboxes] remove in-progress jobs when protecting fert eggs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `channel-safely`: fixed bug resulting in marker mode never being set for any designation
 - `automelt`: fixed bug related to lua stack smashing behavior in returned stockpile configs
 - `autochop`: fixed bug related to lua stack smashing behavior in returned stockpile configs
+- `nestboxes`: now cancels any in-progress hauling jobs when it protects a fertile egg
 
 ## Misc Improvements
 - `automelt`: is now more resistent to savegame corruption

--- a/plugins/nestboxes.cpp
+++ b/plugins/nestboxes.cpp
@@ -1,6 +1,8 @@
 #include "Debug.h"
 #include "PluginManager.h"
 
+#include "modules/Items.h"
+#include "modules/Job.h"
 #include "modules/Persistence.h"
 #include "modules/World.h"
 
@@ -141,6 +143,13 @@ static void do_cycle(color_ostream &out) {
             df::item *item = contained_item->item;
             if (item->flags.bits.forbid != fertile) {
                 item->flags.bits.forbid = fertile;
+                if (fertile && item->flags.bits.in_job) {
+                    // cancel any job involving the egg
+                    df::specific_ref *sref = Items::getSpecificRef(
+                            item, df::specific_ref_type::JOB);
+                    if (sref && sref->data.job)
+                        Job::removeJob(sref->data.job);
+                }
                 out.print("%d eggs %s.\n", item->getStackSize(), fertile ? "forbidden" : "unforbidden");
             }
         }


### PR DESCRIPTION
Fixes #2846

in DF 50, forbidding an item is not enough to cancel the associated job. we now need to do that manually.