### PR TITLE
properly store the id of seed targets in persisted state

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 -@ `nestboxes`: fixed bug causing nestboxes themselves to be forbidden, which prevented citizens from using them to lay eggs. Now only eggs are forbidden.
 - `autobutcher`: implemented work-around for Dwarf Fortress not setting nicknames properly, so that nicknames created in the in-game interface are detected & protect animals from being butchered properly. Note that nicknames for unnamed units are not currently saved by dwarf fortress - use ``enable fix/protect-nicks`` to fix any nicknames created/removed within dwarf fortress so they can be saved/reloaded when you reload the game.
+- `seedwatch`: fix saving and loading of seed stock targets
 
 ## Misc Improvements
 

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -85,6 +85,7 @@ static PersistentDataItem & ensure_seed_config(color_ostream &out, int id) {
     string keyname = SEED_CONFIG_KEY_PREFIX + int_to_string(id);
     DEBUG(config,out).print("creating new persistent key for seed type %d\n", id);
     watched_seeds.emplace(id, World::GetPersistentData(keyname, NULL));
+    set_config_val(watched_seeds[id], SEED_CONFIG_ID, id);
     return watched_seeds[id];
 }
 static void remove_seed_config(color_ostream &out, int id) {


### PR DESCRIPTION
Fixes #2884

this allows stored targets to be loaded and applied to their proper seed types