### PR TITLE
Add getSelectedCivZone to dfhack.gui

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
+- ``Gui::any_civzone_hotkey``, ``Gui::getAnyCivZone``, ``Gui::getSelectedCivZone``:  new functions to operate on the new zone system
 
 - Units module: added new predicates for:
   - ``isGeldable()``
@@ -56,6 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
   - ``isPet()``
 
 ## Lua
+- ``dfhack.gui.getSelectedCivZone``: returns the Zone that the user has selected currently
 
 - ``widgets.FilteredList``: Added ``edit_on_change`` optional parameter to allow a custom callback on filter edit change.
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1009,6 +1009,10 @@ General-purpose selections
 
   Returns the building selected via :kbd:`q`, :kbd:`t`, :kbd:`k` or :kbd:`i`.
 
+* ``dfhack.gui.getSelectedCivZone([silent])``
+
+  Returns the zone currently selected via :kbd:`z`
+
 * ``dfhack.gui.getSelectedPlant([silent])``
 
   Returns the plant selected via :kbd:`k`.

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1476,6 +1476,7 @@ static const LuaWrapper::FunctionReg dfhack_gui_module[] = {
     WRAPM(Gui, getSelectedUnit),
     WRAPM(Gui, getSelectedItem),
     WRAPM(Gui, getSelectedBuilding),
+    WRAPM(Gui, getSelectedCivZone),
     WRAPM(Gui, getSelectedStockpile),
     WRAPM(Gui, getSelectedPlant),
     WRAPM(Gui, getAnyUnit),

--- a/library/include/modules/Gui.h
+++ b/library/include/modules/Gui.h
@@ -105,11 +105,17 @@ namespace DFHack
         DFHACK_EXPORT df::item *getAnyItem(df::viewscreen *top);
         DFHACK_EXPORT df::item *getSelectedItem(color_ostream &out, bool quiet = false);
 
-        // A building is selected via 'q', 't' or 'i' (civzone)
+        // A building is selected via 'q', 't' or 'i' (?)
         DFHACK_EXPORT bool any_building_hotkey(df::viewscreen *top);
         DFHACK_EXPORT df::building *getAnyBuilding(df::viewscreen *top);
         DFHACK_EXPORT df::building *getSelectedBuilding(color_ostream &out, bool quiet = false);
 
+        // A (civ)zone is selected via 'z'
+        DFHACK_EXPORT bool any_civzone_hotkey(df::viewscreen* top);
+        DFHACK_EXPORT df::building_civzonest *getAnyCivZone(df::viewscreen* top);
+        DFHACK_EXPORT df::building_civzonest *getSelectedCivZone(color_ostream& out, bool quiet = false);
+
+        // A stockpile is selected via 'p'
         DFHACK_EXPORT bool any_stockpile_hotkey(df::viewscreen* top);
         DFHACK_EXPORT df::building_stockpilest *getAnyStockpile(df::viewscreen* top);
         DFHACK_EXPORT df::building_stockpilest *getSelectedStockpile(color_ostream& out, bool quiet = false);

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -98,14 +98,15 @@ namespace DFHack
 
 using namespace df::enums;
 
+using df::building_civzonest;
+using df::global::game;
 using df::global::gamemode;
 using df::global::gps;
 using df::global::gview;
 using df::global::init;
-using df::global::selection_rect;
 using df::global::plotinfo;
+using df::global::selection_rect;
 using df::global::ui_menu_width;
-using df::global::game;
 using df::global::world;
 
 /* TODO: understand how this changes for v50
@@ -1109,6 +1110,26 @@ df::building_stockpilest* Gui::getSelectedStockpile(color_ostream& out, bool qui
         out.printerr("No stockpile is selected in the UI.\n");
 
     return stockpile;
+}
+
+bool Gui::any_civzone_hotkey(df::viewscreen* top) {
+    return getAnyCivZone(top) != NULL;
+}
+
+df::building_civzonest *Gui::getAnyCivZone(df::viewscreen* top) {
+    if (matchFocusString("dwarfmode/Zone")) {
+        return game->main_interface.civzone.cur_bld;
+    }
+    return NULL;
+}
+
+df::building_civzonest *Gui::getSelectedCivZone(color_ostream &out, bool quiet) {
+    df::building_civzonest *civzone = getAnyCivZone(Core::getTopViewscreen());
+
+    if (!civzone && !quiet)
+        out.printerr("No zone is selected in the UI");
+
+    return civzone;
 }
 
 df::building *Gui::getAnyBuilding(df::viewscreen *top)


### PR DESCRIPTION
Mostly helpful for my own automation in my custom lua scripts.

Tested it with barracks, meeting areas, and pastures.

![image](https://user-images.githubusercontent.com/5893/218018376-492f72e5-1d3c-4f7b-9162-c50e7c4dc1bd.png)
