### PR TITLE
fix fullscreen DF minimizing on startup

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -40,6 +40,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Fixes
 
 ## Misc Improvements
+- Terminal console no longer appears in front of the game window on startup
 
 ## Documentation
 

--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -508,6 +508,7 @@ bool Console::init(bool)
     inited = true;
     // DOESN'T WORK - locks up DF!
     // ForceForegroundWindow(d->MainWindow);
+    SetForegroundWindow(d->MainWindow);
     return true;
 }
 // FIXME: looks awfully empty, doesn't it?
@@ -608,6 +609,7 @@ void Console::msleep (unsigned int msec)
 bool Console::hide()
 {
     ShowWindow( GetConsoleWindow(), SW_HIDE );
+    SetForegroundWindow(d->MainWindow);
     return true;
 }
 

--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -508,7 +508,7 @@ bool Console::init(bool)
     inited = true;
     // DOESN'T WORK - locks up DF!
     // ForceForegroundWindow(d->MainWindow);
-    SetForegroundWindow(d->MainWindow);
+    hide();
     return true;
 }
 // FIXME: looks awfully empty, doesn't it?
@@ -609,7 +609,6 @@ void Console::msleep (unsigned int msec)
 bool Console::hide()
 {
     ShowWindow( GetConsoleWindow(), SW_HIDE );
-    SetForegroundWindow(d->MainWindow);
     return true;
 }
 

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1304,10 +1304,6 @@ static void run_dfhack_init(color_ostream &out, Core *core)
         return;
     }
 
-    // if we're running on Steam Deck, hide the terminal by default
-    if (DFSteam::DFIsSteamRunningOnSteamDeck())
-        core->getConsole().hide();
-
     // load baseline defaults
     core->loadScriptFile(out, CONFIG_PATH + "init/default.dfhack.init", false);
 
@@ -1315,13 +1311,13 @@ static void run_dfhack_init(color_ostream &out, Core *core)
     std::vector<std::string> prefixes(1, "dfhack");
     loadScriptFiles(core, out, prefixes, CONFIG_PATH + "init");
 
-    // if the option is set, hide the terminal
+    // show the terminal if requested
     auto L = Lua::Core::State;
     Lua::StackUnwinder top(L);
     Lua::CallLuaModuleFunction(out, L, "dfhack", "getHideConsoleOnStartup", 0, 1,
         Lua::DEFAULT_LUA_LAMBDA, [&](lua_State* L) {
-            if (lua_toboolean(L, -1))
-                core->getConsole().hide();
+            if (!lua_toboolean(L, -1))
+                core->getConsole().show();
         }, false);
 }
 


### PR DESCRIPTION
This PR prevents the DFHack console from coming up momentarily, even if it is configured to be hidden on startup. This was causing fullscreen DF to go into hiding on startup.

This PR also removes the check for Steam Deck, since it is now redundant.