### PR TITLE
[issue-2888] Don't change dump and forbid flags on failed autodump

### DIFF
--- a/docs/about/Authors.rst
+++ b/docs/about/Authors.rst
@@ -26,6 +26,7 @@ Ariphaos                Ariphaos
 arzyu                   arzyu
 Atkana                  Atkana
 AtomicChicken           AtomicChicken
+Batt Mush               hobotron-df
 Bearskie                Bearskie
 belal                   jimhester
 Ben Lubar               BenLubar

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 -@ `nestboxes`: fixed bug causing nestboxes themselves to be forbidden, which prevented citizens from using them to lay eggs. Now only eggs are forbidden.
 - `autobutcher`: implemented work-around for Dwarf Fortress not setting nicknames properly, so that nicknames created in the in-game interface are detected & protect animals from being butchered properly. Note that nicknames for unnamed units are not currently saved by dwarf fortress - use ``enable fix/protect-nicks`` to fix any nicknames created/removed within dwarf fortress so they can be saved/reloaded when you reload the game.
+- `autodump`: changed behaviour to only change `dump` and `forbid` flags if an item is successfully dumped.
 
 ## Misc Improvements
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,7 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 -@ `nestboxes`: fixed bug causing nestboxes themselves to be forbidden, which prevented citizens from using them to lay eggs. Now only eggs are forbidden.
 - `autobutcher`: implemented work-around for Dwarf Fortress not setting nicknames properly, so that nicknames created in the in-game interface are detected & protect animals from being butchered properly. Note that nicknames for unnamed units are not currently saved by dwarf fortress - use ``enable fix/protect-nicks`` to fix any nicknames created/removed within dwarf fortress so they can be saved/reloaded when you reload the game.
-- `autodump`: changed behaviour to only change `dump` and `forbid` flags if an item is successfully dumped.
+- `autodump`: changed behaviour to only change ``dump`` and ``forbid`` flags if an item is successfully dumped.
 
 ## Misc Improvements
 

--- a/plugins/autodump.cpp
+++ b/plugins/autodump.cpp
@@ -396,18 +396,22 @@ static command_result autodump_main(color_ostream &out, vector <string> & parame
         if (!need_forbidden && itm->flags.bits.forbid)
             continue;
 
-        if(!destroy) // move to cursor
+        if (!destroy) // move to cursor
         {
-            // Change flags to indicate the dump was completed, as if by super-dwarfs
-            itm->flags.bits.dump = false;
-            itm->flags.bits.forbid = true;
-
             // Don't move items if they're already at the cursor
             if (pos_cursor != pos_item)
             {
-                if (!Items::moveToGround(MC, itm, pos_cursor))
+                if (Items::moveToGround(MC, itm, pos_cursor))
+                {
+                    // Change flags to indicate the dump was completed, as if by super-dwarfs
+                    itm->flags.bits.dump = false;
+                    itm->flags.bits.forbid = true;
+                }
+                else
+                {
                     out.print("Could not move item: %s\n",
-                              Items::getDescription(itm, 0, true).c_str());
+                        Items::getDescription(itm, 0, true).c_str());
+                }
             }
         }
         else // destroy


### PR DESCRIPTION
`autodump` now conditionally removes an item's dump flag and sets forbid flag IFF the item is successfully dumped. Otherwise, the item's original flags are kept intact. This avoids impacting any tasks associated with the item.