### PR TITLE
[hotkeys] fix logo disappearing when hovered on title screen

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `hotkeys`: DFHack logo no longer disappears when hovered on the title screen
 
 ## Misc Improvements
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,7 +36,6 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
-- `hotkeys`: DFHack logo no longer disappears when hovered on the title screen
 
 ## Misc Improvements
 

--- a/plugins/overlay.cpp
+++ b/plugins/overlay.cpp
@@ -72,9 +72,10 @@ struct viewscreen_overlay : T {
         bool input_is_handled = false;
         // don't send input to the overlays if there is a modal dialog up
         if (!world->status.popups.size())
-            call_overlay_lua(NULL, "feed_viewscreen_widgets", 2, 1,
+            call_overlay_lua(NULL, "feed_viewscreen_widgets", 3, 1,
                     [&](lua_State *L) {
                         Lua::Push(L, T::_identity.getName());
+                        Lua::Push(L, this);
                         Lua::PushInterfaceKeys(L, *input);
                     }, [&](lua_State *L) {
                         input_is_handled = lua_toboolean(L, -1);


### PR DESCRIPTION
Fixes #3335

issue was that we weren't passing the viewscreen through to the `dfhack.gui.getFocusStrings()` function so it was using the top viewscreen instead of the one we were interposing