### PR TITLE
[hotkeys] don't display dfhack logo in legends mode

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `hotkeys`: don't display DFHack logo in legends mode since it covers up important interface elements. the Ctrl-Shift-C hotkey to bring up the menu and the mouseover hotspot still function, though.
 
 ## Documentation
 

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -28,13 +28,14 @@ HotspotMenuWidget.ATTRS{
     default_enabled=true,
     hotspot=true,
     viewscreens={
-        -- 'choose_start_site', -- conflicts with vanilla panel layouts
+        'adopt_region',
         'choose_game_type',
+        -- 'choose_start_site', -- conflicts with vanilla panel layouts
         'dwarfmode',
         'export_region',
         'game_cleaner',
         'initial_prep',
-        'legends',
+        --'legends', -- conflicts with vanilla export button and info text
         'loadgame',
         -- 'new_region', -- conflicts with vanilla panel layouts
         'savegame',


### PR DESCRIPTION
since it covers up important vanilla UI elements