### PR TITLE
WIP: Working POC for buttons/buttons groups, PR up for commentary

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1721,6 +1721,8 @@ static const LuaWrapper::FunctionReg dfhack_textures_module[] = {
     WRAPM(Textures, getBoldBordersTexposStart),
     WRAPM(Textures, getPanelBordersTexposStart),
     WRAPM(Textures, getWindowBordersTexposStart),
+    WRAPM(Textures, getGuiDesignModesTexposStart),
+    WRAPM(Textures, getGuiDesignShapesTexposStart),
     { NULL, NULL }
 };
 

--- a/library/include/modules/Textures.h
+++ b/library/include/modules/Textures.h
@@ -60,5 +60,8 @@ DFHACK_EXPORT long getBoldBordersTexposStart();
 DFHACK_EXPORT long getPanelBordersTexposStart();
 DFHACK_EXPORT long getWindowBordersTexposStart();
 
+DFHACK_EXPORT long getGuiDesignModesTexposStart();
+DFHACK_EXPORT long getGuiDesignShapesTexposStart();
 }
+
 }

--- a/library/modules/Textures.cpp
+++ b/library/modules/Textures.cpp
@@ -29,6 +29,8 @@ static long g_medium_borders_texpos_start = -1;
 static long g_bold_borders_texpos_start = -1;
 static long g_panel_borders_texpos_start = -1;
 static long g_window_borders_texpos_start = -1;
+static long g_gui_design_modes_texpos_start = -1;
+static long g_gui_design_shapes_texpos_start = -1;
 
 // Converts an arbitrary Surface to something like the display format
 // (32-bit RGBA), and converts magenta to transparency if convert_magenta is set
@@ -141,6 +143,10 @@ void Textures::init(color_ostream &out) {
                                           &g_panel_borders_texpos_start);
     g_num_dfhack_textures += load_textures(out, "hack/data/art/border-window.png",
                                           &g_window_borders_texpos_start);
+    g_num_dfhack_textures += load_textures(out, "hack/data/art/gui-design-modes.png",
+                                          &g_gui_design_modes_texpos_start);
+    g_num_dfhack_textures += load_textures(out, "hack/data/art/gui-design-shapes.png",
+                                          &g_gui_design_shapes_texpos_start);
 
     DEBUG(textures,out).print("loaded %ld textures\n", g_num_dfhack_textures);
 
@@ -215,4 +221,11 @@ long Textures::getPanelBordersTexposStart() {
 
 long Textures::getWindowBordersTexposStart() {
     return g_window_borders_texpos_start;
+}
+
+long Textures::getGuiDesignModesTexposStart() {
+    return g_gui_design_modes_texpos_start;
+}
+long Textures::getGuiDesignShapesTexposStart() {
+    return g_gui_design_shapes_texpos_start;
 }


### PR DESCRIPTION
Been working on buttons, this is the first working PoC. It allows wrapping a `CycleHotKeyLabel` in the new `ButtonGroup` class.

The `GraphicButton` and `ButtonGroup` classes will automatically load texpos graphics from sprite files and stitch them together to draw buttons. Some C++ is required to get the graphics loaded.

In the Lua, you need to pass in the name of the graphics (maps with the c++ code, which loads the texpos), and `file_dims` which is how many buttons there are and how many rows, so the following files are `file_dims = { x = 7, y = 1 },` and `  file_dims = { x = 6, y = 1 },` respectively.
![gui-design-modes](https://github.com/DFHack/dfhack/assets/4482627/2fe763bb-f30c-404c-86b3-49c71a1c2498)
![gui-design-shapes](https://github.com/DFHack/dfhack/assets/4482627/c03aac4c-3bfc-4d4c-9e07-0573743f75ec)

It's also necessary to include the `button_dims`, which tell the classes what dimensions of texpos characters the buttons are, so for example the above icons are 4x3.

Eventually maybe we can come up with a way to automatically determine these things...

**NOTE:** There's work in progress to add more button states like hover, pressing, etc... so this will be expanded as work moves forward.

The `ButtonGroup` class will automatically keep the hotkey label and buttons in sync, and both controls will work. The `hotkey_controller` field is just the original widget, so it should be easy to upgrade existing controls and add graphics likes this.

Here's an example from `gui/design`

```lua
        widgets.ResizingPanel {
            subviews = {
                widgets.ButtonGroup {
                    view_id = "modes_button_group",
                    graphics = 'GuiDesignModes',
                    file_dims = { x = 7, y = 1 },
                    button_dims = { width = 4, height = 3 },
                    -- Original, unaltered hotkey label code
                    hotkey_controller = widgets.CycleHotkeyLabel {
                        view_id = "mode_name",
                        key = "CUSTOM_F",
                        key_back = "CUSTOM_SHIFT_F",
                        label = "Mode: ",
                        label_width = 8,
                        active = true,
                        enabled = true,
                        options = mode_options,
                        disabled = false,
                        show_tooltip = true,
                        on_change = function(new, old)
                            self.design_panel:updateLayout()
                        end,
                    },
                }
            }
        },
        widgets.ResizingPanel {
            subviews = {
                widgets.ButtonGroup {
                    orientation = 'vertical',
                    view_id = "shapes_button_group",
                    graphics = 'GuiDesignShapes',
                    file_dims = { x = 6, y = 1 },
                    button_dims = { width = 4, height = 3 },
                    -- Original, unaltered hotkey label code
                    hotkey_controller = widgets.CycleHotkeyLabel {
                        view_id = "shape_name",
                        key = "CUSTOM_Z",
                        key_back = "CUSTOM_SHIFT_Z",
                        label = "Shape: ",
                        label_width = 8,
                        active = true,
                        enabled = true,
                        options = options,
                        disabled = false,
                        show_tooltip = true,
                        on_change = self:callback("change_shape"),
                    },

                }
            }
        },
```

This code creates the following example:
![graphics_buttons_demos](https://github.com/DFHack/dfhack/assets/4482627/fad61545-5f68-4545-bab2-05c99874206c)
