### PR TITLE
allow clearing of map interface layer tiles

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -44,6 +44,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## API
 
 ## Lua
+- ``dfhack.screen.paintTile()``: you can now explicitly clear the interface cursor from a map tile by passing ``0`` as the tile value
 
 ## Removed
 

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -130,8 +130,7 @@ static bool doSetTile_map(const Pen &pen, int x, int y) {
     long texpos = pen.tile;
     if (!texpos && pen.ch)
         texpos = init->font.large_font_texpos[(uint8_t)pen.ch];
-    else
-        vp->screentexpos_interface[index] = texpos;
+    vp->screentexpos_interface[index] = texpos;
     return true;
 }
 

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -130,7 +130,7 @@ static bool doSetTile_map(const Pen &pen, int x, int y) {
     long texpos = pen.tile;
     if (!texpos && pen.ch)
         texpos = init->font.large_font_texpos[(uint8_t)pen.ch];
-    if (texpos)
+    else
         vp->screentexpos_interface[index] = texpos;
     return true;
 }


### PR DESCRIPTION
so you can, for example, clear the vanilla selection highlight if you want to draw your own