### PR TITLE
autolabor: fix #3812

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `autolabor`: now unconditionally clears ``game.external_flag`` when unloading a fort or the plugin
 
 ## Misc Improvements
 - `dig`: `digtype` command now has options to choose between designating only visible tiles or hidden tiles, as well as "auto" dig mode. Z-level options adjusted to allow choosing z-levels above, below, or the same as the cursor.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,7 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-- `autolabor`: now unconditionally clears ``game.external_flag`` when unloading a fort or the plugin
+- `autolabor`: now unconditionally re-enables vanilla work details when the fort or the plugin is unloaded
 
 ## Misc Improvements
 - `dig`: `digtype` command now has options to choose between designating only visible tiles or hidden tiles, as well as "auto" dig mode. Z-level options adjusted to allow choosing z-levels above, below, or the same as the cursor.

--- a/plugins/autolabor/autolabor.cpp
+++ b/plugins/autolabor/autolabor.cpp
@@ -305,6 +305,7 @@ static void cleanup_state()
 {
     enable_autolabor = false;
     labor_infos.clear();
+    game->external_flag &= ~1; // reinstate DF's work detail system
 }
 
 static void reset_labor(df::unit_labor labor)
@@ -325,6 +326,8 @@ static void init_state()
 
     if (!enable_autolabor)
         return;
+
+    game->external_flag |= 1; // bypass DF's work detail system
 
     auto cfg_haulpct = World::GetPersistentData("autolabor/haulpct");
     if (cfg_haulpct.isValid())
@@ -413,8 +416,17 @@ static void enable_plugin(color_ostream &out)
 
     cleanup_state();
     init_state();
+}
 
-    game->external_flag |= 1; // shut down DF's work detail system
+static void disable_plugin(color_ostream& out)
+{
+    if (config.isValid())
+        setOptionEnabled(CF_ENABLED, false);
+
+    enable_autolabor = false;
+    out << "Disabling autolabor." << std::endl;
+
+    cleanup_state();
 }
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
@@ -1081,12 +1093,7 @@ DFhackCExport command_result plugin_enable ( color_ostream &out, bool enable )
     }
     else if(!enable && enable_autolabor)
     {
-        enable_autolabor = false;
-        setOptionEnabled(CF_ENABLED, false);
-
-        game->external_flag &= ~1; // reenable DF's work detail system
-
-        out << "Autolabor is disabled." << std::endl;
+        disable_plugin(out);
     }
 
     return CR_OK;


### PR DESCRIPTION
make sure autolabor resets the work detail bypass flag whenever autolabor is unloaded for _any_ reason

i tested `disable autolabor`, `unload autolabor`, and unloading a fort with autolabor enabled; in all cases the work detail bypass flag was cleared as desired

closes #3812