### PR TITLE
TextButton widget class

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -65,6 +65,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 - ``dfhack.items.markForTrade``: mark items for trade
 - ``dfhack.items.isRequestedTradeGood``: discover whether an item is named in a trade agreement with an active caravan
 - ``dfhack.items.getValue``: gained optional ``caravan`` and ``caravan_buying`` parameters for prices that take trader races and agreements into account
+- ``widgets.TextButton``: wraps a ``HotkeyLabel`` and decorates it to look more like a button
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -5063,12 +5063,20 @@ The CycleHotkeyLabel widget implements the following methods:
     selected option if no index is given. If an option was defined as just a
     string, then this function will return ``nil`` for that option.
 
-ToggleHotkeyLabel
------------------
+ToggleHotkeyLabel class
+-----------------------
 
 This is a specialized subclass of CycleHotkeyLabel that has two options:
 ``On`` (with a value of ``true``) and ``Off`` (with a value of ``false``). The
 ``On`` option is rendered in green.
+
+TextButton class
+----------------
+
+This is a Panel subclass that wraps a HotkeyLabel with some decorators on the
+sides to make it look more like a button, suitable for both graphics and ASCII
+mdoes. All HotkeyLabel parameters passed to the constructor are passed through
+to the wrapped HotkeyLabel.
 
 List class
 ----------

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1489,6 +1489,52 @@ function HotkeyLabel:onInput(keys)
     end
 end
 
+----------------
+-- TextButton --
+----------------
+
+TextButton = defclass(TextButton, Panel)
+
+local BUTTON_PEN = dfhack.pen.parse{fg=COLOR_YELLOW, bg=COLOR_RED}
+
+function TextButton:init(info)
+    self.label = HotkeyLabel{
+        frame={t=0, l=1, r=1},
+        key=info.key,
+        key_sep=info.key_sep,
+        label=info.label,
+        on_activate=info.on_activate,
+        text_pen=info.text_pen,
+        text_dpen=info.text_dpen,
+        text_hpen=info.text_hpen,
+        disabled=info.disabled,
+        enabled=info.enabled,
+        auto_height=info.auto_height,
+        auto_width=info.auto_width,
+        on_click=info.on_click,
+        on_rclick=info.on_rclick,
+        scroll_keys=info.scroll_keys,
+    }
+
+    self:addviews{
+        Label{
+            frame={t=0, l=0, w=1},
+            text=string.char(221),  -- half-width stripe on left
+            text_pen=BUTTON_PEN,
+        },
+        self.label,
+        Label{
+            frame={t=0, r=0, w=1},
+            text=string.char(222),  -- half-width stripe on right
+            text_pen=BUTTON_PEN,
+        }
+    }
+end
+
+function TextButton:setLabel(label)
+    self.label:setLabel(label)
+end
+
 ----------------------
 -- CycleHotkeyLabel --
 ----------------------

--- a/plugins/lua/zone.lua
+++ b/plugins/lua/zone.lua
@@ -700,16 +700,16 @@ end
 
 PastureOverlay = defclass(PastureOverlay, overlay.OverlayWidget)
 PastureOverlay.ATTRS{
-    default_pos={x=9,y=13},
+    default_pos={x=7,y=13},
     default_enabled=true,
     viewscreens='dwarfmode/Zone/Some/Pen',
-    frame={w=30, h=1},
+    frame={w=32, h=1},
     frame_background=gui.CLEAR_PEN,
 }
 
 function PastureOverlay:init()
     self:addviews{
-        widgets.HotkeyLabel{
+        widgets.TextButton{
             frame={t=0, l=0},
             label='DFHack search and sort',
             key='CUSTOM_CTRL_T',


### PR DESCRIPTION
to make overlay buttons that don't have a DFHack frame around them more visible
![image](https://github.com/DFHack/dfhack/assets/977482/88626caf-85e4-4a1d-9c7d-82d7af42d14f)
