### PR TITLE
hide terminal console when running on steam deck

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -52,6 +52,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Mods: scripts from only the most recent version of an installed mod are added to the script path
 - Mods: give active mods a chance to reattach their load hooks when a world is reloaded
 - `gui/control-panel`: bugfix services are now enabled by default
+- Core: hide DFHack terminal console by default when running on Steam Deck
 
 ## Documentation
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -125,6 +125,7 @@ set(MODULE_HEADERS
     include/modules/Burrows.h
     include/modules/Constructions.h
     include/modules/DFSDL.h
+    include/modules/DFSteam.h
     include/modules/Designations.h
     include/modules/EventManager.h
     include/modules/Filesystem.h
@@ -154,6 +155,7 @@ set(MODULE_SOURCES
     modules/Burrows.cpp
     modules/Constructions.cpp
     modules/DFSDL.cpp
+    modules/DFSteam.cpp
     modules/Designations.cpp
     modules/EventManager.cpp
     modules/Filesystem.cpp

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2281,6 +2281,7 @@ int Core::Shutdown ( void )
     allModules.clear();
     Textures::cleanup();
     DFSDL::cleanup();
+    DFSteam::cleanup();
     memset(&(s_mods), 0, sizeof(s_mods));
     d.reset();
     return -1;

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -49,6 +49,7 @@ distribution.
 #include "PluginManager.h"
 #include "ModuleFactory.h"
 #include "modules/DFSDL.h"
+#include "modules/DFSteam.h"
 #include "modules/EventManager.h"
 #include "modules/Filesystem.h"
 #include "modules/Gui.h"
@@ -1303,6 +1304,10 @@ static void run_dfhack_init(color_ostream &out, Core *core)
         return;
     }
 
+    // if we're running on Steam Deck, hide the terminal by default
+    if (DFSteam::DFIsSteamRunningOnSteamDeck())
+        core->getConsole().hide();
+
     // load baseline defaults
     core->loadScriptFile(out, CONFIG_PATH + "init/default.dfhack.init", false);
 
@@ -1668,6 +1673,8 @@ bool Core::Init()
         fatal("cannot bind SDL libraries");
         return false;
     }
+    if (DFSteam::init(con))
+        std::cerr << "Found Steam.\n";
     std::cerr << "Initializing textures.\n";
     Textures::init(con);
     // create mutex for syncing with interactive tasks

--- a/library/include/modules/DFSteam.h
+++ b/library/include/modules/DFSteam.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ColorText.h"
+#include "Export.h"
+
+namespace DFHack
+{
+
+/**
+ * The DFSteam module - provides access to Steam functions without actually
+ * requiring build-time linkage to Steam
+ * \ingroup grp_modules
+ * \ingroup grp_dfsdl
+ */
+namespace DFSteam
+{
+
+/**
+ * Call this on DFHack init so we can load the function pointers. Returns false on
+ * failure.
+ */
+bool init(DFHack::color_ostream& out);
+
+/**
+ * Call this when DFHack is being unloaded.
+ */
+void cleanup();
+
+DFHACK_EXPORT bool DFIsSteamRunningOnSteamDeck();
+
+}
+}

--- a/library/modules/DFSteam.cpp
+++ b/library/modules/DFSteam.cpp
@@ -39,6 +39,8 @@ bool DFSteam::init(color_ostream& out) {
         }
 
     bind(g_steam_handle, SteamAPI_Init);
+
+    // TODO: can we remove this initialization of the Steam API once we move to dfhooks?
     if (!g_SteamAPI_Init || !g_SteamAPI_Init())
         return false;
 

--- a/library/modules/DFSteam.cpp
+++ b/library/modules/DFSteam.cpp
@@ -21,7 +21,7 @@ static const std::vector<std::string> STEAM_LIBS {
 
 bool (*g_SteamAPI_Init)() = nullptr;
 void (*g_SteamAPI_Shutdown)() = nullptr;
-void* (*g_SteamInternal_FindOrCreateUserInterface)(int, char *) = nullptr;
+void* (*g_SteamInternal_FindOrCreateUserInterface)(int, char*) = nullptr;
 bool (*g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)(void*) = nullptr;
 
 bool DFSteam::init(color_ostream& out) {
@@ -44,8 +44,10 @@ bool DFSteam::init(color_ostream& out) {
     bind(g_steam_handle, SteamAPI_Shutdown);
 
     // TODO: can we remove this initialization of the Steam API once we move to dfhooks?
-    if (!g_SteamAPI_Init || !g_SteamAPI_Shutdown || !g_SteamAPI_Init())
+    if (!g_SteamAPI_Init || !g_SteamAPI_Shutdown || !g_SteamAPI_Init()) {
+        DEBUG(dfsteam, out).print("steam detected but cannot be initialized\n");
         return false;
+    }
 
     bind(g_steam_handle, SteamInternal_FindOrCreateUserInterface);
     bind(g_steam_handle, SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck);

--- a/library/modules/DFSteam.cpp
+++ b/library/modules/DFSteam.cpp
@@ -21,7 +21,8 @@ static const std::vector<std::string> STEAM_LIBS {
 
 bool (*g_SteamAPI_Init)() = nullptr;
 void (*g_SteamAPI_Shutdown)() = nullptr;
-bool (*g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)() = nullptr;
+void* (*g_SteamInternal_FindOrCreateUserInterface)(int, char *) = nullptr;
+bool (*g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)(void*) = nullptr;
 
 bool DFSteam::init(color_ostream& out) {
     for (auto& lib_str : STEAM_LIBS) {
@@ -46,6 +47,7 @@ bool DFSteam::init(color_ostream& out) {
     if (!g_SteamAPI_Init || !g_SteamAPI_Shutdown || !g_SteamAPI_Init())
         return false;
 
+    bind(g_steam_handle, SteamInternal_FindOrCreateUserInterface);
     bind(g_steam_handle, SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck);
 #undef bind
 
@@ -67,5 +69,11 @@ void DFSteam::cleanup() {
 bool DFSteam::DFIsSteamRunningOnSteamDeck() {
     if (!g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)
         return false;
-    return g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck();
+
+    if (!g_SteamInternal_FindOrCreateUserInterface)
+        return false;
+
+    void* SteamUtils = g_SteamInternal_FindOrCreateUserInterface(0, "SteamUtils010");
+
+    return g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck(SteamUtils);
 }

--- a/library/modules/DFSteam.cpp
+++ b/library/modules/DFSteam.cpp
@@ -1,0 +1,64 @@
+#include "Internal.h"
+
+#include "modules/DFSteam.h"
+
+#include "Debug.h"
+#include "PluginManager.h"
+
+namespace DFHack
+{
+DBG_DECLARE(core, dfsteam, DebugCategory::LINFO);
+}
+
+using namespace DFHack;
+
+static DFLibrary* g_steam_handle = nullptr;
+static const std::vector<std::string> STEAM_LIBS {
+    "steam_api64.dll",
+        "steam_api", // TODO: validate this on OSX
+        "libsteam_api.so" // TODO: validate this on Linux
+};
+
+bool (*g_SteamAPI_Init)() = nullptr;
+bool (*g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)() = nullptr;
+
+bool DFSteam::init(color_ostream& out) {
+    for (auto& lib_str : STEAM_LIBS) {
+        if ((g_steam_handle = OpenPlugin(lib_str.c_str())))
+            break;
+    }
+    if (!g_steam_handle) {
+        DEBUG(dfsteam, out).print("steam library not found; stubbing calls\n");
+        return false;
+    }
+
+#define bind(handle, name) \
+        g_##name = (decltype(g_##name))LookupPlugin(handle, #name); \
+        if (!g_##name) { \
+            WARN(dfsteam, out).print("steam library function not found: " #name "\n"); \
+        }
+
+    bind(g_steam_handle, SteamAPI_Init);
+    if (!g_SteamAPI_Init || !g_SteamAPI_Init())
+        return false;
+
+    bind(g_steam_handle, SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck);
+#undef bind
+
+    DEBUG(dfsteam, out).print("steam library linked\n");
+    return true;
+}
+
+void DFSteam::cleanup() {
+    if (!g_steam_handle)
+        return;
+
+    ClosePlugin(g_steam_handle);
+    g_steam_handle = nullptr;
+}
+
+bool DFSteam::DFIsSteamRunningOnSteamDeck() {
+    if (!g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)
+        return false;
+    return g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck();
+}

--- a/library/modules/DFSteam.cpp
+++ b/library/modules/DFSteam.cpp
@@ -21,7 +21,7 @@ static const std::vector<std::string> STEAM_LIBS {
 
 bool (*g_SteamAPI_Init)() = nullptr;
 void (*g_SteamAPI_Shutdown)() = nullptr;
-void* (*g_SteamInternal_FindOrCreateUserInterface)(int, char*) = nullptr;
+void* (*g_SteamInternal_FindOrCreateUserInterface)(int, const char*) = nullptr;
 bool (*g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)(void*) = nullptr;
 
 bool DFSteam::init(color_ostream& out) {

--- a/library/modules/DFSteam.cpp
+++ b/library/modules/DFSteam.cpp
@@ -20,6 +20,7 @@ static const std::vector<std::string> STEAM_LIBS {
 };
 
 bool (*g_SteamAPI_Init)() = nullptr;
+void (*g_SteamAPI_Shutdown)() = nullptr;
 bool (*g_SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck)() = nullptr;
 
 bool DFSteam::init(color_ostream& out) {
@@ -39,9 +40,10 @@ bool DFSteam::init(color_ostream& out) {
         }
 
     bind(g_steam_handle, SteamAPI_Init);
+    bind(g_steam_handle, SteamAPI_Shutdown);
 
     // TODO: can we remove this initialization of the Steam API once we move to dfhooks?
-    if (!g_SteamAPI_Init || !g_SteamAPI_Init())
+    if (!g_SteamAPI_Init || !g_SteamAPI_Shutdown || !g_SteamAPI_Init())
         return false;
 
     bind(g_steam_handle, SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck);
@@ -54,6 +56,9 @@ bool DFSteam::init(color_ostream& out) {
 void DFSteam::cleanup() {
     if (!g_steam_handle)
         return;
+
+    if (g_SteamAPI_Shutdown)
+        g_SteamAPI_Shutdown();
 
     ClosePlugin(g_steam_handle);
     g_steam_handle = nullptr;


### PR DESCRIPTION
- Finds and loads Steam lib
- initializes Steam lib (since we need it before DF initializes it itself)
- discovers the SteamDeck detection function
- calls it just before we process dfhack.init
- if we're on steam deck, hide the console window

I'm not entirely happy with having to initialize the steam lib. it's now being initialized twice, which might leak memory, but it doesn't appear to cause any real problems.

This is something we might be able to avoid once we move to the dfhooks api, since we'll be initialized later in the loading process.

Fixes #3182 