### PR TITLE
[buildingplan] don't select artifacts as masterful quality

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -37,6 +37,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - `logistics`: automatically mark and route items or animals that come to monitored stockpiles. options are toggleable on an overlay that comes up when you have a stockpile selected.
 
 ## Fixes
+- `buildingplan`: don't include artifacts when max quality is masterful
 - `dig-now`: clear item occupancy flags for channeled tiles that had items on them
 - `RemoteFortressReader`: fix a crash with engravings with undefined images
 

--- a/plugins/buildingplan/itemfilter.cpp
+++ b/plugins/buildingplan/itemfilter.cpp
@@ -152,9 +152,10 @@ bool ItemFilter::matches(DFHack::MaterialInfo &material) const {
 }
 
 bool ItemFilter::matches(df::item *item) const {
-    if (item->getQuality() < min_quality || item->getQuality() > max_quality) {
+    int16_t quality = (item->flags.bits.artifact ? df::item_quality::Artifact : item->getQuality());
+    if (quality < min_quality || quality > max_quality) {
         TRACE(cycle).print("item outside of quality range (%d not between %d and %d)\n",
-                item->getQuality(), min_quality, max_quality);
+                quality, min_quality, max_quality);
         return false;
     }
 


### PR DESCRIPTION
artifacts no longer have the artifact quality rating. we need to check for the flag explicitly.