### PR TITLE
[buildingplan] suspendmanager integration

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `buildingplan`: filters and global settings are now ignored when manually choosing items for a building
+- `buildingplan`: if `suspendmanager` is running, then planned buildings will be left suspended when their items are all attached. `suspendmanager` will unsuspsend them for construction when it is safe to do so.
 - `stockpiles`: support applying stockpile configurations with fully enabled categories to stockpiles in worlds other than the one where the configuration was exported from
 - `stockpiles`: support partial application of a saved config based on dynamic filtering
 - `stockpiles`: additive and subtractive modes when applying a second stockpile configuration on top of a first

--- a/docs/plugins/buildingplan.rst
+++ b/docs/plugins/buildingplan.rst
@@ -20,7 +20,10 @@ building. Once all items are attached, the construction job will be unsuspended
 and a dwarf will come and build the building. If you have the `unsuspend`
 overlay enabled (it is enabled by default), then buildingplan-suspended
 buildings will appear with a ``P`` marker on the main map, as opposed to the
-usual ``x`` marker for "regular" suspended buildings.
+usual ``x`` marker for "regular" suspended buildings. If you have
+`suspendmanager` running, then buildings will be left suspended when their
+items are all attached and ``suspendmanager`` will unsuspend them for
+construction when it is safe to do so.
 
 If you want to impose restrictions on which items are chosen for the buildings,
 buildingplan has full support for quality and material filters (see `below

--- a/plugins/buildingplan/buildingplan.h
+++ b/plugins/buildingplan/buildingplan.h
@@ -52,4 +52,4 @@ bool itemPassesScreen(df::item * item);
 df::job_item getJobItemWithHeatSafety(const df::job_item *job_item, HeatSafety heat);
 bool matchesFilters(df::item * item, const df::job_item * job_item, HeatSafety heat, const ItemFilter &item_filter, const std::set<std::string> &special);
 bool isJobReady(DFHack::color_ostream &out, const std::vector<df::job_item *> &jitems);
-void finalizeBuilding(DFHack::color_ostream &out, df::building *bld);
+void finalizeBuilding(DFHack::color_ostream &out, df::building *bld, bool unsuspend_on_finalize);

--- a/plugins/lua/buildingplan.lua
+++ b/plugins/lua/buildingplan.lua
@@ -51,6 +51,11 @@ function parse_commandline(...)
     return true
 end
 
+function is_suspendmanager_enabled()
+    local ok, sm = pcall(reqscript, 'suspendmanager')
+    return ok and sm.isEnabled()
+end
+
 function get_num_filters(btype, subtype, custom)
     local filters = dfhack.buildings.getFiltersByType({}, btype, subtype, custom)
     return filters and #filters or 0


### PR DESCRIPTION
if `suspendmanager` is running, then planned buildings will be left suspended when their items are all attached. `suspendmanager` will unsuspsend them for construction when it is safe to do so.

Fixes #3052