### PR TITLE
CMake: fix find_package(Python) when inactive pyenv Python installations are present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,9 @@ endif()
 
 #### expose depends ####
 
+# fix for pyenv: default to `python3` before `python3.x`
+set(Python_FIND_UNVERSIONED_NAMES FIRST)
+
 if(UNIX)
     # Rescan for pthread and zlib if the build arch changed
     if(NOT "${DFHACK_BUILD_ARCH}" STREQUAL "${DFHACK_BUILD_ARCH_PREV}")


### PR DESCRIPTION
`find_package(Python)`'s default behavior is to attempt to use any `python3.x` executables it finds before `python3`. This is problematic when using tools such as pyenv, where `python3.x` executables may be present in a user's PATH but not be functional.

Setting the `Python_FIND_UNVERSIONED_NAMES` hint to `FIRST` causes `python3` to be attempted first, if it exists.

Note that this option was introduced in CMake 3.20: https://cmake.org/cmake/help/latest/module/FindPython.html#hints