### PR TITLE
retrieve steam SDK from a private repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,13 +139,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Get 3rd party SDKs
-        uses: actions/checkout@v3
-        with:
-          repository: DFHack/3rdparty
-          ref: main
-          token: ${{ secrets.DFHACK_3RDPARTY_TOKEN }}
-          path: depends
       - name: Fetch ccache
         uses: actions/cache@v3
         with:
@@ -156,7 +149,7 @@ jobs:
             ccache-win64-cross-msvc
       - name: Cross-compile win64 artifacts
         env:
-          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1'
+          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1'
         run: |
           cd build
           bash -x build-win64-from-linux.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,6 @@ jobs:
           #    - name: Download DF
           #      run: |
           #        sh ci/download-df.sh
-    - name: Restore steam SDK
-      uses: actions/cache@v3
-      with:
-        path: depends/steam
-        key: steam-sdk-156
-        enableCrossOsArchive: true
     - name: Configure DFHack
       env:
         CC: gcc-${{ matrix.gcc }}
@@ -145,6 +139,13 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Get 3rd party SDKs
+        uses: actions/checkout@v3
+        with:
+          repository: DFHack/3rdparty
+          ref: main
+          token: ${{ secrets.DFHACK_3RDPARTY_TOKEN }}
+          path: depends
       - name: Fetch ccache
         uses: actions/cache@v3
         with:
@@ -155,7 +156,7 @@ jobs:
             ccache-win64-cross-msvc
       - name: Cross-compile win64 artifacts
         env:
-          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1'
+          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1'
         run: |
           cd build
           bash -x build-win64-from-linux.sh

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -32,6 +32,13 @@ jobs:
           submodules: true
           fetch-depth: 0
           ref: ${{ github.event.inputs.commit_hash }}
+      - name: Get 3rd party SDKs
+        uses: actions/checkout@v3
+        with:
+          repository: DFHack/3rdparty
+          ref: main
+          token: ${{ secrets.DFHACK_3RDPARTY_TOKEN }}
+          path: depends
       - name: Fetch ccache
         uses: actions/cache@v3
         with:
@@ -40,12 +47,6 @@ jobs:
           restore-keys: |
             ccache-win64-cross-msvc-${{ github.event.inputs.commit_hash }}
             ccache-win64-cross-msvc
-      - name: Restore steam SDK
-        uses: actions/cache@v3
-        with:
-          path: depends/steam
-          key: steam-sdk-156
-          enableCrossOsArchive: true
       - name: Cross-compile win64 artifacts
         env:
           CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1'

--- a/package/windows/CMakeLists.txt
+++ b/package/windows/CMakeLists.txt
@@ -1,38 +1,32 @@
 project(package_windows)
 
-if(WIN32)
-    if (BUILD_DFLAUNCH)
-        if ((DEFINED ENV{steam_username}) AND (DEFINED ENV{steam_password}))
-            # download Steam SDK
-            set (STEAMAPI_DIR ${dfhack_SOURCE_DIR}/depends/steam)
-            file(DOWNLOAD "https://partner.steamgames.com/downloads/steamworks_sdk_156.zip"
-                    ${STEAMAPI_DIR}/steamworks_sdk_156.zip
-                    EXPECTED_HASH MD5=af5a579990dbe5ae4c1b0689260d001b
-                    USERPWD $ENV{steam_username}:$ENV{steam_password}
-                    STATUS STEAM_SDK_DOWNLOAD_STATUS
-                    SHOW_PROGRESS
-            )
-            list(GET STEAM_SDK_DOWNLOAD_STATUS 0 STEAM_SDK_DL_STATUS_CODE)
-            list(GET STEAM_SDK_DOWNLOAD_STATUS 1 STEAM_SDK_DL_ERROR_MESSAGE)
-            if (NOT (${STEAM_SDK_DL_STATUS_CODE} EQUAL 0))
-                message(FATAL_ERROR "Steam SDK download: " ${STEAM_SDK_DL_ERROR_MESSAGE})
-            else ()
-                message(STATUS "Steam SDK download: " ${STEAM_SDK_DL_ERROR_MESSAGE})
-                file(ARCHIVE_EXTRACT
-                        INPUT ${STEAMAPI_DIR}/steamworks_sdk_156.zip
-                        DESTINATION ${STEAMAPI_DIR})
-                set(STEAMAPI_LIBRARY "${STEAMAPI_DIR}/sdk/redistributable_bin/win64/steam_api64.lib")
-                set(STEAMAPI_SOURCE_DIR "${STEAMAPI_DIR}/sdk/public/steam")
-                set(STEAMAPI_SHARED_LIBRARY "${STEAMAPI_DIR}/sdk/redistributable_bin/win64/steam_api64.dll")
-            endif()
-        else()
-            message(SEND_ERROR "Need to set steam_username and steam_password in environment to download Steamworks SDK")
-        endif()
+option(BUILD_DFLAUNCH "Whether to build the Steam launcher exectuable (requires Steam SDK)." OFF)
 
-        include_directories(${STEAMAPI_SOURCE_DIR})
-        link_libraries(${STEAMAPI_LIBRARY})
-        add_executable(launchdf WIN32 launchdf.cpp)
-        install(TARGETS launchdf DESTINATION ${DFHACK_DATA_DESTINATION})
-        install(FILES ${STEAMAPI_SHARED_LIBRARY} DESTINATION ${DFHACK_DATA_DESTINATION})
+if(WIN32 AND BUILD_DFLAUNCH)
+    # builder must manually download Steam SDK
+    set (STEAMAPI_DIR ${dfhack_SOURCE_DIR}/depends/steam)
+    set (STEAMAPI_VER 156)
+    set (STEAMAPI_ZIP_EXPECTED_HASH af5a579990dbe5ae4c1b0689260d001b)
+    set (STEAMSDK_ZIP ${STEAMAPI_DIR}/steamworks_sdk_${STEAMAPI_VER}.zip)
+
+    set (STEAM_SDK_HASH "NOT FOUND")
+    file(MD5 ${STEAMSDK_ZIP} STEAM_SDK_HASH)
+    if (NOT (${STEAM_SDK_HASH} STREQUAL ${STEAMAPI_ZIP_EXPECTED_HASH}))
+        message(FATAL_ERROR "You need the Steamworks SDK at ${STEAMSDK_ZIP} to build launchdf.exe. Please disable the BUILD_DFLAUNCH CMake option or download the Steam SDK from: https://partner.steamgames.com/downloads/steamworks_sdk_${STEAMAPI_VER}.zip")
     endif()
+    if (${STEAMSDK_ZIP} IS_NEWER_THAN ${STEAMAPI_DIR}/sdk)
+        file(ARCHIVE_EXTRACT
+            INPUT ${STEAMSDK_ZIP}
+            DESTINATION ${STEAMAPI_DIR})
+    endif()
+
+    set(STEAMAPI_LIBRARY "${STEAMAPI_DIR}/sdk/redistributable_bin/win64/steam_api64.lib")
+    set(STEAMAPI_SOURCE_DIR "${STEAMAPI_DIR}/sdk/public/steam")
+    set(STEAMAPI_SHARED_LIBRARY "${STEAMAPI_DIR}/sdk/redistributable_bin/win64/steam_api64.dll")
+
+    include_directories(${STEAMAPI_SOURCE_DIR})
+    link_libraries(${STEAMAPI_LIBRARY})
+    add_executable(launchdf WIN32 launchdf.cpp)
+    install(TARGETS launchdf DESTINATION ${DFHACK_DATA_DESTINATION})
+    install(FILES ${STEAMAPI_SHARED_LIBRARY} DESTINATION ${DFHACK_DATA_DESTINATION})
 endif()


### PR DESCRIPTION
repo secrets can't be accessed from PRs, so no building launchdf.exe in PRs. We can set it up for the steam deploy action, though, where it is truly needed