### PR TITLE
suppress SDL events if a DFHack keybinding is matched

### DIFF
--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -377,6 +377,26 @@ Other (non-DFHack-specific) variables that affect DFHack:
   sensitive), ``DF2CONSOLE()`` will produce UTF-8-encoded text. Note that this
   should be the case in most UTF-8-capable \*nix terminal emulators already.
 
+Core preferences
+================
+
+There are a few settings that can be changed dynamically via
+`gui/control-panel` to affect runtime behavior. You can also toggle these from
+the commandline using the `lua` command, e.g.
+``lua dfhack.HIDE_ARMOK_TOOLS=true`` or by editing the generated
+``dfhack-config/init/dfhack.control-panel-preferences.init`` file and
+restarting DF.
+
+- ``dfhack.HIDE_CONSOLE_ON_STARTUP``: Whether to hide the external DFHack
+  terminal window on startup. This, of course, is not useful to change
+  dynamically. You'll have to use `gui/control-panel` or edit the init file
+  directly and restart DF for it to have an effect.
+
+- ``dfhack.HIDE_ARMOK_TOOLS``: Whether to hide "armok" tools in command lists.
+
+- ``dfhack.SUPPRESS_DUPLICATE_KEYBOARD_EVENTS``: Whether to prevent DFHack
+  keybindings from producing DF key events.
+
 Miscellaneous notes
 ===================
 This section is for odd but important notes that don't fit anywhere else.

--- a/docs/builtins/keybinding.rst
+++ b/docs/builtins/keybinding.rst
@@ -33,6 +33,11 @@ The ``<key>`` parameter above has the following **case-sensitive** syntax::
 where the ``KEY`` part can be any recognized key and :kbd:`[`:kbd:`]` denote
 optional parts.
 
+DFHack commands can advertise the contexts in which they can be usefully run.
+For example, a command that acts on a selected unit can tell `keybinding` that
+it is not "applicable" in the current context if a unit is not actively
+selected.
+
 When multiple commands are bound to the same key combination, DFHack selects
 the first applicable one. Later ``add`` commands, and earlier entries within one
 ``add`` command have priority. Commands that are not specifically intended for

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -41,6 +41,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 
 ## Misc Improvements
 - ``widgets.EditField``: DFHack edit fields now support cut/copy/paste with the system clipboard with Ctrl-X/Ctrl-C/Ctrl-V
+- Suppress DF keyboard events when a DFHack keybinding is matched. This prevents, for example, a backtick from appearing in a textbox as text when you launch `gui/launcher` from the backtick keybinding.
 
 ## Documentation
 

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2356,6 +2356,18 @@ bool Core::DFH_ncurses_key(int key)
     return ncurses_wgetch(key, dummy);
 }
 
+static bool getSuppressDuplicateKeyboardEvents() {
+    auto L = Lua::Core::State;
+    color_ostream_proxy out(Core::getInstance().getConsole());
+    Lua::StackUnwinder top(L);
+    bool suppress = false;
+    Lua::CallLuaModuleFunction(out, L, "dfhack", "getSuppressDuplicateKeyboardEvents", 0, 1,
+        Lua::DEFAULT_LUA_LAMBDA, [&](lua_State* L) {
+            suppress = lua_toboolean(L, -1);
+        }, false);
+    return suppress;
+}
+
 // returns true if the event is handled
 bool Core::DFH_SDL_Event(SDL_Event* ev)
 {
@@ -2390,7 +2402,7 @@ bool Core::DFH_SDL_Event(SDL_Event* ev)
             if (handled) {
                 DEBUG(keybinding).print("inhibiting SDL key down event\n");
                 hotkey_states[sym] = true;
-                return true;
+                return getSuppressDuplicateKeyboardEvents();
             }
         }
         else if (ke.state == SDL_RELEASED)

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2360,12 +2360,8 @@ static bool getSuppressDuplicateKeyboardEvents() {
     auto L = Lua::Core::State;
     color_ostream_proxy out(Core::getInstance().getConsole());
     Lua::StackUnwinder top(L);
-    bool suppress = false;
-    Lua::CallLuaModuleFunction(out, L, "dfhack", "getSuppressDuplicateKeyboardEvents", 0, 1,
-        Lua::DEFAULT_LUA_LAMBDA, [&](lua_State* L) {
-            suppress = lua_toboolean(L, -1);
-        }, false);
-    return suppress;
+    return DFHack::Lua::PushModulePublic(out, L, "dfhack", "SUPPRESS_DUPLICATE_KEYBOARD_EVENTS") &&
+        lua_toboolean(L, -1);
 }
 
 // returns true if the event is handled

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -250,7 +250,6 @@ namespace DFHack
         int8_t modstate;
 
         std::map<int, std::vector<KeyBinding> > key_bindings;
-        std::map<int, bool> hotkey_states;
         std::string hotkey_cmd;
         enum hotkey_set_t {
             NO,

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -63,6 +63,11 @@ function dfhack.getHideArmokTools()
     return dfhack.HIDE_ARMOK_TOOLS
 end
 
+dfhack.SUPPRESS_DUPLICATE_KEYBOARD_EVENTS = true
+function dfhack.getSuppressDuplicateKeyboardEvents()
+    return dfhack.SUPPRESS_DUPLICATE_KEYBOARD_EVENTS
+end
+
 -- Error handling
 
 safecall = dfhack.safecall


### PR DESCRIPTION
This PR tracks whether a keybinding has been matched and suppresses SDL events related to that key so DF doesn't react to them (or pass them through as text events)

This prevents such inconveniences as:
- Hitting Ctrl-Shift-A to bring up `gui/quickcmd` and having the "Add new command" hotkey immediately trigger because DF generates a `CUSTOM_SHIFT_A` event
- Having hotkeys get added as text in a DF or DFHack text field if one happens to be focused when a DFHack keybinding is pressed

However, it introduces a risk of preventing vanilla keyboard shortcuts from working if a DFHack keybinding is active in the same context. We could just document "don't do this", but solving some players' frustrations may introduce frustrations for others