### PR TITLE
[buildingplan] normalize stairs so they all use the same filter

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - `buildingplan`: filters are now properly applied to planned stairs
+- `buildingplan`: existing carved up/down stairs are now taken into account when determining which stair shape to construct
 - `buildingplan`: upright spike traps are now placed extended rather than retracted
 - `buildingplan`: fixed material filter getting lost for planning buildings on save/reload
 - `buildingplan`: respect building size limits (e.g. roads and bridges cannot be more than 31 tiles in any dimension)

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `prospector`: prospector tool in fort mode is now available. embark prospect is not yet available and is disabled at this time.
 
 ## Fixes
+- `buildingplan`: filters are now properly applied to planned stairs
 - `buildingplan`: upright spike traps are now placed extended rather than retracted
 - `buildingplan`: fixed material filter getting lost for planning buildings on save/reload
 - `buildingplan`: respect building size limits (e.g. roads and bridges cannot be more than 31 tiles in any dimension)

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -782,7 +782,7 @@ function PlannerOverlay:get_stairs_subtype(pos, bounds)
         if opt == 'auto' then
             local tt = dfhack.maps.getTileType(pos)
             local shape = df.tiletype.attrs[tt].shape
-            if shape ~= df.tiletype_shape.STAIR_DOWN then
+            if shape ~= df.tiletype_shape.STAIR_DOWN and shape ~= df.tiletype_shape.STAIR_UPDOWN then
                 subtype = df.construction_type.UpStair
             end
         else
@@ -793,7 +793,7 @@ function PlannerOverlay:get_stairs_subtype(pos, bounds)
         if opt == 'auto' then
             local tt = dfhack.maps.getTileType(pos)
             local shape = df.tiletype.attrs[tt].shape
-            if shape ~= df.tiletype_shape.STAIR_UP then
+            if shape ~= df.tiletype_shape.STAIR_UP and shape ~= df.tiletype_shape.STAIR_UPDOWN then
                 subtype = df.construction_type.DownStair
             end
         else


### PR DESCRIPTION
up and down stairs were using their own (empty) filters. all stairs are configured as a single "type" in the UI.

also change existing tile shape detection to take carved stairs into account

Fixes #3066