### PR TITLE
add raw/cooked z level output to prospector

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``launchdf``: launch Dwarf Fortress via the Steam client so Steam Workshop is functional
 - `blueprint`: interpret saplings, shrubs, and twigs as floors instead of walls
 - `combine`: fix error processing stockpiles with boundaries that extend outside of the map
+- `prospector`: display both "raw" Z levels and "cooked" elevations
 
 ## Misc Improvements
 - `buildingplan`: items in the item selection dialog should now use the same item quality symbols as the base game

--- a/plugins/prospector.cpp
+++ b/plugins/prospector.cpp
@@ -168,9 +168,13 @@ static void printMatdata(color_ostream &con, const matdata &data, bool only_z = 
         con << std::setw(9) << int(data.count);
 
     if(data.lower_z != data.upper_z)
-        con <<"   Z:" << std::setw(4) << data.lower_z << ".." <<  data.upper_z << std::endl;
+        con <<"   Z:" << std::setw(4) << data.lower_z << " .." << std::setw(4) << data.upper_z
+            <<"   Elev:" << std::setw(4) << (data.lower_z - 100) << " .." << std::setw(4) << (data.upper_z - 100)
+            << std::endl;
     else
-        con <<"   Z:" << std::setw(4) << data.lower_z << std::endl;
+        con <<"   Z:" << std::setw(4) << data.lower_z << "       "
+            <<"   Elev:" << std::setw(4) << (data.lower_z - 100)
+            << std::endl;
 }
 
 static int getValue(const df::inorganic_raw &info)


### PR DESCRIPTION
toady shifted displayed z levels by 100 for v50

closes #3187 