### PR TITLE
remove refrence to unused field

### DIFF
--- a/plugins/strangemood.cpp
+++ b/plugins/strangemood.cpp
@@ -1217,7 +1217,6 @@ command_result df_strangemood (color_ostream &out, vector <string> & parameters)
     ref->setID(unit->id);
     job->general_refs.push_back(ref);
     unit->job.current_job = job;
-    job->wait_timer = 0;
 
     // Generate the artifact's name
     if (type == mood_type::Fell || type == mood_type::Macabre)


### PR DESCRIPTION
`wait_timer` is not really there; what we have labeled as `wait_timer` is actually padding so there is no need to do this and as this references a field that doesn't exist having the reference is blocking updating the structures definition for `job`