### PR TITLE
Expose struct_field_info to Lua

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -306,7 +306,32 @@ All types and the global object have the following features:
 * ``type._identity``
 
   Contains a lightuserdata pointing to the underlying
-  ``DFHack::type_instance`` object.
+  ``DFHack::type_identity`` object.
+
+All compound types (structs, classes, unions, and the global object) support:
+
+* ``type._fields``
+
+  Contains a table mapping field names to descriptions of the type's fields,
+  including data members and functions. Iterating with ``pairs()`` returns data
+  fields in the order they are defined in the type. Functions and globals may
+  appear in an arbitrary order.
+
+  Each entry contains the following fields:
+
+  * ``name``: the name of the field (matches the ``_fields`` table key)
+  * ``offset``: for data members, the position of the field relative to the start of the type, in bytes
+  * ``count``: for arrays, the number of elements
+  * ``mode``: implementation detail. See ``struct_field_info::Mode`` in ``DataDefs.h``.
+
+  Each entry may also contain the following fields, depending on its type:
+
+  * ``type_name``: present for most fields; a string representation of the field's type
+  * ``type``: the type object matching the field's type; present if such an object exists
+    (e.g. present for DF types, absent for primitive types)
+  * ``type_identity``: present for most fields; a lightuserdata pointing to the field's underlying ``DFHack::type_identity`` object
+  * ``index_enum``, ``ref_target``: the type object corresponding to the field's similarly-named XML attribute, if present
+  * ``union_tag_field``, ``union_tag_attr``, ``original_name``: the string value of the field's similarly-named XML attribute, if present
 
 Types excluding the global object also support:
 

--- a/library/LuaTypes.cpp
+++ b/library/LuaTypes.cpp
@@ -1403,7 +1403,6 @@ static void PushFieldInfoSubTable(lua_State *state, const struct_field_info *fie
             Lua::TableInsert(state, "original_name", field->extra->original_name);
         }
     }
-    // freeze_table(state);  // TODO: make pairs() work
 }
 
 /**

--- a/library/LuaTypes.cpp
+++ b/library/LuaTypes.cpp
@@ -1426,19 +1426,16 @@ static void AddFieldInfoTable(lua_State *state, int ftable_idx, struct_identity 
             lua_settable(state, -3);
         }
 
+        // freeze_table(state);  // TODO: make pairs() work
         lua_settable(state, ix_fields);
 
         lua_pop(state, 1); // field name
     }
 
+    // lua_pushvalue(state, ix_fields);
+    // freeze_table(state); // TODO: figure out why this creates an __index cycle for nonexistent fields
     lua_pushvalue(state, ix_wrapper);
     lua_setfield(state, ftable_idx, "_fields");
-    lua_pushvalue(state, ix_fieldinfo);
-    lua_setfield(state, ftable_idx, "_fieldsinfo");
-    lua_pushvalue(state, ix_meta);
-    lua_setfield(state, ftable_idx, "_fieldsmeta");
-    lua_pushvalue(state, ix_fielditer);
-    lua_setfield(state, ftable_idx, "_fieldsiter");
 }
 
 void LuaWrapper::IndexStatics(lua_State *state, int meta_idx, int ftable_idx, struct_identity *pstruct)

--- a/library/LuaWrapper.cpp
+++ b/library/LuaWrapper.cpp
@@ -1670,6 +1670,7 @@ static void RenderType(lua_State *state, compound_identity *node)
 
         {
             RenderTypeChildren(state, node->getScopeChildren());
+            IndexStatics(state, ix_meta, ftable, (struct_identity*)node);
 
             lua_pushlightuserdata(state, node);
             lua_setfield(state, ftable, "_identity");

--- a/test/structures/struct_fields.lua
+++ b/test/structures/struct_fields.lua
@@ -1,0 +1,54 @@
+config.target = 'core'
+
+local COORD_FIELD_NAMES = {'x', 'y', 'z', 'isValid', 'clear'}
+local COORD_FIELD_EXPECTED_DATA = {
+    x = {type_name='int16_t'},
+    y = {type_name='int16_t'},
+    z = {type_name='int16_t'},
+    isValid = {type_name='function'},
+    clear = {type_name='function'},
+}
+
+local READONLY_MSG = 'Attempt to change a read%-only table.'
+
+function test.access()
+    local fields = df.coord._fields
+    expect.true_(fields)
+    expect.eq(fields, df.coord._fields)
+
+    for name, expected in pairs(COORD_FIELD_EXPECTED_DATA) do
+        expect.true_(fields[name], name)
+        expect.eq(fields[name].name, name, name)
+        expect.eq(fields[name].type_name, expected.type_name, name)
+        expect.eq(type(fields[name].offset), 'number', name)
+    end
+end
+
+function test.order()
+    local i = 0
+    for name in pairs(df.coord._fields) do
+        i = i + 1
+        expect.eq(name, COORD_FIELD_NAMES[i], i)
+    end
+    expect.eq(i, #COORD_FIELD_NAMES)
+end
+
+function test.nonexistent()
+    expect.nil_(df.coord._fields.nonexistent)
+end
+
+function test.readonly()
+    expect.error_match(READONLY_MSG, function()
+        df.coord._fields.x = 'foo'
+    end)
+    expect.error_match(READONLY_MSG, function()
+        df.coord._fields.nonexistent = 'foo'
+    end)
+    -- see TODOs in LuaTypes.cpp
+    -- expect.error_match(READONLY_MSG, function()
+    --     df.coord._fields.x.name = 'foo'
+    -- end)
+
+    expect.eq(df.coord._fields.x.name, 'x')
+    expect.nil_(df.coord._fields.nonexistent)
+end

--- a/test/structures/struct_fields.lua
+++ b/test/structures/struct_fields.lua
@@ -60,3 +60,15 @@ function test.readonly()
     expect.eq(df.coord._fields.x.name, 'x')
     expect.nil_(df.coord._fields.nonexistent)
 end
+
+function test.circular_refs_init()
+    expect.eq(df.job._fields.list_link.type, df.job_list_link)
+    expect.eq(df.job_list_link._fields.item.type, df.job)
+end
+
+function test.subclass_match()
+    for f, parent in pairs(df.viewscreen._fields) do
+        local child = df.viewscreen_titlest._fields[f]
+        expect.table_eq(parent, child, f)
+    end
+end

--- a/test/structures/struct_fields.lua
+++ b/test/structures/struct_fields.lua
@@ -21,6 +21,14 @@ function test.access()
         expect.eq(fields[name].name, name, name)
         expect.eq(fields[name].type_name, expected.type_name, name)
         expect.eq(type(fields[name].offset), 'number', name)
+        expect.eq(type(fields[name].mode), 'number', name)
+        expect.eq(type(fields[name].count), 'number', name)
+    end
+end
+
+function test.globals_original_name()
+    for name, info in pairs(df.global._fields) do
+        expect.eq(type(info.original_name), 'string', name)
     end
 end
 

--- a/test/structures/struct_fields.lua
+++ b/test/structures/struct_fields.lua
@@ -52,6 +52,18 @@ function test.nonexistent()
     end)
 end
 
+function test.count()
+    expect.eq(df.unit._fields.relationship_ids.count, 10)
+end
+
+function test.index_enum()
+    expect.eq(df.unit._fields.relationship_ids.index_enum, df.unit_relationship_type)
+end
+
+function test.ref_target()
+    expect.eq(df.unit._fields.hist_figure_id.ref_target, df.historical_figure)
+end
+
 function test.readonly()
     expect.error_match(READONLY_MSG, function()
         df.coord._fields.x = 'foo'

--- a/test/structures/struct_fields.lua
+++ b/test/structures/struct_fields.lua
@@ -43,6 +43,13 @@ end
 
 function test.nonexistent()
     expect.nil_(df.coord._fields.nonexistent)
+
+    expect.error_match('string expected', function()
+        expect.nil_(df.coord._fields[2])
+    end)
+    expect.error_match('string expected', function()
+        expect.nil_(df.coord._fields[nil])
+    end)
 end
 
 function test.readonly()
@@ -52,13 +59,11 @@ function test.readonly()
     expect.error_match(READONLY_MSG, function()
         df.coord._fields.nonexistent = 'foo'
     end)
-    -- see TODOs in LuaTypes.cpp
-    -- expect.error_match(READONLY_MSG, function()
-    --     df.coord._fields.x.name = 'foo'
-    -- end)
-
-    expect.eq(df.coord._fields.x.name, 'x')
     expect.nil_(df.coord._fields.nonexistent)
+
+    -- should have no effect
+    df.coord._fields.x.name = 'foo'
+    expect.eq(df.coord._fields.x.name, 'x')
 end
 
 function test.circular_refs_init()


### PR DESCRIPTION
For #3668 

To do:
- [x] fix initialization order for the `type` field (`A._fields.b.type` won't be set to `B` if `A._fields` is initialized first)
- [x] add `struct_field_info_extra` fields