### PR TITLE
create and delete textures

### DIFF
--- a/docs/about/Authors.rst
+++ b/docs/about/Authors.rst
@@ -203,6 +203,7 @@ Sebastian Wolfertz      Enkrod
 SeerSkye                SeerSkye
 seishuuu                seishuuu
 Seth Woodworth          sethwoodworth
+shevernitskiy           shevernitskiy
 Shim Panze              Shim-Panze
 Silver                  silverflyone
 simon

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3864,6 +3864,9 @@ These modules make extensive use of the ``class`` module, and define
 things ranging from the basic ``Painter``, ``View`` and ``Screen``
 classes, to fully functional predefined dialogs.
 
+In addition to the ``gui`` module, there is a ``textures`` module that allows
+you to perform actions on textures to use them as tiles during rendering.
+
 gui
 ===
 
@@ -5341,6 +5344,48 @@ The parent widget owns the range values, and can control them independently (e.g
 :get_right_idx_fn: The function used by the RangeSlider to get the notch index on which to display the right handle.
 :on_left_change: Callback executed when moving the left handle.
 :on_right_change: Callback executed when moving the right handle.
+
+textures
+========
+
+In order for the game to render a particular tile (graphic), it needs to know ``texpos`` - the position in the vector of the registered game textures.
+Add your own texture to it and get ``texpos`` is not difficult. But the game periodically deletes textures that are in the vector, and that's the problem.
+Because the ``texpos`` we got earlier no longer points to our added texture.
+The ``texture`` module solves this problem. Instead of ``texpos`` directly, it operates on the ``TexposHandle`` entity, which is essentially a reference to ``texpos``.
+Thanks to this handle, it is possible to get a valid ``texpos`` at any time.
+
+* ``loadTileset(file, tile_px_w, tile_px_h)``
+
+  Loads tileset from the image ``file`` with give tile dimension in pixels (image will be sliced in row major order).
+
+  Returns an array of ``TexposHandle``
+
+* ``getTexposByHandle(handle)``
+
+  Get ``texpos`` by ``TexposHandle``.
+  Always use this method if you need to get valid texpos for your texture.
+  ``texpos`` can change on game textures reset, but the handle will be the same.
+
+* ``createTile(pixels, tile_px_w, tile_px_h)``
+
+  Create and register new a texture with the given tile dimension and array of ``pixels`` as data in row major order.
+  Each pixel is an integer representing color in packed RBGA format (for example, #0022FF11).
+
+  Returns ``TexposHandle``.
+
+* ``createTileset(pixels, texture_px_w, texture_px_h, tile_px_w, tile_px_h)``
+
+  Create and register a new texture with the given texture dimension and array of ``pixels`` as data in row major order.
+  Then slice it on tiles with the given dimension in row major order.
+  Each pixel is an integer representing color in packed RBGA format (for example #0022FF11).
+
+  Returns an array of ``TexposHandle``.
+
+* ``deleteHandle(handle)``
+
+  ``handle`` here can be signle ``TexposHandle``, or array of ``TexposHandle``.
+  Deletes all metadata and texture(s) itself by given handle(s).
+  You must be sure that the game does not use this texture in rendering process.
 
 .. _lua-plugins:
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2635,11 +2635,10 @@ raw ``texpos``. When we need to draw a particular tile, we can look up the curre
 
 * ``createTileset(pixels, texture_px_w, texture_px_h, tile_px_w, tile_px_h)``
 
-  Create and register a new texture with the given texture dimension and array of ``pixels`` as data in row major order.
-  Then slice it on tiles with the given dimension in row major order.
-  Each pixel is an integer representing color in packed RBGA format (for example #0022FF11).
-
-  Returns an array of ``TexposHandle``.
+  Create and register a new texture with the given texture dimensions and an array of
+  ``pixels`` in row major order. Then slice it into tiles with the given tile
+  dimensions. Each pixel is an integer representing color in packed RBGA format (for
+  example #0022FF11). Returns an array of ``TexposHandle``.
 
 * ``deleteHandle(handle)``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2596,6 +2596,55 @@ a ``dfhack.penarray`` instance to cache their output.
 
   ``bufferx`` and ``buffery`` default to 0.
 
+
+Textures Module
+---------------
+
+In order for the game to render a particular tile (graphic), it needs to know ``texpos`` - the position in the vector of the registered game textures (also the graphical tile id passed as the tile field in a `Pen <lua-screen-pen>`).
+Add your own texture to it and get ``texpos`` is not difficult. But the game periodically deletes textures that are in the vector, and that's the problem.
+Because the ``texpos`` we got earlier no longer points to our added texture.
+The ``texture`` module solves this problem. Instead of ``texpos`` directly, it operates on the ``TexposHandle`` entity, which is essentially a reference to ``texpos``.
+Thanks to this handle, it is possible to get a valid ``texpos`` at any time.
+
+* ``loadTileset(file, tile_px_w, tile_px_h)``
+
+  Loads tileset from the image ``file`` with give tile dimension in pixels (image will be sliced in row major order).
+
+  Returns an array of ``TexposHandle``
+
+  Example usage::
+
+  local logo_textures = dfhack.textures.loadTileset('hack/data/art/dfhack.png', 8, 12)
+  local first_texposhandle = logo_textures[1]
+
+* ``getTexposByHandle(handle)``
+
+  Get ``texpos`` by ``TexposHandle``.
+  Always use this method if you need to get valid texpos for your texture.
+  ``texpos`` can change on game textures reset, but the handle will be the same.
+
+* ``createTile(pixels, tile_px_w, tile_px_h)``
+
+  Create and register new a texture with the given tile dimension and array of ``pixels`` as data in row major order.
+  Each pixel is an integer representing color in packed RBGA format (for example, #0022FF11).
+
+  Returns ``TexposHandle``.
+
+* ``createTileset(pixels, texture_px_w, texture_px_h, tile_px_w, tile_px_h)``
+
+  Create and register a new texture with the given texture dimension and array of ``pixels`` as data in row major order.
+  Then slice it on tiles with the given dimension in row major order.
+  Each pixel is an integer representing color in packed RBGA format (for example #0022FF11).
+
+  Returns an array of ``TexposHandle``.
+
+* ``deleteHandle(handle)``
+
+  ``handle`` here can be signle ``TexposHandle``, or array of ``TexposHandle``.
+  Deletes all metadata and texture(s) itself by given handle(s).
+  You must be sure that the game does not use this texture in rendering process.
+
+
 Filesystem module
 -----------------
 
@@ -5345,47 +5394,28 @@ The parent widget owns the range values, and can control them independently (e.g
 :on_left_change: Callback executed when moving the left handle.
 :on_right_change: Callback executed when moving the right handle.
 
-textures
-========
 
-In order for the game to render a particular tile (graphic), it needs to know ``texpos`` - the position in the vector of the registered game textures.
-Add your own texture to it and get ``texpos`` is not difficult. But the game periodically deletes textures that are in the vector, and that's the problem.
-Because the ``texpos`` we got earlier no longer points to our added texture.
-The ``texture`` module solves this problem. Instead of ``texpos`` directly, it operates on the ``TexposHandle`` entity, which is essentially a reference to ``texpos``.
-Thanks to this handle, it is possible to get a valid ``texpos`` at any time.
+gui.textures
+============
 
-* ``loadTileset(file, tile_px_w, tile_px_h)``
+This module contains preloaded ``DFHack`` graphic assets and provide several helper methods to get ``texpos`` by offset in tilest (in row major position).
 
-  Loads tileset from the image ``file`` with give tile dimension in pixels (image will be sliced in row major order).
+* ``tp_green_pin(offset)`` tileset: ``hack/data/art/green-pin.png``
+* ``tp_red_pin(offset)`` tileset: ``hack/data/art/red-pin.png``
+* ``tp_icons(offset)`` tileset: ``hack/data/art/icons.png``
+* ``tp_on_off(offset)`` tileset: ``hack/data/art/on-off.png``
+* ``tp_control_panel(offset)`` tileset: ``hack/data/art/control-panel.png``
+* ``tp_border_thin(offset)`` tileset: ``hack/data/art/border-thin.png``
+* ``tp_border_medium(offset)`` tileset: ``hack/data/art/border-medium.png``
+* ``tp_border_bold(offset)`` tileset: ``hack/data/art/border-bold.png``
+* ``tp_border_panel(offset)`` tileset: ``hack/data/art/border-panel.png``
+* ``tp_border_window(offset)`` tileset: ``hack/data/art/order-window.png``
 
-  Returns an array of ``TexposHandle``
+Example usega::
 
-* ``getTexposByHandle(handle)``
+  local textures = require('gui.textures')
+  local first_border_texpos = textures.tp_border_thin(1)
 
-  Get ``texpos`` by ``TexposHandle``.
-  Always use this method if you need to get valid texpos for your texture.
-  ``texpos`` can change on game textures reset, but the handle will be the same.
-
-* ``createTile(pixels, tile_px_w, tile_px_h)``
-
-  Create and register new a texture with the given tile dimension and array of ``pixels`` as data in row major order.
-  Each pixel is an integer representing color in packed RBGA format (for example, #0022FF11).
-
-  Returns ``TexposHandle``.
-
-* ``createTileset(pixels, texture_px_w, texture_px_h, tile_px_w, tile_px_h)``
-
-  Create and register a new texture with the given texture dimension and array of ``pixels`` as data in row major order.
-  Then slice it on tiles with the given dimension in row major order.
-  Each pixel is an integer representing color in packed RBGA format (for example #0022FF11).
-
-  Returns an array of ``TexposHandle``.
-
-* ``deleteHandle(handle)``
-
-  ``handle`` here can be signle ``TexposHandle``, or array of ``TexposHandle``.
-  Deletes all metadata and texture(s) itself by given handle(s).
-  You must be sure that the game does not use this texture in rendering process.
 
 .. _lua-plugins:
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3915,9 +3915,6 @@ These modules make extensive use of the ``class`` module, and define
 things ranging from the basic ``Painter``, ``View`` and ``Screen``
 classes, to fully functional predefined dialogs.
 
-In addition to the ``gui`` module, there is a ``textures`` module that allows
-you to perform actions on textures to use them as tiles during rendering.
-
 gui
 ===
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2622,9 +2622,9 @@ raw ``texpos``. When we need to draw a particular tile, we can look up the curre
 
 * ``getTexposByHandle(handle)``
 
-  Get ``texpos`` by ``TexposHandle``.
-  Always use this method if you need to get valid texpos for your texture.
-  ``texpos`` can change on game textures reset, but the handle will be the same.
+  Get the current ``texpos`` for the given ``TexposHandle``. Always use this method to
+  get the ``texpos`` for your texture. ``texpos`` can change when game textures are
+  reset, but the handle will be the same.
 
 * ``createTile(pixels, tile_px_w, tile_px_h)``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2628,10 +2628,9 @@ raw ``texpos``. When we need to draw a particular tile, we can look up the curre
 
 * ``createTile(pixels, tile_px_w, tile_px_h)``
 
-  Create and register new a texture with the given tile dimension and array of ``pixels`` as data in row major order.
-  Each pixel is an integer representing color in packed RBGA format (for example, #0022FF11).
-
-  Returns ``TexposHandle``.
+  Create and register a new texture with the given tile dimensions and an array of
+  ``pixels`` in row major order. Each pixel is an integer representing color in packed
+  RBGA format (for example, #0022FF11). Returns a ``TexposHandle``.
 
 * ``createTileset(pixels, texture_px_w, texture_px_h, tile_px_w, tile_px_h)``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2606,8 +2606,9 @@ graphical tile id passed as the ``tile`` field in a `Pen <lua-screen-pen>`).
 Adding new textures to the vector is not difficult, but the game periodically
 deletes textures that are in the vector, and that's a problem since it
 invalidates the ``texpos`` value that used to point to that texture.
-The ``texture`` module solves this problem. Instead of ``texpos`` directly, it operates on the ``TexposHandle`` entity, which is essentially a reference to ``texpos``.
-Thanks to this handle, it is possible to get a valid ``texpos`` at any time.
+The ``textures`` module solves this problem by providing a stable handle instead of a
+raw ``texpos``. When we need to draw a particular tile, we can look up the current
+``texpos`` value via the handle.
 
 * ``loadTileset(file, tile_px_w, tile_px_h)``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2642,9 +2642,9 @@ raw ``texpos``. When we need to draw a particular tile, we can look up the curre
 
 * ``deleteHandle(handle)``
 
-  ``handle`` here can be signle ``TexposHandle``, or array of ``TexposHandle``.
-  Deletes all metadata and texture(s) itself by given handle(s).
-  You must be sure that the game does not use this texture in rendering process.
+  ``handle`` here can be single ``TexposHandle`` or an array of ``TexposHandle``.
+  Deletes all metadata and texture(s) related to the given handle(s). The handles
+  become invalid after this call.
 
 
 Filesystem module

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2600,7 +2600,9 @@ a ``dfhack.penarray`` instance to cache their output.
 Textures module
 ---------------
 
-In order for the game to render a particular tile (graphic), it needs to know ``texpos`` - the position in the vector of the registered game textures (also the graphical tile id passed as the tile field in a `Pen <lua-screen-pen>`).
+In order for the game to render a particular tile (graphic), it needs to know the
+``texpos`` - the position in the vector of the registered game textures (also the
+graphical tile id passed as the ``tile`` field in a `Pen <lua-screen-pen>`).
 Add your own texture to it and get ``texpos`` is not difficult. But the game periodically deletes textures that are in the vector, and that's the problem.
 Because the ``texpos`` we got earlier no longer points to our added texture.
 The ``texture`` module solves this problem. Instead of ``texpos`` directly, it operates on the ``TexposHandle`` entity, which is essentially a reference to ``texpos``.

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2603,8 +2603,9 @@ Textures module
 In order for the game to render a particular tile (graphic), it needs to know the
 ``texpos`` - the position in the vector of the registered game textures (also the
 graphical tile id passed as the ``tile`` field in a `Pen <lua-screen-pen>`).
-Add your own texture to it and get ``texpos`` is not difficult. But the game periodically deletes textures that are in the vector, and that's the problem.
-Because the ``texpos`` we got earlier no longer points to our added texture.
+Adding new textures to the vector is not difficult, but the game periodically
+deletes textures that are in the vector, and that's a problem since it
+invalidates the ``texpos`` value that used to point to that texture.
 The ``texture`` module solves this problem. Instead of ``texpos`` directly, it operates on the ``TexposHandle`` entity, which is essentially a reference to ``texpos``.
 Thanks to this handle, it is possible to get a valid ``texpos`` at any time.
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -5415,7 +5415,7 @@ asset. ``offset`` 0 is the first tile.
 * ``tp_border_panel(offset)`` tileset: ``hack/data/art/border-panel.png``
 * ``tp_border_window(offset)`` tileset: ``hack/data/art/order-window.png``
 
-Example usega::
+Example usage::
 
   local textures = require('gui.textures')
   local first_border_texpos = textures.tp_border_thin(1)

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -5400,7 +5400,9 @@ The parent widget owns the range values, and can control them independently (e.g
 gui.textures
 ============
 
-This module contains preloaded ``DFHack`` graphic assets and provide several helper methods to get ``texpos`` by offset in tilest (in row major position).
+This module contains convenience methods for accessing default DFHack graphic assets.
+Pass the ``offset`` in tiles (in row major position) to get a particular tile from the
+asset. ``offset`` 0 is the first tile.
 
 * ``tp_green_pin(offset)`` tileset: ``hack/data/art/green-pin.png``
 * ``tp_red_pin(offset)`` tileset: ``hack/data/art/red-pin.png``

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2614,8 +2614,8 @@ Thanks to this handle, it is possible to get a valid ``texpos`` at any time.
 
   Example usage::
 
-  local logo_textures = dfhack.textures.loadTileset('hack/data/art/dfhack.png', 8, 12)
-  local first_texposhandle = logo_textures[1]
+    local logo_textures = dfhack.textures.loadTileset('hack/data/art/dfhack.png', 8, 12)
+    local first_texposhandle = logo_textures[1]
 
 * ``getTexposByHandle(handle)``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2597,7 +2597,7 @@ a ``dfhack.penarray`` instance to cache their output.
   ``bufferx`` and ``buffery`` default to 0.
 
 
-Textures Module
+Textures module
 ---------------
 
 In order for the game to render a particular tile (graphic), it needs to know ``texpos`` - the position in the vector of the registered game textures (also the graphical tile id passed as the tile field in a `Pen <lua-screen-pen>`).

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2612,9 +2612,8 @@ raw ``texpos``. When we need to draw a particular tile, we can look up the curre
 
 * ``loadTileset(file, tile_px_w, tile_px_h)``
 
-  Loads tileset from the image ``file`` with give tile dimension in pixels (image will be sliced in row major order).
-
-  Returns an array of ``TexposHandle``
+  Loads a tileset from the image ``file`` with give tile dimensions in pixels. The
+  image will be sliced in row major order. Returns an array of ``TexposHandle``.
 
   Example usage::
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1775,9 +1775,51 @@ static int textures_getTexposByHandle(lua_State *state)
     return 1;
 }
 
+static int textures_deleteHandle(lua_State *state)
+{
+    if (lua_isinteger(state,1)) {
+        auto handle = luaL_checkunsigned(state, 1);
+        Textures::deleteHandle(handle);
+    } else if (lua_istable(state,1)) {
+        std::vector<TexposHandle> handles;
+        Lua::GetVector(state, handles);
+        for (auto& handle: handles) {
+            Textures::deleteHandle(handle);
+        }
+    }
+    return 0;
+}
+
+static int textures_createTile(lua_State *state)
+{
+    std::vector<uint32_t> pixels;
+    Lua::GetVector(state, pixels);
+    auto tile_w = luaL_checkint(state, 2);
+    auto tile_h = luaL_checkint(state, 3);
+    auto handle = Textures::createTile(pixels, tile_w, tile_h);
+    Lua::Push(state, handle);
+    return 1;
+}
+
+static int textures_createTileset(lua_State *state)
+{
+    std::vector<uint32_t> pixels;
+    Lua::GetVector(state, pixels);
+    auto texture_w = luaL_checkint(state, 2);
+    auto texture_h = luaL_checkint(state, 3);
+    auto tile_w = luaL_checkint(state, 4);
+    auto tile_h = luaL_checkint(state, 5);
+    auto handles = Textures::createTileset(pixels, texture_w, texture_h, tile_w, tile_h);
+    Lua::PushVector(state, handles);
+    return 1;
+}
+
 static const luaL_Reg dfhack_textures_funcs[] = {
     { "loadTileset", textures_loadTileset },
     { "getTexposByHandle", textures_getTexposByHandle },
+    { "deleteHandle", textures_deleteHandle },
+    { "createTile", textures_createTile },
+    { "createTileset", textures_createTileset },
     { NULL, NULL }
 };
 

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -410,6 +410,17 @@ namespace DFHack {namespace Lua {
         }
     }
 
+    template<typename T>
+    requires std::is_arithmetic_v<T>
+    void GetVector(lua_State *state, std::vector<T> &pvec, int idx = 1) {
+        lua_pushnil(state);   // first key
+        while (lua_next(state, idx) != 0)
+        {
+            pvec.push_back(lua_tointeger(state, -1));
+            lua_pop(state, 1);  // remove value, leave key
+        }
+    }
+
     DFHACK_EXPORT void GetVector(lua_State *state, std::vector<std::string> &pvec, int idx = 1);
 
     DFHACK_EXPORT void CheckPen(lua_State *L, Screen::Pen *pen, int index, bool allow_nil = false, bool allow_color = true);

--- a/library/include/modules/DFSDL.h
+++ b/library/include/modules/DFSDL.h
@@ -48,6 +48,8 @@ DFHACK_EXPORT void DFSDL_FreeSurface(SDL_Surface *surface);
 // DFHACK_EXPORT int DFSDL_SemPost(SDL_sem *sem);
 DFHACK_EXPORT int DFSDL_PushEvent(SDL_Event *event);
 DFHACK_EXPORT void DFSDL_free(void *ptr);
+DFHACK_EXPORT SDL_PixelFormat* DFSDL_AllocFormat(uint32_t pixel_format);
+DFHACK_EXPORT SDL_Surface* DFSDL_CreateRGBSurfaceWithFormat(uint32_t flags, int width, int height, int depth, uint32_t format);
 
 // submitted and returned text is UTF-8
 // see wrapper functions below for cp-437 variants

--- a/library/include/modules/Textures.h
+++ b/library/include/modules/Textures.h
@@ -49,14 +49,14 @@ DFHACK_EXPORT long getTexposByHandle(TexposHandle handle);
 DFHACK_EXPORT void deleteHandle(TexposHandle handle);
 
 /**
- * Create new texture with RGBA32 format and pixels as data.
+ * Create new texture with RGBA32 format and pixels as data in row major order.
  * Register this texture and return TexposHandle.
  */
 DFHACK_EXPORT TexposHandle createTile(std::vector<uint32_t>& pixels, int tile_px_w = TILE_WIDTH_PX,
                                       int tile_px_h = TILE_HEIGHT_PX);
 
 /**
- * Create new textures as tileset with RGBA32 format and pixels as data.
+ * Create new textures as tileset with RGBA32 format and pixels as data in row major order.
  * Register this textures and return vector of TexposHandle.
  */
 DFHACK_EXPORT std::vector<TexposHandle> createTileset(std::vector<uint32_t>& pixels,

--- a/library/include/modules/Textures.h
+++ b/library/include/modules/Textures.h
@@ -44,6 +44,27 @@ DFHACK_EXPORT std::vector<TexposHandle> loadTileset(const std::string& file,
 DFHACK_EXPORT long getTexposByHandle(TexposHandle handle);
 
 /**
+ * Delete all info about texture by TexposHandle
+ */
+DFHACK_EXPORT void deleteHandle(TexposHandle handle);
+
+/**
+ * Create new texture with RGBA32 format and pixels as data.
+ * Register this texture and return TexposHandle.
+ */
+DFHACK_EXPORT TexposHandle createTile(std::vector<uint32_t>& pixels, int tile_px_w = TILE_WIDTH_PX,
+                                      int tile_px_h = TILE_HEIGHT_PX);
+
+/**
+ * Create new textures as tileset with RGBA32 format and pixels as data.
+ * Register this textures and return vector of TexposHandle.
+ */
+DFHACK_EXPORT std::vector<TexposHandle> createTileset(std::vector<uint32_t>& pixels,
+                                                      int texture_px_w, int texture_px_h,
+                                                      int tile_px_w = TILE_WIDTH_PX,
+                                                      int tile_px_h = TILE_HEIGHT_PX);
+
+/**
  * Call this on DFHack init just once to setup interposed handlers and
  * init static assets.
  */

--- a/library/modules/DFSDL.cpp
+++ b/library/modules/DFSDL.cpp
@@ -41,6 +41,8 @@ SDL_bool (*g_SDL_HasClipboardText)();
 int (*g_SDL_SetClipboardText)(const char *text);
 char * (*g_SDL_GetClipboardText)();
 void (*g_SDL_free)(void *);
+SDL_PixelFormat* (*g_SDL_AllocFormat)(uint32_t pixel_format) = nullptr;
+SDL_Surface* (*g_SDL_CreateRGBSurfaceWithFormat)(uint32_t flags, int width, int height, int depth, uint32_t format) = nullptr;
 
 bool DFSDL::init(color_ostream &out) {
     for (auto &lib_str : SDL_LIBS) {
@@ -81,7 +83,9 @@ bool DFSDL::init(color_ostream &out) {
     bind(g_sdl_handle, SDL_SetClipboardText);
     bind(g_sdl_handle, SDL_GetClipboardText);
     bind(g_sdl_handle, SDL_free);
-    #undef bind
+    bind(g_sdl_handle, SDL_AllocFormat);
+    bind(g_sdl_handle, SDL_CreateRGBSurfaceWithFormat);
+#undef bind
 
     DEBUG(dfsdl,out).print("sdl successfully loaded\n");
     return true;
@@ -146,6 +150,15 @@ char * DFSDL::DFSDL_GetClipboardText() {
 int DFSDL::DFSDL_SetClipboardText(const char *text) {
     return g_SDL_SetClipboardText(text);
 }
+
+SDL_PixelFormat* DFSDL::DFSDL_AllocFormat(uint32_t pixel_format) {
+    return g_SDL_AllocFormat(pixel_format);
+}
+
+SDL_Surface* DFSDL::DFSDL_CreateRGBSurfaceWithFormat(uint32_t flags, int width, int height, int depth, uint32_t format) {
+    return g_SDL_CreateRGBSurfaceWithFormat(flags, width, height, depth, format);
+}
+
 
 DFHACK_EXPORT std::string DFHack::getClipboardTextCp437() {
     if (!g_sdl_handle || g_SDL_HasClipboardText() != SDL_TRUE)

--- a/library/modules/Textures.cpp
+++ b/library/modules/Textures.cpp
@@ -86,7 +86,8 @@ static void delete_texture(long texpos) {
 // create new surface with RGBA32 format and pixels as data
 SDL_Surface* create_texture(std::vector<uint32_t>& pixels, int texture_px_w, int texture_px_h) {
     auto surface = DFSDL_CreateRGBSurfaceWithFormat(0, texture_px_w, texture_px_h, 32, RGBA32);
-    for (size_t i = 0; i < pixels.size() && i < texture_px_w * texture_px_h; i++) {
+    auto canvas_length = static_cast<size_t>(texture_px_w * texture_px_h);
+    for (size_t i = 0; i < pixels.size() && i < canvas_length; i++) {
         uint32_t* p = (uint32_t*)surface->pixels + i;
         *p = pixels[i];
     }

--- a/library/modules/Textures.cpp
+++ b/library/modules/Textures.cpp
@@ -77,7 +77,8 @@ static long add_texture(SDL_Surface* surface) {
 // delete surface from texture raws
 static void delete_texture(long texpos) {
     std::lock_guard<std::mutex> lg_add_texture(g_adding_mutex);
-    if (texpos >= enabler->textures.raws.size())
+    auto pos = static_cast<size_t>(texpos);
+    if (pos >= enabler->textures.raws.size())
         return;
     enabler->textures.raws[texpos] = NULL;
 }
@@ -85,7 +86,7 @@ static void delete_texture(long texpos) {
 // create new surface with RGBA32 format and pixels as data
 SDL_Surface* create_texture(std::vector<uint32_t>& pixels, int texture_px_w, int texture_px_h) {
     auto surface = DFSDL_CreateRGBSurfaceWithFormat(0, texture_px_w, texture_px_h, 32, RGBA32);
-    for (auto i = 0; i < pixels.size() && i < texture_px_w * texture_px_h; i++) {
+    for (size_t i = 0; i < pixels.size() && i < texture_px_w * texture_px_h; i++) {
         uint32_t* p = (uint32_t*)surface->pixels + i;
         *p = pixels[i];
     }


### PR DESCRIPTION
This PR add ability to generate and delete textures dynamicaly.

New methods:

 - **createTile**
Create single texture with w/h in pixels from given pixels array. Register it in `texture.raws` and return `TexposHandle`.
```cpp
TexposHandle Textures::createTile(std::vector<uint32_t>& pixels, int tile_px_w, int tile_px_h)
```
```lua
dfhack.textures.createTile(pixels: integer[], tile_px_w: integer, tile_px_h: integer)
```

 - **createTileset**
Create one texture with texture w/h in pixels from given pixels array. Slice it on array of tiles wih given w/h in pixels, register those tiles in `texture.raws` and return array of `TexposHandle`.
```cpp
std::vector<TexposHandle> Textures::createTileset(std::vector<uint32_t>& pixels, int texture_px_w,
                                                  int texture_px_h, int tile_px_w, int tile_px_h)
```
```lua
dfhack.textures.createTileset(pixels: integer[], texture_px_w: integer, texture_px_h: integer, tile_px_w: integer, tile_px_h: integer)
```

 - **deleteHandle**
Delete texture by given `TexposHandle` (lua method can receive array of handles as well). It means delete textures from `texture.raws`, clear all data in internal handles cache and destroy cached  surface.
```cpp
void Textures::deleteHandle(TexposHandle handle)
```
```lua
dfhack.textures.deleteHandle(handles: integer | integer[])
```
---
Pixel in pixels array is integer representing packed RGBA color. For example `#0022FF50`