### PR TITLE
Adjusted behaviour of "digtype" to only designate non-hidden squares, and designate them as auto-dig

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `dig`: `digtype` command now has options to choose between designating only visible tiles or hidden tiles, as well as "auto" dig mode. Z-level options adjusted to allow choosing z-levels above, below, or the same as the cursor.
 
 ## Documentation
 

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -50,7 +50,7 @@ Usage
     Designate circles. The diameter is the number of tiles across the center of
     the circle that you want to dig. See the `digcircle`_ section below for
     options.
-``digtype [<designation>] [-p<number>] [-z]``
+``digtype [<designation>] [-p<number>] [--zup|-u] [--zdown|-zu] [--cur-zlevel|-z] [--hidden|-h] [--no-auto|-a]``
     Designate all vein tiles of the same type as the selected tile. See the
     `digtype`_ section below for options.
 ``digexp [<pattern>] [<filter>] [-p<number>]``
@@ -119,9 +119,11 @@ the last selected parameters.
 digtype
 -------
 
-For every tile on the map of the same vein type as the selected tile, this
-command designates it to have the same designation as the selected tile. If the
-selected tile has no designation, they will be dig designated.
+For every tile on the map of the same vein type as the selected tile, this command
+designates it to have the same designation as the selected tile. If the selected
+tile has no designation, they will be dig designated. By default, only designates
+visible tiles, and in the case of dig designation, applies automatic mining to them
+(designates uncovered neighbouring tiles of the same type to be dug).
 
 If an argument is given, the designation of the selected tile is ignored, and
 all appropriate tiles are set to the specified designation.
@@ -143,10 +145,17 @@ Designation options:
 ``clear``
     Clear any designations.
 
-You can also pass a ``-z`` and/or a ``+z``` option, which restricts designations to the
-current z-level and down/up. This is useful when you don't want to designate tiles on the
-same z-levels as your carefully dug fort above/below. To dig only at the current z-level,
-pass in both.
+Other options:
+``--zdown`` or ``-d``
+    Only designates tiles on the cursor's z-level and below
+``--zup`` or ``-u``
+    Only designates tiles on the cursor's z-level and above
+``--cur-zlevel`` or ``-z``
+    Only designates tiles on the same z-level as the cursor
+``--hidden`` or ``-h``
+    Allows designation of hidden tiles, and using a hidden tile as the "palette"
+``--no-auto`` or ``-a``
+    No automatic mining mode designation - useful if you want to avoid dwarves digging where you don't want them
 
 digexp
 ------

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -147,15 +147,15 @@ Designation options:
 
 Other options:
 ``--zdown`` or ``-d``
-    Only designates tiles on the cursor's z-level and below
+    Only designates tiles on the cursor's z-level and below.
 ``--zup`` or ``-u``
-    Only designates tiles on the cursor's z-level and above
+    Only designates tiles on the cursor's z-level and above.
 ``--cur-zlevel`` or ``-z``
-    Only designates tiles on the same z-level as the cursor
+    Only designates tiles on the same z-level as the cursor.
 ``--hidden`` or ``-h``
-    Allows designation of hidden tiles, and using a hidden tile as the "palette"
+    Allows designation of hidden tiles, and using a hidden tile as the "palette".
 ``--no-auto`` or ``-a``
-    No automatic mining mode designation - useful if you want to avoid dwarves digging where you don't want them
+    No automatic mining mode designation - useful if you want to avoid dwarves digging where you don't want them.
 
 digexp
 ------

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -146,15 +146,15 @@ Designation options:
     Clear any designations.
 
 Other options:
-``--zdown`` or ``-d``
+``--zdown``, ``-d``
     Only designates tiles on the cursor's z-level and below.
-``--zup`` or ``-u``
+``--zup``, ``-u``
     Only designates tiles on the cursor's z-level and above.
-``--cur-zlevel`` or ``-z``
+``--cur-zlevel``, ``-z``
     Only designates tiles on the same z-level as the cursor.
-``--hidden`` or ``-h``
+``--hidden``, ``-h``
     Allows designation of hidden tiles, and using a hidden tile as the "palette".
-``--no-auto`` or ``-a``
+``--no-auto``, ``-a``
     No automatic mining mode designation - useful if you want to avoid dwarves digging where you don't want them.
 
 digexp

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -146,6 +146,7 @@ Designation options:
     Clear any designations.
 
 Other options:
+
 ``--zdown``, ``-d``
     Only designates tiles on the cursor's z-level and below.
 ``--zup``, ``-u``

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -154,7 +154,7 @@ Other options:
 ``--cur-zlevel``, ``-z``
     Only designates tiles on the same z-level as the cursor.
 ``--hidden``, ``-h``
-    Allows designation of hidden tiles, and using a hidden tile as the "palette".
+    Allows designation of hidden tiles, and picking a hidden tile as the target type.
 ``--no-auto``, ``-a``
     No automatic mining mode designation - useful if you want to avoid dwarves digging where you don't want them.
 

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -143,9 +143,10 @@ Designation options:
 ``clear``
     Clear any designations.
 
-You can also pass a ``-z`` option, which restricts designations to the current
-z-level and down. This is useful when you don't want to designate tiles on the
-same z-levels as your carefully dug fort above.
+You can also pass a ``-z`` and/or a ``+z``` option, which restricts designations to the
+current z-level and down/up. This is useful when you don't want to designate tiles on the
+same z-levels as your carefully dug fort above/below. To dig only at the current z-level,
+pass in both.
 
 digexp
 ------

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -1489,8 +1489,10 @@ command_result digtype (color_ostream &out, vector <string> & parameters)
             baseDes.bits.dig = tile_dig_designation::Default;
         }
     }
-
-    baseOcc.bits.dig_auto = true;
+    // Auto dig only works on default dig designation. Setting dig_auto for any other designation
+    // prevents dwarves from digging that tile at all.
+    if (baseDes.bits.dig == tile_dig_designation::Default) baseOcc.bits.dig_auto = true;
+    else baseOcc.bits.dig_auto = false; 
 
     for( uint32_t z = 0; z < zMax; z++ )
     {

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -1424,6 +1424,8 @@ command_result digtype (color_ostream &out, vector <string> & parameters)
     uint32_t xMax,yMax,zMax;
     Maps::getSize(xMax,yMax,zMax);
 
+    uint32_t zMin = 0;
+
     int32_t targetDigType = -1;
     for (string parameter : parameters) {
         if ( parameter == "clear" )
@@ -1442,6 +1444,8 @@ command_result digtype (color_ostream &out, vector <string> & parameters)
             targetDigType = tile_dig_designation::UpStair;
         else if ( parameter == "-z" )
             zMax = *window_z + 1;
+        else if ( parameter == "+z")
+            zMin = *window_z;
         else
         {
             out.printerr("Invalid parameter: '%s'.\n", parameter.c_str());
@@ -1494,7 +1498,7 @@ command_result digtype (color_ostream &out, vector <string> & parameters)
     if (baseDes.bits.dig == tile_dig_designation::Default) baseOcc.bits.dig_auto = true;
     else baseOcc.bits.dig_auto = false; 
 
-    for( uint32_t z = 0; z < zMax; z++ )
+    for( uint32_t z = zMin; z < zMax; z++ )
     {
         for( uint32_t x = 1; x < tileXMax-1; x++ )
         {

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -1496,7 +1496,7 @@ command_result digtype (color_ostream &out, vector <string> & parameters)
     // Auto dig only works on default dig designation. Setting dig_auto for any other designation
     // prevents dwarves from digging that tile at all.
     if (baseDes.bits.dig == tile_dig_designation::Default) baseOcc.bits.dig_auto = true;
-    else baseOcc.bits.dig_auto = false; 
+    else baseOcc.bits.dig_auto = false;
 
     for( uint32_t z = zMin; z < zMax; z++ )
     {

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -1421,11 +1421,10 @@ command_result digtype (color_ostream &out, vector <string> & parameters)
         return CR_FAILURE;
     }
 
+    uint32_t zMin = 0;
     uint32_t xMax,yMax,zMax;
     Maps::getSize(xMax,yMax,zMax);
 
-    uint32_t zMin = 0;
-    
     bool hidden = false;
     bool automine = true;
 


### PR DESCRIPTION
The current behaviour of `digtype` designates all tiles on the map of the same type, regardless of visibility. The player might not want to have the locations of all the veins revealed to them, so designating visible veins of that type as "auto-dig" is probably more desirable and useful behaviour for players. I also took the liberty of adding a new option `+z` to this command which is analogous to the existing `-z` option but to only dig layers above. (Hence, the player can combine the two to only dig at the same z-level as the cursor).

Note that for designations other than the default we can't set them to autodig, it simply does not work. So the dig_auto flag is only set if the designation is default.