### PR TITLE
[dig] add ASCII-mode highlight for smoothing and carving designations

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -54,6 +54,7 @@ Template for new versions:
 ## New Tools
 
 ## New Features
+- `dig`: new overlay for ASCII mode that visualizes designations for smoothing, engraving, carving tracks, and carving fortifications
 
 ## Fixes
 - `buildingplan`: make the construction dimensions readout visible again

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -183,8 +183,19 @@ After you have a pattern set, you can use ``expdig`` to apply it again.
 Overlay
 -------
 
-This tool also provides an overlay that is managed by the `overlay` framework.
-When the ``dig.asciiwarmdamp`` overlay is enabled and you are in non-graphics
-(ASCII) mode, warm tiles will be highlighted in red and damp tiles will be
-highlighted in blue. Box selection characters and the keyboard cursor will also
+This tool also provides two overlays that are managed by the `overlay`
+framework. Both have no effect when in graphics mode, but when in ASCII mode,
+they display useful highlights that are otherwise missing from the ASCII mode
+interface.
+
+The ``dig.asciiwarmdamp`` overlay highlights warm tiles red and damp tiles in
+blue. Box selection characters and the keyboard cursor will also
 change color as appropriate when over the warm or damp tile.
+
+The ``dig.asciicarve`` overlay highlights tiles that are designated for
+smoothing, engraving, track carving, or fortification carving. The designations
+blink so you can still see what is underneath them.
+
+Note that due to the limitations of the ASCII mode screen buffer, the
+designation highlights may show through other interface elements that overlap
+the designated area.

--- a/library/include/modules/Maps.h
+++ b/library/include/modules/Maps.h
@@ -293,13 +293,13 @@ extern DFHACK_EXPORT df::tiletype *getTileType(int32_t x, int32_t y, int32_t z);
 extern DFHACK_EXPORT df::tile_designation *getTileDesignation(int32_t x, int32_t y, int32_t z);
 extern DFHACK_EXPORT df::tile_occupancy *getTileOccupancy(int32_t x, int32_t y, int32_t z);
 
-inline df::tiletype *getTileType(df::coord pos) {
+inline df::tiletype *getTileType(const df::coord &pos) {
     return getTileType(pos.x, pos.y, pos.z);
 }
-inline df::tile_designation *getTileDesignation(df::coord pos) {
+inline df::tile_designation *getTileDesignation(const df::coord &pos) {
     return getTileDesignation(pos.x, pos.y, pos.z);
 }
-inline df::tile_occupancy *getTileOccupancy(df::coord pos) {
+inline df::tile_occupancy *getTileOccupancy(const df::coord &pos) {
     return getTileOccupancy(pos.x, pos.y, pos.z);
 }
 

--- a/plugins/lua/dig.lua
+++ b/plugins/lua/dig.lua
@@ -20,10 +20,30 @@ WarmDampOverlay.ATTRS{
     overlay_only=true,
 }
 
-function WarmDampOverlay:onRenderFrame(dc)
+function WarmDampOverlay:onRenderFrame()
     pathable.paintScreenWarmDamp()
 end
 
-OVERLAY_WIDGETS = {asciiwarmdamp=WarmDampOverlay}
+CarveOverlay = defclass(CarveOverlay, overlay.OverlayWidget)
+CarveOverlay.ATTRS{
+    viewscreens={
+        'dwarfmode/Designate/SMOOTH',
+        'dwarfmode/Designate/ENGRAVE',
+        'dwarfmode/Designate/TRACK',
+        'dwarfmode/Designate/FORTIFY',
+        'dwarfmode/Designate/ERASE',
+    },
+    default_enabled=true,
+    overlay_only=true,
+}
+
+function CarveOverlay:onRenderFrame()
+    pathable.paintScreenCarve()
+end
+
+OVERLAY_WIDGETS = {
+    asciiwarmdamp=WarmDampOverlay,
+    asciicarve=CarveOverlay,
+}
 
 return _ENV

--- a/plugins/pathable.cpp
+++ b/plugins/pathable.cpp
@@ -284,7 +284,7 @@ static char get_tile_char(const df::coord &pos, char desig_char, bool draw_prior
     std::vector<df::block_square_event_designation_priorityst *> priorities;
     Maps::SortBlockEvents(Maps::getTileBlock(pos), NULL, NULL, NULL, NULL, NULL, NULL, NULL, &priorities);
     if (priorities.empty())
-        return '4';
+        return desig_char;
     switch (priorities[0]->priority[pos.x % 16][pos.y % 16] / 1000) {
     case 1: return '1';
     case 2: return '2';
@@ -294,7 +294,7 @@ static char get_tile_char(const df::coord &pos, char desig_char, bool draw_prior
     case 6: return '6';
     case 7: return '7';
     default:
-        return '0';
+        return '4';
     }
 }
 

--- a/plugins/pathable.cpp
+++ b/plugins/pathable.cpp
@@ -231,6 +231,41 @@ static bool is_designated_for_track_carving(const df::coord &pos) {
     return occ->bits.carve_track_east || occ->bits.carve_track_north || occ->bits.carve_track_south || occ->bits.carve_track_west;
 }
 
+static char get_track_char(const df::coord &pos) {
+    auto occ = Maps::getTileOccupancy(pos);
+    if (occ->bits.carve_track_east && occ->bits.carve_track_north && occ->bits.carve_track_south && occ->bits.carve_track_west)
+        return 0xCE; // NSEW
+    if (occ->bits.carve_track_east && occ->bits.carve_track_north && occ->bits.carve_track_south)
+        return 0xCC; // NSE
+    if (occ->bits.carve_track_east && occ->bits.carve_track_north && occ->bits.carve_track_west)
+        return 0xCA; // NEW
+    if (occ->bits.carve_track_east && occ->bits.carve_track_south && occ->bits.carve_track_west)
+        return 0xCB; // SEW
+    if (occ->bits.carve_track_north && occ->bits.carve_track_south && occ->bits.carve_track_west)
+        return 0xB9; // NSW
+    if (occ->bits.carve_track_north && occ->bits.carve_track_south)
+        return 0xBA; // NS
+    if (occ->bits.carve_track_east && occ->bits.carve_track_west)
+        return 0xCD; // EW
+    if (occ->bits.carve_track_east && occ->bits.carve_track_north)
+        return 0xC8; // NE
+    if (occ->bits.carve_track_north && occ->bits.carve_track_west)
+        return 0xBC; // NW
+    if (occ->bits.carve_track_east && occ->bits.carve_track_south)
+        return 0xC9; // SE
+    if (occ->bits.carve_track_south && occ->bits.carve_track_west)
+        return 0xBB; // SW
+    if (occ->bits.carve_track_north)
+        return 0xD0; // N
+    if (occ->bits.carve_track_south)
+        return 0xD2; // S
+    if (occ->bits.carve_track_east)
+        return 0xC6; // E
+    if (occ->bits.carve_track_west)
+        return 0xB5; // W
+    return 0xC5; // single line cross; should never happen
+}
+
 static bool is_smooth_wall(const df::coord &pos) {
     df::tiletype *tt = Maps::getTileType(pos);
     return tt && tileSpecial(*tt) == df::tiletype_special::SMOOTH
@@ -268,15 +303,15 @@ static void paintScreenCarve() {
 
             if (is_designated_for_smoothing(map_pos)) {
                 if (is_smooth_wall(map_pos))
-                    cur_tile.ch = 206; // hash, indicating a fortification designation
+                    cur_tile.ch = (char)206; // hash, indicating a fortification designation
                 else
-                    cur_tile.ch = 219; // solid block, indicating a smoothing designation
+                    cur_tile.ch = (char)219; // solid block, indicating a smoothing designation
             }
             else if (is_designated_for_engraving(map_pos)) {
-                cur_tile.ch = 10; // solid block with a circle on it
+                cur_tile.ch = (char)10; // solid block with a circle on it
             }
             else if (is_designated_for_track_carving(map_pos)) {
-                cur_tile.ch = 186; // parallel tracks
+                cur_tile.ch = get_track_char(map_pos); // directional track
             }
             else {
                 TRACE(log).print("skipping tile with no carving designation\n");

--- a/plugins/pathable.cpp
+++ b/plugins/pathable.cpp
@@ -235,36 +235,36 @@ static bool is_designated_for_track_carving(const df::coord &pos) {
 static char get_track_char(const df::coord &pos) {
     auto occ = Maps::getTileOccupancy(pos);
     if (occ->bits.carve_track_east && occ->bits.carve_track_north && occ->bits.carve_track_south && occ->bits.carve_track_west)
-        return 0xCE; // NSEW
+        return (char)0xCE; // NSEW
     if (occ->bits.carve_track_east && occ->bits.carve_track_north && occ->bits.carve_track_south)
-        return 0xCC; // NSE
+        return (char)0xCC; // NSE
     if (occ->bits.carve_track_east && occ->bits.carve_track_north && occ->bits.carve_track_west)
-        return 0xCA; // NEW
+        return (char)0xCA; // NEW
     if (occ->bits.carve_track_east && occ->bits.carve_track_south && occ->bits.carve_track_west)
-        return 0xCB; // SEW
+        return (char)0xCB; // SEW
     if (occ->bits.carve_track_north && occ->bits.carve_track_south && occ->bits.carve_track_west)
-        return 0xB9; // NSW
+        return (char)0xB9; // NSW
     if (occ->bits.carve_track_north && occ->bits.carve_track_south)
-        return 0xBA; // NS
+        return (char)0xBA; // NS
     if (occ->bits.carve_track_east && occ->bits.carve_track_west)
-        return 0xCD; // EW
+        return (char)0xCD; // EW
     if (occ->bits.carve_track_east && occ->bits.carve_track_north)
-        return 0xC8; // NE
+        return (char)0xC8; // NE
     if (occ->bits.carve_track_north && occ->bits.carve_track_west)
-        return 0xBC; // NW
+        return (char)0xBC; // NW
     if (occ->bits.carve_track_east && occ->bits.carve_track_south)
-        return 0xC9; // SE
+        return (char)0xC9; // SE
     if (occ->bits.carve_track_south && occ->bits.carve_track_west)
-        return 0xBB; // SW
+        return (char)0xBB; // SW
     if (occ->bits.carve_track_north)
-        return 0xD0; // N
+        return (char)0xD0; // N
     if (occ->bits.carve_track_south)
-        return 0xD2; // S
+        return (char)0xD2; // S
     if (occ->bits.carve_track_east)
-        return 0xC6; // E
+        return (char)0xC6; // E
     if (occ->bits.carve_track_west)
-        return 0xB5; // W
-    return 0xC5; // single line cross; should never happen
+        return (char)0xB5; // W
+    return (char)0xC5; // single line cross; should never happen
 }
 
 static bool is_smooth_wall(const df::coord &pos) {
@@ -327,12 +327,12 @@ static void paintScreenCarve() {
 
             if (is_designated_for_smoothing(map_pos)) {
                 if (is_smooth_wall(map_pos))
-                    cur_tile.ch = get_tile_char(map_pos, 206, draw_priority); // hash, indicating a fortification designation
+                    cur_tile.ch = get_tile_char(map_pos, (char)206, draw_priority); // hash, indicating a fortification designation
                 else
-                    cur_tile.ch = get_tile_char(map_pos, 219, draw_priority); // solid block, indicating a smoothing designation
+                    cur_tile.ch = get_tile_char(map_pos, (char)219, draw_priority); // solid block, indicating a smoothing designation
             }
             else if (is_designated_for_engraving(map_pos)) {
-                cur_tile.ch = get_tile_char(map_pos, 10, draw_priority); // solid block with a circle on it
+                cur_tile.ch = get_tile_char(map_pos, (char)10, draw_priority); // solid block with a circle on it
             }
             else if (is_designated_for_track_carving(map_pos)) {
                 cur_tile.ch = get_tile_char(map_pos, get_track_char(map_pos), draw_priority); // directional track


### PR DESCRIPTION
graphics: 
![image](https://github.com/DFHack/dfhack/assets/977482/ff52d789-a389-426d-84e3-7cb5ae3b358a)

new ascii highlights:
![ascii_smooth](https://github.com/DFHack/dfhack/assets/977482/e832a3ae-85e1-4c75-943c-1c267696d1ff)
