### PR TITLE
Add default keybinding an alias for gui/design

### DIFF
--- a/data/init/dfhack.keybindings.init
+++ b/data/init/dfhack.keybindings.init
@@ -153,6 +153,10 @@ keybinding add Ctrl-Shift-Q@dwarfmode gui/quickfort
 #keybinding add Ctrl-Shift-N@dwarfmode|unit|unitlist|joblist|dungeon_monsterstatus|layer_unit_relationship|item|workshop_profile|layer_noblelist|locations|pets|layer_overall_health|textviewer|reportlist|announcelist|layer_military|layer_unit_health|customize_unit|buildinglist gui/rename
 #keybinding add Ctrl-Shift-T@dwarfmode|unit|unitlist|joblist|dungeon_monsterstatus|layer_unit_relationship|item|workshop_profile|layer_noblelist|locations|pets|layer_overall_health|textviewer|reportlist|announcelist|layer_military|layer_unit_health|customize_unit "gui/rename unit-profession"
 
+# gui/design
+keybinding add Ctrl-D@dwarfmode gui/design
+
+
 
 #####################
 # adv mode bindings #

--- a/data/init/dfhack.tools.init
+++ b/data/init/dfhack.tools.init
@@ -142,4 +142,4 @@ enable \
 # Default Aliases #
 ###################
 
-alias gui/dig gui/design
+alias add gui/dig gui/design

--- a/data/init/dfhack.tools.init
+++ b/data/init/dfhack.tools.init
@@ -137,3 +137,9 @@ enable \
 
 # a replacement for the "load game" screen
 #gui/load-screen enable
+
+###################
+# Default Aliases #
+###################
+
+alias gui/dig gui/design

--- a/docs/about/Removed.rst
+++ b/docs/about/Removed.rst
@@ -146,6 +146,12 @@ This script is no longer useful in current DF versions. The script required a
 binpatch <binpatches/needs-patch>`, which has not been available since DF
 0.34.11.
 
+.. _gui/dig:
+
+gui/dig
+=======
+Renamed to gui/design
+
 .. _gui/hack-wish:
 
 gui/hack-wish
@@ -193,8 +199,3 @@ warn-stuck-trees
 ================
 The corresponding DF :bug:`9252` was fixed in DF 0.44.01.
 
-.. _gui/dig:
-
-gui/dig
-=======
-Renamed to gui/design

--- a/docs/about/Removed.rst
+++ b/docs/about/Removed.rst
@@ -193,7 +193,7 @@ warn-stuck-trees
 ================
 The corresponding DF :bug:`9252` was fixed in DF 0.44.01.
 
-.. gui/dig:
+.. _gui/dig:
 
 gui/dig
 =======

--- a/docs/about/Removed.rst
+++ b/docs/about/Removed.rst
@@ -192,3 +192,9 @@ Replaced with a GUI version: `gui/unit-syndromes`.
 warn-stuck-trees
 ================
 The corresponding DF :bug:`9252` was fixed in DF 0.44.01.
+
+.. gui/dig:
+
+gui/dig
+=======
+Renamed to gui/design

--- a/docs/about/Removed.rst
+++ b/docs/about/Removed.rst
@@ -198,4 +198,3 @@ Replaced with a GUI version: `gui/unit-syndromes`.
 warn-stuck-trees
 ================
 The corresponding DF :bug:`9252` was fixed in DF 0.44.01.
-


### PR DESCRIPTION
Should not be merged until after https://github.com/DFHack/scripts/pull/643

Creates an `alias` for `gui/dig` -> `gui/design` to preserve existing custom user hotkeys.