### PR TITLE
Usability: Show mouse hover on all clickable Labels/Lists

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4917,6 +4917,8 @@ item to call the ``on_submit`` callback for that item.
 It has the following attributes:
 
 :text_pen: Specifies the pen for deselected list entries.
+:text_hpen: Specifies the pen for entries that the mouse is hovered over.
+            Defaults to swapping the background/foreground colors.
 :cursor_pen: Specifies the pen for the selected entry.
 :inactive_pen: If specified, used for the cursor when the widget is not active.
 :icon_pen: Default pen for icons.

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3757,6 +3757,12 @@ Misc
   Wraps ``dfhack.screen.getKeyDisplay`` in order to allow using strings for the keycode argument.
 
 
+* ``invert_color(color, bold)``
+
+  This inverts the brightness of ``color``. If this color is coming from a pen's
+  foreground color, include ``pen.bold`` in ``bold`` for this to work properly.
+
+
 ViewRect class
 --------------
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4662,7 +4662,9 @@ It has the following attributes:
 
 :text_pen: Specifies the pen for active text.
 :text_dpen: Specifies the pen for disabled text.
-:text_hpen: Specifies the pen for text hovered over by the mouse, if a click handler is registered.
+:text_hpen: Specifies the pen for text hovered over by the mouse, if a click
+            handler is registered. By default, this will invert the foreground
+            and background colors.
 :disabled: Boolean or a callback; if true, the label is disabled.
 :enabled: Boolean or a callback; if false, the label is disabled.
 :auto_height: Sets self.frame.h from the text height.
@@ -4768,6 +4770,18 @@ The Label widget implements the following methods:
   integers or one of the following keywords: ``+page``, ``-page``,
   ``+halfpage``, ``-halfpage``, ``home``, or ``end``. It returns the number of
   lines that were actually scrolled (negative for scrolling up).
+
+* ``label:shouldHover()``
+
+  This method returns whether or not this widget should show a hover effect,
+  generally you want to return ``true`` if there is some type of mouse handler
+  present. For example, for a ``HotKeyLabel``::
+
+    function HotkeyLabel:shouldHover()
+        -- When on_activate is set, text should also hover on mouseover
+        return HotkeyLabel.super.shouldHover(self) or self.on_activate
+    end
+
 
 WrappedLabel class
 ------------------

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -987,4 +987,10 @@ function FramedScreen:onRenderFrame(dc, rect)
     paint_frame(dc,rect,self.frame_style,self.frame_title)
 end
 
+-- Inverts the brightness of the color, optionally taking a "bold" parameter,
+-- which you should include if you're reading the fg color of a pen.
+function invert_color(color, bold)
+    color = bold and (color + 8) or color
+    return (color + 8) % 16
+end
 return _ENV

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1232,7 +1232,7 @@ Label = defclass(Label, Widget)
 Label.ATTRS{
     text_pen = COLOR_WHITE,
     text_dpen = COLOR_DARKGREY, -- disabled
-    text_hpen = DEFAULT_NIL, -- highlight - default is text_pen with reversed brightness
+    text_hpen = DEFAULT_NIL, -- hover - default is to invert the fg/bg colors
     disabled = DEFAULT_NIL,
     enabled = DEFAULT_NIL,
     auto_height = true,
@@ -1250,8 +1250,6 @@ function Label:init(args)
     self:addviews{self.scrollbar}
 
     self:setText(args.text or self.text)
-
-    -- self.text_hpen = make_hpen(self.text_pen, self.text_hpen)
 end
 
 local function update_label_scrollbar(label)
@@ -1303,15 +1301,6 @@ end
 -- HotkeyLabel.
 function Label:shouldHover()
     return self.on_click or self.on_rclick
-end
-
-function Label:onRenderFrame(dc, rect)
-    Label.super.onRenderFrame(self, dc, rect)
-    -- Fill the background with text_hpen on hover
-    if self:getMousePos() and self:shouldHover() then
-        local hpen = make_hpen(self.text_pen, self.text_hpen)
-        dc:fill(rect, hpen)
-    end
 end
 
 function Label:onRenderBody(dc)
@@ -1614,7 +1603,7 @@ List = defclass(List, Widget)
 
 List.ATTRS{
     text_pen = COLOR_CYAN,
-    text_hpen = DEFAULT_NIL, -- pen to render list item when mouse is hovered over; defaults to text_pen with inverted brightness
+    text_hpen = DEFAULT_NIL, -- hover color, defaults to inverting the FG/BG pens for each text object
     cursor_pen = COLOR_LIGHTCYAN,
     inactive_pen = DEFAULT_NIL,
     on_select = DEFAULT_NIL,
@@ -1644,8 +1633,6 @@ function List:init(info)
     end
 
     self.last_select_click_ms = 0 -- used to track double-clicking on an item
-
-    -- self.text_hpen = make_hpen(self.text_pen, self.text_hpen)
 end
 
 function List:setChoices(choices, selected)

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1461,7 +1461,7 @@ end
 
 function HotkeyLabel:shouldHover()
     -- When on_activate is set, text should also hover on mouseover
-    return HotkeyLabel.super.shouldHover(self) or self.on_activate
+    return self.on_activate or HotkeyLabel.super.shouldHover(self)
 end
 
 function HotkeyLabel:initializeLabel()

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1274,9 +1274,15 @@ function Label:getTextWidth()
     return self.text_width
 end
 
+-- Overridden by subclasses that also want to add new mouse handlers, see
+-- HotkeyLabel.
+function Label:shouldHover()
+    return self.on_click or self.on_rclick
+end
+
 function Label:onRenderBody(dc)
     local text_pen = self.text_pen
-    if self:getMousePos() and (self.on_click or self.on_rclick) then
+    if self:getMousePos() and self:shouldHover() then
         text_pen = self.text_hpen
     end
     render_text(self,dc,0,0,text_pen,self.text_dpen,is_disabled(self))
@@ -1432,6 +1438,11 @@ function HotkeyLabel:setLabel(label)
     self:initializeLabel()
 end
 
+function HotkeyLabel:shouldHover()
+    -- When on_activate is set, text should also hover on mouseover
+    return HotkeyLabel.super.shouldHover(self) or self.on_activate
+end
+
 function HotkeyLabel:initializeLabel()
     self:setText{{key=self.key, key_sep=self.key_sep, text=self.label,
                   on_activate=self.on_activate}}
@@ -1473,6 +1484,12 @@ function CycleHotkeyLabel:init()
         {text=self:callback('getOptionLabel'),
          pen=self:callback('getOptionPen')},
     }
+end
+
+-- CycleHotkeyLabels are always clickable and therefore should always change
+-- color when hovered.
+function CycleHotkeyLabel:shouldHover()
+    return true
 end
 
 function CycleHotkeyLabel:cycle(backwards)

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1139,11 +1139,11 @@ function render_text(obj,dc,x0,y0,pen,dpen,disabled,hpen,hovered)
 
                 if dc then
                     local tpen = getval(token.pen)
-                    local dcpen = tpen or pen
+                    local dcpen = to_pen(tpen or pen)
 
                     -- If disabled, figure out which dpen to use
                     if disabled or is_disabled(token) then
-                        dccpen = getval(token.dpen) or tpen or dpen
+                        dcpen = to_pen(getval(token.dpen) or tpen or dpen)
                         if keypen.fg ~= COLOR_BLACK then
                             keypen.bold = false
                         end


### PR DESCRIPTION
Labels show the hover colour when on_click is set, HotkeyLabels should also do the same when they are clickable.

In my opinion, this makes it a lot easier to click, as someone who's not very good at clicking.

And as a usability suggestion, feel free to disagree and reject this PR!

https://user-images.githubusercontent.com/5893/218945682-c5d0dfdc-9655-4b80-951b-910be1f36630.mp4

