### PR TITLE
Fix startup crashes when global addresses are missing

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1896,8 +1896,8 @@ void Core::doUpdate(color_ostream &out)
         strict_virtual_cast<df::viewscreen_savegamest>(screen);
 
     // save data (do this before updating last_world_data_ptr and triggering unload events)
-    if ((df::global::game->main_interface.options.do_manual_save && !d->last_manual_save_request) ||
-        (df::global::plotinfo->main.autosave_request && !d->last_autosave_request) ||
+    if ((df::global::game && df::global::game->main_interface.options.do_manual_save && !d->last_manual_save_request) ||
+        (df::global::plotinfo && df::global::plotinfo->main.autosave_request && !d->last_autosave_request) ||
         (is_load_save && !d->was_load_save && strict_virtual_cast<df::viewscreen_savegamest>(screen)))
     {
         doSaveData(out);
@@ -1959,8 +1959,10 @@ void Core::doUpdate(color_ostream &out)
     // Execute per-frame handlers
     onUpdate(out);
 
-    d->last_autosave_request = df::global::plotinfo->main.autosave_request;
-    d->last_manual_save_request = df::global::game->main_interface.options.do_manual_save;
+    if (df::global::game && df::global::plotinfo) {
+        d->last_autosave_request = df::global::plotinfo->main.autosave_request;
+        d->last_manual_save_request = df::global::game->main_interface.options.do_manual_save;
+    }
     d->was_load_save = is_load_save;
 
     out << std::flush;

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -2172,10 +2172,12 @@ void DFHack::Lua::Core::Reset(color_ostream &out, const char *where)
         inhibit_m_down = true;
     }
 
-    if (!df::global::enabler->mouse_lbut)
-        inhibit_l_down = false;
-    if (!df::global::enabler->mouse_rbut)
-        inhibit_r_down = false;
-    if (!df::global::enabler->mouse_mbut)
-        inhibit_m_down = false;
+    if (df::global::enabler) {
+        if (!df::global::enabler->mouse_lbut)
+            inhibit_l_down = false;
+        if (!df::global::enabler->mouse_rbut)
+            inhibit_r_down = false;
+        if (!df::global::enabler->mouse_mbut)
+            inhibit_m_down = false;
+    }
 }

--- a/library/lua/argparse.lua
+++ b/library/lua/argparse.lua
@@ -3,7 +3,6 @@
 local _ENV = mkmodule('argparse')
 
 local getopt = require('3rdparty.alt_getopt')
-local guidm = require('gui.dwarfmode')
 
 function processArgs(args, validArgs)
     local result = {}
@@ -174,6 +173,7 @@ end
 
 function coords(arg, arg_name, skip_validation)
     if arg == 'here' then
+        local guidm = require('gui.dwarfmode')  -- globals may not be available yet
         local cursor = guidm.getCursorPos()
         if not cursor then
             arg_error(arg_name,

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -9,7 +9,7 @@ local getval = utils.getval
 
 local to_pen = dfhack.pen.parse
 
-CLEAR_PEN = to_pen{tile=df.global.init.texpos_border_interior, ch=32, fg=0, bg=0, write_to_lower=true}
+CLEAR_PEN = to_pen{tile=dfhack.internal.getAddress('init') and df.global.init.texpos_border_interior, ch=32, fg=0, bg=0, write_to_lower=true}
 TRANSPARENT_PEN = to_pen{tile=0, ch=0}
 KEEP_LOWER_PEN = to_pen{ch=32, fg=0, bg=0, keep_lower=true}
 

--- a/library/modules/Textures.cpp
+++ b/library/modules/Textures.cpp
@@ -121,6 +121,9 @@ static size_t load_textures(color_ostream & out, const char * fname,
 // unloaded.
 //
 void Textures::init(color_ostream &out) {
+    if (!enabler)
+        return;
+
     auto & textures = enabler->textures;
     long num_textures = textures.raws.size();
     if (num_textures <= g_dfhack_logo_texpos_start)


### PR DESCRIPTION
Useful for initial research. Can be tested with `DFHACK_NO_GLOBALS=1`