### PR TITLE
[hotkeys] adjust text margin in popup menu for wide scrollbar

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `hotkeys`: hotkey hints on menu popup will no longer get their last character cut off by the scrollbar
 - ``launchdf``: launch Dwarf Fortress via the Steam client so Steam Workshop is functional
 - `blueprint`: interpret saplings, shrubs, and twigs as floors instead of walls
 

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -107,7 +107,7 @@ local function get_bindings_to_hotkeys(hotkeys, bindings)
 end
 
 -- number of non-text tiles: icon, space, space between cmd and hk, scrollbar
-local LIST_BUFFER = 2 + 1 + 1
+local LIST_BUFFER = 2 + 1 + 1 + 2
 
 local function get_choices(hotkeys, bindings, is_inverted)
     local choices, max_width, seen = {}, 0, {}
@@ -143,7 +143,7 @@ local function get_choices(hotkeys, bindings, is_inverted)
     -- adjust width of command fields so the hotkey tokens are right justified
     for _,choice in ipairs(choices) do
         local command_token = choice.text[1]
-        command_token.width = max_width - choice.hk_width - 3
+        command_token.width = max_width - choice.hk_width - 5
     end
 
     return choices, max_width

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -106,8 +106,8 @@ local function get_bindings_to_hotkeys(hotkeys, bindings)
     return bindings_to_hotkeys
 end
 
--- number of non-text tiles: icon, space, space between cmd and hk, scrollbar
-local LIST_BUFFER = 2 + 1 + 1 + 2
+-- number of non-text tiles: icon, space between cmd and hk, scrollbar+margin
+local LIST_BUFFER = 2 + 1 + 3
 
 local function get_choices(hotkeys, bindings, is_inverted)
     local choices, max_width, seen = {}, 0, {}
@@ -143,7 +143,7 @@ local function get_choices(hotkeys, bindings, is_inverted)
     -- adjust width of command fields so the hotkey tokens are right justified
     for _,choice in ipairs(choices) do
         local command_token = choice.text[1]
-        command_token.width = max_width - choice.hk_width - 5
+        command_token.width = max_width - choice.hk_width - (LIST_BUFFER - 1)
     end
 
     return choices, max_width


### PR DESCRIPTION
adjustment needed for new double-wide scrollbars

Fixes #3146 