### PR TITLE
check-structures-sanity: Allow running without MALLOC_PERTURB_

### DIFF
--- a/plugins/devel/check-structures-sanity/check-structures-sanity.h
+++ b/plugins/devel/check-structures-sanity/check-structures-sanity.h
@@ -82,6 +82,7 @@ public:
     bool failfast;
     bool noprogress;
     bool maybepointer;
+    uint8_t perturb_byte;
 
     Checker(color_ostream & out);
     bool queue_item(const QueueItem & item, CheckedStructure cs);

--- a/plugins/devel/check-structures-sanity/dispatch.cpp
+++ b/plugins/devel/check-structures-sanity/dispatch.cpp
@@ -296,7 +296,7 @@ void Checker::dispatch_primitive(const QueueItem & item, const CheckedStructure 
     else if (cs.identity == df::identity_traits<bool>::get())
     {
         auto val = *reinterpret_cast<const uint8_t *>(item.ptr);
-        if (val > 1 && val != 0xd2)
+        if (val > 1 && perturb_byte && val != perturb_byte && val != (perturb_byte ^ 0xff))
         {
             FAIL("invalid value for bool: " << int(val));
         }


### PR DESCRIPTION
and adjust bool check accordingly