### PR TITLE
remove unneeded modification of CMAKE_CXX_FLAGS_RELWITHDEBINFO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,6 @@ if(UNIX)
     # ensure compatibility with older CPUs
     add_definitions(-DLINUX_BUILD)
     set(GCC_COMMON_FLAGS "-fvisibility=hidden -mtune=generic -Wall -Werror -Wl,--disable-new-dtags")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COMMON_FLAGS}")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GCC_COMMON_FLAGS}")
     if(DFHACK_BUILD_64)


### PR DESCRIPTION
-g is already in the flags, we just end up adding it a second time