### PR TITLE
buildingplan: miscellaneous tweaks

### DIFF
--- a/plugins/lua/buildingplan.lua
+++ b/plugins/lua/buildingplan.lua
@@ -103,6 +103,14 @@ function get_desc(filter)
         desc = 'Mechanism'
     elseif desc == 'Wood' then
         desc = 'Log'
+    elseif desc == 'Any weapon' then
+        desc = 'Weapon'
+    elseif desc == 'Any spike' then
+        desc = 'Spike'
+    elseif desc == 'Ballistapart' then
+        desc = 'Ballista part'
+    elseif desc == 'Catapultpart' then
+        desc = 'Catapult part'
     end
 
     return desc

--- a/plugins/lua/buildingplan/pens.lua
+++ b/plugins/lua/buildingplan/pens.lua
@@ -19,8 +19,8 @@ function reload_pens()
 
     local tb_texpos = dfhack.textures.getThinBordersTexposStart()
     VERT_TOP_PEN = to_pen{tile=tp(tb_texpos, 10), ch=194, fg=COLOR_GREY, bg=COLOR_BLACK}
-    VERT_MID_PEN = to_pen{tile=tp(tb_texpos, 4), ch=192, fg=COLOR_GREY, bg=COLOR_BLACK}
-    VERT_BOT_PEN = to_pen{tile=tp(tb_texpos, 11), ch=179, fg=COLOR_GREY, bg=COLOR_BLACK}
+    VERT_MID_PEN = to_pen{tile=tp(tb_texpos, 4), ch=179, fg=COLOR_GREY, bg=COLOR_BLACK}
+    VERT_BOT_PEN = to_pen{tile=tp(tb_texpos, 11), ch=193, fg=COLOR_GREY, bg=COLOR_BLACK}
 
     local cp_texpos = dfhack.textures.getControlPanelTexposStart()
     BUTTON_START_PEN = to_pen{tile=tp(cp_texpos, 13), ch='[', fg=COLOR_YELLOW}


### PR DESCRIPTION
this is a commit for _two_ (sorry) small things...

- the vertical divider in `filterselection`'s ui used wrong characters in ascii mode. (corner pieces instead of straight lines)
This commit replaces these characters with more appropriate ones.

- some item names that appear on buildingplan uis have been slightly tweaked. The changes are:
`Weapon` instead of `Any weapon`
`Spike` instead of `Any spike`
`Ballista part` instead of `Ballistapart`
`Catapult part` instead of `Catapultpart`