### PR TITLE
RemoteFortressReader: Fix a null pointer access on image descriptions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Fixes
 - `dig-now`: clear item occupancy flags for channeled tiles that had items on them
+- `RemoteFortressReader`: fix a crash with engraving without image
 
 ## Misc Improvements
 - `autonick`: additional nicknames based on burrowing animals, colours, gems and minerals added

--- a/plugins/remotefortressreader/item_reader.cpp
+++ b/plugins/remotefortressreader/item_reader.cpp
@@ -248,7 +248,7 @@ void CopyItem(RemoteFortressReader::Item * NetItem, df::item * DfItem)
                     chunk = world->art_image_chunks[i];
             }
         }
-        if (chunk)
+        if (chunk && chunk->images[statue->image.subid])
         {
             CopyImage(chunk->images[statue->image.subid], NetItem->mutable_image());
         }
@@ -462,7 +462,10 @@ void CopyItem(RemoteFortressReader::Item * NetItem, df::item * DfItem)
             case df::enums::improvement_type::ART_IMAGE:
             {
                 VIRTUAL_CAST_VAR(artImage, df::itemimprovement_art_imagest, improvement);
-                CopyImage(artImage->getImage(DfItem), netImp->mutable_image());
+                auto image = artImage->getImage(DfItem);
+                if (image) {
+                    CopyImage(image, netImp->mutable_image());
+                }
                 break;
             }
             case df::enums::improvement_type::COVERED:

--- a/plugins/remotefortressreader/remotefortressreader.cpp
+++ b/plugins/remotefortressreader/remotefortressreader.cpp
@@ -1530,7 +1530,9 @@ static command_result GetBlockList(color_ostream &stream, const BlockRequest *in
         ConvertDFCoord(engraving->pos, netEngraving->mutable_pos());
         netEngraving->set_quality(engraving->quality);
         netEngraving->set_tile(engraving->tile);
-        CopyImage(chunk->images[engraving->art_subid], netEngraving->mutable_image());
+        if (chunk->images[engraving->art_subid]) {
+            CopyImage(chunk->images[engraving->art_subid], netEngraving->mutable_image());
+        }
         netEngraving->set_floor(engraving->flags.bits.floor);
         netEngraving->set_west(engraving->flags.bits.west);
         netEngraving->set_east(engraving->flags.bits.east);


### PR DESCRIPTION
Seen on saves shared on Blind discord: Some engraving and statues don't have any image description at all, leading to a null pointer exception when trying to access it in RemoteFortressReader. I was not able to recreate such situation myself, but in game they just don't have any image name or description.

In memory, they show as `null` in various locations. I only located access to these description in RFR, but let me know if there would be other places that could be impacted.