### PR TITLE
Use SDL_ShowSimpleMessageBox in Core::fatal()

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1459,12 +1459,9 @@ void Core::fatal (std::string output)
         con.print("\n");
     }
     fprintf(stderr, "%s\n", out.str().c_str());
-#ifndef LINUX_BUILD
-    out << "Check file stderr.log for details\n";
-    MessageBox(0,out.str().c_str(),"DFHack error!", MB_OK | MB_ICONERROR);
-#else
+    out << "Check file stderr.log for details.\n";
     std::cout << "DFHack fatal error: " << out.str() << std::endl;
-#endif
+    DFSDL::DFSDL_ShowSimpleMessageBox(0x10 /* SDL_MESSAGEBOX_ERROR */, "DFHack error!", out.str().c_str(), NULL);
 
     bool is_headless = bool(getenv("DFHACK_HEADLESS"));
     if (is_headless)
@@ -1505,6 +1502,12 @@ bool Core::InitMainThread() {
 
     std::cerr << "DFHack build: " << Version::git_description() << "\n"
          << "Starting with working directory: " << Filesystem::getcwd() << std::endl;
+
+    std::cerr << "Binding to SDL.\n";
+    if (!DFSDL::init(con)) {
+        fatal("cannot bind SDL libraries");
+        return false;
+    }
 
     // find out what we are...
     #ifdef LINUX_BUILD
@@ -1692,11 +1695,6 @@ bool Core::InitSimulationThread()
         return false;
     }
 
-    std::cerr << "Binding to SDL.\n";
-    if (!DFSDL::init(con)) {
-        fatal("cannot bind SDL libraries");
-        return false;
-    }
     if (DFSteam::init(con)) {
         std::cerr << "Found Steam.\n";
         DFSteam::launchSteamDFHackIfNecessary(con);

--- a/library/include/modules/DFSDL.h
+++ b/library/include/modules/DFSDL.h
@@ -6,6 +6,7 @@
 struct SDL_Surface;
 struct SDL_Rect;
 struct SDL_PixelFormat;
+struct SDL_Window;
 union SDL_Event;
 
 namespace DFHack
@@ -50,6 +51,7 @@ DFHACK_EXPORT int DFSDL_PushEvent(SDL_Event *event);
 DFHACK_EXPORT void DFSDL_free(void *ptr);
 DFHACK_EXPORT SDL_PixelFormat* DFSDL_AllocFormat(uint32_t pixel_format);
 DFHACK_EXPORT SDL_Surface* DFSDL_CreateRGBSurfaceWithFormat(uint32_t flags, int width, int height, int depth, uint32_t format);
+DFHACK_EXPORT int DFSDL_ShowSimpleMessageBox(uint32_t flags, const char *title, const char *message, SDL_Window *window);
 
 // submitted and returned text is UTF-8
 // see wrapper functions below for cp-437 variants

--- a/library/modules/DFSDL.cpp
+++ b/library/modules/DFSDL.cpp
@@ -162,6 +162,8 @@ SDL_Surface* DFSDL::DFSDL_CreateRGBSurfaceWithFormat(uint32_t flags, int width, 
 }
 
 int DFSDL::DFSDL_ShowSimpleMessageBox(uint32_t flags, const char *title, const char *message, SDL_Window *window) {
+    if (!g_SDL_ShowSimpleMessageBox)
+        return -1;
     return g_SDL_ShowSimpleMessageBox(flags, title, message, window);
 }
 

--- a/library/modules/DFSDL.cpp
+++ b/library/modules/DFSDL.cpp
@@ -43,6 +43,7 @@ char * (*g_SDL_GetClipboardText)();
 void (*g_SDL_free)(void *);
 SDL_PixelFormat* (*g_SDL_AllocFormat)(uint32_t pixel_format) = nullptr;
 SDL_Surface* (*g_SDL_CreateRGBSurfaceWithFormat)(uint32_t flags, int width, int height, int depth, uint32_t format) = nullptr;
+int (*g_SDL_ShowSimpleMessageBox)(uint32_t flags, const char *title, const char *message, SDL_Window *window) = nullptr;
 
 bool DFSDL::init(color_ostream &out) {
     for (auto &lib_str : SDL_LIBS) {
@@ -85,6 +86,7 @@ bool DFSDL::init(color_ostream &out) {
     bind(g_sdl_handle, SDL_free);
     bind(g_sdl_handle, SDL_AllocFormat);
     bind(g_sdl_handle, SDL_CreateRGBSurfaceWithFormat);
+    bind(g_sdl_handle, SDL_ShowSimpleMessageBox);
 #undef bind
 
     DEBUG(dfsdl,out).print("sdl successfully loaded\n");
@@ -159,6 +161,9 @@ SDL_Surface* DFSDL::DFSDL_CreateRGBSurfaceWithFormat(uint32_t flags, int width, 
     return g_SDL_CreateRGBSurfaceWithFormat(flags, width, height, depth, format);
 }
 
+int DFSDL::DFSDL_ShowSimpleMessageBox(uint32_t flags, const char *title, const char *message, SDL_Window *window) {
+    return g_SDL_ShowSimpleMessageBox(flags, title, message, window);
+}
 
 DFHACK_EXPORT std::string DFHack::getClipboardTextCp437() {
     if (!g_sdl_handle || g_SDL_HasClipboardText() != SDL_TRUE)


### PR DESCRIPTION
This allows the message to be displayed consistently in a dialog on all platforms.

![image](https://github.com/DFHack/dfhack/assets/3719547/1e26b16c-c023-43b9-932e-419a8719c260)
