### PR TITLE
nestboxes: avoid forbidding non-eggs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+-@ `nestboxes`: fixed bug causing nestboxes themselves to be forbidden, which prevented citizens from using them to lay eggs. Now only eggs are forbidden.
 
 ## Misc Improvements
 

--- a/plugins/nestboxes.cpp
+++ b/plugins/nestboxes.cpp
@@ -9,6 +9,7 @@
 #include "df/world.h"
 #include "df/building_nest_boxst.h"
 #include "df/item.h"
+#include "df/item_eggst.h"
 #include "df/unit.h"
 
 using std::string;
@@ -140,8 +141,8 @@ static void do_cycle(color_ostream &out) {
                 fertile = true;
         }
         for (auto &contained_item : nb->contained_items) {
-            df::item *item = contained_item->item;
-            if (item->flags.bits.forbid != fertile) {
+            auto *item = virtual_cast<df::item_eggst>(contained_item->item);
+            if (item && item->flags.bits.forbid != fertile) {
                 item->flags.bits.forbid = fertile;
                 if (fertile && item->flags.bits.in_job) {
                     // cancel any job involving the egg


### PR DESCRIPTION
The rewrite in #2773 introduced a bug (identified by KMFrench on Discord) where nestboxes themselves would be forbidden, which prevents egglaying citizens from using them since the nestboxes would be claimed before use. The previous version of the plugin handled this by skipping the first item in `contained_items`, which is the building material (in this case, the nestbox).

This fix limits the `forbid` flag manipulation to egg items only, which should be a reasonable limitation that still allows the plugin to serve its purpose.