### PR TITLE
[pathable] let vanilla blinking take over when possible

### DIFF
--- a/plugins/pathable.cpp
+++ b/plugins/pathable.cpp
@@ -5,6 +5,7 @@
 
 #include "modules/EventManager.h"
 #include "modules/Gui.h"
+#include "modules/Job.h"
 #include "modules/Maps.h"
 #include "modules/Screen.h"
 #include "modules/Textures.h"
@@ -255,9 +256,13 @@ public:
 
             df::tile_designation td;
             df::tile_occupancy to;
+            bool keep_if_taken = false;
+
             switch (job->job_type) {
                 case df::job_type::SmoothWall:
                 case df::job_type::SmoothFloor:
+                    keep_if_taken = true;
+                    // fallthrough
                 case df::job_type::CarveFortification:
                     td.bits.smooth = 1;
                     break;
@@ -272,9 +277,10 @@ public:
                     to.bits.carve_track_east = (job->item_category.whole >> 21) & 1;
                     break;
                 default:
-                    break;
+                    continue;
             }
-            designations.emplace(job->pos, designation(job->pos, td, to));
+            if (keep_if_taken || !Job::getWorker(job))
+                designations.emplace(job->pos, designation(job->pos, td, to));
         }
     }
 


### PR DESCRIPTION
vanilla handles blinking for fortifications, engraving, and carving tracks when the jobs for those tasks are staffed. let vanilla do its thing when it's doing a thing. we'll just blink when vanilla doesn't