### PR TITLE
[isSuitableMaterial] detect lack of fire and magma safety for vulnerable materials with high melting points

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -54,6 +54,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autobutcher`: implemented work-around for Dwarf Fortress not setting nicknames properly, so that nicknames created in the in-game interface are detected & protect animals from being butchered properly. Note that nicknames for unnamed units are not currently saved by dwarf fortress - use ``enable fix/protect-nicks`` to fix any nicknames created/removed within dwarf fortress so they can be saved/reloaded when you reload the game.
 -@ `seedwatch`: fix saving and loading of seed stock targets
 - `autodump`: changed behaviour to only change ``dump`` and ``forbid`` flags if an item is successfully dumped.
+- ``dfhack.job.isSuitableMaterial``: now properly detects lack of fire and magma safety for vulnerable materials with high melting points
 -@ `autochop`: generate default names for burrows with no assigned names
 - ``Buildings::StockpileIterator``: fix check for stockpile items on block boundary.
 - `tailor`: block making clothing sized for toads; make replacement clothing orders use the size of the wearer, not the size of the garment

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- ``dfhack.job.isSuitableMaterial``: now properly detects lack of fire and magma safety for vulnerable materials with high melting points
 
 ## Misc Improvements
 
@@ -54,7 +55,6 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autobutcher`: implemented work-around for Dwarf Fortress not setting nicknames properly, so that nicknames created in the in-game interface are detected & protect animals from being butchered properly. Note that nicknames for unnamed units are not currently saved by dwarf fortress - use ``enable fix/protect-nicks`` to fix any nicknames created/removed within dwarf fortress so they can be saved/reloaded when you reload the game.
 -@ `seedwatch`: fix saving and loading of seed stock targets
 - `autodump`: changed behaviour to only change ``dump`` and ``forbid`` flags if an item is successfully dumped.
-- ``dfhack.job.isSuitableMaterial``: now properly detects lack of fire and magma safety for vulnerable materials with high melting points
 -@ `autochop`: generate default names for burrows with no assigned names
 - ``Buildings::StockpileIterator``: fix check for stockpile items on block boundary.
 - `tailor`: block making clothing sized for toads; make replacement clothing orders use the size of the wearer, not the size of the garment

--- a/library/modules/Materials.cpp
+++ b/library/modules/Materials.cpp
@@ -513,8 +513,14 @@ void MaterialInfo::getMatchBits(df::job_item_flags2 &ok, df::job_item_flags2 &ma
     TEST(sewn_imageless, is_cloth);
     TEST(glass_making, MAT_FLAG(CRYSTAL_GLASSABLE));
 
-    TEST(fire_safe, material->heat.melting_point > 11000);
-    TEST(magma_safe, material->heat.melting_point > 12000);
+    TEST(fire_safe, material->heat.melting_point > 11000
+                    && material->heat.boiling_point > 11000
+                    && material->heat.ignite_point > 11000
+                    && material->heat.heatdam_point > 11000);
+    TEST(magma_safe, material->heat.melting_point > 12000
+                    && material->heat.boiling_point > 12000
+                    && material->heat.ignite_point > 12000
+                    && material->heat.heatdam_point > 12000);
     TEST(deep_material, FLAG(inorganic, inorganic_flags::SPECIAL));
     TEST(non_economic, !inorganic || !(plotinfo && vector_get(plotinfo->economic_stone, index)));
 


### PR DESCRIPTION
previously we were only checking the melting point, but some fire-unsafe materials (like logs) have no melting point, and the check was giving a false negative. this change calls a material unsafe if any of the relevant properties are in the danger zone.