### PR TITLE
Expose Alias API to Lua

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3577,6 +3577,68 @@ static int internal_md5file(lua_State *L)
     }
 }
 
+/**************************
+ * Wrappers for Alias API *
+ **************************/
+
+static int internal_getAliasCommand(lua_State *L)
+{
+    const char *name = luaL_checkstring(L, 1);
+    std::string ret = Core::getInstance().GetAliasCommand(name);
+    if (!ret.empty())
+        lua_pushstring(L, ret.c_str());
+    else
+        lua_pushnil(L);
+    return 1;
+}
+
+static int internal_listAliases(lua_State *L)
+{
+    auto aliases = Core::getInstance().ListAliases();
+
+    lua_newtable(L);
+    for (const auto& p : aliases)
+    {
+        Lua::Push(L, p.first.c_str()); // alias
+        Lua::PushVector(L, p.second);
+        lua_settable(L, -3);
+    }
+    return 1;
+}
+
+static int internal_isAlias(lua_State *L)
+{
+    const char *name = luaL_checkstring(L, 1);
+    lua_pushboolean(L, Core::getInstance().IsAlias(name));
+    return 1;
+}
+
+static int internal_addAlias(lua_State *L)
+{
+    const char *new_alias = luaL_checkstring(L, 1);
+    std::vector<std::string> alias;
+    split_string(&alias, new_alias, " ");
+
+    if (!alias.empty())
+    {
+        std::string name = alias[0];
+        alias.erase(alias.begin());
+        lua_pushboolean(L, Core::getInstance().AddAlias(name, alias));
+    } else {
+        lua_pushboolean(L, false);
+    }
+
+    return 1;
+}
+
+static int internal_removeAlias(lua_State *L)
+{
+    const char *rem_alias = luaL_checkstring(L, 1);
+
+    lua_pushboolean(L, Core::getInstance().RemoveAlias(rem_alias));
+    return 1;
+}
+
 static const luaL_Reg dfhack_internal_funcs[] = {
     { "getPE", internal_getPE },
     { "getMD5", internal_getmd5 },
@@ -3605,6 +3667,13 @@ static const luaL_Reg dfhack_internal_funcs[] = {
     { "getCommandDescription", internal_getCommandDescription },
     { "threadid", internal_threadid },
     { "md5File", internal_md5file },
+
+    { "getAliasCommand", internal_getAliasCommand },
+    { "isAlias", internal_isAlias },
+    { "listAliases", internal_listAliases },
+    { "addAlias", internal_addAlias },
+    { "removeAlias", internal_removeAlias },
+
     { NULL, NULL }
 };
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3615,9 +3615,8 @@ static int internal_isAlias(lua_State *L)
 
 static int internal_addAlias(lua_State *L)
 {
-    const char *new_alias = luaL_checkstring(L, 1);
     std::vector<std::string> alias;
-    split_string(&alias, new_alias, " ");
+    Lua::GetVector(L, alias, 1);
 
     if (!alias.empty())
     {

--- a/test/library/alias.lua
+++ b/test/library/alias.lua
@@ -1,7 +1,7 @@
 -- Simple tests to ensure the alias functions work as expected
 function test.aliases()
     expect.eq(false, dfhack.internal.isAlias("foo"))
-    expect.eq(true, dfhack.internal.addAlias("foo help"))
+    expect.eq(true, dfhack.internal.addAlias({"foo", "help"}))
     expect.eq(true, dfhack.internal.isAlias("foo"))
     expect.eq("help", dfhack.internal.getAliasCommand("foo"))
     expect.eq("this is not an alias", dfhack.internal.getAliasCommand("this is not an alias"))

--- a/test/library/alias.lua
+++ b/test/library/alias.lua
@@ -1,0 +1,11 @@
+-- Simple tests to ensure the alias functions work as expected
+function test.aliases()
+    expect.eq(false, dfhack.internal.isAlias("foo"))
+    expect.eq(true, dfhack.internal.addAlias("foo help"))
+    expect.eq(true, dfhack.internal.isAlias("foo"))
+    expect.eq("help", dfhack.internal.getAliasCommand("foo"))
+    expect.eq("this is not an alias", dfhack.internal.getAliasCommand("this is not an alias"))
+    expect.eq("help", dfhack.internal.listAliases()["foo"][1])
+    expect.eq(true, dfhack.internal.removeAlias("foo"))
+    expect.eq(false, dfhack.internal.isAlias("foo"))
+end


### PR DESCRIPTION
Issue (#3342)
 - Make aliases available to lua
 - Ensure aliases typed in `gui/launcher` show proper help entry
 - Enhance help entry with aliased command information
 - added a simple set of tests