### PR TITLE
[dig-now] clear item occupancy flags for channeled tiles

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- `dig-now`: clear item occupancy flags for channeled tiles that had items on them
 
 ## Misc Improvements
 - `autonick`: additional nicknames based on burrowing animals, colours, gems and minerals added

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -968,10 +968,20 @@ static void post_process_dug_tiles(color_ostream &out,
             }
 
             if (to.bits.item) {
-                for (auto item : world->items.other.IN_PLAY) {
-                    if (item->pos == pos && item->flags.bits.on_ground)
-                        item->moveToGround(
-                                resting_pos.x, resting_pos.y, resting_pos.z);
+                std::vector<df::item*> items;
+                if (auto b = Maps::ensureTileBlock(pos)) {
+                    for (auto item_id : b->items) {
+                        auto item = df::item::find(item_id);
+                        if (item && item->pos == pos)
+                            items.emplace_back(item);
+                    }
+                }
+                if (!items.empty()) {
+                    // fresh MapCache since tile properties are being actively changed
+                    MapExtras::MapCache mc;
+                    for (auto item : items)
+                        Items::moveToGround(mc, item, resting_pos);
+                    mc.WriteAll();
                 }
             }
         }


### PR DESCRIPTION
Fixes #3458