### PR TITLE
allow msvc 17.7.0 (1937) for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ endif()
 
 if(WIN32)
     if(NOT MSVC)
-        message(SEND_ERROR "No MSVC found! MSVC 2022 version 1930 to 1936 is required.")
-    elseif((MSVC_VERSION LESS 1930) OR (MSVC_VERSION GREATER 1936))
-        message(SEND_ERROR "MSVC 2022 version 1930 to 1936 is required, Version Found: ${MSVC_VERSION}")
+        message(SEND_ERROR "No MSVC found! MSVC 2022 version 1930 to 1937 is required.")
+    elseif((MSVC_VERSION LESS 1930) OR (MSVC_VERSION GREATER 1937))
+        message(SEND_ERROR "MSVC 2022 version 1930 to 1937 is required, Version Found: ${MSVC_VERSION}")
     endif()
 endif()
 


### PR DESCRIPTION
release notes don't show any changes relevant to our use case and a clean test build with 17.7.0 passed the smoke test