### PR TITLE
support disabling DFHack with --disable-dfhack

### DIFF
--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -336,6 +336,11 @@ on UNIX-like systems:
 
   DFHACK_SOME_VAR=1 ./dfhack
 
+- ``DFHACK_DISABLE``: if set, DFHack will not initialize, not even to redirect
+  :file:`stdout.txt` or :file:`stderr.txt`. This is provided as an alternative
+  to the ``--disable-dfhack`` commandline parameter above for when environment
+  variables are more convenient.
+
 - ``DFHACK_PORT``: the port to use for the RPC server (used by ``dfhack-run``
   and `remotefortressreader` among others) instead of the default ``5000``. As
   with the default, if this port cannot be used, the server is not started.

--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -337,7 +337,7 @@ on UNIX-like systems:
   DFHACK_SOME_VAR=1 ./dfhack
 
 - ``DFHACK_DISABLE``: if set, DFHack will not initialize, not even to redirect
-  :file:`stdout.txt` or :file:`stderr.txt`. This is provided as an alternative
+  standard output or standard error. This is provided as an alternative
   to the ``--disable-dfhack`` commandline parameter above for when environment
   variables are more convenient.
 

--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -53,7 +53,7 @@ double quotes.  To include a double quote character, use ``\"``.
 If the first non-whitespace character is ``:``, the command is parsed in
 an alternative mode.  The non-whitespace characters following the ``:`` are
 the command name, and the remaining part of the line is used verbatim as
-the first argument.  This is very useful for the `lua` and `rb` commands.
+the first argument.  This is very useful for the `lua` command.
 As an example, the following two command lines are exactly equivalent::
 
   :foo a b "c d" e f
@@ -306,6 +306,23 @@ the root DF folder.
 Note that ``script-paths.txt`` is only read at startup, but the paths can also be
 modified programmatically at any time through the `Lua API <lua-api-internal>`.
 
+Commandline options
+===================
+
+In addition to `Using an OS terminal`_ to execute commands on startup, DFHack
+also recognizes a single commandline option that can be specified on the
+commandline:
+
+- ``--disable-dfhack``: If this option is passed on the Dwarf Fortress
+  commandline, then DFHack will be disabled for the session. You will have to
+  restart Dwarf Fortress without specifying this option in order to use DFHack.
+  If you are launching Dwarf Fortress from Steam, you can enter the option in
+  the "Launch Options" text box in the properties for the Dwarf Fortress app.
+  Note that if you do this, DFHack will be disabled regardless of whether you
+  run Dwarf Fortress from its own app or DFHack's. You will have to clear the
+  DF Launch Options in order to use DFHack again. Note that even if DFHack is
+  disabled, :file:`stdout.txt` and :file:`stderr.txt` will still be redirected
+  to :file:`stdout.log` and :file:`stderr.log`, respectively.
 
 .. _env-vars:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -48,7 +48,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - Terminal console no longer appears in front of the game window on startup
 - `gui/design`: Improved performance for drawing shapes
-- ``Core``: For debugging purposes, you can now pass ``--disable-dfhack`` on the Dwarf Fortress commandline to disable DFHack for the session.
+- Core: For debugging purposes, you can now pass ``--disable-dfhack`` on the Dwarf Fortress commandline to disable DFHack for the session.
 
 ## Documentation
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -48,6 +48,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - Terminal console no longer appears in front of the game window on startup
 - `gui/design`: Improved performance for drawing shapes
+- ``Core``: For debugging purposes, you can now pass ``--disable-dfhack`` on the Dwarf Fortress commandline to disable DFHack for the session.
 
 ## Documentation
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -48,7 +48,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Misc Improvements
 - Terminal console no longer appears in front of the game window on startup
 - `gui/design`: Improved performance for drawing shapes
-- Core: For debugging purposes, you can now pass ``--disable-dfhack`` on the Dwarf Fortress commandline to disable DFHack for the session.
+- Core: For debugging purposes, you can now pass ``--disable-dfhack`` on the Dwarf Fortress commandline or specify ``DFHACK_DISABLE=1`` in the environment to disable DFHack for the current session.
 
 ## Documentation
 

--- a/library/Hooks.cpp
+++ b/library/Hooks.cpp
@@ -1,31 +1,49 @@
 #include "Core.h"
 #include "Export.h"
 
+#include "df/gamest.h"
+
+static bool disabled = false;
+
 // called from the main thread before the simulation thread is started
 // and the main event loop is initiated
 DFhackCExport void dfhooks_init() {
-    // TODO: initialize things we need to do while still in the main thread
+    if (!DFHack::Core::getInstance().InitMainThread() || !df::global::game)
+        return;
+    const std::string & cmdline = df::global::game->command_line.original;
+    if (cmdline.find("--disable-dfhack") != std::string::npos) {
+        fprintf(stdout, "dfhack: --disable-dfhack specified on commandline; disabling\n");
+        disabled = true;
+    }
 }
 
 // called from the main thread after the main event loops exits
 DFhackCExport void dfhooks_shutdown() {
+    if (disabled)
+        return;
     DFHack::Core::getInstance().Shutdown();
 }
 
 // called from the simulation thread in the main event loop
 DFhackCExport void dfhooks_update() {
+    if (disabled)
+        return;
     DFHack::Core::getInstance().Update();
 }
 
 // called from the simulation thread just before adding the macro
 // recording/playback overlay
 DFhackCExport void dfhooks_prerender() {
+    if (disabled)
+        return;
     // TODO: render overlay widgets that are not attached to a viewscreen
 }
 
 // called from the main thread for each SDL event. if true is returned, then
 // the event has been consumed and further processing shouldn't happen
 DFhackCExport bool dfhooks_sdl_event(SDL::Event* event) {
+    if (disabled)
+        return false;
     return DFHack::Core::getInstance().DFH_SDL_Event(event);
 }
 
@@ -34,5 +52,7 @@ DFhackCExport bool dfhooks_sdl_event(SDL::Event* event) {
 // if true is returned, then the event has been consumed and further processing
 // shouldn't happen
 DFhackCExport bool dfhooks_ncurses_key(int key) {
+    if (disabled)
+        return false;
     return DFHack::Core::getInstance().DFH_ncurses_key(key);
 }

--- a/library/Hooks.cpp
+++ b/library/Hooks.cpp
@@ -8,6 +8,13 @@ static bool disabled = false;
 // called from the main thread before the simulation thread is started
 // and the main event loop is initiated
 DFhackCExport void dfhooks_init() {
+    if (getenv("DFHACK_DISABLE")) {
+        fprintf(stdout, "dfhack: DFHACK_DISABLE detected in environment; disabling\n");
+        disabled = true;
+        return;
+    }
+
+    // we need to init DF globals before we can check the commandline
     if (!DFHack::Core::getInstance().InitMainThread() || !df::global::game)
         return;
     const std::string & cmdline = df::global::game->command_line.original;

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -191,7 +191,8 @@ namespace DFHack
         struct Private;
         std::unique_ptr<Private> d;
 
-        bool Init();
+        bool InitMainThread();
+        bool InitSimulationThread();
         int Update (void);
         int Shutdown (void);
         bool DFH_SDL_Event(SDL::Event* event);


### PR DESCRIPTION
As requested by at least two different streamers.

This PR recognizes `--disable-dfhack` on the DF commandline and stubs out all our hooks if the flag is detected.

df::globals initialization moves to the `dfhooks_init` call in the main thread to support reading the commandline.

if the DF version is not matched in symbols.xml, the error response is exactly the same as it was before.

in order to keep the logic from changing too much, I also moved stderr/stdout redirection to the new main thread init function. this means DFHack will still have a *little* effect on the game when it is disabled, but I think this is acceptable (though always open for discussion).

Fixes #3198