### PR TITLE
Fix annotation parse error

### DIFF
--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -659,7 +659,7 @@ function Script:get_flags()
         local f = io.open(self.path)
         local contents = f:read('*all')
         f:close()
-        for line in contents:gmatch('%-%-@([^\n]+)') do
+        for line in contents:gmatch('^%-%-@([^\n]+)') do
             local chunk = load(line, self.path, 't', self._flags)
             if chunk then
                 chunk()


### PR DESCRIPTION
This PR makes the pattern for matching `--@ module = true` match only from the start of a line, fixing the error `Parse error: ...` for lines like annotations `---@param foo bar`.

This is especially useful as if we start annotating the Lua codebase we could automatically generate future definitions for autocomplete/lsp.