### PR TITLE
[buildingplan] actually record the deserialized material mask val

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -39,6 +39,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `tailor`: now properly discriminates between dyed and undyed cloth and no longer defaults to using adamantine
 - `buildingplan`: upright spike traps are now placed extended rather than retracted
+- `buildingplan`: fixed material filter getting lost for planning buildings on save/reload
 
 ## Misc Improvements
 - `stockpiles`: support applying stockpile configurations with fully enabled categories to stockpiles in worlds other than the one where the configuration was exported from

--- a/plugins/buildingplan/buildingplan.cpp
+++ b/plugins/buildingplan/buildingplan.cpp
@@ -130,7 +130,7 @@ static const vector<const df::job_item *> & get_job_items(color_ostream &out, Bu
                 },
                 [&](lua_State *L) {
                     df::job_item *jitem = Lua::GetDFObject<df::job_item>(L, -1);
-                    DEBUG(status,out).print("retrieving job_item for (%d, %d, %d) index=%d: %p\n",
+                    DEBUG(status,out).print("retrieving job_item for (%d, %d, %d) index=%d: 0x%p\n",
                             std::get<0>(key), std::get<1>(key), std::get<2>(key), index, jitem);
                     if (!jitem)
                         failed = true;
@@ -311,7 +311,7 @@ DFhackCExport command_result plugin_load_data (color_ostream &out) {
         PlannedBuilding pb(out, building_configs[idx]);
         df::building *bld = df::building::find(pb.id);
         if (!bld) {
-            INFO(status,out).print("building %d no longer exists; skipping\n", pb.id);
+            DEBUG(status,out).print("building %d no longer exists; skipping\n", pb.id);
             pb.remove(out);
             continue;
         }

--- a/plugins/buildingplan/itemfilter.cpp
+++ b/plugins/buildingplan/itemfilter.cpp
@@ -35,7 +35,7 @@ bool ItemFilter::isEmpty() const {
             && materials.empty();
 }
 
-static bool deserializeMaterialMask(string ser, df::dfhack_material_category mat_mask) {
+static bool deserializeMaterialMask(const string& ser, df::dfhack_material_category& mat_mask) {
     if (ser.empty())
         return true;
 
@@ -46,7 +46,7 @@ static bool deserializeMaterialMask(string ser, df::dfhack_material_category mat
     return true;
 }
 
-static bool deserializeMaterials(string ser, set<DFHack::MaterialInfo> &materials) {
+static bool deserializeMaterials(const string& ser, set<DFHack::MaterialInfo> &materials) {
     if (ser.empty())
         return true;
 
@@ -63,7 +63,7 @@ static bool deserializeMaterials(string ser, set<DFHack::MaterialInfo> &material
     return true;
 }
 
-ItemFilter::ItemFilter(color_ostream &out, string serialized) : ItemFilter() {
+ItemFilter::ItemFilter(color_ostream &out, const string& serialized) : ItemFilter() {
     vector<string> tokens;
     split_string(&tokens, serialized, "/");
     if (tokens.size() < 5) {
@@ -87,11 +87,9 @@ string ItemFilter::serialize() const {
     std::ostringstream ser;
     ser << bitfield_to_string(mat_mask, ",") << "/";
     vector<string> matstrs;
-    if (!materials.empty()) {
-        for (auto &mat : materials)
-            matstrs.emplace_back(mat.getToken());
-        ser << join_strings(",", matstrs);
-    }
+    for (auto &mat : materials)
+        matstrs.emplace_back(mat.getToken());
+    ser << join_strings(",", matstrs);
     ser << "/" << static_cast<int>(min_quality);
     ser << "/" << static_cast<int>(max_quality);
     ser << "/" << static_cast<int>(decorated_only);

--- a/plugins/buildingplan/itemfilter.h
+++ b/plugins/buildingplan/itemfilter.h
@@ -8,7 +8,7 @@
 class ItemFilter {
 public:
     ItemFilter();
-    ItemFilter(DFHack::color_ostream &out, std::string serialized);
+    ItemFilter(DFHack::color_ostream &out, const std::string& serialized);
 
     void clear();
     bool isEmpty() const;


### PR DESCRIPTION
member field was passed by value instead of reference, causing the deserialized state to just be lost to the aether instead of remembered in the ItemFilter

Fixes #3044 
Fixes #3065