### PR TITLE
Not all stockpile items being returned for getStockpileContents.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,7 +41,6 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 -@ `seedwatch`: fix saving and loading of seed stock targets
 - `autodump`: changed behaviour to only change ``dump`` and ``forbid`` flags if an item is successfully dumped.
 -@ `autochop`: generate default names for burrows with no assigned names
-- ``Buildings::StockpileIterator``: check for stockpile items on block boundary.
 
 ## Misc Improvements
 - DFHack tool windows that capture mouse clicks (and therefore prevent you from clicking on the "pause" button) now unconditionally pause the game when they open (but you can still unpause with the keyboard if you want to). Examples of this behavior: `gui/quickfort`, `gui/blueprint`, `gui/liquids`

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 -@ `seedwatch`: fix saving and loading of seed stock targets
 - `autodump`: changed behaviour to only change ``dump`` and ``forbid`` flags if an item is successfully dumped.
 -@ `autochop`: generate default names for burrows with no assigned names
+- ``Buildings::StockpileIterator``: check for stockpile items on block boundary.
 
 ## Misc Improvements
 - DFHack tool windows that capture mouse clicks (and therefore prevent you from clicking on the "pause" button) now unconditionally pause the game when they open (but you can still unpause with the keyboard if you want to). Examples of this behavior: `gui/quickfort`, `gui/blueprint`, `gui/liquids`

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -1643,10 +1643,10 @@ StockpileIterator& StockpileIterator::operator++() {
 
         while (current >= block->items.size()) {
             // Out of items in this block; find the next block to search.
-            if (block->map_pos.x + 16 < stockpile->x2) {
+            if (block->map_pos.x + 16 <= stockpile->x2) {
                 block = Maps::getTileBlock(block->map_pos.x + 16, block->map_pos.y, stockpile->z);
                 current = 0;
-            } else if (block->map_pos.y + 16 < stockpile->y2) {
+            } else if (block->map_pos.y + 16 <= stockpile->y2) {
                 block = Maps::getTileBlock(stockpile->x1, block->map_pos.y + 16, stockpile->z);
                 current = 0;
             } else {


### PR DESCRIPTION
Changed the StockpileIterator::operator++ to checks blocks based on <= 16 rather than <16. Previously the iterator was not returning items at stockpile tiles at the block boundary. Identified as part of combine.lua changes.