### PR TITLE
[buildingplan] better minimize widget for the planner panel

### DIFF
--- a/plugins/lua/buildingplan/pens.lua
+++ b/plugins/lua/buildingplan/pens.lua
@@ -4,6 +4,7 @@ GOOD_TILE_PEN, BAD_TILE_PEN = nil, nil
 VERT_TOP_PEN, VERT_MID_PEN, VERT_BOT_PEN = nil, nil, nil
 BUTTON_START_PEN, BUTTON_END_PEN = nil, nil
 SELECTED_ITEM_PEN = nil
+MINIMIZED_LEFT_PEN, MINIMIZED_RIGHT_PEN = nil, nil
 
 local to_pen = dfhack.pen.parse
 
@@ -25,6 +26,10 @@ function reload_pens()
     BUTTON_START_PEN = to_pen{tile=tp(cp_texpos, 13), ch='[', fg=COLOR_YELLOW}
     BUTTON_END_PEN = to_pen{tile=tp(cp_texpos, 15), ch=']', fg=COLOR_YELLOW}
     SELECTED_ITEM_PEN = to_pen{tile=tp(cp_texpos, 9), ch=string.char(251), fg=COLOR_YELLOW}
+
+    local wb_texpos = dfhack.textures.getWindowBordersTexposStart()
+    MINIMIZED_LEFT_PEN = to_pen{tile=tp(wb_texpos, 0), ch=199, fg=COLOR_WHITE}
+    MINIMIZED_RIGHT_PEN = to_pen{tile=tp(wb_texpos, 2), ch=182, fg=COLOR_WHITE}
 end
 reload_pens()
 

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -270,15 +270,27 @@ function PlannerOverlay:init()
         visible=function() return not self.minimized end,
     }
 
-    local minimized_panel = widgets.Label{
-        frame={t=0, r=1, w=1, h=1},
-        text={
-            {
-                text=function() return string.char(self.minimized and 31 or 30) end,
-                pen=COLOR_RED,
+    local minimized_panel = widgets.Panel{
+        frame={t=0, r=0, w=4, h=1},
+        subviews={
+            widgets.Label{
+                frame={t=0, l=0, w=1, h=1},
+                text={{tile=pens.MINIMIZED_LEFT_PEN}},
+                visible=function() return self.minimized end,
+            },
+            widgets.Label{
+                frame={t=0, l=1, w=2, h=1},
+                text=string.char(31)..string.char(30),
+                text_pen=dfhack.pen.parse{fg=COLOR_BLACK, bg=COLOR_GREY},
+                text_hpen=dfhack.pen.parse{fg=COLOR_BLACK, bg=COLOR_WHITE},
+                on_click=function() self.minimized = not self.minimized end,
+            },
+            widgets.Label{
+                frame={t=0, r=0, w=1, h=1},
+                text={{tile=pens.MINIMIZED_RIGHT_PEN}},
+                visible=function() return self.minimized end,
             },
         },
-        on_click=function() self.minimized = not self.minimized end,
     }
 
     local function make_is_selected_fn(idx)


### PR DESCRIPTION
iteration on #3022, based on designs by @TaxiService 

unhovered:
![image](https://user-images.githubusercontent.com/977482/225951605-182b56c0-3f15-48f2-8f18-ca834e2b9b04.png)
![image](https://user-images.githubusercontent.com/977482/225951655-7c1a7016-0f0c-4509-9fe8-953e2715060a.png)

hovered:
![image](https://user-images.githubusercontent.com/977482/225951816-7389cba8-ef64-48b2-8cc5-4ac494cc3f70.png)
![image](https://user-images.githubusercontent.com/977482/225951848-42f0bce1-aff9-4223-9322-a2309cbb1a10.png)
