### PR TITLE
add launchdf binary so steam has an exe to launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,3 +615,5 @@ if(BUILD_SIZECHECK)
     add_subdirectory(depends/sizecheck)
     add_dependencies(dfhack sizecheck)
 endif()
+
+add_subdirectory(package/windows)

--- a/package/windows/CMakeLists.txt
+++ b/package/windows/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(package_windows)
+
+if(WIN32)
+    add_executable(launchdf WIN32 launchdf.c)
+    install(TARGETS launchdf
+        DESTINATION ${DFHACK_DATA_DESTINATION})
+endif()

--- a/package/windows/launchdf.c
+++ b/package/windows/launchdf.c
@@ -1,0 +1,42 @@
+#include <windows.h>
+
+int WINAPI wWinMain(HINSTANCE hi, HINSTANCE hpi, PWSTR cmd, int ns)
+{
+    STARTUPINFOA si;
+    PROCESS_INFORMATION pi;
+
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    CHAR dfdir[1024];
+
+    if (GetFullPathNameA("..", 1024, dfdir, NULL) == 0)
+    {
+        MessageBoxA(NULL, "could not get current directory", NULL, 0);
+        exit(1);
+    }
+
+    if (SetCurrentDirectoryA(dfdir) == 0)
+    {
+        MessageBoxA(NULL, "could not change to DF directory", NULL, 0);
+        exit(1);
+    }
+
+    if (CreateProcessA("Dwarf Fortress.exe",
+        NULL,
+        NULL,
+        NULL,
+        FALSE,
+        0,
+        NULL,
+        NULL,
+        &si,
+        &pi) == 0)
+    {
+        MessageBoxA(NULL, "could not launch 'Dwarf Fortress.exe'", NULL, 0);
+        exit(1);
+    }
+
+    exit(0);
+}


### PR DESCRIPTION
required for the steam distribution, which needs an exe to launch when the player runs the DFHack "game" from the steam client. we can't just point it at Dwarf Fortress.exe since the launch exe must be part of the DFHack install package

win32 code provided by ab9rf