### PR TITLE
adjust findCivzonesAt to v50 semantics

### DIFF
--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -465,7 +465,7 @@ bool Buildings::findCivzonesAt(std::vector<df::building_civzonest*> *pvec,
                                df::coord pos) {
     pvec->clear();
 
-    for (df::building_civzonest* zone : world->buildings.other.ACTIVITY_ZONE)
+    for (df::building_civzonest* zone : world->buildings.other.ANY_ZONE)
     {
         if (pos.z != zone->z)
             continue;


### PR DESCRIPTION
now there *are* no zones in ACTIVITY_ZONES. they're still in ANY_ZONE, though, so we use that instead.