### PR TITLE
archive artifacts before upload

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -152,12 +152,22 @@ jobs:
           path: ~/.cache/ccache
           key: linux-gcc-${{ inputs.gcc-ver }}-${{ inputs.cache-id }}-${{ github.sha }}
       - name: Format artifact name
-        if: inputs.append-date-and-hash
+        if: inputs.artifact-name
         id: artifactname
-        run: echo name=${{ inputs.artifact-name }}-$(date +%Y%m%d)-$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
+        run: |
+          if test "false" = "${{ inputs.append-date-and-hash }}"; then
+            echo name=${{ inputs.artifact-name }} >> $GITHUB_OUTPUT
+          else
+            echo name=${{ inputs.artifact-name }}-$(date +%Y%m%d)-$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
+          fi
+      - name: Prep artifact
+        if: inputs.artifact-name
+        run: |
+          cd build/image
+          tar cjf ../../${{ steps.artifactname.outputs.name }}.tar.bz2 .
       - name: Upload artifact
         if: inputs.artifact-name
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ inputs.append-date-and-hash && steps.artifactname.outputs.name || inputs.artifact-name }}
-          path: build/image/*
+          name: ${{ steps.artifactname.outputs.name }}
+          path: ${{ steps.artifactname.outputs.name }}.tar.bz2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -111,12 +111,22 @@ jobs:
           path: build/win64-cross/ccache
           key: win-msvc-${{ inputs.cache-id }}-${{ github.sha }}
       - name: Format artifact name
-        if: inputs.append-date-and-hash
+        if: inputs.artifact-name
         id: artifactname
-        run: echo "name=${{ inputs.artifact-name }}-$(date +%Y%m%d)-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          if test "false" = "${{ inputs.append-date-and-hash }}"; then
+            echo name=${{ inputs.artifact-name }} >> $GITHUB_OUTPUT
+          else
+            echo name=${{ inputs.artifact-name }}-$(date +%Y%m%d)-$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
+          fi
+      - name: Prep artifact
+        if: inputs.artifact-name
+        run: |
+          cd build/win64-cross/output
+          tar cjf ../../../${{ steps.artifactname.outputs.name }}.tar.bz2 .
       - name: Upload artifact
         if: inputs.artifact-name
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ inputs.append-date-and-hash && steps.artifactname.outputs.name || inputs.artifact-name }}
-          path: build/win64-cross/output/*
+          name: ${{ steps.artifactname.outputs.name }}
+          path: ${{ steps.artifactname.outputs.name }}.tar.bz2

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -51,16 +51,15 @@ jobs:
         cat release_body.md
     - name: Stage release
       uses: actions/download-artifact@v3
-    - name: Prep artifact directory
-      run: mkdir artifacts
-    - name: Create win64 release archive
+    - name: Prep artifacts
       run: |
+        mkdir artifacts
         cd dfhack-windows64-build
+        tar xjf dfhack-windows64-build.tar.bz2
+        rm dfhack-windows64-build.tar.bz2
         zip -qr ../artifacts/dfhack-${{ steps.gettag.outputs.name }}-Windows-64bit.zip .
-    - name: Create linux64 release archive
-      run: |
-        cd dfhack-linux64-build
-        tar cjf ../artifacts/dfhack-${{ steps.gettag.outputs.name }}-Linux-64bit.tar.bz2 .
+        cd ../dfhack-linux64-build
+        mv dfhack-linux64-build.tar.bz2 ../artifacts/dfhack-${{ steps.gettag.outputs.name }}-Linux-64bit.tar.bz2
     - name: Create or update GitHub release
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -68,8 +68,16 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: steam
     steps:
-    - name: Stage depot files
+    - name: Download depot files
       uses: actions/download-artifact@v3
+    - name: Stage depot files
+      run: |
+        for name in common win64 linux64; do
+          cd ${name}-depot
+          tar xjf ${name}-depot.tar.bz2
+          rm ${name}-depot.tar.bz2
+          cd ..
+        done
     - name: Steam deploy
       uses: game-ci/steam-deploy@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,11 +110,13 @@ jobs:
         mkdir -p ${{ env.DF_FOLDER }}/dfhack-config/init
         cd data/dfhack-config/init
         for fname in *.init; do touch ../../../${{ env.DF_FOLDER }}/dfhack-config/init/$fname; done
-    - name: Install DFHack
+    - name: Download DFHack
       uses: actions/download-artifact@v3
       with:
         name: test-${{ matrix.compiler }}
-        path: ${{ env.DF_FOLDER }}
+    - name: Install DFHack
+      shell: bash
+      run: tar xjf test-${{ matrix.compiler }}.tar.bz2 -C ${{ env.DF_FOLDER }}
     - name: Run lua tests
       timeout-minutes: 10
       run: python ci/run-tests.py --keep-status "${{ env.DF_FOLDER }}"


### PR DESCRIPTION
upload-artifact and download-artifact are very slow (O(minutes)) for artifacts with many small files. This is likely to be resolved when the v4 release of the artifact actions comes out (see https://github.com/actions/toolkit/tree/main/packages/artifact), but for now we need an interim solution that doesn't waste our time.

This PR compresses our artifacts with `tar` before upload and decompresses them as necessary when they are used by other workflow actions. This speeds the builds up by several minutes each (generally going from ~150s to ~3s).

One side effect of this PR is that the "release" packages are now tar.bzip2 files wrapped in .zip files. This makes them less useful as a method for players to get the latest dev release. We could add logic to the package.yml file (and lower-level build-$os.yml files) to not tar up the files for the package artifacts. This would, of course, slow down those build actions by several minutes, though.

Unless we get complaints, I plan to leave that as is, with the understanding that this PR will possibly get reverted when artifact@v4 comes out.

Fixes #3680