### PR TITLE
don't throw if json is unreadable

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -51,6 +51,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - `autodump`: no longer checks for a keyboard cursor before executing, so ``autodump destroy`` (which doesn't require a cursor) can still function
+- Settings: recover gracefully when settings files become corrupted (e.g. by CTD)
 - `orders`: update orders in orders library for prepared meals, bins, archer uniforms, and weapons
 - Terminal console no longer appears in front of the game window on startup
 - `gui/control-panel`: new preference for whether filters in lists search for substrings in the middle of words (e.g. if set to true, then "ee" will match "steel")

--- a/library/lua/json.lua
+++ b/library/lua/json.lua
@@ -59,7 +59,13 @@ function _file:read(strict)
         end
     else
         self.exists = true
-        self.data = decode_file(self.path)
+        local ok, err = pcall(function() self.data = decode_file(self.path) end)
+        if not ok then
+            if strict then
+                error(('cannot decode file: %s: %s'):format(self.path, err))
+            end
+            self.data = {}
+        end
     end
     return self.data
 end


### PR DESCRIPTION
just act like the file didn't exist (unless strict is set)

Fixes bug brought up on the Steam forums: https://steamcommunity.com/app/2346660/discussions/0/3827540383542758371/