### PR TITLE
[hotkeys] hide the DFHack logo while loading a game

### DIFF
--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -37,8 +37,8 @@ HotspotMenuWidget.ATTRS{
         'export_region',
         'game_cleaner',
         'initial_prep',
-        --'legends', -- conflicts with vanilla export button and info text
-        'loadgame',
+        -- 'legends', -- conflicts with vanilla export button and info text
+        -- 'loadgame', -- disable temporarily while we get texture reloading sorted
         -- 'new_arena', -- conflicts with vanilla panel layouts
         -- 'new_region', -- conflicts with vanilla panel layouts
         'savegame',


### PR DESCRIPTION
so the textures don't visibly flicker
revert this once textures are flicker free

#3709