### PR TITLE
[orders] increase tin ore count requirements in library orders

### DIFF
--- a/data/orders/smelting.json
+++ b/data/orders/smelting.json
@@ -791,13 +791,13 @@
 				"bearing" : "TIN",
 				"condition" : "AtLeast",
 				"item_type" : "BOULDER",
-				"value" : 5
+				"value" : 25
 			},
 			{
 				"bearing" : "COPPER",
 				"condition" : "AtLeast",
 				"item_type" : "BOULDER",
-				"value" : 5
+				"value" : 25
 			},
 			{
 				"condition" : "AtLeast",
@@ -828,13 +828,13 @@
 				"condition" : "AtLeast",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:TIN",
-				"value" : 5
+				"value" : 25
 			},
 			{
 				"condition" : "AtLeast",
 				"item_type" : "BAR",
 				"material" : "INORGANIC:COPPER",
-				"value" : 5
+				"value" : 25
 			},
 			{
 				"condition" : "AtLeast",
@@ -1068,13 +1068,13 @@
 				"bearing" : "TIN",
 				"condition" : "AtLeast",
 				"item_type" : "BOULDER",
-				"value" : 5
+				"value" : 25
 			},
 			{
 				"bearing" : "COPPER",
 				"condition" : "AtLeast",
 				"item_type" : "BOULDER",
-				"value" : 5
+				"value" : 25
 			},
 			{
 				"condition" : "AtLeast",

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -47,6 +47,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - Blueprint library: dreamfort: full rewrite and update for DF v50
 - Blueprint library: pump_stack: updated walkthrough and separated dig and channel steps so boulders can be cleared
 - Blueprint library: aquifer_tap: updated walkthrough
+- `orders`: better order conditions for the ``smelting`` library orders to reduce cancellation spam
 
 ## Documentation
 - `blueprint-library-guide`: update Dreamfort screenshots, add ``aquifer_tap`` screenshot


### PR DESCRIPTION
each order takes multiple boulders of cassiterite. increase limits so when all orders are active, cassiterite stores are not depleted