### PR TITLE
add ensure_keys utility function

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -74,6 +74,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 - ``overlay.reload()``: has been renamed to ``overlay.rescan()`` so as not to conflict with the global ``reload()`` function. If you are developing an overlay, please take note of the new function name for reloading your overlay during development.
 - ``gui``: changed frame naming scheme to ``FRAME_X`` rather than ``X_FRAME``, and added aliases for backwards compatibility. (for example ``BOLD_FRAME`` is now called ``FRAME_BOLD``)
+- ``ensure_keys``: walks a series of keys, creating new tables for any missing values
 
 ## Removed
 - `orders`: ``library/military_include_artifact_materials`` library file removed since recent research indicates that platinum blunt weapons and silver crossbows are not more effective than standard steel. the alternate military orders file was also causing unneeded confusion.

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3019,6 +3019,11 @@ environment by the mandatory init file dfhack.lua:
   set to the value of ``default_value``, which defaults to ``{}`` if not set.
   The new or existing value of ``t[key]`` is then returned.
 
+* ``ensure_keys(t, key...)``
+
+  Walks a series of keys, creating any missing keys as empty tables. The new or
+  existing table from the last specified key is returned from the function.
+
 .. _lua-string:
 
 String class extensions

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -404,6 +404,14 @@ function ensure_key(t, key, default_value)
     return t[key]
 end
 
+function ensure_keys(t, key, ...)
+    t = ensure_key(t, key)
+    if select('#', ...) > 0 then
+        return ensure_keys(t, ...)
+    end
+    return t
+end
+
 -- String class extentions
 
 -- prefix is a literal string, not a pattern


### PR DESCRIPTION
`ensure_key` is handy, but when you have a long chain of keys to dereference, its usage can be unwieldy. `ensure_keys` can take an arbitrary number of keys, similar to the `safe_index` function.