### PR TITLE
Refine keyboard input handing

### DIFF
--- a/data/init/dfhack.keybindings.init
+++ b/data/init/dfhack.keybindings.init
@@ -38,7 +38,7 @@ keybinding add Ctrl-V@dwarfmode digv
 keybinding add Ctrl-Shift-V@dwarfmode "digv x"
 
 # clean the selected tile of blood etc
-keybinding add Ctrl-C spotclean
+keybinding add Ctrl-C@dwarfmode spotclean
 
 # destroy the selected item
 keybinding add Ctrl-K@dwarfmode autodump-destroy-item

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ Template for new versions:
 
 ## Fixes
 - Core: properly reload scripts in mods when a world is unloaded and immediately loaded again
+- Core: fix text getting added to DFHack text entry widgets when Alt- or Ctrl- keys are hit
 
 ## Misc Improvements
 - Surround DFHack-specific UI elements with square brackets instead of red-yellow blocks for better readability

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2400,9 +2400,13 @@ bool Core::DFH_SDL_Event(SDL_Event* ev)
             DEBUG(keybinding).print("key down: sym=%d (%c)\n", sym, sym);
             bool handled = SelectHotkey(sym, modstate);
             if (handled) {
+                hotkey_states[sym] = true;
+                if (modstate & (DFH_MOD_CTRL | DFH_MOD_ALT)) {
+                    DEBUG(keybinding).print("modifier key detected; not inhibiting SDL key down event\n");
+                    return false;
+                }
                 DEBUG(keybinding).print("%sinhibiting SDL key down event\n",
                     suppress_duplicate_keyboard_events ? "" : "not ");
-                hotkey_states[sym] = true;
                 return suppress_duplicate_keyboard_events;
             }
         }
@@ -2414,7 +2418,11 @@ bool Core::DFH_SDL_Event(SDL_Event* ev)
     }
     else if (ev->type == SDL_TEXTINPUT) {
         auto &te = ev->text;
-        DEBUG(keybinding).print("text input: '%s'\n", te.text);
+        DEBUG(keybinding).print("text input: '%s' (modifiers: %s%s%s)\n",
+            te.text,
+            modstate & DFH_MOD_SHIFT ? "Shift" : "",
+            modstate & DFH_MOD_CTRL ? "Ctrl" : "",
+            modstate & DFH_MOD_ALT ? "Alt" : "");
         if (strlen(te.text) == 1 && hotkey_states[te.text[0]]) {
             DEBUG(keybinding).print("%sinhibiting SDL text event\n",
                 suppress_duplicate_keyboard_events ? "" : "not ");

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -589,7 +589,7 @@ std::set<df::interface_key> Screen::normalize_text_keys(const std::set<df::inter
     std::set<df::interface_key> combined_keys;
     std::copy_if(keys.begin(), keys.end(), std::inserter(combined_keys, combined_keys.begin()),
         [](df::interface_key k){ return k <= df::interface_key::STRING_A000 || k > df::interface_key::STRING_A255; } );
-    if (df::global::enabler->last_text_input[0]) {
+    if (!(Core::getInstance().getModstate() & (DFH_MOD_CTRL | DFH_MOD_ALT)) && df::global::enabler->last_text_input[0]) {
         char c = df::global::enabler->last_text_input[0];
         df::interface_key key = charToKey(c);
         DEBUG(screen).print("adding character %c as interface key %ld\n", c, key);


### PR DESCRIPTION
don't suppress SDL key events when modifier keys are used. this allows hotkeys to be successfully processed even if a keybinding "steals" it. plain text keys that match a hotkey are still suppressed (controllable via a DFHack preference setting)

also:
- fix keybinding scope of `spotclean` to just be `dwarfmode`
- don't synthesize text entry events when Ctrl- or Alt- is held down