### PR TITLE
prevent mouse clicks from bleeding through when a window is dismissed

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -45,6 +45,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - DFHack tool windows that capture mouse clicks (and therefore prevent you from clicking on the "pause" button) now unconditionally pause the game when they open (but you can still unpause with the keyboard if you want to). Examples of this behavior: `gui/quickfort`, `gui/blueprint`, `gui/liquids`
 - `showmood`: now shows the number of items needed for cloth and bars in addition to the technically correct but always confusing "total dimension" (150 per bar or 10,000 per cloth)
+-@ Stopped mouse clicks from affecting the map when a click on a DFHack screen dismisses the window
 
 ## Documentation
 

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -697,6 +697,19 @@ DEFAULT_INITIAL_PAUSE = true
 
 local zscreen_inhibit_mouse_l = false
 
+-- ensure underlying DF screens don't also react to handled clicks
+function markMouseClicksHandled(keys)
+    if keys._MOUSE_L_DOWN then
+        -- note we can't clear mouse_lbut here. otherwise we break dragging,
+        df.global.enabler.mouse_lbut_down = 0
+        zscreen_inhibit_mouse_l = true
+    end
+    if keys._MOUSE_R_DOWN then
+        df.global.enabler.mouse_rbut_down = 0
+        df.global.enabler.mouse_rbut = 0
+    end
+end
+
 ZScreen = defclass(ZScreen, Screen)
 ZScreen.ATTRS{
     defocusable=true,
@@ -782,16 +795,7 @@ function ZScreen:onInput(keys)
     end
 
     if ZScreen.super.onInput(self, keys) then
-        -- ensure underlying DF screens don't also react to handled clicks
-        if keys._MOUSE_L_DOWN then
-            -- note we can't clear mouse_lbut here. otherwise we break dragging,
-            df.global.enabler.mouse_lbut_down = 0
-            zscreen_inhibit_mouse_l = true
-        end
-        if keys._MOUSE_R_DOWN then
-            df.global.enabler.mouse_rbut_down = 0
-            df.global.enabler.mouse_rbut = 0
-        end
+        markMouseClicksHandled(keys)
         return
     end
 
@@ -801,9 +805,7 @@ function ZScreen:onInput(keys)
         return
     elseif keys.LEAVESCREEN or keys._MOUSE_R_DOWN then
         self:dismiss()
-        -- ensure underlying DF screens don't also react to the rclick
-        df.global.enabler.mouse_rbut_down = 0
-        df.global.enabler.mouse_rbut = 0
+        markMouseClicksHandled(keys)
         return
     else
         if zscreen_inhibit_mouse_l then

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -262,12 +262,14 @@ function Menu:onInput(keys)
         local x = list:getMousePos()
         if x == 0 then -- clicked on icon
             self:onSubmit2(list:getSelected())
+            df.global.enabler.mouse_lbut = 0
             return true
         end
         if not self:getMouseFramePos() and not self.hotspot:getMousePos() then
             self.parent_view:dismiss()
             return true
         end
+        df.global.enabler.mouse_lbut = 0
     end
     self:inputToSubviews(keys)
     return true -- we're modal

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -488,8 +488,12 @@ local function _feed_viewscreen_widgets(vs_name, keys)
 end
 
 function feed_viewscreen_widgets(vs_name, keys)
-    return _feed_viewscreen_widgets(vs_name, keys) or
-            _feed_viewscreen_widgets('all', keys)
+    if not _feed_viewscreen_widgets(vs_name, keys) and
+            not _feed_viewscreen_widgets('all', keys) then
+        return false
+    end
+    gui.markMouseClicksHandled(keys)
+    return true
 end
 
 local function _render_viewscreen_widgets(vs_name, dc)


### PR DESCRIPTION
because if you're in mining mode, clicking on a tool in the DFHack hotspot menu *still* causes the mining mode cursor to start selecting an area