### PR TITLE
Fix confirm performance

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,7 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 -@ `autochop`: generate default names for burrows with no assigned names
 - ``Buildings::StockpileIterator``: check for stockpile items on block boundary.
 - `tailor`: block making clothing sized for toads; make replacement clothing orders use the size of the wearer, not the size of the garment; add support for adamantine cloth (off by default); improve logging
-- `confirm`: fix fps drop when enabled
+-@ `confirm`: fix fps drop when enabled
 
 ## Misc Improvements
 - DFHack tool windows that capture mouse clicks (and therefore prevent you from clicking on the "pause" button) now unconditionally pause the game when they open (but you can still unpause with the keyboard if you want to). Examples of this behavior: `gui/quickfort`, `gui/blueprint`, `gui/liquids`

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -43,6 +43,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 -@ `autochop`: generate default names for burrows with no assigned names
 - ``Buildings::StockpileIterator``: check for stockpile items on block boundary.
 - `tailor`: block making clothing sized for toads; make replacement clothing orders use the size of the wearer, not the size of the garment; add support for adamantine cloth (off by default); improve logging
+- `confirm`: fix fps drop when enabled
 
 ## Misc Improvements
 - DFHack tool windows that capture mouse clicks (and therefore prevent you from clicking on the "pause" button) now unconditionally pause the game when they open (but you can still unpause with the keyboard if you want to). Examples of this behavior: `gui/quickfort`, `gui/blueprint`, `gui/liquids`

--- a/plugins/confirm.cpp
+++ b/plugins/confirm.cpp
@@ -66,6 +66,7 @@ bool set_conf_paused (string name, bool pause);
 
 class confirmation_base {
 public:
+    bool dirty = false;
     enum cstate { INACTIVE, ACTIVE, SELECTED };
     virtual string get_id() = 0;
     virtual string get_focus_string() = 0;
@@ -281,6 +282,7 @@ public:
         }
 
         state = s;
+        dirty = true;
         if (s == INACTIVE) {
             active_id = "";
             confirmation_base::active = nullptr;
@@ -371,17 +373,18 @@ public:
         return state == ACTIVE;
     }
     void render() {
-        static vector<string> lines;
-        static const std::string pause_message =
-               "Pause confirmations until you exit this screen";
-        Screen::Pen corner_ul = Screen::Pen((char)201, COLOR_GREY, COLOR_BLACK);
-        Screen::Pen corner_ur = Screen::Pen((char)187, COLOR_GREY, COLOR_BLACK);
-        Screen::Pen corner_dl = Screen::Pen((char)200, COLOR_GREY, COLOR_BLACK);
-        Screen::Pen corner_dr = Screen::Pen((char)188, COLOR_GREY, COLOR_BLACK);
-        Screen::Pen border_ud = Screen::Pen((char)205, COLOR_GREY, COLOR_BLACK);
-        Screen::Pen border_lr = Screen::Pen((char)186, COLOR_GREY, COLOR_BLACK);
         if (state == ACTIVE)
         {
+            static vector<string> lines;
+            static const std::string pause_message =
+                   "Pause confirmations until you exit this screen";
+            Screen::Pen corner_ul = Screen::Pen((char)201, COLOR_GREY, COLOR_BLACK);
+            Screen::Pen corner_ur = Screen::Pen((char)187, COLOR_GREY, COLOR_BLACK);
+            Screen::Pen corner_dl = Screen::Pen((char)200, COLOR_GREY, COLOR_BLACK);
+            Screen::Pen corner_dr = Screen::Pen((char)188, COLOR_GREY, COLOR_BLACK);
+            Screen::Pen border_ud = Screen::Pen((char)205, COLOR_GREY, COLOR_BLACK);
+            Screen::Pen border_lr = Screen::Pen((char)186, COLOR_GREY, COLOR_BLACK);
+
             split_string(&lines, get_message(), "\n");
             size_t max_length = 40;
             for (string line : lines)
@@ -463,8 +466,10 @@ public:
             }
             set_state(INACTIVE);
         }
-        // clean up any artifacts
-        df::global::gps->force_full_display_count = 1;
+        if(dirty) {
+            dirty = false;
+            df::global::gps->force_full_display_count = 1;
+        }
     }
     string get_id() override = 0;
     string get_focus_string() override = 0;


### PR DESCRIPTION
When I updated `confirm` I made it so `df::global::gps->force_full_display_count = 1;` was running every frame ><.

This fixes that by adding a `dirty` field to `confirmation_base`. It  defaults to `false`, gets set to `true` during `set_state`, and if `true` we will `df::global::gps->force_full_display_count = 1` at the end of `render()` and set it back to `false`.

I am unable to actually replicate the fps issues on my machine, but this seems like the culprit. Playtested with a breakpoint to confirm it is only executed after a state change. Playtested without the breakpoint and confirmed that the dialogs are still getting cleaned up properly.

While I was at it I moved some other variables into the only branch that uses them, that were getting initialized every frame unnecessarily.