### PR TITLE
scroll mouse wheel to focus window under cursor

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Core: For debugging purposes, you can now pass ``--disable-dfhack`` on the Dwarf Fortress commandline or specify ``DFHACK_DISABLE=1`` in the environment to disable DFHack for the current session.
 - `overlay`: added links to the quickstart guide and the control panel on the DF title screen
 - `gui/autodump`: fort-mode keybinding: Ctrl-H
+- Window behavior: if you have multiple DFHack tool windows open, scrolling the mouse wheel while over an unfocused window will focus it and raise it to the top
 
 ## Documentation
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4240,11 +4240,11 @@ input skips all unfocused ZScreens under that ZScreen and is passed directly to
 the first non-ZScreen viewscreen. There are class attributes that can be set to
 control what kind of unhandled input is passed to the lower layers.
 
-If multiple ZScreens are visible and the player left or right clicks on a
-visible element of a non-focused ZScreen, that ZScreen will be given focus. This
-allows multiple DFHack GUI tools to be usable at the same time. If the mouse is
-clicked away from the ZScreen widgets, that ZScreen loses focus. If no ZScreen
-has focus, all input is passed directly through to the first underlying
+If multiple ZScreens are visible and the player scrolls or left/right clicks on
+a visible element of a non-focused ZScreen, that ZScreen will be given focus.
+This allows multiple DFHack GUI tools to be usable at the same time. If the
+mouse is clicked away from the ZScreen widgets, that ZScreen loses focus. If no
+ZScreen has focus, all input is passed directly through to the first underlying
 non-ZScreen viewscreen.
 
 For a ZScreen with keyboard focus, if :kbd:`Esc` or the right mouse button is

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -789,7 +789,8 @@ function ZScreen:onInput(keys)
     if not self:hasFocus() then
         if has_mouse and
                 (keys._MOUSE_L_DOWN or keys._MOUSE_R_DOWN or
-                 keys.CONTEXT_SCROLL_UP or keys.CONTEXT_SCROLL_DOWN) then
+                 keys.CONTEXT_SCROLL_UP or keys.CONTEXT_SCROLL_DOWN or
+                 keys.CONTEXT_SCROLL_PAGEUP or keys.CONTEXT_SCROLL_PAGEDOWN) then
             self:raise()
         else
             self:sendInputToParent(keys)
@@ -820,7 +821,8 @@ function ZScreen:onInput(keys)
         end
         local passit = self.pass_pause and keys.D_PAUSE
         if not passit and self.pass_mouse_clicks then
-            if keys.CONTEXT_SCROLL_UP or keys.CONTEXT_SCROLL_DOWN then
+            if keys.CONTEXT_SCROLL_UP or keys.CONTEXT_SCROLL_DOWN or
+                    keys.CONTEXT_SCROLL_PAGEUP or keys.CONTEXT_SCROLL_PAGEDOWN then
                 passit = true
             else
                 for key in pairs(MOUSE_KEYS) do

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -787,7 +787,9 @@ end
 function ZScreen:onInput(keys)
     local has_mouse = self:isMouseOver()
     if not self:hasFocus() then
-        if (keys._MOUSE_L_DOWN or keys._MOUSE_R_DOWN) and has_mouse then
+        if has_mouse and
+                (keys._MOUSE_L_DOWN or keys._MOUSE_R_DOWN or
+                 keys.CONTEXT_SCROLL_UP or keys.CONTEXT_SCROLL_DOWN) then
             self:raise()
         else
             self:sendInputToParent(keys)
@@ -818,10 +820,14 @@ function ZScreen:onInput(keys)
         end
         local passit = self.pass_pause and keys.D_PAUSE
         if not passit and self.pass_mouse_clicks then
-            for key in pairs(MOUSE_KEYS) do
-                if keys[key] then
-                    passit = true
-                    break
+            if keys.CONTEXT_SCROLL_UP or keys.CONTEXT_SCROLL_DOWN then
+                passit = true
+            else
+                for key in pairs(MOUSE_KEYS) do
+                    if keys[key] then
+                        passit = true
+                        break
+                    end
                 end
             end
         end


### PR DESCRIPTION
because otherwise it's a pain in the butt to focus another `gui/gm-editor` window without accidentally clicking on (and therefore editing/changing) one of the displayed fields.