### PR TITLE
Fix off-by-one error in Textures::cleanup()

### DIFF
--- a/library/modules/Textures.cpp
+++ b/library/modules/Textures.cpp
@@ -175,7 +175,7 @@ void Textures::cleanup() {
 
     auto & textures = enabler->textures;
     auto &raws = textures.raws;
-    size_t texpos_end = g_dfhack_logo_texpos_start + g_num_dfhack_textures;
+    size_t texpos_end = g_dfhack_logo_texpos_start + g_num_dfhack_textures - 1;
     for (size_t idx = g_dfhack_logo_texpos_start; idx <= texpos_end; ++idx) {
         DFSDL_FreeSurface((SDL_Surface *)raws[idx]);
         raws[idx] = NULL;


### PR DESCRIPTION
In a ASCII-only configuration, I was seeing `textures.raws.size() == 164` and `texpos_end == 164`. This resulted in reading one item past the end of the vector.

This may not be occurring in configurations with graphics enabled, or Windows/WINE may be more permissive.