### PR TITLE
don't softlock the game on modal popups

### DIFF
--- a/plugins/overlay.cpp
+++ b/plugins/overlay.cpp
@@ -13,6 +13,7 @@
 #include "df/viewscreen_titlest.h"
 #include "df/viewscreen_update_regionst.h"
 #include "df/viewscreen_worldst.h"
+#include "df/world.h"
 
 #include "Debug.h"
 #include "LuaTools.h"
@@ -26,6 +27,8 @@ using namespace DFHack;
 
 DFHACK_PLUGIN("overlay");
 DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+
+REQUIRE_GLOBAL(world);
 
 namespace DFHack {
     DBG_DECLARE(overlay, control, DebugCategory::LINFO);
@@ -67,13 +70,15 @@ struct viewscreen_overlay : T {
     }
     DEFINE_VMETHOD_INTERPOSE(void, feed, (std::set<df::interface_key> *input)) {
         bool input_is_handled = false;
-        call_overlay_lua(NULL, "feed_viewscreen_widgets", 2, 1,
-                [&](lua_State *L) {
-                    Lua::Push(L, T::_identity.getName());
-                    Lua::PushInterfaceKeys(L, *input);
-                }, [&](lua_State *L) {
-                    input_is_handled = lua_toboolean(L, -1);
-                });
+        // don't send input to the overlays if there is a modal dialog up
+        if (!world->status.popups.size())
+            call_overlay_lua(NULL, "feed_viewscreen_widgets", 2, 1,
+                    [&](lua_State *L) {
+                        Lua::Push(L, T::_identity.getName());
+                        Lua::PushInterfaceKeys(L, *input);
+                    }, [&](lua_State *L) {
+                        input_is_handled = lua_toboolean(L, -1);
+                    });
         if (!input_is_handled)
             INTERPOSE_NEXT(feed)(input);
     }


### PR DESCRIPTION
overlays can prevent clicks from being handled by DF. likewise, vanilla modal popups can prevent clicks from getting handled by DFHack. to prevent a softlock, overlay will skip sending input to the overlay widgets when a modal dialog is visible

Fixes #2985