### PR TITLE
[reveal] anchor revflood at a unit's position

### DIFF
--- a/docs/plugins/reveal.rst
+++ b/docs/plugins/reveal.rst
@@ -17,7 +17,7 @@ reveal
    :summary: Switch between reveal and unreveal.
 
 .. dfhack-command:: revflood
-   :summary: Hide everything, then reveal tiles with a path to the cursor.
+   :summary: Hide everything, then reveal tiles with a path to a unit.
 
 .. dfhack-command:: nopause
    :summary: Disable pausing.
@@ -44,9 +44,10 @@ Usage
     where (for example) you abandoned with the fort revealed and no longer need
     the saved map data when you load a new fort.
 ``revflood``
-    Hide everything, then reveal tiles with a path to the cursor. This allows
-    reparing maps that you accidentally saved while they were revealed. Note
-    that tiles behind constructed walls are also revealed as a workaround for
+    Hide everything, then reveal tiles with a path to the keyboard cursor (if
+    enabled) or the selected unit (if a unit is selected) or else a random citizen.
+    This allows reparing maps that you accidentally saved while they were revealed.
+    Note that tiles behind constructed walls are also revealed as a workaround for
     :bug:`1871`.
 ``nopause 1|0``
     Disables pausing (both manual and automatic) with the exception of the pause

--- a/plugins/reveal.cpp
+++ b/plugins/reveal.cpp
@@ -12,6 +12,7 @@
 #include "modules/World.h"
 #include "modules/MapCache.h"
 #include "modules/Gui.h"
+#include "modules/Units.h"
 #include "modules/Screen.h"
 
 #include "df/block_square_event_frozen_liquidst.h"
@@ -502,21 +503,32 @@ command_result revflood(color_ostream &out, vector<string> & params)
         out.printerr("Only in proper dwarf mode.\n");
         return CR_FAILURE;
     }
-    int32_t cx, cy, cz;
+    df::coord pos;
     Maps::getSize(x_max,y_max,z_max);
 
-    Gui::getCursorCoords(cx,cy,cz);
-    if(cx == -30000)
-    {
-        out.printerr("Cursor is not active. Point the cursor at some empty space you want to be unhidden.\n");
+    Gui::getCursorCoords(pos);
+    if (!pos.isValid()) {
+        df::unit *unit = Gui::getSelectedUnit(out, true);
+        if (unit)
+            pos = Units::getPosition(unit);
+    }
+
+    if (!pos.isValid()) {
+        vector<df::unit *> citizens;
+        Units::getCitizens(citizens);
+        if (citizens.size())
+            pos = Units::getPosition(citizens[0]);
+    }
+
+    if(!pos.isValid()) {
+        out.printerr("Please select a unit or place the keyboard cursor at some empty space you want to be unhidden.\n");
         return CR_FAILURE;
     }
-    DFCoord xy ((uint32_t)cx,(uint32_t)cy,cz);
     MapCache * MCache = new MapCache;
-    df::tiletype tt = MCache->tiletypeAt(xy);
+    df::tiletype tt = MCache->tiletypeAt(pos);
     if(isWallTerrain(tt))
     {
-        out.printerr("Point the cursor at some empty space you want to be unhidden.\n");
+        out.printerr("Please select a unit or place the keyboard cursor at some empty space you want to be unhidden.\n");
         delete MCache;
         return CR_FAILURE;
     }
@@ -534,7 +546,7 @@ command_result revflood(color_ostream &out, vector<string> & params)
     }
     MCache->trash();
 
-    unhideFlood_internal(MCache, xy);
+    unhideFlood_internal(MCache, pos);
     MCache->WriteAll();
     delete MCache;
 


### PR DESCRIPTION
makes it more user friendly and reduces chance of mishap by placing the cursor in an unforgiving location (like in a closed cavity)

Fixes #2962