### PR TITLE
add DFHack title version overlay

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -44,6 +44,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `gui/control-panel`: add preference option for hiding the terminal console on startup
 - `gui/control-panel`: add preference option for hiding "armok" tools in command lists
 - ``Dwarf Therapist``: add a warning to the Labors screen when Dwarf Therapist is active so players know that changes they make to that screen will have no effect. If you're starting a new embark and nobody seems to be doing anything, check your Labors tab for this warning to see if Dwarf Therapist thinks it is in control (even if it's not running).
+- `overlay`: add the DFHack version string to the DF title screen
 
 ## Documentation
 

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -273,7 +273,7 @@ static std::string dfhack_version_desc()
     if (Version::is_release())
         s << "(release)";
     else
-        s << "(development build " << Version::git_description() << ")";
+        s << "(git: " << Version::git_commit(true) << ")";
     s << " on " << (sizeof(void*) == 8 ? "x86_64" : "x86");
     if (strlen(Version::dfhack_build_id()))
         s << " [build ID: " << Version::dfhack_build_id() << "]";

--- a/library/DFHackVersion.cpp
+++ b/library/DFHackVersion.cpp
@@ -1,6 +1,8 @@
 #define NO_DFHACK_VERSION_MACROS
 #include "DFHackVersion.h"
 #include "git-describe.h"
+#include <string>
+
 namespace DFHack {
     namespace Version {
         int dfhack_abi_version()
@@ -27,9 +29,10 @@ namespace DFHack {
         {
             return DFHACK_GIT_DESCRIPTION;
         }
-        const char *git_commit()
+        const char* git_commit(bool short_hash)
         {
-            return DFHACK_GIT_COMMIT;
+            static std::string shorty(DFHACK_GIT_COMMIT, 0, 7);
+            return short_hash ? shorty.c_str() : DFHACK_GIT_COMMIT;
         }
         const char *git_xml_commit()
         {

--- a/library/include/DFHackVersion.h
+++ b/library/include/DFHackVersion.h
@@ -8,7 +8,7 @@ namespace DFHack {
         int dfhack_abi_version();
 
         const char *git_description();
-        const char *git_commit();
+        const char* git_commit(bool short_hash = false);
         const char *git_xml_commit();
         const char *git_xml_expected_commit();
         bool git_xml_match();

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -84,6 +84,7 @@ using namespace DFHack;
 #include "df/unit.h"
 #include "df/unit_inventory_item.h"
 #include "df/viewscreen_dwarfmodest.h"
+#include "df/viewscreen_titlest.h"
 #include "df/world.h"
 
 const size_t MAX_REPORTS_SIZE = 3000; // DF clears old reports to maintain this vector size
@@ -143,6 +144,17 @@ static std::map<virtual_identity*, getFocusStringsHandler> getFocusStringsHandle
         (getFocusStringsHandler)getFocusStrings_##screen_type \
     ); \
     static void getFocusStrings_##screen_type(std::string &baseFocus, std::vector<std::string> &focusStrings, VIEWSCREEN(screen_type) *screen)
+
+DEFINE_GET_FOCUS_STRING_HANDLER(title)
+{
+    if (screen->managing_mods)
+        focusStrings.push_back(baseFocus + "/Mods");
+    else if (game->main_interface.settings.open)
+        focusStrings.push_back(baseFocus + "/Settings");
+
+    if (focusStrings.empty())
+        focusStrings.push_back(baseFocus + "/Default");
+}
 
 DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
 {

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -39,7 +39,7 @@ HotspotMenuWidget.ATTRS{
         -- 'new_region', -- conflicts with vanilla panel layouts
         'savegame',
         'setupdwarfgame',
-        'title',
+        'title/Default',
         'update_region',
         'world'
     },

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -571,13 +571,13 @@ TitleVersionOverlay.ATTRS{
     default_pos={x=50, y=-2},
     default_enabled=true,
     viewscreens='title',
-    frame={w=30, h=3},
+    frame={w=35, h=3},
 }
 
 function TitleVersionOverlay:init()
     local text = {}
     table.insert(text, 'DFHack ' .. dfhack.getDFHackVersion() ..
-            (dfhack.isPrerelease() and (' (%s)'):format(dfhack.getGitCommit():sub(1,7)) or ''))
+            (dfhack.isPrerelease() and (' (git: %s)'):format(dfhack.getGitCommit(true)) or ''))
     if #dfhack.getDFHackBuildID() > 0 then
         table.insert(text, NEWLINE)
         table.insert(text, 'Build ID: ' .. dfhack.getDFHackBuildID())

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -562,4 +562,42 @@ function OverlayWidget:init()
     self.frame.h = self.frame.h or 1
 end
 
+-- ------------------- --
+-- TitleVersionOverlay --
+-- ------------------- --
+
+TitleVersionOverlay = defclass(TitleVersionOverlay, OverlayWidget)
+TitleVersionOverlay.ATTRS{
+    default_pos={x=50, y=-2},
+    default_enabled=true,
+    viewscreens='title',
+    frame={w=30, h=3},
+}
+
+function TitleVersionOverlay:init()
+    local text = {}
+    table.insert(text, 'DFHack ' .. dfhack.getDFHackVersion() ..
+            (dfhack.isPrerelease() and (' (%s)'):format(dfhack.getGitCommit():sub(1,7)) or ''))
+    if #dfhack.getDFHackBuildID() > 0 then
+        table.insert(text, NEWLINE)
+        table.insert(text, 'Build ID: ' .. dfhack.getDFHackBuildID())
+    end
+    if dfhack.isPrerelease() then
+        table.insert(text, NEWLINE)
+        table.insert(text, {text='Pre-release build', pen=COLOR_LIGHTRED})
+    end
+
+    self:addviews{
+        widgets.Label{
+            frame={b=0, l=0},
+            text=text,
+            text_pen=COLOR_WHITE,
+        },
+    }
+end
+
+OVERLAY_WIDGETS = {
+    title_version = TitleVersionOverlay,
+}
+
 return _ENV

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -570,7 +570,7 @@ TitleVersionOverlay = defclass(TitleVersionOverlay, OverlayWidget)
 TitleVersionOverlay.ATTRS{
     default_pos={x=50, y=-2},
     default_enabled=true,
-    viewscreens='title',
+    viewscreens='title/Default',
     frame={w=35, h=3},
 }
 
@@ -589,7 +589,7 @@ function TitleVersionOverlay:init()
 
     self:addviews{
         widgets.Label{
-            frame={b=0, l=0},
+            frame={t=0, l=0},
             text=text,
             text_pen=COLOR_WHITE,
         },


### PR DESCRIPTION
replaces the `title-version` plugin

I changed the formatting a little to make it more compact:
![image](https://user-images.githubusercontent.com/977482/233879106-27b2c510-192f-4307-bab6-8d0c04514bd7.png)

Fixes #3290 

edit: After feedback from @TaxiService, I moved the version string to the top, next to the DFHack logo:
![image](https://user-images.githubusercontent.com/977482/234037745-034475e7-7a1e-40e6-b1c1-5d04c36bd894.png)

Also, prevented both the logo and the version string from appearing on any title screen subscreens to avoid conflicting with vanilla widgets