### PR TITLE
fix an ambiguity in def'n of operator==

### DIFF
--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -106,9 +106,13 @@ namespace DFHack
         StateChangeScript(state_change_event event, std::string path, bool save_specific = false)
             :event(event), path(path), save_specific(save_specific)
         { }
-        bool operator==(const StateChangeScript& other)
+        bool const operator==(const StateChangeScript& other)
         {
             return event == other.event && path == other.path && save_specific == other.save_specific;
+        }
+        bool const operator!=(const StateChangeScript& other)
+        {
+            return !(operator==(other));
         }
     };
 


### PR DESCRIPTION
this resolve an error that arises when compiling with msvc 1936 which was previously ignored due a combination of a bug in the compiler and not being on C++20 compliance (which is stricter in this area than previous standards)