### PR TITLE
[SDL2] temporarily disable faststart

### DIFF
--- a/plugins/faststart.cpp
+++ b/plugins/faststart.cpp
@@ -48,8 +48,10 @@ DFhackCExport command_result plugin_enable(color_ostream &out, bool enable)
 {
     if (enable != is_enabled)
     {
+#if 0
         if (!INTERPOSE_HOOK(prep_hook, logic).apply(enable))
             return CR_FAILURE;
+#endif
 
         is_enabled = enable;
     }


### PR DESCRIPTION
Just until DF is race-condition-free. prevents crashes for experimental branch users (since `faststart` is on by default)