### PR TITLE
Make check-rpc pass

### DIFF
--- a/ci/check-rpc.py
+++ b/ci/check-rpc.py
@@ -3,6 +3,7 @@ import glob
 import sys
 
 actual = {'': {}}
+SEP = ('=' * 80)
 
 with open(sys.argv[1]) as f:
     plugin_name = ''
@@ -53,6 +54,7 @@ for plugin_name in actual:
     methods = actual[plugin_name]
 
     if plugin_name not in expected:
+        print(SEP)
         print('Missing documentation for plugin proto files: ' + plugin_name)
         print('Add the following lines:')
         print('// Plugin: ' + plugin_name)
@@ -73,12 +75,14 @@ for plugin_name in actual:
                 missing.append('// RPC ' + m + ' : ' + io[0] + ' -> ' + io[1])
 
         if len(missing) > 0:
+            print(SEP)
             print('Incomplete documentation for ' + ('core' if plugin_name == '' else 'plugin "' + plugin_name + '"') + ' proto files. Add the following lines:')
             for m in missing:
                 print(m)
                 error_count += 1
 
         if len(wrong) > 0:
+            print(SEP)
             print('Incorrect documentation for ' + ('core' if plugin_name == '' else 'plugin "' + plugin_name + '"') + ' proto files. Replace the following comments:')
             for m in wrong:
                 print(m)
@@ -88,6 +92,7 @@ for plugin_name in expected:
     methods = expected[plugin_name]
 
     if plugin_name not in actual:
+        print(SEP)
         print('Incorrect documentation for plugin proto files: ' + plugin_name)
         print('The following methods are documented, but the plugin does not provide any RPC methods:')
         for m in methods:
@@ -102,6 +107,7 @@ for plugin_name in expected:
                 missing.append('// RPC ' + m + ' : ' + io[0] + ' -> ' + io[1])
 
         if len(missing) > 0:
+            print(SEP)
             print('Incorrect documentation for ' + ('core' if plugin_name == '' else 'plugin "' + plugin_name + '"') + ' proto files. Remove the following lines:')
             for m in missing:
                 print(m)

--- a/ci/check-rpc.py
+++ b/ci/check-rpc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import glob
+import itertools
 import sys
 
 actual = {'': {}}
@@ -27,7 +28,7 @@ for p in glob.iglob('library/proto/*.proto'):
                 parts = line.split(' ')
                 expected[''][parts[2]] = (parts[4], parts[6])
 
-for p in glob.iglob('plugins/proto/*.proto'):
+for p in itertools.chain(glob.iglob('plugins/proto/*.proto'), glob.iglob('plugins/*/proto/*.proto')):
     plugin_name = ''
     with open(p) as f:
         for line in f:

--- a/plugins/proto/isoworldremote.proto
+++ b/plugins/proto/isoworldremote.proto
@@ -5,7 +5,7 @@ package isoworldremote;
 
 option optimize_for = LITE_RUNTIME;
 
-// Plugin: isoworldremote
+// DISABLED Plugin: isoworldremote
 
 enum BasicMaterial {
     AIR = 0;
@@ -54,7 +54,7 @@ message EmbarkTile {
     optional bool is_valid = 7;
 }
 
-// RPC GetEmbarkTile : TileRequest -> EmbarkTile
+// DISABLED RPC GetEmbarkTile : TileRequest -> EmbarkTile
 message TileRequest {
     optional int32 want_x = 1;
     optional int32 want_y = 2;
@@ -64,7 +64,7 @@ message MapRequest {
     optional string save_folder = 1;
 }
 
-// RPC GetEmbarkInfo : MapRequest -> MapReply
+// DISABLED RPC GetEmbarkInfo : MapRequest -> MapReply
 message MapReply {
     required bool available = 1;
     optional int32 region_x = 2;
@@ -75,7 +75,7 @@ message MapReply {
     optional int32 current_season = 7;
 }
 
-// RPC GetRawNames : MapRequest -> RawNames
+// DISABLED RPC GetRawNames : MapRequest -> RawNames
 message RawNames {
     required bool available = 1;
     repeated string inorganic = 2;

--- a/plugins/proto/rename.proto
+++ b/plugins/proto/rename.proto
@@ -4,9 +4,9 @@ package dfproto;
 
 option optimize_for = LITE_RUNTIME;
 
-// Plugin: rename
+// DISABLED Plugin: rename
 
-// RPC RenameSquad : RenameSquadIn -> EmptyMessage
+// DISABLED RPC RenameSquad : RenameSquadIn -> EmptyMessage
 message RenameSquadIn {
     required int32 squad_id = 1;
 
@@ -14,7 +14,7 @@ message RenameSquadIn {
     optional string alias = 3;
 }
 
-// RPC RenameUnit : RenameUnitIn -> EmptyMessage
+// DISABLED RPC RenameUnit : RenameUnitIn -> EmptyMessage
 message RenameUnitIn {
     required int32 unit_id = 1;
 
@@ -22,7 +22,7 @@ message RenameUnitIn {
     optional string profession = 3;
 }
 
-// RPC RenameBuilding : RenameBuildingIn -> EmptyMessage
+// DISABLED RPC RenameBuilding : RenameBuildingIn -> EmptyMessage
 message RenameBuildingIn {
     required int32 building_id = 1;
 


### PR DESCRIPTION
Two fixes here to fix the errors seen in https://github.com/DFHack/dfhack/actions/runs/5758538496/job/15611318369?pr=3622:

* `.proto`s in plugin subdirectories weren't being scanned for docs (broke in #3184 when our tests weren't running), which caused:
    ```
    Missing documentation for plugin proto files: RemoteFortressReader
    Add the following lines:
    // Plugin: RemoteFortressReader
    // RPC GetMaterialList : EmptyMessage -> MaterialList
    // RPC GetGrowthList : EmptyMessage -> MaterialList
    ....
    ```
    Fixed by adding another glob pattern.
* devel/dump-rpc doesn't (and can't) dump RPCs for plugins that aren't loaded, which was causing the check script to fail with:
    ```
    Incorrect documentation for plugin proto files: isoworldremote
    The following methods are documented, but the plugin does not provide any RPC methods:
    // RPC GetEmbarkTile : TileRequest -> EmbarkTile
    // RPC GetEmbarkInfo : MapRequest -> MapReply
    ...
    ```
    Fixed by disabling the docs so the check-rpc doesn't recognize them. This will force us to update the docs when we do re-enable the plugins.