### PR TITLE
ensure active mod scripts are properly reloaded

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- Core: properly reload scripts in mods when a world is unloaded and immediately loaded again
 
 ## Misc Improvements
 - `hotkeys`: don't display DFHack logo in legends mode since it covers up important interface elements. the Ctrl-Shift-C hotkey to bring up the menu and the mouseover hotspot still function, though.

--- a/library/lua/script-manager.lua
+++ b/library/lua/script-manager.lua
@@ -51,9 +51,10 @@ function reload(refresh_active_mod_scripts)
     enabled_map = utils.OrderedTable()
     local force_refresh_fn = refresh_active_mod_scripts and function(script_path, script_name)
         if script_path:find('scripts_modactive') then
-            internal_script = dfhack.internal.scripts[script_path..'/'..script_name]
+            local full_path = script_path..'/'..script_name
+            internal_script = dfhack.internal.scripts[full_path]
             if internal_script then
-                internal_script.env = nil
+                dfhack.internal.scripts[full_path] = nil
             end
         end
     end or nil


### PR DESCRIPTION
setting the script env to nil is not enough; need to completely reload the script

Fixes #3618 