### PR TITLE
[buildingplan] comment out heat safety feature

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 
 ## Removed
+-@ `buildingplan`: "heat safety" setting is temporarily removed while we investigate incorrect item matching
 
 # 50.07-alpha3
 

--- a/plugins/buildingplan/buildingplan.cpp
+++ b/plugins/buildingplan/buildingplan.cpp
@@ -196,8 +196,9 @@ static void load_material_cache() {
 }
 
 static HeatSafety get_heat_safety_filter(const BuildingTypeKey &key) {
-    if (cur_heat_safety.count(key))
-        return cur_heat_safety.at(key);
+    // comment out until we can get heat safety working as intended
+    // if (cur_heat_safety.count(key))
+    //     return cur_heat_safety.at(key);
     return HEAT_SAFETY_ANY;
 }
 
@@ -486,7 +487,7 @@ static bool registerPlannedBuilding(color_ostream &out, PlannedBuilding & pb) {
             for (int item_num = 0; item_num < job_item->quantity; ++item_num) {
                 tasks[vector_id][bucket].emplace_back(id, rev_jitem_index);
                 DEBUG(status,out).print("added task: %s/%s/%d,%d; "
-                      "%zu vector(s), %zu filter bucket(s), %zu task(s) in bucket",
+                      "%zu vector(s), %zu filter bucket(s), %zu task(s) in bucket\n",
                       ENUM_KEY_STR(job_item_vector_id, vector_id).c_str(),
                       bucket.c_str(), id, rev_jitem_index, tasks.size(),
                       tasks[vector_id].size(), tasks[vector_id][bucket].size());

--- a/plugins/buildingplan/plannedbuilding.cpp
+++ b/plugins/buildingplan/plannedbuilding.cpp
@@ -109,7 +109,8 @@ PlannedBuilding::PlannedBuilding(color_ostream &out, df::building *bld, HeatSafe
 PlannedBuilding::PlannedBuilding(color_ostream &out, PersistentDataItem &bld_config)
     : id(get_config_val(bld_config, BLD_CONFIG_ID)),
         vector_ids(deserialize_vector_ids(out, bld_config)),
-        heat_safety((HeatSafety)get_config_val(bld_config, BLD_CONFIG_HEAT)),
+        //heat_safety((HeatSafety)get_config_val(bld_config, BLD_CONFIG_HEAT)), // until this works
+        heat_safety(HEAT_SAFETY_ANY),
         item_filters(get_item_filters(out, bld_config)),
         specials(get_specials(out, bld_config)),
         bld_config(bld_config) { }

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -454,6 +454,7 @@ function PlannerOverlay:init()
                     on_change=function(heat)
                         buildingplan.setHeatSafetyFilter(uibs.building_type, uibs.building_subtype, uibs.custom_type, heat)
                     end,
+                    visible=false, -- until we can make this work the way it's intended
                 },
             },
         },


### PR DESCRIPTION
since it's just not working right.

it appears to be matching the heat safety of the *item* rather than of the *material*, leading it to ignore items with materials that *would* be heat safe once they are built into buildings.