### PR TITLE
[buildingplan] check items for accessibility for dialogs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -38,6 +38,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 - `autoclothing`: eliminate game lag when there are many inventory items in the fort
 - `buildingplan`: fixed size limit calculations for rollers
+- `buildingplan`: fixed items not being checked for accessibility in the filter and item selection dialogs
 - `dig-now`: properly detect and complete smoothing designations that have been converted into active jobs
 
 ## Misc Improvements

--- a/plugins/buildingplan/buildingplan.cpp
+++ b/plugins/buildingplan/buildingplan.cpp
@@ -704,7 +704,7 @@ static int scanAvailableItems(color_ostream &out, df::building_type type, int16_
                 filter.setMaterials(set<MaterialInfo>());
                 special.clear();
             }
-            if (itemPassesScreen(item) && matchesFilters(item, jitem, heat, filter, special)) {
+            if (itemPassesScreen(out, item) && matchesFilters(item, jitem, heat, filter, special)) {
                 if (item_ids)
                     item_ids->emplace_back(item->id);
                 if (counts) {

--- a/plugins/buildingplan/buildingplan.h
+++ b/plugins/buildingplan/buildingplan.h
@@ -54,7 +54,7 @@ void set_config_val(DFHack::PersistentDataItem &c, int index, int value);
 void set_config_bool(DFHack::PersistentDataItem &c, int index, bool value);
 
 std::vector<df::job_item_vector_id> getVectorIds(DFHack::color_ostream &out, const df::job_item *job_item, bool ignore_filters);
-bool itemPassesScreen(df::item * item);
+bool itemPassesScreen(DFHack::color_ostream& out, df::item* item);
 df::job_item getJobItemWithHeatSafety(const df::job_item *job_item, HeatSafety heat);
 bool matchesFilters(df::item * item, const df::job_item * job_item, HeatSafety heat, const ItemFilter &item_filter, const std::set<std::string> &special);
 bool isJobReady(DFHack::color_ostream &out, const std::vector<df::job_item *> &jitems);


### PR DESCRIPTION
before we only checked when doing the cycle, so if an inaccessible item were manually selected, we'd never be able to build

Fixes #3318