### PR TITLE
Fix so failed accept doesn't terminate the server

### DIFF
--- a/library/RemoteServer.cpp
+++ b/library/RemoteServer.cpp
@@ -476,11 +476,14 @@ void ServerMainImpl::threadFn(std::promise<bool> promise, int port)
     CActiveSocket *client = nullptr;
 
     try {
-        while ((client = server.socket.Accept()) != NULL)
+        while (true)
         {
-            BlockGuard lock;
-            ServerConnection::Accepted(client);
-            client = nullptr;
+            if ((client = server.socket.Accept()) != NULL)
+            {
+                BlockGuard lock;
+                ServerConnection::Accepted(client);
+                client = nullptr;
+            }
         }
     } catch(BlockedException &) {
         if (client)


### PR DESCRIPTION
On my steam install the accept function failes with SocketEwouldblock, this doesn't fix that but the fail would terminate the RemoteServer completely instead of waiting for the next attempt to establish an connection.
