### PR TITLE
clean up Items.cpp quality symbols definitions

### DIFF
--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -720,13 +720,14 @@ df::coord Items::getPosition(df::item *item)
     return item->pos;
 }
 
-// These '\xFF' chars refer to quality markers from curses.png, namely: 250 (≡), 15 (☼), 174 («) and 175 (»).
-static const char MARKER_EXCEPTIONAL = '\xF0';
-static const char MARKER_MASTERWORK = '\x0F';
-static const char MARKER_IMPROVED_LEFT = '\xAE';
-static const char MARKER_IMPROVED_RIGHT = '\xAF';
-
-static char quality_table[] = { 0, '-', '+', '*', MARKER_EXCEPTIONAL, MARKER_MASTERWORK };
+static const char quality_table[] = {
+    '\0',   // (base)
+    '-',    // well-crafted
+    '+',    // finely-crafted
+    '*',    // superior quality
+    '\xF0', // (≡) exceptional
+    '\x0F'  // (☼) masterful
+};
 
 static void addQuality(std::string &tmp, int quality)
 {
@@ -831,7 +832,7 @@ std::string Items::getDescription(df::item *item, int type, bool decorate)
         addQuality(tmp, item->getQuality());
 
         if (item->isImproved()) {
-            tmp = MARKER_IMPROVED_LEFT + tmp + MARKER_IMPROVED_RIGHT;
+            tmp = '\xAE' + tmp + '\xAF'; // («) + tmp + (»)
             addQuality(tmp, item->getImprovementQuality());
         }
     }


### PR DESCRIPTION
following a suggestion by Quietust https://github.com/DFHack/dfhack/pull/3137#issuecomment-1493439012

this removes those consts introduced in #3137 

...in theory we could add `'\xAE'` and `'\xAF'` at the end of `quality_table[]`, and then say like:
```tmp = 'quality_table[6]' + tmp + 'quality_table[7]';``` or something... but uggghhhh 🙄 