### PR TITLE
[Gui] differentiate the new region loading screen in the focus string

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 ## Fixes
 - `buildingplan`: make the construction dimensions readout visible again
 - `seedwatch`: fix a crash when reading data saved by very very old versions of the plugin
+- `gui/mod-manager`: don't continue to display overlay after the raws loading progress bar appears
 
 ## Misc Improvements
 - `sort`: sort by need for training on squad assignment screen

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -161,7 +161,9 @@ DEFINE_GET_FOCUS_STRING_HANDLER(title)
 
 DEFINE_GET_FOCUS_STRING_HANDLER(new_region)
 {
-    if (screen->doing_mods)
+    if (screen->raw_load)
+        focusStrings.push_back(baseFocus + "/Loading");
+    else if (screen->doing_mods)
         focusStrings.push_back(baseFocus + "/Mods");
     else if (screen->doing_simple_params)
         focusStrings.push_back(baseFocus + "/Basic");


### PR DESCRIPTION
so the mod manager overlay doesn't continue to get displayed even after the progress bar has come up and the world is being generated