### PR TITLE
pass getAnyStockpile and getAnyCivZone through ZScreens

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -75,6 +75,7 @@ Template for new versions:
 - ``Items::getValue()``: remove ``caravan_buying`` parameter since the identity of the selling party doesn't actually affect the item value
 - `RemoteFortressReader`: add a ``force_reload`` option to the GetBlockList RPC API to return blocks regardless of whether they have changed since the last request
 - ``Units``: new animal propery check functions ``isMarkedForTraining(unit)``, ``isMarkedForTaming(unit)``, ``isMarkedForWarTraining(unit)``, and ``isMarkedForHuntTraining(unit)``
+- ``Gui``: ``getAnyStockpile`` and ``getAnyCivzone`` (along with their ``getSelected`` variants) now work through layers of ZScreens. This means that they will still return valid results even if a DFHack tool window is in the foereground.
 
 ## Lua
 - ``new()``: improved error handling so that certain errors that were previously uncatchable (creating objects with members with unknown vtables) are now catchable with ``pcall()``
@@ -83,6 +84,7 @@ Template for new versions:
 - ``widgets.Panel``: new functions to override instead of setting corresponding properties (useful when subclassing instead of just setting attributes): ``onDragBegin``, ``onDragEnd``, ``onResizeBegin``, ``onResizeEnd``
 - ``dfhack.screen.readTile()``: now populates extended tile property fields (like ``top_of_text``) in the returned ``Pen`` object
 - ``dfhack.units``: new animal propery check functions ``isMarkedForTraining(unit)``, ``isMarkedForTaming(unit)``, ``isMarkedForWarTraining(unit)``, and ``isMarkedForHuntTraining(unit)``
+- ``dfhack.gui``: new ``getAnyCivZone`` and ``getAnyStockpile`` functions; also behavior of ``getSelectedCivZone`` and ``getSelectedStockpile`` functions has changes as per the related API notes
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1010,41 +1010,26 @@ General-purpose selections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * ``dfhack.gui.getSelectedWorkshopJob([silent])``
-
-  When a job is selected in :kbd:`q` mode, returns the job, else
-  prints error unless silent and returns *nil*.
-
 * ``dfhack.gui.getSelectedJob([silent])``
-
-  Returns the job selected in a workshop or unit/jobs screen.
-
 * ``dfhack.gui.getSelectedUnit([silent])``
-
-  Returns the unit selected via :kbd:`v`, :kbd:`k`, unit/jobs, or
-  a full-screen item view of a cage or suchlike.
-
 * ``dfhack.gui.getSelectedItem([silent])``
-
-  Returns the item selected via :kbd:`v` ->inventory, :kbd:`k`, :kbd:`t`, or
-  a full-screen item view of a container. Note that in the
-  last case, the highlighted *contained item* is returned, not
-  the container itself.
-
 * ``dfhack.gui.getSelectedBuilding([silent])``
-
-  Returns the building selected via :kbd:`q`, :kbd:`t`, :kbd:`k` or :kbd:`i`.
-
 * ``dfhack.gui.getSelectedCivZone([silent])``
-
-  Returns the zone currently selected via :kbd:`z`
-
+* ``dfhack.gui.getSelectedStockpile([silent])``
 * ``dfhack.gui.getSelectedPlant([silent])``
 
-  Returns the plant selected via :kbd:`k`.
+  Returns the currently selected in-game object or the indicated thing
+  associated with the selected in-game object. For example, Calling
+  ``getSelectedJob`` when a building is selected will return the job associated
+  with the building (e.g. the ``ConstructBuilding`` job). If ``silent`` is
+  ommitted or set to ``false`` and a selected object cannot be found, then an
+  error is printed to the console.
 
 * ``dfhack.gui.getAnyUnit(screen)``
 * ``dfhack.gui.getAnyItem(screen)``
 * ``dfhack.gui.getAnyBuilding(screen)``
+* ``dfhack.gui.getAnyCivZone(screen)``
+* ``dfhack.gui.getAnyStockpile(screen)``
 * ``dfhack.gui.getAnyPlant(screen)``
 
   Similar to the corresponding ``getSelected`` functions, but operate on the

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1527,6 +1527,8 @@ static const LuaWrapper::FunctionReg dfhack_gui_module[] = {
     WRAPM(Gui, getAnyUnit),
     WRAPM(Gui, getAnyItem),
     WRAPM(Gui, getAnyBuilding),
+    WRAPM(Gui, getAnyCivZone),
+    WRAPM(Gui, getAnyStockpile),
     WRAPM(Gui, getAnyPlant),
     WRAPM(Gui, writeToGamelog),
     WRAPM(Gui, makeAnnouncement),

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -36,6 +36,8 @@ distribution.
 #include "DataDefs.h"
 #include "df/graphic.h"
 #include "df/viewscreen.h"
+#include "df/building_civzonest.h"
+#include "df/building_stockpilest.h"
 #include "df/zoom_commands.h"
 
 #include "modules/GuiHooks.h"
@@ -362,6 +364,8 @@ namespace DFHack
         virtual df::item *getSelectedItem() { return nullptr; }
         virtual df::job *getSelectedJob() { return nullptr; }
         virtual df::building *getSelectedBuilding() { return nullptr; }
+        virtual df::building_stockpilest *getSelectedStockpile() { return nullptr; }
+        virtual df::building_civzonest *getSelectedCivZone() { return nullptr; }
         virtual df::plant *getSelectedPlant() { return nullptr; }
 
         static virtual_identity _identity;
@@ -406,6 +410,8 @@ namespace DFHack
         virtual df::item *getSelectedItem();
         virtual df::job *getSelectedJob();
         virtual df::building *getSelectedBuilding();
+        virtual df::building_civzonest *getSelectedCivZone();
+        virtual df::building_stockpilest *getSelectedStockpile();
         virtual df::plant *getSelectedPlant();
 
         static virtual_identity _identity;

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -872,6 +872,12 @@ end
 function ZScreen:onGetSelectedBuilding()
     return zscreen_get_any(self, 'Building')
 end
+function ZScreen:onGetSelectedStockpile()
+    return zscreen_get_any(self, 'Stockpile')
+end
+function ZScreen:onGetSelectedCivZone()
+    return zscreen_get_any(self, 'CivZone')
+end
 function ZScreen:onGetSelectedPlant()
     return zscreen_get_any(self, 'Plant')
 end

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -1235,9 +1235,11 @@ bool Gui::any_stockpile_hotkey(df::viewscreen* top)
 }
 
 df::building_stockpilest* Gui::getAnyStockpile(df::viewscreen* top) {
-    if (matchFocusString("dwarfmode/Some/Stockpile")) {
+    if (auto dfscreen = dfhack_viewscreen::try_cast(top))
+        return dfscreen->getSelectedStockpile();
+
+    if (game->main_interface.bottom_mode_selected == main_bottom_mode_type::STOCKPILE)
         return game->main_interface.stockpile.cur_bld;
-    }
 
     return NULL;
 }
@@ -1256,9 +1258,12 @@ bool Gui::any_civzone_hotkey(df::viewscreen* top) {
 }
 
 df::building_civzonest *Gui::getAnyCivZone(df::viewscreen* top) {
-    if (matchFocusString("dwarfmode/Zone")) {
+    if (auto dfscreen = dfhack_viewscreen::try_cast(top))
+        return dfscreen->getSelectedCivZone();
+
+    if (game->main_interface.bottom_mode_selected == main_bottom_mode_type::ZONE)
         return game->main_interface.civzone.cur_bld;
-    }
+
     return NULL;
 }
 
@@ -1273,8 +1278,6 @@ df::building_civzonest *Gui::getSelectedCivZone(color_ostream &out, bool quiet) 
 
 df::building *Gui::getAnyBuilding(df::viewscreen *top)
 {
-    using df::global::game;
-
     if (auto dfscreen = dfhack_viewscreen::try_cast(top))
         return dfscreen->getSelectedBuilding();
 

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -1104,6 +1104,22 @@ df::building *dfhack_lua_viewscreen::getSelectedBuilding()
     return Lua::GetDFObject<df::building>(Lua::Core::State, -1);
 }
 
+df::building_stockpilest *dfhack_lua_viewscreen::getSelectedStockpile()
+{
+    Lua::StackUnwinder frame(Lua::Core::State);
+    lua_pushstring(Lua::Core::State, "onGetSelectedStockpile");
+    safe_call_lua(do_notify, 1, 1);
+    return Lua::GetDFObject<df::building_stockpilest>(Lua::Core::State, -1);
+}
+
+df::building_civzonest *dfhack_lua_viewscreen::getSelectedCivZone()
+{
+    Lua::StackUnwinder frame(Lua::Core::State);
+    lua_pushstring(Lua::Core::State, "onGetSelectedCivZone");
+    safe_call_lua(do_notify, 1, 1);
+    return Lua::GetDFObject<df::building_civzonest>(Lua::Core::State, -1);
+}
+
 df::plant *dfhack_lua_viewscreen::getSelectedPlant()
 {
     Lua::StackUnwinder frame(Lua::Core::State);


### PR DESCRIPTION
this appears to be an oversight from when we introduced those API methods