### PR TITLE
[autodump] remove cursor guard so autodump destroy can work

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -49,6 +49,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `autolabor`: work detail override warning now only appears on the work details screen
 
 ## Misc Improvements
+- `autodump`: no longer checks for a keyboard cursor before executing, so ``autodump destroy`` (which doesn't require a cursor) can still function
 - `orders`: update orders in orders library for prepared meals, bins, archer uniforms, and weapons
 - Terminal console no longer appears in front of the game window on startup
 - `gui/control-panel`: new preference for whether filters in lists search for substrings in the middle of words (e.g. if set to true, then "ee" will match "steel")

--- a/plugins/autodump.cpp
+++ b/plugins/autodump.cpp
@@ -280,8 +280,7 @@ DFhackCExport command_result plugin_init ( color_ostream &out, vector <PluginCom
     commands.push_back(PluginCommand(
         "autodump",
         "Teleport items marked for dumping to the keyboard cursor.",
-        df_autodump,
-        Gui::cursor_hotkey));
+        df_autodump));
     commands.push_back(PluginCommand(
         "autodump-destroy-here",
         "Destroy items marked for dumping under the keyboard cursor.",


### PR DESCRIPTION
note that autodump has an interior check for the cursor when it is actually required, so the player still gets an appropriate error message when the keyboard cursor is needed but not available.

Fixes #3362