### PR TITLE
Add standard interior frame to gui.lua

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -44,8 +44,10 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## API
 
 ## Lua
+-@ ``gui.INTERIOR_FRAME``: a panel frame style for use in highlighting off interior areas of a UI
 
 ## Removed
+-@ ``gui.THIN_FRAME``: replaced by ``gui.INTERIOR_FRAME``
 
 # 50.07-alpha2
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4325,9 +4325,11 @@ There are the following predefined frame style tables:
 
   A frame suitable for overlay widget panels.
 
-* ``THIN_FRAME``
+* ``INTERIOR_FRAME``
 
-  A frame suitable for light accent elements.
+  A frame suitable for light interior accent elements. This frame does *not* have
+  a visible ``DFHack`` signature on it, so it must not be used as the most external
+  frame for a DFHack-owned UI.
 
 gui.widgets
 ===========

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -916,7 +916,8 @@ end
 WINDOW_FRAME = make_frame('Window', true)
 PANEL_FRAME = make_frame('Panel', false)
 MEDIUM_FRAME = make_frame('Medium', false)
-THIN_FRAME = make_frame('Thin', false)
+INTERIOR_FRAME = make_frame('Thin', false)
+INTERIOR_FRAME.signature_pen = false
 
 -- for compatibility with pre-steam code
 GREY_LINE_FRAME = WINDOW_FRAME


### PR DESCRIPTION
thinnest border line and no DFHack signature on the bottom, for interior accent areas.