### PR TITLE
Hack to force GCC to invoke cancel_job() through DF's vtable

### DIFF
--- a/test/modules/job.lua
+++ b/test/modules/job.lua
@@ -1,0 +1,19 @@
+config.target = 'core'
+config.mode = 'title' -- alters world state, not safe when a world is loaded
+
+function test.removeJob()
+    -- removeJob() calls DF code, so ensure that that DF code is actually running
+
+    -- for an explanation of why this is necessary to check,
+    -- see https://github.com/DFHack/dfhack/pull/3713 and Job.cpp:removeJob()
+
+    expect.nil_(df.global.world.jobs.list.next, 'job list is not empty')
+
+    local job = df.job:new()  -- will be deleted by removeJob() if the test passes
+    dfhack.job.linkIntoWorld(job)
+    expect.true_(df.global.world.jobs.list.next, 'job list is empty')
+    expect.eq(df.global.world.jobs.list.next.item, job, 'expected job not found in list')
+
+    expect.true_(dfhack.job.removeJob(job))
+    expect.nil_(df.global.world.jobs.list.next, 'job list is not empty after removeJob()')
+end


### PR DESCRIPTION
GCC appears to be optimizing the call to `cancel_job()` to use the stub in *DFHack's* job_handler vtable, which is a no-op. Lua was unaffected because it invokes vmethods through method pointers (without knowing the target instance at compile time), so use a similar approach here for now.

As mentioned by @ab9rf on Discord, we should pursue an alternative like asking Bay12 to expose the relevant code through a global `std::function` instead of a vmethod.