### PR TITLE
give widgets.TabBar default hotkeys

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -5113,7 +5113,9 @@ This widget implements a set of one or more tabs to allow navigation between gro
 the width of the window and will continue rendering on the next line(s) if all tabs cannot fit on a single line.
 
 :key: Specifies a keybinding that can be used to switch to the next tab.
-:key_back: Specifies a keybinding that can be used to switch to the previous tab.
+      Defaults to ``CUSTOM_CTRL_T``.
+:key_back: Specifies a keybinding that can be used to switch to the previous
+      tab. Defaults to ``CUSTOM_CTRL_Y``.
 :labels: A table of strings; entry representing the label text for a single tab. The order of the entries
          determines the order the tabs will appear in.
 :on_select: Callback executed when a tab is selected. It receives the selected tab index as an argument. The provided function

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -2241,8 +2241,8 @@ TabBar.ATTRS{
     active_tab_pens=DEFAULT_ACTIVE_TAB_PENS,
     inactive_tab_pens=DEFAULT_INACTIVE_TAB_PENS,
     get_pens=DEFAULT_NIL,
-    key=DEFAULT_NIL,
-    key_back=DEFAULT_NIL,
+    key='CUSTOM_CTRL_T',
+    key_back='CUSTOM_CTRL_Y',
 }
 
 function TabBar:init()


### PR DESCRIPTION
Standardizing tab selection seems like a good idea. This had been enforced only through code review, but now we have proper defaults. This pairs with DFHack/scripts#622 where the only users of TabBar migrate to the widgets library version. Both users previously also used Ctrl-T as the "next tab" key.