### PR TITLE
[Gui] don't prefix focus strings that are already properly marked

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
+- Gui focus strings will no longer get the "dfhack/" prefix if the string "dfhack/" already exists in the focus string
 
 ## Lua
 

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -491,7 +491,12 @@ bool Gui::matchFocusString(std::string focus_string, df::viewscreen *top) {
 static void push_dfhack_focus_string(dfhack_viewscreen *vs, std::vector<std::string> &focusStrings)
 {
     auto name = vs->getFocusString();
-    focusStrings.push_back(name.empty() ? "dfhack" : "dfhack/" + name);
+    if (name.empty())
+        name = "dfhack";
+    else if (string::npos == name.find("dfhack/"))
+        name = "dfhack/" + name;
+
+    focusStrings.push_back(name);
 }
 
 std::vector<std::string> Gui::getFocusStrings(df::viewscreen* top)

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -877,7 +877,7 @@ void dfhack_lua_viewscreen::update_focus(lua_State *L, int idx)
 
     if (focus.empty())
         focus = "lua";
-    else
+    else if (string::npos == focus.find("lua/"))
         focus = "lua/"+focus;
 }
 


### PR DESCRIPTION
this allows you to "masquerade" as a vanilla context if you so desire. For example, the `buildingplan` ZScreen-based dialogs indicate that they are still part of the building placement context by declaring a focus string of "dwarfmode/Building/Placement/dfhack/lua/buildingplan/itemselection"