### PR TITLE
Add option to force-fetch world blocks in RemoteFortressReader

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,6 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
+- `RemoteFortressReader`: add a `force_reload` option to the GetBlockList RPC API to return blocks regardless of whether they have changed since the last request
 
 ## Internals
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -42,7 +42,7 @@ changelog.txt uses a syntax similar to RST, with a few special sequences:
 ## Documentation
 
 ## API
-- `RemoteFortressReader`: add a `force_reload` option to the GetBlockList RPC API to return blocks regardless of whether they have changed since the last request
+- `RemoteFortressReader`: add a ``force_reload`` option to the GetBlockList RPC API to return blocks regardless of whether they have changed since the last request
 
 ## Internals
 

--- a/plugins/remotefortressreader/proto/RemoteFortressReader.proto
+++ b/plugins/remotefortressreader/proto/RemoteFortressReader.proto
@@ -526,6 +526,7 @@ message BlockRequest
     optional int32 max_y = 5;
     optional int32 min_z = 6;
     optional int32 max_z = 7;
+    optional bool force_reload = 8;
 }
 
 message BlockList

--- a/plugins/remotefortressreader/remotefortressreader.cpp
+++ b/plugins/remotefortressreader/remotefortressreader.cpp
@@ -1393,6 +1393,7 @@ static command_result GetBlockList(color_ostream &stream, const BlockRequest *in
     int max_y = in->max_y();
     int min_z = in->min_z();
     int max_z = in->max_z();
+    bool forceReload = in->force_reload();
     bool firstBlock = true; //Always send all the buildings needed on the first block, and none on the rest.
                                 //stream.print("Got request for blocks from (%d, %d, %d) to (%d, %d, %d).\n", in->min_x(), in->min_y(), in->min_z(), in->max_x(), in->max_y(), in->max_z());
     for (int zz = max_z - 1; zz >= min_z; zz--)
@@ -1440,19 +1441,19 @@ static command_result GetBlockList(color_ostream &stream, const BlockRequest *in
                         bool itemsChanged = block->items.size() > 0;
                         bool flows = block->flows.size() > 0;
                         RemoteFortressReader::MapBlock *net_block = nullptr;
-                        if (tileChanged || desChanged || spatterChanged || firstBlock || itemsChanged || flows)
+                        if (tileChanged || desChanged || spatterChanged || firstBlock || itemsChanged || flows || forceReload)
                         {
                             net_block = out->add_map_blocks();
                             net_block->set_map_x(block->map_pos.x);
                             net_block->set_map_y(block->map_pos.y);
                             net_block->set_map_z(block->map_pos.z);
                         }
-                        if (tileChanged)
+                        if (tileChanged || forceReload)
                         {
                             CopyBlock(block, net_block, &MC, pos);
                             blocks_sent++;
                         }
-                        if (desChanged)
+                        if (desChanged || forceReload)
                             CopyDesignation(block, net_block, &MC, pos);
                         if (firstBlock)
                         {
@@ -1460,7 +1461,7 @@ static command_result GetBlockList(color_ostream &stream, const BlockRequest *in
                             CopyProjectiles(net_block);
                             firstBlock = false;
                         }
-                        if (spatterChanged)
+                        if (spatterChanged || forceReload)
                             Copyspatters(block, net_block, &MC, pos);
                         if (itemsChanged)
                             CopyItems(block, net_block, &MC, pos);


### PR DESCRIPTION
The current behavior of GetBlockList in the RemoteFortressReader
Protobuf RPC API is to only return blocks that have changed since
the last fetch. This causes problems when the RPC client (i.e. a
world renderer) wants to restart, as it can no longer fetch the
full world state.

This patch adds a `force_reload` option to BlockRequest, defaulting
to `false` (the current behavior). When passed, it returns all
requested blocks regardless of whether they have changed or not.


Tested against the `develop` and `v0.47.05` branches.
Using the `dfhack-remote` JS RPC client:
![Screenshot from 2023-08-06 13-33-02](https://github.com/DFHack/dfhack/assets/1633923/ffdfedc9-2bcb-4c25-8972-e9d2b9bde6ba)