### PR TITLE
`tailor`: remove crash

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -29,6 +29,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `tailor`: remove crash caused by clothing items with an invalid ``maker_race``
 
 ## Misc Improvements
 

--- a/plugins/tailor.cpp
+++ b/plugins/tailor.cpp
@@ -186,6 +186,9 @@ public:
             }
             if (i->getWear() >= 1)
                 continue;
+            if (i->getMakerRace() < 0) // sometimes we get borked items with no valid maker race
+                continue;
+
             df::item_type t = i->getType();
             int size = world->raws.creatures.all[i->getMakerRace()]->adultsize;
 


### PR DESCRIPTION
clothing items may have an invalid maker race; this should not happen but it does so we have to deal with it

fixes #3685 