### PR TITLE
update steam launcher

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- Steam launcher now launches Dwarf Fortress via the Steam client
 
 ## Misc Improvements
 

--- a/package/windows/launchdf.c
+++ b/package/windows/launchdf.c
@@ -2,15 +2,28 @@
 
 int WINAPI wWinMain(HINSTANCE hi, HINSTANCE hpi, PWSTR cmd, int ns)
 {
-    STARTUPINFOA si;
+    STARTUPINFOW si;
     PROCESS_INFORMATION pi;
 
     ZeroMemory(&si, sizeof(si));
     si.cb = sizeof(si);
     ZeroMemory(&pi, sizeof(pi));
 
-    if (CreateProcessA("Dwarf Fortress.exe",
-        NULL,
+    WCHAR steamPath[1024];
+    DWORD datasize = 1024;
+
+    LONG retCode = RegGetValueW(HKEY_CURRENT_USER, L"SOFTWARE\\Valve\\Steam", L"SteamExe", RRF_RT_REG_SZ, NULL, &steamPath, &datasize);
+
+    if (retCode != ERROR_SUCCESS)
+    {
+        MessageBoxW(NULL, L"Could not find Steam client executable", NULL, 0);
+        exit(1);
+    }
+
+    WCHAR commandLine[1024] = L"steam.exe -applaunch 975370";
+
+    if (CreateProcessW(steamPath,
+        commandLine,
         NULL,
         NULL,
         FALSE,
@@ -20,7 +33,7 @@ int WINAPI wWinMain(HINSTANCE hi, HINSTANCE hpi, PWSTR cmd, int ns)
         &si,
         &pi) == 0)
     {
-        MessageBoxA(NULL, "could not launch 'Dwarf Fortress.exe'", NULL, 0);
+        MessageBoxW(NULL, L"could not launch Dwarf Fortress", NULL, 0);
         exit(1);
     }
 


### PR DESCRIPTION
this version launches dwarf fortress via the steam client instead of launching it directly

the existing one doesn't set up the steam app context which means access  to DF's steam workshop is broken. launching through the steam client avoids this issue.