### PR TITLE
UI: "divider" rendering rework

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -75,6 +75,9 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Lua
 - ``overlay.reload()``: has been renamed to ``overlay.rescan()`` so as not to conflict with the global ``reload()`` function. If you are developing an overlay, please take note of the new function name for reloading your overlay during development.
 - ``gui``: changed frame naming scheme to ``FRAME_X`` rather than ``X_FRAME``, and added aliases for backwards compatibility. (for example ``BOLD_FRAME`` is now called ``FRAME_BOLD``)
+- ``gui.make_frame()``: now maps every tile sprite from a border spritesheet.
+- ``gui.paint_frame()``: Panels with width or height equal to 1 will now draw a ``divider``.
+- ``buildingplan``: has been updated to make use of the new gui elements internally.
 - ``ensure_keys``: walks a series of keys, creating new tables for any missing values
 
 ## Removed

--- a/plugins/lua/buildingplan/filterselection.lua
+++ b/plugins/lua/buildingplan/filterselection.lua
@@ -112,7 +112,7 @@ function QualityAndMaterialsPage:init()
         widgets.Panel{
             view_id='materials_lists',
             frame={l=0, t=HEADER_HEIGHT, r=0, b=FOOTER_HEIGHT+QUALITY_HEIGHT},
-            frame_style=gui.INTERIOR_FRAME,
+            frame_style=gui.FRAME_INTERIOR,
             subviews={
                 widgets.List{
                     view_id='materials_categories',
@@ -133,12 +133,12 @@ function QualityAndMaterialsPage:init()
         widgets.Panel{
             view_id='divider',
             frame={l=TYPE_COL_WIDTH-1, t=HEADER_HEIGHT, b=FOOTER_HEIGHT+QUALITY_HEIGHT, w=1},
-            on_render=self:callback('draw_divider'),
+            frame_style=gui.FRAME_INTERIOR,
         },
         widgets.Panel{
             view_id='quality_panel',
             frame={l=0, r=0, h=QUALITY_HEIGHT, b=FOOTER_HEIGHT},
-            frame_style=gui.INTERIOR_FRAME,
+            frame_style=gui.FRAME_INTERIOR,
             frame_title='Item quality',
             subviews={
                 widgets.CycleHotkeyLabel{
@@ -437,20 +437,6 @@ function QualityAndMaterialsPage:set_max_quality(idx)
     self.dirty = true
 end
 
-function QualityAndMaterialsPage:draw_divider(dc)
-    local y2 = dc.height - 1
-    for y=0,y2 do
-        dc:seek(0, y)
-        if y == 0 then
-            dc:char(nil, pens.VERT_TOP_PEN)
-        elseif y == y2 then
-            dc:char(nil, pens.VERT_BOT_PEN)
-        else
-            dc:char(nil, pens.VERT_MID_PEN)
-        end
-    end
-end
-
 function QualityAndMaterialsPage:onRenderFrame(dc, rect)
     QualityAndMaterialsPage.super.onRenderFrame(self, dc, rect)
     if self.dirty then
@@ -466,7 +452,7 @@ GlobalSettingsPage = defclass(GlobalSettingsPage, widgets.ResizingPanel)
 GlobalSettingsPage.ATTRS{
     autoarrange_subviews=true,
     frame={t=0, l=0},
-    frame_style=gui.INTERIOR_FRAME,
+    frame_style=gui.FRAME_INTERIOR,
 }
 
 function GlobalSettingsPage:init()

--- a/plugins/lua/buildingplan/inspectoroverlay.lua
+++ b/plugins/lua/buildingplan/inspectoroverlay.lua
@@ -67,7 +67,7 @@ InspectorOverlay.ATTRS{
     default_enabled=true,
     viewscreens='dwarfmode/ViewSheets/BUILDING',
     frame={w=30, h=15},
-    frame_style=gui.MEDIUM_FRAME,
+    frame_style=gui.FRAME_MEDIUM,
     frame_background=gui.CLEAR_PEN,
 }
 

--- a/plugins/lua/buildingplan/itemselection.lua
+++ b/plugins/lua/buildingplan/itemselection.lua
@@ -146,7 +146,7 @@ function ItemSelection:init()
                 },
                 widgets.Panel{
                     frame={l=0, t=3, r=0, b=0},
-                    frame_style=gui.INTERIOR_FRAME,
+                    frame_style=gui.FRAME_INTERIOR,
                     subviews={
                         widgets.FilteredList{
                             view_id='flist',

--- a/plugins/lua/buildingplan/pens.lua
+++ b/plugins/lua/buildingplan/pens.lua
@@ -1,38 +1,15 @@
 local _ENV = mkmodule('plugins.buildingplan.pens')
 
 GOOD_TILE_PEN, BAD_TILE_PEN = nil, nil
-VERT_TOP_PEN, VERT_MID_PEN, VERT_BOT_PEN = nil, nil, nil
-HORI_LEFT_PEN, HORI_MID_PEN, HORI_RIGHT_PEN = nil, nil, nil
-BUTTON_START_PEN, BUTTON_END_PEN = nil, nil
 SELECTED_ITEM_PEN = nil
 MINI_TEXT_PEN, MINI_TEXT_HPEN, MINI_BUTT_PEN, MINI_BUTT_HPEN = nil, nil, nil, nil
 
 local to_pen = dfhack.pen.parse
 
-local tp = function(base, offset)
-    if base == -1 then return nil end
-    return base + offset
-end
-
 function reload_pens()
     GOOD_TILE_PEN = to_pen{ch='o', fg=COLOR_GREEN, tile=dfhack.screen.findGraphicsTile('CURSORS', 1, 2)}
     BAD_TILE_PEN = to_pen{ch='X', fg=COLOR_RED, tile=dfhack.screen.findGraphicsTile('CURSORS', 3, 0)}
-
-    local tb_texpos = dfhack.textures.getThinBordersTexposStart()
-    VERT_TOP_PEN = to_pen{tile=tp(tb_texpos, 10), ch=194, fg=COLOR_GREY, bg=COLOR_BLACK}
-    VERT_MID_PEN = to_pen{tile=tp(tb_texpos, 4), ch=179, fg=COLOR_GREY, bg=COLOR_BLACK}
-    VERT_BOT_PEN = to_pen{tile=tp(tb_texpos, 11), ch=193, fg=COLOR_GREY, bg=COLOR_BLACK}
-
-    local mb_texpos = dfhack.textures.getMediumBordersTexposStart()
-    HORI_LEFT_PEN = to_pen{tile=tp(mb_texpos, 12), ch=195, fg=COLOR_GREY, bg=COLOR_BLACK}
-    HORI_MID_PEN = to_pen{tile=tp(mb_texpos, 5), ch=196, fg=COLOR_GREY, bg=COLOR_BLACK}
-    HORI_RIGHT_PEN = to_pen{tile=tp(mb_texpos, 13), ch=180, fg=COLOR_GREY, bg=COLOR_BLACK}
-
-    local cp_texpos = dfhack.textures.getControlPanelTexposStart()
-    BUTTON_START_PEN = to_pen{tile=tp(cp_texpos, 13), ch='[', fg=COLOR_YELLOW}
-    BUTTON_END_PEN = to_pen{tile=tp(cp_texpos, 15), ch=']', fg=COLOR_YELLOW}
-    SELECTED_ITEM_PEN = to_pen{tile=tp(cp_texpos, 9), ch=string.char(251), fg=COLOR_YELLOW}
-
+    SELECTED_ITEM_PEN = to_pen{ch=string.char(251), fg=COLOR_YELLOW}
     MINI_TEXT_PEN = to_pen{fg=COLOR_BLACK, bg=COLOR_GREY}
     MINI_TEXT_HPEN = to_pen{fg=COLOR_BLACK, bg=COLOR_WHITE}
     MINI_BUTT_PEN = to_pen{fg=COLOR_BLACK, bg=COLOR_LIGHTRED}

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -345,10 +345,12 @@ function PlannerOverlay:init()
     local main_panel = widgets.Panel{
         view_id='main',
         frame={t=1, l=0, r=0, h=14},
-        frame_style=gui.INTERIOR_MEDIUM_FRAME,
+        frame_style=gui.FRAME_MEDIUM,
         frame_background=gui.CLEAR_PEN,
         visible=self:callback('is_not_minimized'),
     }
+
+    main_panel.frame_style.signature_pen = false
 
     local minimized_panel = widgets.Panel{
         frame={t=0, r=1, w=17, h=1},
@@ -557,14 +559,14 @@ function PlannerOverlay:init()
     local divider_widget = widgets.Panel{
         view_id='divider',
         frame={t=10, l=0, r=0, h=1},
-        on_render=self:callback('draw_divider_h'),
+        frame_style=gui.FRAME_MEDIUM,
         visible=self:callback('is_not_minimized'),
     }
 
     local error_panel = widgets.ResizingPanel{
         view_id='errors',
         frame={t=15, l=0, r=0},
-        frame_style=gui.BOLD_FRAME,
+        frame_style=gui.FRAME_BOLD,
         frame_background=gui.CLEAR_PEN,
         visible=self:callback('is_not_minimized'),
     }
@@ -639,20 +641,6 @@ end
 function PlannerOverlay:toggle_minimized()
     self.state.minimized = not self.state.minimized
     config:write()
-end
-
-function PlannerOverlay:draw_divider_h(dc)
-    local x2 = dc.width -1
-    for x=0,x2 do
-        dc:seek(x, 0)
-        if x == 0 then
-            dc:char(nil, pens.HORI_LEFT_PEN)
-        elseif x == x2 then
-            dc:char(nil, pens.HORI_RIGHT_PEN)
-        else
-            dc:char(nil, pens.HORI_MID_PEN)
-        end
-    end
 end
 
 function PlannerOverlay:reset()


### PR DESCRIPTION
by 'divider' i mean one of these horizontal or vertical lines that visually "divide" a frame.
![Dwarf_Fortress_tyNzHqdCjv](https://github.com/DFHack/dfhack/assets/5853667/3ae81fe9-b55e-4586-9e4a-fcd9c68fc962)

Previously, these were rendered using a custom function within each script that used a divider.

This PR modifies the way a Panel is rendered, so that to achieve the same effect, you can just make a 1-width or 1-height Panel to get a vertical or horizontal divider respectively.

### gui.lua
- `make_frame` - now assigns a name to every tile in a border spritesheet, so we can access T pieces etc.
- `paint_frame` - a Frame with height/width equal to 1 will now render appropriate T-pieces at its extremities, and an horizontal/vertical bar between them. 
It will also draw a cross-piece if both height and width are equal to 1.
(Additionally, logic has been added that disables the `signature_pen` whenever a Panel's height and/or width is equal to 1.)

