### PR TITLE
Remove redundant checks on open tiles

### DIFF
--- a/plugins/autodump.cpp
+++ b/plugins/autodump.cpp
@@ -131,7 +131,7 @@ static command_result autodump_main(color_ostream &out, vector <string> & parame
                 return CR_FAILURE;
             }
             df::tiletype ttype = MC.tiletypeAt(pos_cursor);
-            if(!DFHack::isWalkable(ttype) || DFHack::isOpenTerrain(ttype))
+            if(!DFHack::isWalkable(ttype))
             {
                 out.printerr("Cursor should be placed over a floor.\n");
                 return CR_FAILURE;

--- a/plugins/channel-safely/channel-safely-plugin.cpp
+++ b/plugins/channel-safely/channel-safely-plugin.cpp
@@ -120,8 +120,7 @@ df::coord simulate_fall(const df::coord &pos) {
 
     while (Maps::ensureTileBlock(resting_pos)) {
         df::tiletype tt = *Maps::getTileType(resting_pos);
-        df::tiletype_shape_basic basic_shape = tileShapeBasic(tileShape(tt));
-        if (isWalkable(tt) && basic_shape != df::tiletype_shape_basic::Open)
+        if (isWalkable(tt))
             break;
         --resting_pos.z;
     }

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -832,8 +832,7 @@ static DFCoord simulate_fall(const DFCoord &pos) {
 
     while (Maps::ensureTileBlock(resting_pos)) {
         df::tiletype tt = *Maps::getTileType(resting_pos);
-        df::tiletype_shape_basic basic_shape = tileShapeBasic(tileShape(tt));
-        if (isWalkable(tt) && basic_shape != df::tiletype_shape_basic::Open)
+        if (isWalkable(tt))
             break;
         --resting_pos.z;
     }


### PR DESCRIPTION
Remove redundant checks on open tiles now that "walkable" implies that items and creature can stand on a tile

Fixes https://github.com/DFHack/dfhack/issues/3526

I've verified the change on autodump only - but still a very safe change to do

