### PR TITLE
Add `boolean` function for argparse

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 ## API
 
 ## Lua
+- ``argparse.boolean``: convert arguments to lua boolean values.
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3538,6 +3538,12 @@ parameters.
   ``tonumber(arg)``. If ``arg_name`` is specified, it is used to make error
   messages more useful.
 
+* ``argparse.boolean(arg, arg_name)``
+  Converts ``string.lower(arg)`` from "yes/no/on/off/true/false/etc..." to a lua
+  boolean. Throws if the value can't be converted, otherwise returns
+  ``true``/``false``. If ``arg_name`` is specified, it is used to make error
+  messages more useful.
+
 dumper
 ======
 

--- a/library/lua/argparse.lua
+++ b/library/lua/argparse.lua
@@ -196,4 +196,17 @@ function coords(arg, arg_name, skip_validation)
     return pos
 end
 
+function boolean(arg, arg_name)
+    local toBool={["true"]=true,["yes"]=true,["y"]=true,["on"]=true,["1"]=true,
+                  ["false"]=false,["no"]=false,["n"]=false,["off"]=false,["0"]=false}
+
+    arg = string.lower(arg)
+    if toBool[arg] == nil then
+        arg_error(arg_name,
+            'unknown value: "%s"; expected "true", "yes", "false", or "no"')
+    end
+
+    return toBool[arg]
+end
+
 return _ENV

--- a/library/lua/argparse.lua
+++ b/library/lua/argparse.lua
@@ -196,17 +196,16 @@ function coords(arg, arg_name, skip_validation)
     return pos
 end
 
+local toBool={["true"]=true,["yes"]=true,["y"]=true,["on"]=true,["1"]=true,
+              ["false"]=false,["no"]=false,["n"]=false,["off"]=false,["0"]=false}
 function boolean(arg, arg_name)
-    local toBool={["true"]=true,["yes"]=true,["y"]=true,["on"]=true,["1"]=true,
-                  ["false"]=false,["no"]=false,["n"]=false,["off"]=false,["0"]=false}
-
-    arg = string.lower(arg)
-    if toBool[arg] == nil then
+    local arg_lower = string.lower(arg)
+    if toBool[arg_lower] == nil then
         arg_error(arg_name,
-            'unknown value: "%s"; expected "true", "yes", "false", or "no"')
+            'unknown value: "%s"; expected "true", "yes", "false", or "no"', arg)
     end
 
-    return toBool[arg]
+    return toBool[arg_lower]
 end
 
 return _ENV


### PR DESCRIPTION
Implementing a boolean parser function for `argparse`

Accepts a "truthy" value like "yes" , "no",  "true", etc. and converts it to a lua boolean value. Throws an appropriate error should the value not be accepted.

Was discussing this on discord and thought it might be simple but useful addition to `argparse.`
(still needs docs update and likely further improvements)