### PR TITLE
make val_sep useful if label_below == true

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4918,11 +4918,11 @@ It has the following attributes:
     hotkey.
 :label_width: The number of spaces to allocate to the ``label`` (for use in
     aligning a column of ``CycleHotkeyLabel`` labels).
-:label_below: If ``true``, then the option value will apear below the label
+:label_below: If ``true``, then the option value will appear below the label
     instead of to the right of it. Defaults to ``false``.
 :val_gap: The size of the gap between the label text and the option value.
     Default is ``1``. If set to ``0``, there'll be no gap between the strings.
-    Note that ``val_gap`` is ignored if ``label_below`` is set to ``true``.
+    If ``label_below`` == ``true``, negative values will shift the value leftwards.
 :options: A list of strings or tables of
     ``{label=string or fn, value=val[, pen=pen]}``. String options use the same
     string for the label and value and use the default pen. The optional ``pen``

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1502,7 +1502,7 @@ function CycleHotkeyLabel:init()
     self:setOption(self.initial_option)
 
     if self.label_below then
-        self.val_gap = 0 + (self.key_back and 1 or 0) + (self.key and 3 or 0)
+        self.val_gap = self.val_gap + (self.key_back and 1 or 0) + (self.key and 2 or 0)
     end
 
     self:setText{


### PR DESCRIPTION
i should've come up with this earlier... 

basically this makes the `val_sep` attribute able to affect the option value's position even if `label_below` is set to true.
meaning that if we set `val_sep` to `-3`, we can do this:

![image](https://user-images.githubusercontent.com/5853667/235343145-17af2b96-a69f-41b6-bf76-adbeeb19a7d9.png)

setting it to `-4` crops the first letter of the option value, but we don't care.