### PR TITLE
deploy linux build to steam

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-test:
     runs-on: ${{ matrix.os }}
-    name: build (Linux, GCC ${{ matrix.gcc }}, ${{ matrix.plugins }} plugins)
+    name: Test (Linux, GCC ${{ matrix.gcc }}, ${{ matrix.plugins }} plugins)
     strategy:
       fail-fast: false
       matrix:
@@ -29,11 +29,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install \
             ccache \
-            libsdl2-dev \
-            libxml-libxml-perl \
             libxml-libxslt-perl \
-            ninja-build \
-            zlib1g-dev
+            ninja-build
         pip install 'sphinx<4.4.0'
     - name: Install GCC
       run: |
@@ -41,8 +38,8 @@ jobs:
     - name: Clone DFHack
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0  # unlimited - we need past tags
         submodules: true
+        fetch-depth: 0
     - name: Set up environment
       id: env_setup
       run: |
@@ -51,11 +48,6 @@ jobs:
         echo "DF_VERSION=${DF_VERSION}" >> $GITHUB_ENV
         echo "DF_FOLDER=${HOME}/DF/${DF_VERSION}/df_linux" >> $GITHUB_ENV
         echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
-        #    - name: Fetch DF cache
-        #      uses: actions/cache@v3
-        #      with:
-        #        path: ~/DF
-        #        key: dfcache-${{ steps.env_setup.outputs.df_version }}-${{ hashFiles('ci/download-df.sh') }}
     - name: Fetch ccache
       uses: actions/cache@v3
       with:
@@ -64,9 +56,14 @@ jobs:
         restore-keys: |
           ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.ref_name }}
           ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}
-          #    - name: Download DF
-          #      run: |
-          #        sh ci/download-df.sh
+    # - name: Fetch DF cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/DF
+    #     key: df-${{ steps.env_setup.outputs.df_version }}-${{ hashFiles('ci/download-df.sh') }}
+    # - name: Download DF
+    #   run: |
+    #     sh ci/download-df.sh
     - name: Configure DFHack
       env:
         CC: gcc-${{ matrix.gcc }}
@@ -96,32 +93,92 @@ jobs:
       run: |
         ninja -C build-ci test
         exit $?
-        #    - name: Run lua tests
-        #      id: run_tests_lua
-        #      run: |
-        #        export TERM=dumb
-        #        status=0
-        #        script -qe -c "python ci/run-tests.py --headless --keep-status \"$DF_FOLDER\"" || status=$((status + 1))
-        #        python ci/check-rpc.py "$DF_FOLDER/dfhack-rpc.txt" || status=$((status + 2))
-        #        mkdir -p artifacts
-        #        cp "$DF_FOLDER"/test*.json "$DF_FOLDER"/*.log artifacts || status=$((status + 4))
-        #        exit $status
-        #    - name: Upload test artifacts
-        #      uses: actions/upload-artifact@v1
-        #      if: (success() || failure()) && steps.run_tests.outcome != 'skipped'
-        #      continue-on-error: true
-        #      with:
-        #        name: test-artifacts-${{ matrix.gcc }}
-        #        path: artifacts
-    - name: Clean up DF folder
-      # prevent DFHack-generated files from ending up in the cache
-      # (download-df.sh also removes them, this is just to save cache space)
-      if: success() || failure()
-      run: |
-        rm -rf "$DF_FOLDER"
+    # - name: Run lua tests
+    #   id: run_tests_lua
+    #   run: |
+    #     export TERM=dumb
+    #     status=0
+    #     script -qe -c "python ci/run-tests.py --headless --keep-status \"$DF_FOLDER\"" || status=$((status + 1))
+    #     python ci/check-rpc.py "$DF_FOLDER/dfhack-rpc.txt" || status=$((status + 2))
+    #     mkdir -p artifacts
+    #     cp "$DF_FOLDER"/test*.json "$DF_FOLDER"/*.log artifacts || status=$((status + 4))
+    #     exit $status
+    # - name: Upload test artifacts
+    #   uses: actions/upload-artifact@v3
+    #   if: (success() || failure()) && steps.run_tests.outcome != 'skipped'
+    #   continue-on-error: true
+    #   with:
+    #     name: test-artifacts-${{ matrix.gcc }}
+    #     path: artifacts
+    # - name: Clean up DF folder
+    #   # prevent DFHack-generated files from ending up in the cache
+    #   # (download-df.sh also removes them, this is just to save cache space)
+    #   if: success() || failure()
+    #   run: |
+    #     rm -rf "$DF_FOLDER"
+
+  build-linux64:
+    name: Linux package
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+              ccache \
+              libxml-libxslt-perl \
+              ninja-build
+          pip install 'sphinx<4.4.0'
+      - name: Clone DFHack
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Fetch ccache
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: ccache-ubuntu-22.04-gcc-11-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-ubuntu-22.04-gcc-11-${{ github.ref_name }}
+            ccache-ubuntu-22.04-gcc-11
+      - name: Set up environment
+        id: env_setup
+        run: |
+          echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
+      - name: Configure DFHack
+        run: |
+          cmake \
+            -S . \
+            -B build \
+            -G Ninja \
+            -DDFHACK_BUILD_ARCH=64 \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DBUILD_DOCS:BOOL=1 \
+            -DCMAKE_INSTALL_PREFIX=build/output
+      - name: Build DFHack
+        run: |
+          ninja -C build install
+          ccache --max-size 50M
+          ccache --cleanup
+          ccache --show-stats
+      - name: Format artifact name
+        id: artifactname
+        run: |
+          echo name=$(date +%Y%m%d)-$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dfhack-linux64-build-${{ steps.artifactname.outputs.name }}
+          path: build/output/*
 
   build-cross-win64:
-    name: Build MSVC win64
+    name: Win64 package
     runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies
@@ -141,7 +198,7 @@ jobs:
           restore-keys: |
             ccache-win64-cross-msvc-${{ github.ref_name }}
             ccache-win64-cross-msvc
-      - name: Cross-compile win64 artifacts
+      - name: Cross-compile win64
         run: |
           cd build
           bash -x build-win64-from-linux.sh
@@ -152,7 +209,7 @@ jobs:
         id: artifactname
         run: |
           echo name=$(date +%Y%m%d)-$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
-      - name: Upload win64 artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: dfhack-win64-build-${{ steps.artifactname.outputs.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
           -DBUILD_DEV_PLUGINS:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SIZECHECK:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SKELETON:BOOL=${{ matrix.plugins == 'all' }} \
+          -DBUILD_STONESENSE:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SUPPORTED:BOOL=1 \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -199,6 +200,8 @@ jobs:
             ccache-win64-cross-msvc-${{ github.ref_name }}
             ccache-win64-cross-msvc
       - name: Cross-compile win64
+        env:
+          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1'
         run: |
           cd build
           bash -x build-win64-from-linux.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         sudo apt-get install \
             ccache \
             libxml-libxslt-perl \
+            libgl-dev \
             ninja-build
         pip install 'sphinx<4.4.0'
     - name: Install GCC
@@ -132,6 +133,7 @@ jobs:
           sudo apt-get install \
               ccache \
               libxml-libxslt-perl \
+              libgl-dev \
               ninja-build
           pip install 'sphinx<4.4.0'
       - name: Clone DFHack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install \
             ccache \
-            libgtk2.0-0 \
-            libncursesw5 \
-            libsdl-image1.2-dev \
-            libsdl-ttf2.0-dev \
-            libsdl1.2-dev \
+            libsdl2-dev \
             libxml-libxml-perl \
             libxml-libxslt-perl \
-            lua5.3 \
             ninja-build \
             zlib1g-dev
         pip install 'sphinx<4.4.0'
@@ -44,7 +39,7 @@ jobs:
       run: |
         sudo apt-get install gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
     - name: Clone DFHack
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # unlimited - we need past tags
         submodules: true
@@ -177,7 +172,7 @@ jobs:
       run: |
         pip install 'sphinx'
     - name: Clone DFHack
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Build docs
@@ -196,7 +191,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install lua5.3
     - name: Clone DFHack
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
         # don't need tags here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install \
             ccache \
-            libxml-libxslt-perl \
             libgl-dev \
+            libxml-libxslt-perl \
             ninja-build
         pip install 'sphinx<4.4.0'
     - name: Install GCC
@@ -132,8 +132,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
               ccache \
-              libxml-libxslt-perl \
               libgl-dev \
+              libxml-libxslt-perl \
               ninja-build
           pip install 'sphinx<4.4.0'
       - name: Clone DFHack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_DOCS:BOOL=1 \
+            -DBUILD_STONESENSE:BOOL=1 \
             -DCMAKE_INSTALL_PREFIX=build/output
       - name: Build DFHack
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.ccache
-        key: ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.ref_name }}-${{ github.sha }}
+        key: ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.sha }}
         restore-keys: |
-          ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}-${{ github.ref_name }}
           ccache-${{ matrix.os }}-gcc-${{ matrix.gcc }}
     # - name: Fetch DF cache
     #   uses: actions/cache@v3
@@ -147,9 +146,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.ccache
-          key: ccache-ubuntu-22.04-gcc-10-${{ github.ref_name }}-${{ github.sha }}
+          key: ccache-ubuntu-22.04-gcc-10-${{ github.sha }}
           restore-keys: |
-            ccache-ubuntu-22.04-gcc-10-${{ github.ref_name }}
             ccache-ubuntu-22.04-gcc-10
       - name: Set up environment
         id: env_setup
@@ -202,9 +200,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: build/win64-cross/ccache
-          key: ccache-win64-cross-msvc-${{ github.ref_name }}-${{ github.sha }}
+          key: ccache-win64-cross-msvc-${{ github.sha }}
           restore-keys: |
-            ccache-win64-cross-msvc-${{ github.ref_name }}
             ccache-win64-cross-msvc
       - name: Cross-compile win64
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
               ccache \
+              gcc-10 \
+              g++-10 \
               libgl-dev \
               libxml-libxslt-perl \
               ninja-build
@@ -145,15 +147,18 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.ccache
-          key: ccache-ubuntu-22.04-gcc-11-${{ github.ref_name }}-${{ github.sha }}
+          key: ccache-ubuntu-22.04-gcc-10-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            ccache-ubuntu-22.04-gcc-11-${{ github.ref_name }}
-            ccache-ubuntu-22.04-gcc-11
+            ccache-ubuntu-22.04-gcc-10-${{ github.ref_name }}
+            ccache-ubuntu-22.04-gcc-10
       - name: Set up environment
         id: env_setup
         run: |
           echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
       - name: Configure DFHack
+        env:
+          CC: gcc-10
+          CXX: g++-10
         run: |
           cmake \
             -S . \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,6 @@ jobs:
           -DBUILD_DEV_PLUGINS:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SIZECHECK:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SKELETON:BOOL=${{ matrix.plugins == 'all' }} \
-          -DBUILD_STONESENSE:BOOL=${{ matrix.plugins == 'all' }} \
           -DBUILD_SUPPORTED:BOOL=1 \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -143,8 +142,6 @@ jobs:
             ccache-win64-cross-msvc-${{ github.ref_name }}
             ccache-win64-cross-msvc
       - name: Cross-compile win64 artifacts
-        env:
-          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1'
         run: |
           cd build
           bash -x build-win64-from-linux.sh

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -32,8 +32,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
               ccache \
-              libxml-libxslt-perl \
               libgl-dev \
+              libxml-libxslt-perl \
               ninja-build
           pip install 'sphinx<4.4.0'
       - name: Clone DFHack

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -96,7 +96,6 @@ jobs:
             -DBUILD_STONESENSE:BOOL=1 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DBUILD_DFLAUNCH:BOOL=1 \
             -DBUILD_LIBRARY:BOOL=1 \
             -DBUILD_BINARIES:BOOL=1 \
             -DBUILD_DOCS:BOOL=0 \

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -23,10 +23,23 @@ jobs:
     name: Deploy to Steam
     runs-on: ubuntu-22.04
     steps:
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install ccache
+          sudo apt-get install \
+              ccache \
+              libsdl2-dev \
+              libxml-libxml-perl \
+              libxml-libxslt-perl \
+              ninja-build \
+              zlib1g-dev \
+              gcc \
+              g++
+          pip install 'sphinx<4.4.0'
       - name: Clone DFHack
         uses: actions/checkout@v3
         with:
@@ -40,13 +53,43 @@ jobs:
           ref: main
           ssh-key: ${{ secrets.DFHACK_3RDPARTY_TOKEN }}
           path: depends/steam
-      - name: Fetch ccache
+      - name: Fetch linux64 ccache
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: ccache-ubuntu-22.04-gcc-10-${{ github.sha }}
+          restore-keys: |
+            ccache-ubuntu-22.04-gcc-10
+      - name: Fetch win64 ccache
         uses: actions/cache@v3
         with:
           path: build/win64-cross/ccache
           key: ccache-win64-cross-msvc-${{ github.sha }}
           restore-keys: |
             ccache-win64-cross-msvc
+      - name: Set up environment
+        id: env_setup
+        run: |
+          echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
+      - name: Configure DFHack
+        run: |
+          cmake \
+            -S . \
+            -B build \
+            -G Ninja \
+            -DDFHACK_BUILD_ARCH=64 \
+            -DBUILD_STONESENSE:BOOL=1 \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DBUILD_DFLAUNCH:BOOL=1 \
+            -DBUILD_DOCS:BOOL=1 \
+            -DCMAKE_INSTALL_PREFIX=linux64/output
+      - name: Build DFHack
+        run: |
+          ninja -C build install
+          ccache --max-size 50M
+          ccache --cleanup
+          ccache --show-stats
       - name: Cross-compile win64 artifacts
         env:
           CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1'
@@ -72,4 +115,5 @@ jobs:
           buildDescription: ${{ github.event.inputs.version }}
           rootPath: build
           depot1Path: win64-cross/output
+          depot2Path: linux64/output
           releaseBranch: ${{ github.event.inputs.release_channel }}

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -73,6 +73,7 @@ jobs:
             -B build \
             -G Ninja \
             -DDFHACK_BUILD_ARCH=64 \
+            -DBUILD_STONESENSE:BOOL=1 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_DFLAUNCH:BOOL=1 \
@@ -86,7 +87,7 @@ jobs:
           ccache --show-stats
       - name: Cross-compile win64 artifacts
         env:
-          CMAKE_EXTRA_ARGS: '-DBUILD_DFLAUNCH:BOOL=1'
+          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1'
           steam_username: ${{ secrets.STEAM_SDK_USERNAME }}
           steam_password: ${{ secrets.STEAM_SDK_PASSWORD }}
         run: |

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -33,6 +33,7 @@ jobs:
           sudo apt-get install \
               ccache \
               libxml-libxslt-perl \
+              libgl-dev \
               ninja-build
           pip install 'sphinx<4.4.0'
       - name: Clone DFHack

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -32,6 +32,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
               ccache \
+              gcc-10 \
+              g++-10 \
               libgl-dev \
               libxml-libxslt-perl \
               ninja-build
@@ -53,9 +55,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.ccache
-          key: ccache-ubuntu-22.04-gcc-11-${{ github.sha }}
+          key: ccache-ubuntu-22.04-gcc-10-${{ github.sha }}
           restore-keys: |
-            ccache-ubuntu-22.04-gcc-11
+            ccache-ubuntu-22.04-gcc-10
       - name: Fetch win64 ccache
         uses: actions/cache@v3
         with:
@@ -68,6 +70,9 @@ jobs:
         run: |
           echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
       - name: Configure DFHack
+        env:
+          CC: gcc-10
+          CXX: g++-10
         run: |
           cmake \
             -S . \

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -69,7 +69,21 @@ jobs:
         id: env_setup
         run: |
           echo "CCACHE_DIR=${HOME}/.ccache" >> $GITHUB_ENV
-      - name: Configure DFHack
+      - name: Configure DFHack (common files)
+        run: |
+          cmake \
+            -S . \
+            -B build \
+            -G Ninja \
+            -DDFHACK_BUILD_ARCH=64 \
+            -DBUILD_LIBRARY:BOOL=0 \
+            -DBUILD_BINARIES:BOOL=0 \
+            -DBUILD_DOCS:BOOL=1 \
+            -DCMAKE_INSTALL_PREFIX=build/common-output
+      - name: Build DFHack (common files)
+        run: |
+          ninja -C build install
+      - name: Configure DFHack (linux build)
         env:
           CC: gcc-10
           CXX: g++-10
@@ -83,9 +97,13 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_DFLAUNCH:BOOL=1 \
-            -DBUILD_DOCS:BOOL=1 \
-            -DCMAKE_INSTALL_PREFIX=build/output
-      - name: Build DFHack
+            -DBUILD_LIBRARY:BOOL=1 \
+            -DBUILD_BINARIES:BOOL=1 \
+            -DBUILD_DOCS:BOOL=0 \
+            -DINSTALL_SCRIPTS:BOOL=0 \
+            -DINSTALL_DATA_FILES:BOOL=0 \
+            -DCMAKE_INSTALL_PREFIX=build/linux-output
+      - name: Build DFHack (linux build)
         run: |
           ninja -C build install
           ccache --max-size 50M
@@ -93,7 +111,7 @@ jobs:
           ccache --show-stats
       - name: Cross-compile win64 artifacts
         env:
-          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1'
+          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1 -DBUILD_DOCS:BOOL=0 -DINSTALL_SCRIPTS:BOOL=0 -DINSTALL_DATA_FILES:BOOL=0'
           steam_username: ${{ secrets.STEAM_SDK_USERNAME }}
           steam_password: ${{ secrets.STEAM_SDK_PASSWORD }}
         run: |
@@ -115,6 +133,7 @@ jobs:
           appId: 2346660
           buildDescription: ${{ github.event.inputs.version }}
           rootPath: build
-          depot1Path: win64-cross/output
-          depot2Path: output
+          depot1Path: common-output
+          depot2Path: win64-cross/output
+          depot3Path: linux-output
           releaseBranch: ${{ github.event.inputs.release_channel }}

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -32,13 +32,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
               ccache \
-              libsdl2-dev \
-              libxml-libxml-perl \
               libxml-libxslt-perl \
-              ninja-build \
-              zlib1g-dev \
-              gcc \
-              g++
+              ninja-build
           pip install 'sphinx<4.4.0'
       - name: Clone DFHack
         uses: actions/checkout@v3
@@ -57,9 +52,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.ccache
-          key: ccache-ubuntu-22.04-gcc-10-${{ github.sha }}
+          key: ccache-ubuntu-22.04-gcc-11-${{ github.sha }}
           restore-keys: |
-            ccache-ubuntu-22.04-gcc-10
+            ccache-ubuntu-22.04-gcc-11
       - name: Fetch win64 ccache
         uses: actions/cache@v3
         with:
@@ -82,7 +77,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_DFLAUNCH:BOOL=1 \
             -DBUILD_DOCS:BOOL=1 \
-            -DCMAKE_INSTALL_PREFIX=linux64/output
+            -DCMAKE_INSTALL_PREFIX=build/output
       - name: Build DFHack
         run: |
           ninja -C build install
@@ -114,5 +109,5 @@ jobs:
           buildDescription: ${{ github.event.inputs.version }}
           rootPath: build
           depot1Path: win64-cross/output
-          depot2Path: linux64/output
+          depot2Path: output
           releaseBranch: ${{ github.event.inputs.release_channel }}

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -78,7 +78,6 @@ jobs:
             -B build \
             -G Ninja \
             -DDFHACK_BUILD_ARCH=64 \
-            -DBUILD_STONESENSE:BOOL=1 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_DFLAUNCH:BOOL=1 \
@@ -92,7 +91,7 @@ jobs:
           ccache --show-stats
       - name: Cross-compile win64 artifacts
         env:
-          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=1 -DBUILD_DFLAUNCH:BOOL=1'
+          CMAKE_EXTRA_ARGS: '-DBUILD_DFLAUNCH:BOOL=1'
           steam_username: ${{ secrets.STEAM_SDK_USERNAME }}
           steam_password: ${{ secrets.STEAM_SDK_PASSWORD }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,17 +210,16 @@ set(DFHACK_BINARY_DESTINATION .)
 set(DFHACK_PLUGIN_DESTINATION ${DFHACK_DATA_DESTINATION}/plugins)
 # dfhack lua files go here:
 set(DFHACK_LUA_DESTINATION ${DFHACK_DATA_DESTINATION}/lua)
-# the windows .lib file goes here:
-set(DFHACK_DEVLIB_DESTINATION ${DFHACK_DATA_DESTINATION})
 
 # user documentation goes here:
 set(DFHACK_USERDOC_DESTINATION ${DFHACK_DATA_DESTINATION})
-# developer documentation goes here:
-set(DFHACK_DEVDOC_DESTINATION ${DFHACK_DATA_DESTINATION})
 
 # some options for the user/developer to play with
 option(BUILD_LIBRARY "Build the DFHack library." ON)
 option(BUILD_PLUGINS "Build the DFHack plugins." ON)
+option(BUILD_BINARIES "Build the DFHack binary tools." ON)
+option(INSTALL_SCRIPTS "Install DFHack scripts." ON)
+option(INSTALL_DATA_FILES "Install DFHack common data files." ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 if(UNIX)
@@ -387,11 +386,14 @@ include_directories(depends/lodepng)
 include_directories(depends/tthread)
 include_directories(depends/clsocket/src)
 include_directories(depends/xlsxio/include)
-add_subdirectory(depends)
+
+if(BUILD_LIBRARY)
+    add_subdirectory(depends)
+endif()
 
 # Testing with CTest
 macro(dfhack_test name files)
-if(UNIX AND NOT APPLE) # remove this once our MSVC build env has been updated
+if(BUILD_LIBRARY AND UNIX AND NOT APPLE) # remove this once our MSVC build env has been updated
     add_executable(${name} ${files})
     target_include_directories(${name} PUBLIC depends/googletest/googletest/include)
     target_link_libraries(${name} dfhack gtest)
@@ -416,12 +418,17 @@ file(WRITE "${CMAKE_BINARY_DIR}/dfhack_setarch.txt" ${DFHACK_SETARCH})
 install(FILES "${CMAKE_BINARY_DIR}/dfhack_setarch.txt" DESTINATION "${DFHACK_DATA_DESTINATION}")
 
 # build the plugins
-if(BUILD_PLUGINS)
+if(BUILD_LIBRARY AND BUILD_PLUGINS)
     add_subdirectory(plugins)
 endif()
 
-add_subdirectory(data)
-add_subdirectory(scripts)
+if(INSTALL_DATA_FILES)
+    add_subdirectory(data)
+endif()
+
+if(INSTALL_SCRIPTS)
+    add_subdirectory(scripts)
+endif()
 
 if(BUILD_DOCS)
     find_package(Python3)
@@ -582,7 +589,7 @@ endif()
 set(DFHACK_BUILD_ARCH_PREV "${DFHACK_BUILD_ARCH}" CACHE STRING "Previous build architecture" FORCE)
 
 option(BUILD_SIZECHECK "Build the sizecheck library, for research" OFF)
-if(BUILD_SIZECHECK)
+if(BUILD_LIBRARY AND BUILD_SIZECHECK)
     add_subdirectory(depends/sizecheck)
     add_dependencies(dfhack sizecheck)
 endif()

--- a/package/linux/dfhack
+++ b/package/linux/dfhack
@@ -1,26 +1,20 @@
 #!/bin/sh
 
-# NOTE: This is dfhack's modification of the normal invocation script,
-# changed to properly set LD_PRELOAD so as to run DFHACK.
-#
 # You can run DF under gdb by passing -g or --gdb as the first argument.
 #
 # If the file ".dfhackrc" exists in the DF directory or your home directory
 # it will be sourced by this script, to let you set environmental variables.
 # If it exists in both places it will first source the one in your home
-# directory, then the on in the game directory.
+# directory, then the one in the game directory.
 #
 # Shell variables .dfhackrc can set to affect this script:
 #     DF_GDB_OPTS: Options to pass to gdb, if it's being run
 #     DF_VALGRIND_OPTS: Options to pass to valgrind, if it's being run
 #     DF_HELGRIND_OPTS: Options to pass to helgrind, if it's being run
 #     DF_POST_CMD: Shell command to be run at very end of script
-#     DFHACK_NO_RENAME_LIBSTDCXX: Non-empty to prevent automatically renaming libstdc++
 
 DF_DIR=$(dirname "$0")
 cd "${DF_DIR}"
-export SDL_DISABLE_LOCK_KEYS=1 # Work around for bug in Debian/Ubuntu SDL patch.
-#export SDL_VIDEO_CENTERED=1 # Centre the screen.  Messes up resizing.
 
 # User config files
 RC=".dfhackrc"
@@ -32,22 +26,6 @@ if [ -r "./$RC" ]; then
     . "./$RC"
 fi
 
-# Disable bundled libstdc++
-libcxx_orig="libs/libstdc++.so.6"
-libcxx_backup="libs/libstdc++.so.6.backup"
-if [ -z "${DFHACK_NO_RENAME_LIBSTDCXX:-}" ] && [ -e "$libcxx_orig" ] && [ ! -e "$libcxx_backup" ]; then
-    mv "$libcxx_orig" "$libcxx_backup"
-    cat <<EOF
-NOTICE: $libcxx_orig has been moved to $libcxx_backup
-for better compatibility. If you are using an older distro and this breaks,
-run "cp $libcxx_backup $libcxx_orig", or add this to
-$HOME/$RC to affect future DFHack installations:
-
-    export DFHACK_NO_RENAME_LIBSTDCXX=1
-
-EOF
-fi
-
 if [ ! -t 0 ]; then
     stty() {
         return
@@ -57,14 +35,7 @@ fi
 # Save current terminal settings
 old_tty_settings=$(stty -g)
 
-# Use distro_fixes.sh from LNP if it exists
-DISTROFIXES="distro_fixes.sh"
-if [ -r "$DISTROFIXES" ]; then
-    . "./$DISTROFIXES"
-fi
-
 # Now run
-
 export LD_LIBRARY_PATH="./hack/libs:./hack:$LD_LIBRARY_PATH"
 
 LIB="./hack/libdfhack.so"
@@ -74,7 +45,7 @@ if which objdump > /dev/null; then
 fi
 PRELOAD_LIB="${PRELOAD_LIB:+$PRELOAD_LIB:}${LIBSAN}${LIB}"
 
-setarch_arch=$(cat hack/dfhack_setarch.txt || printf i386)
+setarch_arch=$(cat hack/dfhack_setarch.txt || printf x86_64)
 if ! setarch "$setarch_arch" -R true 2>/dev/null; then
     echo "warn: architecture '$setarch_arch' not supported by setarch" >&2
     if [ "$setarch_arch" = "i386" ]; then
@@ -90,7 +61,7 @@ case "$1" in
   -g | --gdb)
     shift
     echo "set exec-wrapper env LD_LIBRARY_PATH='$LD_LIBRARY_PATH' LD_PRELOAD='$PRELOAD_LIB' MALLOC_PERTURB_=45" > gdbcmd.tmp
-    gdb $DF_GDB_OPTS -x gdbcmd.tmp --args ./libs/Dwarf_Fortress "$@"
+    gdb $DF_GDB_OPTS -x gdbcmd.tmp --args ./dwarfort "$@"
     rm gdbcmd.tmp
     ret=$?
     ;;
@@ -107,11 +78,11 @@ case "$1" in
     echo "set environment MALLOC_PERTURB_ 45" >> gdbcmd.tmp
     echo "set startup-with-shell off" >> gdbcmd.tmp
     echo "target extended-remote localhost:12345" >> gdbcmd.tmp
-    echo "set remote exec-file ./libs/Dwarf_Fortress" >> gdbcmd.tmp
+    echo "set remote exec-file ./dwarfort" >> gdbcmd.tmp
     # For some reason gdb ignores sysroot setting if it is from same file as
     # target extended-remote command
     echo "set sysroot /" > gdbcmd_sysroot.tmp
-    gdb $DF_GDB_OPTS -x gdbcmd.tmp -x gdbcmd_sysroot.tmp --args ./libs/Dwarf_Fortress "$@"
+    gdb $DF_GDB_OPTS -x gdbcmd.tmp -x gdbcmd_sysroot.tmp --args ./dwarfort "$@"
     rm gdbcmd.tmp gdbcmd_sysroot.tmp
     ret=$?
     ;;
@@ -124,35 +95,35 @@ case "$1" in
     ;;
   -h | --helgrind)
     shift
-    LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_HELGRIND_OPTS --tool=helgrind --log-file=helgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_HELGRIND_OPTS --tool=helgrind --log-file=helgrind.log ./dwarfort "$@"
     ret=$?
     ;;
   -v | --valgrind)
     shift
-    LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_VALGRIND_OPTS --log-file=valgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_VALGRIND_OPTS --log-file=valgrind.log ./dwarfort "$@"
     ret=$?
     ;;
   -c | --callgrind)
     shift
-    LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_CALLGRIND_OPTS --tool=callgrind --separate-threads=yes --dump-instr=yes --instr-atstart=no --log-file=callgrind.log ./libs/Dwarf_Fortress "$@"
+    LD_PRELOAD="$PRELOAD_LIB" setarch "$setarch_arch" -R valgrind $DF_CALLGRIND_OPTS --tool=callgrind --separate-threads=yes --dump-instr=yes --instr-atstart=no --log-file=callgrind.log ./dwarfort "$@"
     ret=$?
     ;;
   --strace)
     shift
-    strace -f setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@" 2> strace.log
+    strace -f setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./dwarfort "$@" 2> strace.log
     ret=$?
     ;;
   -x | --exec)
-    exec setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@"
+    exec setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./dwarfort "$@"
     # script does not resume
     ;;
   --sc | --sizecheck)
     PRELOAD_LIB="${PRELOAD_LIB:+$PRELOAD_LIB:}./hack/libsizecheck.so"
-    MALLOC_PERTURB_=45 setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@"
+    MALLOC_PERTURB_=45 setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./dwarfort "$@"
     ret=$?
     ;;
   *)
-    setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./libs/Dwarf_Fortress "$@"
+    setarch "$setarch_arch" -R env LD_PRELOAD="$PRELOAD_LIB" ./dwarfort "$@"
     ret=$?
     ;;
 esac


### PR DESCRIPTION
This PR adds a linux build and deploy step to our steam pipeline

it also adds a Linux package build action for PRs to complement the existing MSVC package build action.

question: do we care which gcc version we use to build the distribution packages? the ubuntu image has gcc-11 by default, but we can install and use a different version if we want to. our test actions use gcc-10 and gcc-12.