### PR TITLE
[seedwatch] fix crash on bad seed ids in configs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ Template for new versions:
 
 ## Fixes
 - `buildingplan`: make the construction dimensions readout visible again
+- `seedwatch`: fix a crash when reading data saved by very very old versions of the plugin
 
 ## Misc Improvements
 - `sort`: sort by need for training on squad assignment screen

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -103,6 +103,10 @@ static bool validate_seed_config(color_ostream& out, PersistentDataItem c)
 {
     int seed_id = get_config_val(c, SEED_CONFIG_ID);
     auto plant = binsearch_in_vector(world->raws.plants.all, &df::plant_raw::index, seed_id);
+    if (!plant) {
+        WARN(config, out).print("discarded invalid seed id: %d\n", seed_id);
+        return false;
+    }
     bool valid = (!plant->flags.is_set(df::enums::plant_raw_flags::TREE));
     if (!valid) {
         DEBUG(config, out).print("invalid configuration for %s discarded\n", plant->id.c_str());

--- a/plugins/seedwatch.cpp
+++ b/plugins/seedwatch.cpp
@@ -102,7 +102,7 @@ static void remove_seed_config(color_ostream &out, int id) {
 static bool validate_seed_config(color_ostream& out, PersistentDataItem c)
 {
     int seed_id = get_config_val(c, SEED_CONFIG_ID);
-    auto plant = binsearch_in_vector(world->raws.plants.all, &df::plant_raw::index, seed_id);
+    auto plant = df::plant_raw::find(seed_id);
     if (!plant) {
         WARN(config, out).print("discarded invalid seed id: %d\n", seed_id);
         return false;


### PR DESCRIPTION
reported on Bay 12 forums: http://www.bay12forums.com/smf/index.php?topic=164123.msg8499609#msg8499609

seedwatch crashes when reading config data with invalid seed ids. the very first v50 seedwatch plugin did not record the seed id properly, and unlucky players who happened to use that version to save their game run into this crash.