### PR TITLE
treat doc warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,7 +487,7 @@ if(BUILD_DOCS)
     )
     add_custom_command(OUTPUT ${SPHINX_OUTPUT}
         COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/docs/build.py"
-            html text --sphinx="${SPHINX_EXECUTABLE}" -- -q
+            html text --sphinx="${SPHINX_EXECUTABLE}" -- -q -W
         DEPENDS ${SPHINX_DEPS}
         COMMENT "Building documentation with Sphinx"
     )


### PR DESCRIPTION
right now we have a bad section ref in our structures changelog. the warnings are being printed to the build output, but the build check workflows are *passing*. This change should surface the failure in our build action checks.