### PR TITLE
enable fortress mode tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,9 @@ jobs:
       if: matrix.os == 'ubuntu'
       run: |
         sudo apt-get update
-        sudo apt-get install libsdl2-dev libsdl2-image-dev
+        sudo apt-get install \
+          libsdl2-2.0-0 \
+          libsdl2-image-2.0-0
     - name: Clone DFHack
       uses: actions/checkout@v3
       with:
@@ -121,8 +123,13 @@ jobs:
     - name: Install DFHack
       shell: bash
       run: tar xjf test-${{ matrix.compiler }}.tar.bz2 -C ${{ env.DF_FOLDER }}
+    - name: Start X server
+      if: matrix.os == 'ubuntu'
+      run: Xvfb :0 -screen 0 1600x1200x32 &
     - name: Run lua tests
       timeout-minutes: 10
+      env:
+        DISPLAY: :0
       run: python ci/run-tests.py --keep-status "${{ env.DF_FOLDER }}"
     - name: Check RPC interface
       run: python ci/check-rpc.py "${{ env.DF_FOLDER }}/dfhack-rpc.txt"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,11 @@ jobs:
     - name: Set env
       shell: bash
       run: echo "DF_FOLDER=DF" >> $GITHUB_ENV
+    - name: Install dependencies
+      if: matrix.os == 'ubuntu'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libsdl2-dev libsdl2-image-dev
     - name: Clone DFHack
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
       run: tar xjf test-${{ matrix.compiler }}.tar.bz2 -C ${{ env.DF_FOLDER }}
     - name: Start X server
       if: matrix.os == 'ubuntu'
-      run: Xvfb :0 -screen 0 1600x1200x32 &
+      run: Xvfb :0 -screen 0 1600x1200x24 &
     - name: Run lua tests
       timeout-minutes: 10
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,15 +67,14 @@ jobs:
             compiler: msvc
             plugins: "default"
             config: "empty"
-          # TODO: uncomment once we have a linux build we can download from bay12
-          # - os: ubuntu
-          #   compiler: gcc-10
-          #   plugins: "default"
-          #   config: "default"
-          # - os: ubuntu
-          #   compiler: gcc-12
-          #   plugins: "all"
-          #   config: "default"
+          - os: ubuntu
+            compiler: gcc-10
+            plugins: "default"
+            config: "default"
+          - os: ubuntu
+            compiler: gcc-12
+            plugins: "all"
+            config: "default"
     steps:
     - name: Set env
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,7 @@ jobs:
       timeout-minutes: 10
       env:
         DISPLAY: :0
+        TERM: xterm-256color
       run: python ci/run-tests.py --keep-status "${{ env.DF_FOLDER }}"
     - name: Check RPC interface
       run: python ci/check-rpc.py "${{ env.DF_FOLDER }}/dfhack-rpc.txt"

--- a/ci/download-df.sh
+++ b/ci/download-df.sh
@@ -18,7 +18,7 @@ elif test "$OS_TARGET" = "ubuntu"; then
     WGET=wget
     df_url="${df_url}_linux.tar.bz2"
     df_archive_name="df.tar.bz2"
-    df_extract_cmd="tar -x -j --strip-components=1 -f"
+    df_extract_cmd="tar -x -j -C ${DF_FOLDER} -f"
 else
     echo "Unhandled OS target: ${OS_TARGET}"
     exit 1
@@ -29,22 +29,25 @@ if ! $WGET -v "$df_url" -O "$df_archive_name"; then
     exit 1
 fi
 
+md5sum "$df_archive_name"
+
 save_url="https://dffd.bay12games.com/download.php?id=15434&f=dreamfort.7z"
 save_archive_name="test_save.7z"
-save_extract_cmd="7z x -oDF/save"
+save_extract_cmd="7z x -o${DF_FOLDER}/save"
 
 if ! $WGET -v "$save_url" -O "$save_archive_name"; then
     echo "Failed to download test save from $save_url"
     exit 1
 fi
 
+md5sum "$save_archive_name"
+
 echo Extracting
+mkdir -p ${DF_FOLDER}
 $df_extract_cmd "$df_archive_name"
 $save_extract_cmd "$save_archive_name"
-mv DF/save/* DF/save/region1
+mv ${DF_FOLDER}/save/* ${DF_FOLDER}/save/region1
 
 echo Done
 
 ls -l
-
-md5sum "$df_archive_name" "$save_archive_name"

--- a/ci/run-tests.py
+++ b/ci/run-tests.py
@@ -31,7 +31,7 @@ if args.test_dir is not None:
     if not os.path.isdir(args.test_dir):
         print('ERROR: invalid test folder: %r' % args.test_dir)
 
-MAX_TRIES = 5
+MAX_TRIES = 1
 
 dfhack = 'Dwarf Fortress.exe' if sys.platform == 'win32' else './dfhack'
 test_status_file = 'test_status.json'

--- a/ci/run-tests.py
+++ b/ci/run-tests.py
@@ -65,14 +65,12 @@ if not os.path.exists(init_txt_path):
 shutil.copyfile(init_txt_path, init_txt_path + '.orig')
 with open(init_txt_path) as f:
     init_contents = f.read()
-init_contents = change_setting(init_contents, 'INTRO', 'NO')
 init_contents = change_setting(init_contents, 'SOUND', 'NO')
 init_contents = change_setting(init_contents, 'WINDOWED', 'YES')
-init_contents = change_setting(init_contents, 'WINDOWEDX', '80')
-init_contents = change_setting(init_contents, 'WINDOWEDY', '25')
-init_contents = change_setting(init_contents, 'FPS', 'YES')
-if args.headless:
-    init_contents = change_setting(init_contents, 'PRINT_MODE', 'TEXT')
+init_contents = change_setting(init_contents, 'WINDOWEDX', '1200')
+init_contents = change_setting(init_contents, 'WINDOWEDY', '800')
+#if args.headless:
+#    init_contents = change_setting(init_contents, 'PRINT_MODE', 'TEXT')
 
 init_path = 'dfhack-config/init'
 if not os.path.isdir('hack/init'):

--- a/ci/run-tests.py
+++ b/ci/run-tests.py
@@ -31,7 +31,7 @@ if args.test_dir is not None:
     if not os.path.isdir(args.test_dir):
         print('ERROR: invalid test folder: %r' % args.test_dir)
 
-MAX_TRIES = 1
+MAX_TRIES = 5
 
 dfhack = 'Dwarf Fortress.exe' if sys.platform == 'win32' else './dfhack'
 test_status_file = 'test_status.json'

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -220,6 +220,7 @@ local function click_top_title_button(scr)
     else
         df.global.gps.mouse_y = (sh // 2) + 1
     end
+    print(('simulating click at screen coordinates %d, %d'):format(df.global.gps.mouse_x, df.global.gps.mouse_y))
     df.global.gps.precise_mouse_y = df.global.gps.mouse_y * df.global.gps.tile_pixel_y
     df.global.enabler.tracking_on = 1
     df.global.enabler.mouse_lbut = 1

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -645,12 +645,13 @@ local function run_tests(tests, status, counts, config)
                 goto skip
             end
         end
+        -- pre-emptively mark the test as failed in case we induce a crash
+        status[test.full_name] = TestStatus.FAILED
+        save_test_status(status)
         if run_test(test, status, counts) then
             status[test.full_name] = TestStatus.PASSED
-        else
-            status[test.full_name] = TestStatus.FAILED
+            save_test_status(status)
         end
-        save_test_status(status)
         ::skip::
     end
     local elapsed_ms = dfhack.getTickCount() - start_ms

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -213,7 +213,7 @@ end
 
 local function click_top_title_button(scr)
     local sw, sh = dfhack.screen.getWindowSize()
-    print(('screen dimensions: %d, %d'):format(sw. sh))
+    print(('screen dimensions: %d, %d'):format(sw, sh))
     df.global.gps.mouse_x = sw // 2
     df.global.gps.precise_mouse_x = df.global.gps.mouse_x * df.global.gps.tile_pixel_x
     if sh < 60 then

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -156,19 +156,18 @@ local function is_title_screen()
     return dfhack.gui.matchFocusString('title/Default')
 end
 
-local function wait_for_game_load()
+local function wait_for(ms, desc, predicate)
     local start_ms = dfhack.getTickCount()
     local prev_ms = start_ms
-    while df.viewscreen_initial_prepst:is_instance(dfhack.gui.getDFViewscreen()) do
+    while not predicate() do
         delay(10)
-        -- wait up to 1 minute for the game to load and show the title screen
         local now_ms = dfhack.getTickCount()
-        if now_ms - start_ms > 60000 then
-            qerror(('Could not find title screen (timed out at %s)'):format(
-                dfhack.gui.getCurFocus(true)[1]))
+        if now_ms - start_ms > ms then
+            qerror(('%s took too long (timed out at %s)'):format(
+                desc, dfhack.gui.getCurFocus(true)[1]))
         end
         if now_ms - prev_ms > 1000 then
-            print('Waiting for game to load and show title screen...')
+            print(('Waiting for %s...'):format(desc))
             prev_ms = now_ms
         end
     end
@@ -178,7 +177,6 @@ end
 -- has already loaded a fortress or is in any screen that can't get to the title
 -- screen by sending ESC keys.
 local function ensure_title_screen()
-    wait_for_game_load()
     if df.viewscreen_dwarfmodest:is_instance(dfhack.gui.getDFViewscreen(true)) then
         qerror('Cannot reach title screen from loaded fort')
     end
@@ -208,21 +206,21 @@ local function ensure_ci_save(scr)
         or #scr.savegame_header_world ~= 1
         or not string.find(scr.savegame_header[0].fort_name, 'Dream')
     then
-        qerror('Unexpected test save in slot 0; please manually load a fort for testing. note that tests may corrupt the game!')
+        qerror('Unexpected test save in slot 0; please manually load a fort for ' ..
+            'running fortress mode tests. note that tests may alter or corrupt the ' ..
+            'fort! Do not save after running tests.')
     end
 end
 
 local function click_top_title_button(scr)
     local sw, sh = dfhack.screen.getWindowSize()
-    print(('screen dimensions: %d, %d'):format(sw, sh))
     df.global.gps.mouse_x = sw // 2
     df.global.gps.precise_mouse_x = df.global.gps.mouse_x * df.global.gps.tile_pixel_x
     if sh < 60 then
-        df.global.gps.mouse_y = 23
+        df.global.gps.mouse_y = 25
     else
-        df.global.gps.mouse_y = (sh // 2) + 1
+        df.global.gps.mouse_y = (sh // 2) + 3
     end
-    print(('simulating click at screen coordinates %d, %d'):format(df.global.gps.mouse_x, df.global.gps.mouse_y))
     df.global.gps.precise_mouse_y = df.global.gps.mouse_y * df.global.gps.tile_pixel_y
     df.global.enabler.tracking_on = 1
     df.global.enabler.mouse_lbut = 1
@@ -234,18 +232,25 @@ local function load_first_save(scr)
     if #scr.savegame_header == 0 then
         qerror('no savegames available to load')
     end
-    scr.mode = 2
+
     click_top_title_button(scr)
-    delay()
+    wait_for(1000, 'world list', function()
+        return scr.mode == 2
+    end)
     click_top_title_button(scr)
-    delay()
+    wait_for(1000, 'savegame list', function()
+        return scr.mode == 3
+    end)
+    click_top_title_button(scr)
+    wait_for(1000, 'loadgame progress bar', function()
+        return dfhack.gui.matchFocusString('loadgame')
+    end)
 end
 
 -- Requires that a fortress game is already loaded or is ready to be loaded via
 -- the "Continue active game" option in the title screen. Otherwise the function
 -- will time out and/or exit with error.
 local function ensure_fortress(config)
-    wait_for_game_load()
     for screen_timeout = 1,10 do
         if is_fortress() then
             print('Fortress map is loaded')
@@ -253,8 +258,8 @@ local function ensure_fortress(config)
             dfhack.gui.resetDwarfmodeView(true)
             return
         end
-        local scr = dfhack.gui.getDFViewscreen(true)
-        if dfhack.gui.matchFocusString('title/Default') then
+        local scr = dfhack.gui.getCurViewscreen()
+        if dfhack.gui.matchFocusString('title/Default', scr) then
             print('Attempting to load the test fortress')
             -- TODO: reinstate loading of a specified save dir; for now
             -- just load the first possible save, which will at least let us
@@ -263,29 +268,17 @@ local function ensure_fortress(config)
             -- dfhack.run_script('load-save', config.save_dir)
             ensure_ci_save(scr)
             load_first_save(scr)
-        elseif not dfhack.gui.matchFocusString('loadgame') then
+        elseif not dfhack.gui.matchFocusString('loadgame', scr) then
             -- if we're not actively loading a game, hope we're in
             -- a screen where hitting ESC will get us to the game map
             -- or the title screen
             scr:feed_key(df.interface_key.LEAVESCREEN)
         end
         -- wait for current screen to change
-        local prev_focus_string = dfhack.gui.getCurFocus(true)[1]
-        for frame_timeout = 1,100 do
-            delay(10)
-            local focus_string = dfhack.gui.getCurFocus(true)[1]
-            if focus_string ~= prev_focus_string then
-                goto next_screen
-            end
-            if frame_timeout % 10 == 0 then
-                print(string.format(
-                    'Loading fortress (currently at screen: %s)',
-                    focus_string))
-            end
-        end
-        print('Timed out waiting for screen to change')
-        break
-        ::next_screen::
+        local prev_focus_string = dfhack.gui.getCurFocus()[1]
+        wait_for(60000, 'screen change', function()
+            return dfhack.gui.getCurFocus()[1] ~= prev_focus_string
+        end)
     end
     qerror(string.format('Could not load fortress (timed out at %s)',
                          table.concat(dfhack.gui.getCurFocus(), ' ')))
@@ -630,6 +623,10 @@ local function filter_tests(tests, config)
 end
 
 local function run_tests(tests, status, counts, config)
+    wait_for(60000, 'game load', function()
+        local scr = dfhack.gui.getDFViewscreen()
+        return not df.viewscreen_initial_prepst:is_instance(scr)
+    end)
     print(('Running %d tests'):format(#tests))
     local start_ms = dfhack.getTickCount()
     local num_skipped = 0

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -2,6 +2,7 @@
 --@ module = true
 
 local expect = require('test_util.expect')
+local gui = require('gui')
 local helpdb = require('helpdb')
 local json = require('json')
 local mock = require('test_util.mock')
@@ -226,7 +227,7 @@ local function click_top_title_button(scr)
     df.global.enabler.tracking_on = 1
     df.global.enabler.mouse_lbut = 1
     df.global.enabler.mouse_lbut_down = 1
-    dfhack.screen._doSimulateInput(scr, {})
+    gui.simulateInput(scr, '_MOUSE_L')
 end
 
 local function load_first_save(scr)

--- a/ci/test.lua
+++ b/ci/test.lua
@@ -213,6 +213,7 @@ end
 
 local function click_top_title_button(scr)
     local sw, sh = dfhack.screen.getWindowSize()
+    print(('screen dimensions: %d, %d'):format(sw. sh))
     df.global.gps.mouse_x = sw // 2
     df.global.gps.precise_mouse_x = df.global.gps.mouse_x * df.global.gps.tile_pixel_x
     if sh < 60 then

--- a/test/plugins/orders.lua
+++ b/test/plugins/orders.lua
@@ -1,5 +1,5 @@
 config.mode = 'fortress'
---config.target = 'orders'
+config.target = 'orders'
 
 local FILE_PATH_PATTERN = 'dfhack-config/orders/%s.json'
 


### PR DESCRIPTION
significant changes:

- tests on linux are enabled
- fortress mode tests are enabled
- test harness code is changed to wait for a number of ms instead of a number of frames
- tests don't start until DF initial prep is complete
- crashing tests are marked as failed and skipped instead of retried