### PR TITLE
make FilteredList searching case insensitive by default

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 - ``dfhack.screen.paintTile()``: you can now explicitly clear the interface cursor from a map tile by passing ``0`` as the tile value
 - ``widgets.Label``: token ``tile`` properties can now be functions that return a value
+-@ ``widgets.FilteredList``: search key matching is now case insensitive by default
 -@ ``gui.INTERIOR_FRAME``: a panel frame style for use in highlighting off interior areas of a UI
 
 ## Removed

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -5007,7 +5007,7 @@ construction that allows filtering the list by subwords of its items.
 In addition to passing through all attributes supported by List, it
 supports:
 
-:case_sensitive: If true, matching is case sensitive. Defaults to true.
+:case_sensitive: If ``true``, matching is case sensitive. Defaults to ``false``.
 :edit_pen: If specified, used instead of ``cursor_pen`` for the edit field.
 :edit_below: If true, the edit field is placed below the list instead of above.
 :edit_key: If specified, the edit field is disabled until this key is pressed.

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1926,7 +1926,7 @@ end
 FilteredList = defclass(FilteredList, Widget)
 
 FilteredList.ATTRS {
-    case_sensitive = true,
+    case_sensitive = false,
     edit_below = false,
     edit_key = DEFAULT_NIL,
     edit_ignore_keys = DEFAULT_NIL,


### PR DESCRIPTION
as a follow-on to #2837

checking this in early in the dev cycle for this release so we have time to discover if it causes any issues with current dialogs.