### PR TITLE
[buildingplan] move the dimensions readout out from under the heat safety filter

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `buildingplan`: make the construction dimensions readout visible again
 
 ## Misc Improvements
 

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -478,7 +478,7 @@ function PlannerOverlay:init()
             end,
         },
         widgets.Label{
-            frame={b=2, l=23},
+            frame={b=4, l=23},
             text_pen=COLOR_DARKGREY,
             text={
                 'Selected area: ',


### PR DESCRIPTION
the reinstated the heat safety filter unintentionally covered the dimensions readout widget, which had moved to the same screen space in the time that the heat safety filter was hidden.

this PR moves the dimension readout into the upper panel where there is free space

![image](https://github.com/DFHack/dfhack/assets/977482/1297228a-72ad-4a04-9c75-37042e7f8154)