### PR TITLE
allow the reusable workflows to build xml-dump-type-sizes

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -38,6 +38,9 @@ on:
       tests:
         type: boolean
         default: false
+      xml-dump-type-sizes:
+        type: boolean
+        default: false
       gcc-ver:
         type: string
         default: "10"
@@ -52,7 +55,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build
       - name: Install binary build dependencies
-        if: inputs.platform-files
+        if: inputs.platform-files || inputs.xml-dump-type-sizes
         run: |
           sudo apt-get install \
               ccache \
@@ -116,6 +119,7 @@ jobs:
             -DBUILD_SKELETON:BOOL=${{ inputs.extras }} \
             -DBUILD_DOCS:BOOL=${{ inputs.docs }} \
             -DBUILD_TESTS:BOOL=${{ inputs.tests }} \
+            -DBUILD_XMLDUMP:BOOL=${{ inputs.xml-dump-type-sizes }} \
             -DINSTALL_DATA_FILES:BOOL=${{ inputs.common-files }} \
             -DINSTALL_SCRIPTS:BOOL=${{ inputs.common-files }}
       - name: Build DFHack

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,6 +20,9 @@ on:
       cache-readonly:
         type: boolean
         default: false
+      platform-files:
+        type: boolean
+        default: true
       common-files:
         type: boolean
         default: true
@@ -30,6 +33,9 @@ on:
         type: boolean
         default: false
       tests:
+        type: boolean
+        default: false
+      xml-dump-type-sizes:
         type: boolean
         default: false
       launchdf:
@@ -75,6 +81,7 @@ jobs:
           ssh-key: ${{ secrets.DFHACK_3RDPARTY_TOKEN }}
           path: depends/steam
       - name: Fetch ccache
+        if: inputs.platform-files
         uses: actions/cache/restore@v3
         with:
           path: build/win64-cross/ccache
@@ -84,7 +91,7 @@ jobs:
             win-msvc
       - name: Cross-compile
         env:
-          CMAKE_EXTRA_ARGS: '-DBUILD_STONESENSE:BOOL=${{ inputs.stonesense }} -DBUILD_DOCS:BOOL=${{ inputs.docs }} -DINSTALL_DATA_FILES:BOOL=${{ inputs.common-files }} -DINSTALL_SCRIPTS:BOOL=${{ inputs.common-files }} -DBUILD_DFLAUNCH:BOOL=${{ inputs.launchdf }} -DBUILD_TESTS:BOOL=${{ inputs.tests }}'
+          CMAKE_EXTRA_ARGS: '-DBUILD_LIBRARY=${{ inputs.platform-files }} -DBUILD_STONESENSE:BOOL=${{ inputs.stonesense }} -DBUILD_DOCS:BOOL=${{ inputs.docs }} -DINSTALL_DATA_FILES:BOOL=${{ inputs.common-files }} -DINSTALL_SCRIPTS:BOOL=${{ inputs.common-files }} -DBUILD_DFLAUNCH:BOOL=${{ inputs.launchdf }} -DBUILD_TESTS:BOOL=${{ inputs.tests }} -DBUILD_XMLDUMP:BOOL=${{ inputs.xml-dump-type-sizes }}'
         run: |
           cd build
           bash -x build-win64-from-linux.sh
@@ -95,7 +102,7 @@ jobs:
           ccache -d win64-cross/ccache --cleanup
           ccache -d win64-cross/ccache --show-stats --verbose
       - name: Save ccache
-        if: '!inputs.cache-readonly'
+        if: inputs.platform-files && !inputs.cache-readonly
         uses: actions/cache/save@v3
         with:
           path: build/win64-cross/ccache

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -4,21 +4,48 @@ cmake_minimum_required(VERSION 3.21)
 # prevent CMake warnings about INTERFACE_LINK_LIBRARIES vs LINK_INTERFACE_LIBRARIES
 cmake_policy(SET CMP0022 NEW)
 
-if(BUILD_LIBRARY)
-
 # build options
 if(UNIX)
     option(CONSOLE_NO_CATCH "Make the console not catch 'CTRL+C' events for easier debugging." OFF)
 endif()
 
-include_directories(proto)
-include_directories(include)
+# Generation
+set(CODEGEN_OUT ${dfapi_SOURCE_DIR}/include/df/codegen.out.xml)
+
+file(GLOB GENERATE_INPUT_SCRIPTS ${dfapi_SOURCE_DIR}/xml/*.pm ${dfapi_SOURCE_DIR}/xml/*.xslt)
+file(GLOB GENERATE_INPUT_XMLS ${dfapi_SOURCE_DIR}/xml/df.*.xml)
 
 execute_process(COMMAND ${PERL_EXECUTABLE} xml/list.pl xml ${dfapi_SOURCE_DIR}/include/df ";"
     WORKING_DIRECTORY ${dfapi_SOURCE_DIR}
     OUTPUT_VARIABLE GENERATED_HDRS)
 
 set_source_files_properties(${GENERATED_HDRS} PROPERTIES HEADER_FILE_ONLY TRUE GENERATED TRUE)
+
+add_custom_command(
+    OUTPUT ${CODEGEN_OUT}
+    BYPRODUCTS ${GENERATED_HDRS}
+    COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/xml/codegen.pl
+        ${CMAKE_CURRENT_SOURCE_DIR}/xml
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/df
+    MAIN_DEPENDENCY ${dfapi_SOURCE_DIR}/xml/codegen.pl
+    COMMENT "Generating codegen.out.xml and df/headers"
+    DEPENDS ${GENERATE_INPUT_XMLS} ${GENERATE_INPUT_SCRIPTS}
+)
+
+if(NOT("${CMAKE_GENERATOR}" STREQUAL Ninja))
+    # use BYPRODUCTS instead under Ninja to avoid rebuilds
+    list(APPEND CODEGEN_OUT ${GENERATED_HDRS})
+endif()
+
+add_custom_target(generate_headers DEPENDS ${CODEGEN_OUT})
+
+include_directories(include)
+
+add_subdirectory(xml)
+
+if(BUILD_LIBRARY)
+
+include_directories(proto)
 
 set(MAIN_HEADERS
     include/Internal.h
@@ -263,32 +290,7 @@ add_custom_target(generate_proto_core DEPENDS ${PROJECT_PROTO_TMP_FILES})
 # Merge headers into sources
 set_source_files_properties( ${PROJECT_HEADERS} PROPERTIES HEADER_FILE_ONLY TRUE )
 list(APPEND PROJECT_SOURCES ${PROJECT_HEADERS})
-
-# Generation
 list(APPEND PROJECT_SOURCES ${GENERATED_HDRS})
-
-file(GLOB GENERATE_INPUT_SCRIPTS ${dfapi_SOURCE_DIR}/xml/*.pm ${dfapi_SOURCE_DIR}/xml/*.xslt)
-file(GLOB GENERATE_INPUT_XMLS ${dfapi_SOURCE_DIR}/xml/df.*.xml)
-
-set(CODEGEN_OUT ${dfapi_SOURCE_DIR}/include/df/codegen.out.xml)
-if(NOT("${CMAKE_GENERATOR}" STREQUAL Ninja))
-    # use BYPRODUCTS instead under Ninja to avoid rebuilds
-    list(APPEND CODEGEN_OUT ${GENERATED_HDRS})
-endif()
-
-add_custom_command(
-    OUTPUT ${CODEGEN_OUT}
-    BYPRODUCTS ${GENERATED_HDRS}
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/xml/codegen.pl
-        ${CMAKE_CURRENT_SOURCE_DIR}/xml
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/df
-    MAIN_DEPENDENCY ${dfapi_SOURCE_DIR}/xml/codegen.pl
-    COMMENT "Generating codegen.out.xml and df/headers"
-    DEPENDS ${GENERATE_INPUT_XMLS} ${GENERATE_INPUT_SCRIPTS}
-)
-
-add_custom_target(generate_headers
-    DEPENDS ${dfapi_SOURCE_DIR}/include/df/codegen.out.xml)
 
 if(REMOVE_SYMBOLS_FROM_DF_STUBS)
     if(UNIX)
@@ -442,8 +444,6 @@ install(TARGETS dfhack
 install(TARGETS dfhack-run dfhack-client binpatch
     LIBRARY DESTINATION ${DFHACK_LIBRARY_DESTINATION}
     RUNTIME DESTINATION ${DFHACK_LIBRARY_DESTINATION})
-
-add_subdirectory(xml)
 
 endif(BUILD_LIBRARY)
 


### PR DESCRIPTION
in prep for a new cross-platform check-type-sizes workflow