### PR TITLE
unclutter build command

### DIFF
--- a/build/build-win64-from-linux.sh
+++ b/build/build-win64-from-linux.sh
@@ -45,7 +45,7 @@ if ! docker run --rm -i -v "$srcdir":/src -v "$srcdir/build/win64-cross/":/src/b
     -e steam_password \
     --name dfhack-win \
     ghcr.io/dfhack/build-env:msvc \
-    bash -c "cd /src/build && dfhack-configure windows 64 Release -DCMAKE_INSTALL_PREFIX=/src/build/output cmake .. -DBUILD_DOCS=1 $CMAKE_EXTRA_ARGS && dfhack-make -j$jobs install" \
+    bash -c "cd /src/build && dfhack-configure windows 64 Release -DCMAKE_INSTALL_PREFIX=/src/build/output -DBUILD_DOCS=1 $CMAKE_EXTRA_ARGS && dfhack-make -j$jobs install" \
     ; then
     echo
     echo "Build failed"


### PR DESCRIPTION
it wasn't causing any errors, but it was also clearly leftover from a previous commandline