### PR TITLE
[showmood] show more understandable units for bars and cloths

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autodump`: changed behaviour to only change ``dump`` and ``forbid`` flags if an item is successfully dumped.
 
 ## Misc Improvements
+- `showmood`: now shows the number of items needed for cloth and bars in addition to the technically correct but always confusing "total dimension" (150 per bar or 10,000 per cloth)
 
 ## Documentation
 

--- a/plugins/showmood.cpp
+++ b/plugins/showmood.cpp
@@ -275,17 +275,29 @@ command_result df_showmood (color_ostream &out, vector <string> & parameters)
             // count how many items of this type the crafter already collected
             {
                 int count_got = 0;
+                int dimension_got = 0;
+                int divisor = 1;
+                bool has_dims = false;
+                if (item->item_type == item_type::BAR) {
+                    divisor = 150;
+                    has_dims = true;
+                } else if (item->item_type == item_type::CLOTH) {
+                    divisor = 10000;
+                    has_dims = true;
+                }
                 for (size_t j = 0; j < job->items.size(); j++)
                 {
                     if(job->items[j]->job_item_idx == int32_t(i))
                     {
-                        if (item->item_type == item_type::BAR || item->item_type == item_type::CLOTH)
-                            count_got += job->items[j]->item->getTotalDimension();
-                        else
-                            count_got += 1;
+                        if (has_dims)
+                            dimension_got += job->items[j]->item->getTotalDimension();
+                        count_got += 1;
                     }
                 }
-                out.print(", quantity %i (got %i)\n", item->quantity, count_got);
+                out.print(", got %i of %i", count_got, item->quantity/divisor);
+                if (has_dims)
+                    out.print(" (%i of %i sub-units)", dimension_got, item->quantity);
+                out.print("\n");
             }
         }
     }


### PR DESCRIPTION
Fixes #2610

now prints out the item quantity as well as the "total dimensions" for bars and cloth. other item types have unchanged output