### PR TITLE
infrastructure for hiding armok tools

### DIFF
--- a/docs/Tags.rst
+++ b/docs/Tags.rst
@@ -21,7 +21,7 @@ for the tag assignment spreadsheet.
 
 "why" tags
 ----------
-- `armok <armok-tag-index>`: Tools that give you complete control over an aspect of the game or provide access to information that the game intentionally keeps hidden.
+- `armok <armok-tag-index>`: Tools that give you complete control over an aspect of the game or provide access to information that the game intentionally keeps hidden. Players that do not wish to see these tools listed in DFHack command lists can hide them in the ``Preferences`` tab of `gui/control-panel`.
 - `auto <auto-tag-index>`: Tools that run in the background and automatically manage routine, toilsome aspects of your fortress.
 - `bugfix <bugfix-tag-index>`: Tools that fix specific bugs, either permanently or on-demand.
 - `design <design-tag-index>`: Tools that help you design your fort.

--- a/docs/Tags.rst
+++ b/docs/Tags.rst
@@ -21,7 +21,9 @@ for the tag assignment spreadsheet.
 
 "why" tags
 ----------
-- `armok <armok-tag-index>`: Tools that give you complete control over an aspect of the game or provide access to information that the game intentionally keeps hidden. Players that do not wish to see these tools listed in DFHack command lists can hide them in the ``Preferences`` tab of `gui/control-panel`.
+- `armok <armok-tag-index>`: Tools which give the player god-like powers of any variety, such as control over game events, creating items from thin air, or viewing information the game intentionally keeps hidden. Players that do not wish to see these tools listed in DFHack command lists can hide them in the ``Preferences`` tab of `gui/control-panel`.
+
+
 - `auto <auto-tag-index>`: Tools that run in the background and automatically manage routine, toilsome aspects of your fortress.
 - `bugfix <bugfix-tag-index>`: Tools that fix specific bugs, either permanently or on-demand.
 - `design <design-tag-index>`: Tools that help you design your fort.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,7 +40,8 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - `buildingplan`: minimized planner panel stays minimized until you change it again
 - ``toggle-kbd-cursor``: add hotkey for toggling the keyboard cursor (Alt-K)
-- `gui/control-panel`: add option for hiding the terminal console by default
+- `gui/control-panel`: add preference option for hiding the terminal console on startup
+- `gui/control-panel`: add preference option for hiding "armok" tools in command lists
 
 ## Documentation
 

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -58,6 +58,11 @@ function dfhack.getHideConsoleOnStartup()
     return dfhack.HIDE_CONSOLE_ON_STARTUP
 end
 
+dfhack.HIDE_ARMOK_TOOLS = false
+function dfhack.getHideArmokTools()
+    return dfhack.HIDE_ARMOK_TOOLS
+end
+
 -- Error handling
 
 safecall = dfhack.safecall

--- a/library/lua/helpdb.lua
+++ b/library/lua/helpdb.lua
@@ -788,7 +788,11 @@ function ls(filter_str, skip_tags, show_dev_commands, exclude_strs)
         table.insert(excludes, {str=argparse.stringList(exclude_strs)})
     end
     if not show_dev_commands then
-        table.insert(excludes, {tag='dev'})
+        local dev_tags = {'dev', 'unavailable'}
+        if dfhack.getHideArmokTools() then
+            table.insert(dev_tags, 'armok')
+        end
+        table.insert(excludes, {tag=dev_tags})
     end
     list_entries(skip_tags, include, excludes)
 end
@@ -813,7 +817,16 @@ function tags(tag)
 
     local skip_tags = true
     local include = {entry_type={ENTRY_TYPES.COMMAND}, tag=tag}
-    list_entries(skip_tags, include)
+
+    local excludes = {tag={}}
+    if tag ~= 'unavailable' then
+        table.insert(excludes.tag, 'unavailable')
+    end
+    if tag ~= 'armok' and dfhack.getHideArmokTools() then
+        table.insert(excludes.tag, 'armok')
+    end
+
+    list_entries(skip_tags, include, excludes)
 end
 
 return _ENV

--- a/plugins/hotkeys.cpp
+++ b/plugins/hotkeys.cpp
@@ -49,13 +49,33 @@ static int cleanupHotkeys(lua_State *) {
     return 0;
 }
 
-static void add_binding_if_valid(const string &sym, const string &cmdline, df::viewscreen *screen, bool filtermenu) {
+static bool should_hide_armok(color_ostream &out, const string &cmdline) {
+    bool should_hide = false;
+
+    auto L = Lua::Core::State;
+    Lua::StackUnwinder top(L);
+    Lua::CallLuaModuleFunction(out, L, "plugins.hotkeys", "should_hide_armok", 1, 1,
+        [&](lua_State *L){
+            Lua::Push(L, cmdline);
+        }, [&](lua_State *L){
+            should_hide = lua_toboolean(L, -1);
+        });
+
+    return should_hide;
+}
+
+static void add_binding_if_valid(color_ostream &out, const string &sym, const string &cmdline, df::viewscreen *screen, bool filtermenu) {
     if (!can_invoke(cmdline, screen))
         return;
 
     if (filtermenu && (cmdline == INVOKE_MENU_COMMAND ||
                        cmdline == INVOKE_HOTKEYS_COMMAND)) {
         DEBUG(log).print("filtering out hotkey menu keybinding\n");
+        return;
+    }
+
+    if (should_hide_armok(out, cmdline)) {
+        DEBUG(log).print("filtering out armok keybinding\n");
         return;
     }
 
@@ -67,7 +87,7 @@ static void add_binding_if_valid(const string &sym, const string &cmdline, df::v
     Core::getInstance().AddKeyBinding(keyspec, binding);
 }
 
-static void find_active_keybindings(df::viewscreen *screen, bool filtermenu) {
+static void find_active_keybindings(color_ostream &out, df::viewscreen *screen, bool filtermenu) {
     DEBUG(log).print("scanning for active keybindings\n");
     if (valid)
         cleanupHotkeys(NULL);
@@ -103,7 +123,7 @@ static void find_active_keybindings(df::viewscreen *screen, bool filtermenu) {
                         string::size_type colon_pos = invoke_cmd->find(":");
                         // colons at location 0 are for commands like ":lua"
                         if (colon_pos == string::npos || colon_pos == 0) {
-                            add_binding_if_valid(sym, *invoke_cmd, screen, filtermenu);
+                            add_binding_if_valid(out, sym, *invoke_cmd, screen, filtermenu);
                         }
                         else {
                             vector<string> tokens;
@@ -111,7 +131,7 @@ static void find_active_keybindings(df::viewscreen *screen, bool filtermenu) {
                             string focus = tokens[0].substr(1);
                             if(Gui::matchFocusString(focus)) {
                                 auto cmdline = trim(tokens[1]);
-                                add_binding_if_valid(sym, cmdline, screen, filtermenu);
+                                add_binding_if_valid(out, sym, cmdline, screen, filtermenu);
                             }
                         }
                     }
@@ -124,7 +144,10 @@ static void find_active_keybindings(df::viewscreen *screen, bool filtermenu) {
 }
 
 static int getHotkeys(lua_State *L) {
-    find_active_keybindings(Gui::getCurViewscreen(true), true);
+    color_ostream *out = Lua::GetOutput(L);
+    if (!out)
+        out = &Core::getInstance().getConsole();
+    find_active_keybindings(*out, Gui::getCurViewscreen(true), true);
     Lua::PushVector(L, sorted_keys);
     Lua::Push(L, current_bindings);
     return 2;
@@ -140,7 +163,7 @@ static void list(color_ostream &out) {
     DEBUG(log).print("listing active hotkeys\n");
     bool was_valid = valid;
     if (!valid)
-        find_active_keybindings(Gui::getCurViewscreen(true), false);
+        find_active_keybindings(out, Gui::getCurViewscreen(true), false);
 
     out.print("Valid keybindings for the current focus:\n %s\n",
               join_strings("\n", Gui::getCurFocus(true)).c_str());
@@ -176,6 +199,8 @@ static command_result hotkeys_cmd(color_ostream &out, vector <string> & paramete
         return Core::getInstance().runCommand(out, INVOKE_MENU_COMMAND );
     }
 
+    CoreSuspender guard;
+
     if (parameters[0] == "list") {
         list(out);
         return CR_OK;
@@ -184,8 +209,6 @@ static command_result hotkeys_cmd(color_ostream &out, vector <string> & paramete
     // internal command -- intentionally undocumented
     if (parameters.size() != 2 || parameters[0] != "invoke")
         return CR_WRONG_USAGE;
-
-    CoreSuspender guard;
 
     int index = string_to_int(parameters[1], -1);
     if (index < 0)

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -12,10 +12,10 @@ local function get_command(cmdline)
 end
 
 function should_hide_armok(cmdline)
-    local first_word = get_command(cmdline)
+    local command = get_command(cmdline)
     return dfhack.getHideArmokTools() and
-            helpdb.is_entry(first_word) and
-            helpdb.get_entry_tags(first_word).armok
+            helpdb.is_entry(command) and
+            helpdb.get_entry_tags(command).armok
 end
 
 -- ----------------- --
@@ -245,10 +245,9 @@ end
 
 function Menu:onSelect(_, choice)
     if not choice or #self.subviews == 0 then return end
-    local first_word = choice.command:trim():split(' +')[1]
-    if first_word:startswith(':') then first_word = first_word:sub(2) end
-    self.subviews.help.text_to_wrap = helpdb.is_entry(first_word) and
-            helpdb.get_entry_short_help(first_word) or 'Command not found'
+    local command = get_command(choice.command)
+    self.subviews.help.text_to_wrap = helpdb.is_entry(command) and
+            helpdb.get_entry_short_help(command) or 'Command not found'
     self.subviews.help_panel:updateLayout()
 end
 

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -5,6 +5,19 @@ local helpdb = require('helpdb')
 local overlay = require('plugins.overlay')
 local widgets = require('gui.widgets')
 
+local function get_command(cmdline)
+    local first_word = cmdline:trim():split(' +')[1]
+    if first_word:startswith(':') then first_word = first_word:sub(2) end
+    return first_word
+end
+
+function should_hide_armok(cmdline)
+    local first_word = get_command(cmdline)
+    return dfhack.getHideArmokTools() and
+            helpdb.is_entry(first_word) and
+            helpdb.get_entry_tags(first_word).armok
+end
+
 -- ----------------- --
 -- HotspotMenuWidget --
 -- ----------------- --


### PR DESCRIPTION
Fixes #3206

also removes "unavailable" tools from `ls` and `tags` output unless they are specifically requested