### PR TITLE
[autoclothing] demote chatty WARN messages to DEBUG

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `autoclothing`: eliminate game lag when there are many inventory items in the fort
 
 ## Misc Improvements
 - `buildingplan`: planner panel is minimized by default and now remembers minimized state

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -565,7 +565,7 @@ static void find_needed_clothing_items()
 
                 if (!item)
                 {
-                    WARN(cycle).print("autoclothing: Invalid inventory item ID: %d\n", ownedItem);
+                    DEBUG(cycle).print("autoclothing: Invalid inventory item ID: %d\n", ownedItem);
                     continue;
                 }
 
@@ -818,7 +818,7 @@ static void generate_report(color_ostream& out)
             auto item = Items::findItemByID(itemId);
             if (!item)
             {
-                WARN(cycle,out).print("autoclothing: Invalid inventory item ID: %d\n", itemId);
+                DEBUG(cycle, out).print("autoclothing: Invalid inventory item ID: %d\n", itemId);
                 continue;
             }
             if (item->getWear() >= 1)


### PR DESCRIPTION
This is a fix of least effort. I did not investigate whether the messages are an indicator of a deeper problem.

@ab9rf could you verify that this fixes the lag on the fort where you saw the problem?

Fixes #3259 