### PR TITLE
Add `key_sep` and `val_gap` attributes to `CycleHotkeyLabel` for more stylistic control

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 - ``widgets.RangeSlider``: new mouse-controlled two-headed slider widget
 - ``gui.ZScreenModal``: ZScreen subclass for modal dialogs
+- ``widgets.CycleHotkeyLabel``: exposed `key_sep` and `val_gap` attributes for improved stylistic control.
 
 ## Removed
 - `title-version`: replaced by an `overlay` widget

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4912,12 +4912,16 @@ It has the following attributes:
 
 :key: The hotkey keycode to display, e.g. ``'CUSTOM_A'``.
 :key_back: Similar to ``key``, but will cycle backwards (optional)
+:key_sep: If specified, will be used to customize how the activation key is
+          displayed. See ``token.key_sep`` in the ``Label`` documentation.
 :label: The string (or a function that returns a string) to display after the
     hotkey.
 :label_width: The number of spaces to allocate to the ``label`` (for use in
     aligning a column of ``CycleHotkeyLabel`` labels).
 :label_below: If ``true``, then the option value will apear below the label
     instead of to the right of it. Defaults to ``false``.
+:val_gap: The size of the gap between the label text and the option value.
+    Default is ``1``. If set to ``0``, there'll be no gap between the strings.
 :options: A list of strings or tables of
     ``{label=string or fn, value=val[, pen=pen]}``. String options use the same
     string for the label and value and use the default pen. The optional ``pen``

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1488,6 +1488,8 @@ CycleHotkeyLabel = defclass(CycleHotkeyLabel, Label)
 CycleHotkeyLabel.ATTRS{
     key=DEFAULT_NIL,
     key_back=DEFAULT_NIL,
+    key_sep=': ',
+    val_gap=1,
     label=DEFAULT_NIL,
     label_width=DEFAULT_NIL,
     label_below=false,
@@ -1499,17 +1501,16 @@ CycleHotkeyLabel.ATTRS{
 function CycleHotkeyLabel:init()
     self:setOption(self.initial_option)
 
-    local val_gap = 1
     if self.label_below then
-        val_gap = 0 + (self.key_back and 1 or 0) + (self.key and 3 or 0)
+        self.val_gap = 0 + (self.key_back and 1 or 0) + (self.key and 3 or 0)
     end
 
     self:setText{
         self.key_back ~= nil and {key=self.key_back, key_sep='', width=0, on_activate=self:callback('cycle', true)} or {},
-        {key=self.key, key_sep=': ', text=self.label, width=self.label_width,
+        {key=self.key, key_sep=self.key_sep, text=self.label, width=self.label_width,
          on_activate=self:callback('cycle')},
         self.label_below and NEWLINE or '',
-        {gap=val_gap, text=self:callback('getOptionLabel'),
+        {gap=self.val_gap, text=self:callback('getOptionLabel'),
          pen=self:callback('getOptionPen')},
     }
 end


### PR DESCRIPTION
hello. This PR adds two attributes to `CycleHotkeyLabel`

`key_sep=': '` could already be user-defined in `HotkeyLabel`, but was hard-coded in `CycleHotkeyLabel`.
`val_gap=1` was another variable that could not (easily?) be accessed externally. It's the whitespace between the _label_ and the _value_ of a CycleHotkeyLabel. It defaulted to 1, but exposing it like this lets us set it to 0, and have both strings be "flush" with each other/have no space.

i've also added some changelog/docs entries... if i mis-describe something, feel free to change it to better wording. ;_; 