### PR TITLE
don't read cur_savegame.save_dir when invalid

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2083,7 +2083,9 @@ void Core::handleLoadAndUnloadScripts(color_ostream& out, state_change_event eve
 
     if (!df::global::world)
         return;
-    std::string rawFolder = "save/" + (df::global::world->cur_savegame.save_dir) + "/init";
+
+    std::string rawFolder = !isWorldLoaded() ? "" :
+        "save/" + (df::global::world->cur_savegame.save_dir) + "/init";
 
     auto i = table.find(event);
     if ( i != table.end() ) {

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2084,8 +2084,7 @@ void Core::handleLoadAndUnloadScripts(color_ostream& out, state_change_event eve
     if (!df::global::world)
         return;
 
-    std::string rawFolder = !isWorldLoaded() ? "" :
-        "save/" + (df::global::world->cur_savegame.save_dir) + "/init";
+    std::string rawFolder = !isWorldLoaded() ? "" : "save/" + World::ReadWorldFolder() + "/init";
 
     auto i = table.find(event);
     if ( i != table.end() ) {


### PR DESCRIPTION
avoid reading `cur_savegame.save_dir` during state change events outside of a loaded world