### PR TITLE
[hotkeys] make the ascii DFHack logo easier to read

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 ## Misc Improvements
 - `dig`: `digtype` command now has options to choose between designating only visible tiles or hidden tiles, as well as "auto" dig mode. Z-level options adjusted to allow choosing z-levels above, below, or the same as the cursor.
 - `hotkeys`: make the DFHack logo brighten on hover in ascii mode to indicate that it is clickable
+- `hotkeys`: use vertical bars instead of "!" symbols for the DFHack logo to make it easier to read
 
 ## Documentation
 

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -79,9 +79,9 @@ function HotspotMenuWidget:init()
     self:addviews{
         widgets.Label{
             text={
-                get_tile_token(1, '!'), get_tile_token(2, 'D'), get_tile_token(3, 'F'), get_tile_token(4, '!'), NEWLINE,
-                get_tile_token(5, '!'), get_tile_token(6, 'H'), get_tile_token(7, 'a'), get_tile_token(8, '!'), NEWLINE,
-                get_tile_token(9, '!'), get_tile_token(10, 'c'), get_tile_token(11, 'k'), get_tile_token(12, '!'),
+                get_tile_token(1, 179), get_tile_token(2, 'D'), get_tile_token(3, 'F'), get_tile_token(4, 179), NEWLINE,
+                get_tile_token(5, 179), get_tile_token(6, 'H'), get_tile_token(7, 'a'), get_tile_token(8, 179), NEWLINE,
+                get_tile_token(9, 179), get_tile_token(10, 'c'), get_tile_token(11, 'k'), get_tile_token(12, 179),
             },
             on_click=function() dfhack.run_command('hotkeys') end,
         },


### PR DESCRIPTION
![image](https://github.com/DFHack/dfhack/assets/977482/bc9f2171-a422-4274-a233-49a9800f8f85)
![image](https://github.com/DFHack/dfhack/assets/977482/d989d285-a6e8-473a-b70f-b1be0bb4d13e)

other options (first one is existing style):
![image](https://github.com/DFHack/dfhack/assets/977482/ceb5715a-2e0d-4ff6-8723-9daedbb3c9ee)
