### PR TITLE
[BannerPanel] use square brackets instead of color blocks

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- Surround DFHack-specific UI elements with square brackets instead of red-yellow blocks for better readability
 - `hotkeys`: don't display DFHack logo in legends mode since it covers up important interface elements. the Ctrl-Shift-C hotkey to bring up the menu and the mouseover hotspot still function, though.
 
 ## Documentation

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1496,13 +1496,11 @@ end
 
 BannerPanel = defclass(BannerPanel, Panel)
 
-local BANNER_PEN = dfhack.pen.parse{fg=COLOR_YELLOW, bg=COLOR_RED}
-
 function BannerPanel:onRenderBody(dc)
-    dc:pen(BANNER_PEN)
+    dc:pen(COLOR_RED)
     for y=0,self.frame_rect.height-1 do
-        dc:seek(0, y):char(string.char(221)) -- half-width stripe on left
-        dc:seek(self.frame_rect.width-1):char(string.char(222)) -- half-width stripe on right
+        dc:seek(0, y):char('[')
+        dc:seek(self.frame_rect.width-1):char(']')
     end
 end
 


### PR DESCRIPTION
feedback was that the red-yellow blocks were confusing

this changes the banner to use red square brackets

Examples:
![image](https://github.com/DFHack/dfhack/assets/977482/7ab5287f-42ba-4b99-95e6-0d45c30ce800)
![image](https://github.com/DFHack/dfhack/assets/977482/56b08ae7-1bbc-4b9f-9b24-5c2512fa668f)
![image](https://github.com/DFHack/dfhack/assets/977482/8f150d72-fda8-41f9-96f2-5ca9acf294d3)
![image](https://github.com/DFHack/dfhack/assets/977482/9f67a15e-653a-4554-9d33-63cc577b3946)
![image](https://github.com/DFHack/dfhack/assets/977482/85300004-6263-494b-a2b1-6059fd6115e7)
![image](https://github.com/DFHack/dfhack/assets/977482/d802834b-3c53-41ca-9695-9ee64a4df98b)

Prev look for reference:
![](https://cdn.discordapp.com/attachments/1017471248567124049/1138192194902183996/image.png)
