### PR TITLE
filter out spurious STRING keybindings

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -36,6 +36,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## New Plugins
 
 ## Fixes
+- Fix extra keys appearing in DFHack text boxes when shift (or any other modifier) is released before the other key you were pressing
 
 ## Misc Improvements
 

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -229,8 +229,8 @@ namespace DFHack
         DFHACK_EXPORT bool hasActiveScreens(Plugin *p);
         DFHACK_EXPORT void raise(df::viewscreen *screen);
 
-        // returns a new set with text interface keys from the text buffer added in (if any)
-        DFHACK_EXPORT std::set<df::interface_key> add_text_keys(const std::set<df::interface_key>& keys);
+        // returns a new set of interface keys that ensures that string input matches the DF text buffer
+        DFHACK_EXPORT std::set<df::interface_key> normalize_text_keys(const std::set<df::interface_key>& keys);
 
         /// Retrieve the string representation of the bound key.
         DFHACK_EXPORT std::string getKeyDisplay(df::interface_key key);

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -585,8 +585,10 @@ void Hide::merge() {
 }
 } }
 
-std::set<df::interface_key> Screen::add_text_keys(const std::set<df::interface_key>& keys) {
-    std::set<df::interface_key> combined_keys(keys);
+std::set<df::interface_key> Screen::normalize_text_keys(const std::set<df::interface_key>& keys) {
+    std::set<df::interface_key> combined_keys;
+    std::copy_if(keys.begin(), keys.end(), std::inserter(combined_keys, combined_keys.begin()),
+        [](df::interface_key k){ return k <= df::interface_key::STRING_A000 || k > df::interface_key::STRING_A255; } );
     if (df::global::enabler->last_text_input[0]) {
         char c = df::global::enabler->last_text_input[0];
         df::interface_key key = charToKey(c);
@@ -952,7 +954,7 @@ int dfhack_lua_viewscreen::do_input(lua_State *L)
     }
 
     lua_pushvalue(L, -2);
-    Lua::PushInterfaceKeys(L, Screen::add_text_keys(*keys));
+    Lua::PushInterfaceKeys(L, Screen::normalize_text_keys(*keys));
 
     lua_call(L, 2, 0);
     self->update_focus(L, -1);

--- a/plugins/overlay.cpp
+++ b/plugins/overlay.cpp
@@ -76,7 +76,7 @@ struct viewscreen_overlay : T {
                     [&](lua_State *L) {
                         Lua::Push(L, T::_identity.getName());
                         Lua::Push(L, this);
-                        Lua::PushInterfaceKeys(L, Screen::add_text_keys(*input));
+                        Lua::PushInterfaceKeys(L, Screen::normalize_text_keys(*input));
                     }, [&](lua_State *L) {
                         input_is_handled = lua_toboolean(L, -1);
                     });


### PR DESCRIPTION
that don't match actual SDL string input. this prevents, say `a` from appearing after you type `A` and release shift before you release the "a" key

Fixes #3525