### PR TITLE
[sdl2] ensure we get all string input

### DIFF
--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -229,6 +229,9 @@ namespace DFHack
         DFHACK_EXPORT bool hasActiveScreens(Plugin *p);
         DFHACK_EXPORT void raise(df::viewscreen *screen);
 
+        // returns a new set with text interface keys from the text buffer added in (if any)
+        DFHACK_EXPORT std::set<df::interface_key> add_text_keys(const std::set<df::interface_key>& keys);
+
         /// Retrieve the string representation of the bound key.
         DFHACK_EXPORT std::string getKeyDisplay(df::interface_key key);
 

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -78,7 +78,6 @@ namespace DFHack {
     DBG_DECLARE(core, screen, DebugCategory::LINFO);
 }
 
-
 /*
  * Screen painting API.
  */
@@ -586,6 +585,17 @@ void Hide::merge() {
 }
 } }
 
+std::set<df::interface_key> Screen::add_text_keys(const std::set<df::interface_key>& keys) {
+    std::set<df::interface_key> combined_keys(keys);
+    if (df::global::enabler->last_text_input[0]) {
+        char c = df::global::enabler->last_text_input[0];
+        df::interface_key key = charToKey(c);
+        DEBUG(screen).print("adding character %c as interface key %ld\n", c, key);
+        combined_keys.emplace(key);
+    }
+    return combined_keys;
+}
+
 string Screen::getKeyDisplay(df::interface_key key)
 {
     if (enabler)
@@ -940,7 +950,7 @@ int dfhack_lua_viewscreen::do_input(lua_State *L)
     }
 
     lua_pushvalue(L, -2);
-    Lua::PushInterfaceKeys(L, *keys);
+    Lua::PushInterfaceKeys(L, Screen::add_text_keys(*keys));
 
     lua_call(L, 2, 0);
     self->update_focus(L, -1);
@@ -1023,6 +1033,7 @@ void dfhack_lua_viewscreen::feed(std::set<df::interface_key> *keys)
 
     lua_pushlightuserdata(Lua::Core::State, keys);
     safe_call_lua(do_input, 1, 0);
+    df::global::enabler->last_text_input[0] = '\0';
 }
 
 void dfhack_lua_viewscreen::onShow()

--- a/plugins/overlay.cpp
+++ b/plugins/overlay.cpp
@@ -76,7 +76,7 @@ struct viewscreen_overlay : T {
                     [&](lua_State *L) {
                         Lua::Push(L, T::_identity.getName());
                         Lua::Push(L, this);
-                        Lua::PushInterfaceKeys(L, *input);
+                        Lua::PushInterfaceKeys(L, Screen::add_text_keys(*input));
                     }, [&](lua_State *L) {
                         input_is_handled = lua_toboolean(L, -1);
                     });


### PR DESCRIPTION
This only gets the first character in order to keep the logic simple, but I have yet to find a case where there is more than one character in the buffer (maybe with a system IME?).

If we have to loop, then we have to make multiple calls to `feed`/`onInput`, *without* duplicating mouse clicks or other forms of input. That would get hairy. Let's hope the single character approach is sufficient.

There are no other plugins that currently interpose feed, but if we add any more/add any more back, we need to make sure to add in the `Screen:add_text_keys()` wrapper.

Fixes #3433
Fixes #3471