### PR TITLE
generate names for nameless burrows; check for nil

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,8 +38,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 -@ `nestboxes`: fixed bug causing nestboxes themselves to be forbidden, which prevented citizens from using them to lay eggs. Now only eggs are forbidden.
 - `autobutcher`: implemented work-around for Dwarf Fortress not setting nicknames properly, so that nicknames created in the in-game interface are detected & protect animals from being butchered properly. Note that nicknames for unnamed units are not currently saved by dwarf fortress - use ``enable fix/protect-nicks`` to fix any nicknames created/removed within dwarf fortress so they can be saved/reloaded when you reload the game.
-- `seedwatch`: fix saving and loading of seed stock targets
+-@ `seedwatch`: fix saving and loading of seed stock targets
 - `autodump`: changed behaviour to only change ``dump`` and ``forbid`` flags if an item is successfully dumped.
+-@ `autochop`: generate default names for burrows with no assigned names
 
 ## Misc Improvements
 

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -857,12 +857,11 @@ static int autochop_getTreeCountsAndBurrowConfigs(lua_State *L) {
 
     for (auto &burrow : plotinfo->burrows.list) {
         int id = burrow->id;
-        if (watched_burrows_indices.count(id)) {
-            // push_burrow_config(L, watched_burrows[watched_burrows_indices[id]]);
-            emplace_bulk_burrow_config(L, burrow_config_map, watched_burrows[watched_burrows_indices[id]]);
-        } else {
+        if (watched_burrows_indices.count(id))
+            emplace_bulk_burrow_config(L, burrow_config_map,
+                    watched_burrows[watched_burrows_indices[id]]);
+        else
             emplace_bulk_burrow_config(L, burrow_config_map, id);
-        }
     }
 
     Lua::Push(L, burrow_config_map);

--- a/plugins/lua/autochop.lua
+++ b/plugins/lua/autochop.lua
@@ -100,13 +100,19 @@ function getTreeCountsAndBurrowConfigs()
 
     ret.burrow_configs = {}
     for idx,c in pairs(unparsed_burrow_configs) do
-        c.name = df.burrow.find(c.id).name
+        local burrow = df.burrow.find(c.id)
+        if not burrow then goto continue end
+        c.name = burrow.name
+        if #c.name == 0 then
+            c.name = ('Burrow %d'):format(c.id + 1)
+        end
         c.chop = c.chop ~= 0
         c.clearcut = c.clearcut ~= 0
         c.protect_brewable = c.protect_brewable ~= 0
         c.protect_edible = c.protect_edible ~= 0
         c.protect_cookable = c.protect_cookable ~= 0
         table.insert(ret.burrow_configs, c)
+        ::continue::
     end
     return ret
 end


### PR DESCRIPTION
Fixes #2887

looking through the code, I'm actually not quite sure how the burrow was found during validation in the cpp but not found when getting its name in the lua. I added a check in the Lua to catch this case regardless.