### PR TITLE
[sdl2] prefer symbols to descriptions for hotkey names

### DIFF
--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -588,10 +588,12 @@ void Hide::merge() {
 
 string Screen::getKeyDisplay(df::interface_key key)
 {
-    if (enabler)
-        return enabler->GetKeyDisplay(key);
-
-    return "?";
+    int c = keyToChar(key);
+    if (c != -1)
+        return string(1, c);
+    if (key >= df::interface_key::CUSTOM_SHIFT_A && key <= df::interface_key::CUSTOM_SHIFT_Z)
+        return string(1, 'A' + (key - df::interface_key::CUSTOM_SHIFT_A));
+    return enabler->GetKeyDisplay(key);
 }
 
 int Screen::keyToChar(df::interface_key key)


### PR DESCRIPTION
prints "?" instead of "Question"
prints "U" instead of "Shift + u"

in short; it makes the hotkey hints on our UIs readable again

Before:

![image](https://github.com/DFHack/dfhack/assets/977482/6c0c37bb-fb92-464d-8d6f-6967922f9fba)
![image](https://github.com/DFHack/dfhack/assets/977482/3b7ab357-c306-4335-803d-eea2f20cc03d)
![image](https://github.com/DFHack/dfhack/assets/977482/747b9695-3185-43d3-8735-f07eb556c438)

After:

![image](https://github.com/DFHack/dfhack/assets/977482/329a829b-a793-4824-a806-133076e1f32a)
![image](https://github.com/DFHack/dfhack/assets/977482/fae3e74f-3bb9-4f55-9d22-f3cd9ec2334e)
![image](https://github.com/DFHack/dfhack/assets/977482/14854748-97cf-4436-982c-2bc2a0c00719)