### PR TITLE
[buildingplan] account for reverse ordering in job_items vector

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+-@ `buildingplan`: items are now attached correctly to screw pumps and other multi-item buildings
 
 ## Misc Improvements
 -@ `buildingplan`: can now filter by clay materials

--- a/plugins/buildingplan/itemfilter.cpp
+++ b/plugins/buildingplan/itemfilter.cpp
@@ -6,6 +6,7 @@
 
 namespace DFHack {
     DBG_EXTERN(buildingplan, status);
+    DBG_EXTERN(buildingplan, cycle);
 }
 
 using std::set;
@@ -153,11 +154,19 @@ bool ItemFilter::matches(DFHack::MaterialInfo &material) const {
 }
 
 bool ItemFilter::matches(df::item *item) const {
-    if (item->getQuality() < min_quality || item->getQuality() > max_quality)
+    if (item->getQuality() < min_quality || item->getQuality() > max_quality) {
+        TRACE(cycle).print("item outside of quality range (%d not between %d and %d)\n",
+                item->getQuality(), min_quality, max_quality);
         return false;
+    }
 
-    if (decorated_only && !item->hasImprovements())
+    if (decorated_only && !item->hasImprovements()) {
+        TRACE(cycle).print("item needs improvements and doesn't have any\n");
         return false;
+    }
+
+    if (!mat_mask.whole)
+        return true;
 
     auto imattype = item->getActualMaterial();
     auto imatindex = item->getActualMaterialIndex();

--- a/plugins/buildingplan/plannedbuilding.cpp
+++ b/plugins/buildingplan/plannedbuilding.cpp
@@ -26,9 +26,10 @@ static vector<vector<df::job_item_vector_id>> get_vector_ids(color_ostream &out,
     if (!bld || bld->jobs.size() != 1)
         return ret;
 
-    auto &job = bld->jobs[0];
-    for (auto &jitem : job->job_items) {
-        ret.emplace_back(getVectorIds(out, jitem));
+    auto &jitems = bld->jobs[0]->job_items;
+    int num_job_items = (int)jitems.size();
+    for (int jitem_idx = num_job_items - 1; jitem_idx >= 0; --jitem_idx) {
+        ret.emplace_back(getVectorIds(out, jitems[jitem_idx]));
     }
     return ret;
 }


### PR DESCRIPTION
Fixes #3016 

the `bld->job_items` vector is in *reverse* order compared to the filter list from which it is generated. what a world!