### PR TITLE
[widgets] fix and extend Labels/CycleHotkeyLabels

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -72,6 +72,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Lua
 - ``widget.Label``: tokens can now specify a ``htile`` property to indicate the tile that should be shown when the Label is hovered over with the mouse
+- ``widget.Label``: click handlers no longer get the label itself as the first param to the click handler
+- ``widget.CycleHotkeyLabel``: options that are bare integers will no longer be interpreted as the pen color in addition to being the label and value
+- ``widget.CycleHotkeyLabel``: option labels and pens can now be functions that return a label or pen
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4901,8 +4901,8 @@ It has the following attributes:
 :label_below: If ``true``, then the option value will apear below the label
     instead of to the right of it. Defaults to ``false``.
 :options: A list of strings or tables of
-    ``{label=string, value=string[, pen=pen]}``. String options use the same
-    string for the label and value and the default pen. The optional ``pen``
+    ``{label=string or fn, value=val[, pen=pen]}``. String options use the same
+    string for the label and value and use the default pen. The optional ``pen``
     element could be a color like ``COLOR_RED``.
 :initial_option: The value or numeric index of the initial option.
 :on_change: The callback to call when the selected option changes. It is called

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1361,11 +1361,11 @@ function Label:onInput(keys)
         return true
     end
     if keys._MOUSE_L_DOWN and self:getMousePos() and self.on_click then
-        self:on_click()
+        self.on_click()
         return true
     end
     if keys._MOUSE_R_DOWN and self:getMousePos() and self.on_rclick then
-        self:on_rclick()
+        self.on_rclick()
         return true
     end
     for k,v in pairs(self.scroll_keys) do
@@ -1560,17 +1560,17 @@ function CycleHotkeyLabel:setOption(value_or_index, call_on_change)
     end
 end
 
-local function cyclehotkeylabel_getOptionElem(self, option_idx, key)
+local function cyclehotkeylabel_getOptionElem(self, option_idx, key, require_key)
     option_idx = option_idx or self.option_idx
     local option = self.options[option_idx]
     if type(option) == 'table' then
         return option[key]
     end
-    return option
+    return not require_key and option or nil
 end
 
 function CycleHotkeyLabel:getOptionLabel(option_idx)
-    return cyclehotkeylabel_getOptionElem(self, option_idx, 'label')
+    return getval(cyclehotkeylabel_getOptionElem(self, option_idx, 'label'))
 end
 
 function CycleHotkeyLabel:getOptionValue(option_idx)
@@ -1578,7 +1578,7 @@ function CycleHotkeyLabel:getOptionValue(option_idx)
 end
 
 function CycleHotkeyLabel:getOptionPen(option_idx)
-    local pen = cyclehotkeylabel_getOptionElem(self, option_idx, 'pen')
+    local pen = getval(cyclehotkeylabel_getOptionElem(self, option_idx, 'pen', true))
     if type(pen) == 'string' then return nil end
     return pen
 end


### PR DESCRIPTION
- fix bug in Label where it was sending itself to a callback (because it was calling with `:` instead of `.`)
- fix bug in CycleHotkeyLabel where it was interpreting an option value as a pen -- no more rainbow weapon selection in buildingplan : (
- add ability to CycleHotkeyLabel to have dynamic option labels and pens