### PR TITLE
Add edit_on_change to FilteredList

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -53,6 +53,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 
+- ``widgets.FilteredList``: Added ``edit_on_change`` optional paramter to allow a custom callback on filter edit change.
+
 ## Removed
 
 # 50.07-alpha1

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -53,7 +53,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 
-- ``widgets.FilteredList``: Added ``edit_on_change`` optional paramter to allow a custom callback on filter edit change.
+- ``widgets.FilteredList``: Added ``edit_on_change`` optional parameter to allow a custom callback on filter edit change.
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4975,6 +4975,7 @@ supports:
 :edit_below: If true, the edit field is placed below the list instead of above.
 :edit_key: If specified, the edit field is disabled until this key is pressed.
 :edit_ignore_keys: If specified, will be passed to the filter edit field as its ``ignore_keys`` attribute.
+:edit_on_change: If specified, will be passed to the filter edit field as its ``on_change`` attribute.
 :edit_on_char: If specified, will be passed to the filter edit field as its ``on_char`` attribute.
 :not_found_label: Specifies the text of the label shown when no items match the filter.
 

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1887,6 +1887,7 @@ FilteredList.ATTRS {
     edit_key = DEFAULT_NIL,
     edit_ignore_keys = DEFAULT_NIL,
     edit_on_char = DEFAULT_NIL,
+    edit_on_change = DEFAULT_NIL,
 }
 
 function FilteredList:init(info)
@@ -1897,10 +1898,18 @@ function FilteredList:init(info)
         end
     end
 
+    local on_change = self:callback('onFilterChange')
+    if self.edit_on_change then
+        on_change = function(text)
+            self.edit_on_change(text)
+            self:onFilterChange(text)
+        end
+    end
+
     self.edit = EditField{
         text_pen = info.edit_pen or info.cursor_pen,
         frame = { l = info.icon_width, t = 0, h = 1 },
-        on_change = self:callback('onFilterChange'),
+        on_change = on_change,
         on_char = on_char,
         key = self.edit_key,
         ignore_keys = self.edit_ignore_keys,


### PR DESCRIPTION
Allow providing a custom callback for `edit.on_change` in the same way we do for `edit.on_char`. I had a need to get the final value of the edit widget after a change, and `on_char` wasn't able to reliably give me what I needed (can't concat `c` and `text` without taking the cursor position into account).