### PR TITLE
turn down autounsuspend gracefully

### DIFF
--- a/data/init/dfhack.tools.init
+++ b/data/init/dfhack.tools.init
@@ -142,4 +142,5 @@ enable \
 # Default Aliases #
 ###################
 
+alias add autounsuspend suspendmanager
 alias add gui/dig gui/design

--- a/docs/about/Removed.rst
+++ b/docs/about/Removed.rst
@@ -26,6 +26,12 @@ Moved frequently used materials to the top of the materials list when building
 buildings. Also offered extended options when building constructions. All
 functionality has been merged into `buildingplan`.
 
+.. _autounsuspend:
+
+autounsuspend
+=============
+Replaced by `suspendmanager`.
+
 .. _combine-drinks:
 
 combine-drinks

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -51,6 +51,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `stockpiles`: now includes a library of useful stockpile configs (see docs for details)
 - `automelt`: now allows metal chests to be melted (workaround for DF bug 2493 is no longer needed)
 - `orders`: add minimize button to overlay panel so you can get it out of the way to read long statue descriptions when choosing a subject in the details screen
+- `enable`: can now interpret aliases defined with the `alias` command
 
 ## Documentation
 

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -763,6 +763,8 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, s
                     }
                 }
 
+                part = GetAliasCommand(part, true);
+
                 Plugin * plug = (*plug_mgr)[part];
 
                 if(!plug)
@@ -2657,13 +2659,14 @@ std::map<std::string, std::vector<std::string>> Core::ListAliases()
     return aliases;
 }
 
-std::string Core::GetAliasCommand(const std::string &name, const std::string &default_)
+std::string Core::GetAliasCommand(const std::string &name, bool ignore_params)
 {
     std::lock_guard<std::recursive_mutex> lock(alias_mutex);
-    if (IsAlias(name))
-        return join_strings(" ", aliases[name]);
-    else
-        return default_;
+    if (!IsAlias(name) || aliases[name].empty())
+        return name;
+    if (ignore_params)
+        return aliases[name][0];
+    return join_strings(" ", aliases[name]);
 }
 
 /////////////////

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -173,7 +173,7 @@ namespace DFHack
         bool RunAlias(color_ostream &out, const std::string &name,
             const std::vector<std::string> &parameters, command_result &result);
         std::map<std::string, std::vector<std::string>> ListAliases();
-        std::string GetAliasCommand(const std::string &name, const std::string &default_ = "");
+        std::string GetAliasCommand(const std::string &name, bool ignore_params = false);
 
         std::string getHackPath();
 


### PR DESCRIPTION
adds alias for `autounsuspend` -> `suspendmanager` and adds alias resolving capability to the `enable` and `disable` commands

Fixes #2955 
Fixes #2979 