### PR TITLE
fix masterwork/exceptional/decorated symbols

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `blueprint`: interpret saplings, shrubs, and twigs as floors instead of walls
 
 ## Misc Improvements
+- `buildingplan`: items in the item selection dialog should now use the same item quality symbols as the base game
 
 ## Documentation
 

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -720,13 +720,13 @@ df::coord Items::getPosition(df::item *item)
     return item->pos;
 }
 
-static char quality_table[] = { 0, '-', '+', '*', '=', '@' };
+static int quality_table[] = { 0, 45, 43, 42, 240, 15 };
 
 static void addQuality(std::string &tmp, int quality)
 {
     if (quality > 0 && quality <= 5) {
-        char c = quality_table[quality];
-        tmp = c + tmp + c;
+        int c = quality_table[quality];
+        tmp = static_cast<char>(c) + tmp + static_cast<char>(c);
     }
 }
 
@@ -825,7 +825,7 @@ std::string Items::getDescription(df::item *item, int type, bool decorate)
         addQuality(tmp, item->getQuality());
 
         if (item->isImproved()) {
-            tmp = "<" + tmp + ">";
+            tmp = static_cast<char>(174) + tmp + static_cast<char>(175);
             addQuality(tmp, item->getImprovementQuality());
         }
     }

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -720,12 +720,7 @@ df::coord Items::getPosition(df::item *item)
     return item->pos;
 }
 
-static const char MARKER_EXCEPTIONAL = static_cast<char>(240);
-static const char MARKER_MASTERWORK = static_cast<char>(15);
-static const char MARKER_IMPROVED_LEFT = static_cast<char>(174);
-static const char MARKER_IMPROVED_RIGHT = static_cast<char>(175);
-
-static char quality_table[] = { 0, '-', '+', '*', MARKER_EXCEPTIONAL, MARKER_MASTERWORK };
+static char quality_table[] = { 0, '-', '+', '*', '\xF0', '\x0F' };
 
 static void addQuality(std::string &tmp, int quality)
 {
@@ -830,7 +825,7 @@ std::string Items::getDescription(df::item *item, int type, bool decorate)
         addQuality(tmp, item->getQuality());
 
         if (item->isImproved()) {
-            tmp = MARKER_IMPROVED_LEFT + tmp + MARKER_IMPROVED_RIGHT;
+            tmp = '\xAE' + tmp + '\xAF';
             addQuality(tmp, item->getImprovementQuality());
         }
     }

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -720,7 +720,13 @@ df::coord Items::getPosition(df::item *item)
     return item->pos;
 }
 
-static char quality_table[] = { 0, '-', '+', '*', '\xF0', '\x0F' };
+// These '\xFF' chars refer to quality markers from curses.png, namely: 250 (≡), 15 (☼), 174 («) and 175 (»).
+static const char MARKER_EXCEPTIONAL = '\xF0';
+static const char MARKER_MASTERWORK = '\x0F';
+static const char MARKER_IMPROVED_LEFT = '\xAE';
+static const char MARKER_IMPROVED_RIGHT = '\xAF';
+
+static char quality_table[] = { 0, '-', '+', '*', MARKER_EXCEPTIONAL, MARKER_MASTERWORK };
 
 static void addQuality(std::string &tmp, int quality)
 {
@@ -825,7 +831,7 @@ std::string Items::getDescription(df::item *item, int type, bool decorate)
         addQuality(tmp, item->getQuality());
 
         if (item->isImproved()) {
-            tmp = '\xAE' + tmp + '\xAF';
+            tmp = MARKER_IMPROVED_LEFT + tmp + MARKER_IMPROVED_RIGHT;
             addQuality(tmp, item->getImprovementQuality());
         }
     }

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -720,13 +720,18 @@ df::coord Items::getPosition(df::item *item)
     return item->pos;
 }
 
-static int quality_table[] = { 0, 45, 43, 42, 240, 15 };
+static const char MARKER_EXCEPTIONAL = static_cast<char>(240);
+static const char MARKER_MASTERWORK = static_cast<char>(15);
+static const char MARKER_IMPROVED_LEFT = static_cast<char>(174);
+static const char MARKER_IMPROVED_RIGHT = static_cast<char>(175);
+
+static char quality_table[] = { 0, '-', '+', '*', MARKER_EXCEPTIONAL, MARKER_MASTERWORK };
 
 static void addQuality(std::string &tmp, int quality)
 {
     if (quality > 0 && quality <= 5) {
-        int c = quality_table[quality];
-        tmp = static_cast<char>(c) + tmp + static_cast<char>(c);
+        char c = quality_table[quality];
+        tmp = c + tmp + c;
     }
 }
 
@@ -825,7 +830,7 @@ std::string Items::getDescription(df::item *item, int type, bool decorate)
         addQuality(tmp, item->getQuality());
 
         if (item->isImproved()) {
-            tmp = static_cast<char>(174) + tmp + static_cast<char>(175);
+            tmp = MARKER_IMPROVED_LEFT + tmp + MARKER_IMPROVED_RIGHT;
             addQuality(tmp, item->getImprovementQuality());
         }
     }


### PR DESCRIPTION
this seems to fix the issue in which some quality levels were displayed with incorrect characters in some DFHack windows, namely:

`@` instead of `☼`
`=` instead of `≡`
`<>` instead of `«»`