### PR TITLE
[logistics] support optionally melting masterworks

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 - `preserve-tombs`: tracks tomb assignments to living units and ensures that the tomb stays assigned to them when they die.
 
 ## New Features
+- `logistics`: ``automelt`` now optionally supports melting masterworks; feature accessible from `stockpiles` overlay
 
 ## Fixes
 

--- a/docs/plugins/logistics.rst
+++ b/docs/plugins/logistics.rst
@@ -72,3 +72,7 @@ Options
     Causes the command to act upon stockpiles with the given names or numbers
     instead of the stockpile that is currently selected in the UI. Note that
     the numbers are the stockpile numbers, not the building ids.
+``-m``, ``--melt-masterworks``
+    If specified with a ``logistics add melt`` command, will configure the
+    stockpile to allow melting of masterworks. By default, masterworks are not
+    marked for melting, even if they are in an automelt stockpile.

--- a/docs/plugins/stockpiles.rst
+++ b/docs/plugins/stockpiles.rst
@@ -100,7 +100,13 @@ Overlay
 
 This plugin provides a panel that appears when you select a stockpile via an
 `overlay` widget. You can use it to easily toggle `logistics` plugin features
-like autotrade, automelt, or autotrain.
+like autotrade, automelt, or autotrain. There are also buttons along the top frame for:
+
+- minimizing the panel (if it is in the way of the vanilla stockpile
+  configuration widgets)
+- showing help for the overlay widget in `gui/launcher` (this page)
+- configuring advanced settings for the stockpile, such as whether automelt
+  will melt masterworks
 
 .. _stockpiles-library:
 

--- a/plugins/lua/logistics.lua
+++ b/plugins/lua/logistics.lua
@@ -29,6 +29,7 @@ function getStockpileData()
             trade=make_stat('trade', stockpile_number, stats, configs),
             dump=make_stat('dump', stockpile_number, stats, configs),
             train=make_stat('train', stockpile_number, stats, configs),
+            melt_masterworks=configs[stockpile_number] and configs[stockpile_number].melt_masterworks == 'true',
         })
     end
     table.sort(data, function(a, b) return a.sort_key < b.sort_key end)
@@ -41,16 +42,24 @@ local function print_stockpile_data(data)
         name_len = math.min(40, math.max(name_len, #sp.name))
     end
 
+    local has_melt_mastworks = false
+
     print('Designated/designatable items in stockpiles:')
     print()
     local fmt = '%6s  %-' .. name_len .. 's  %4s %10s  %5s %11s  %4s %10s  %5s %11s';
     print(fmt:format('number', 'name', 'melt', 'melt items', 'trade', 'trade items', 'dump', 'dump items', 'train', 'train items'))
     local function uline(len) return ('-'):rep(len) end
     print(fmt:format(uline(6), uline(name_len), uline(4), uline(10), uline(5), uline(11), uline(4), uline(10), uline(5), uline(11)))
-    local function get_enab(stats) return ('[%s]'):format(stats.enabled and 'x' or ' ') end
+    local function get_enab(stats, ch) return ('[%s]'):format(stats.enabled and (ch or 'x') or ' ') end
     local function get_dstat(stats) return ('%d/%d'):format(stats.designated, stats.designated + stats.can_designate) end
     for _,sp in ipairs(data) do
-        print(fmt:format(sp.stockpile_number, sp.name, get_enab(sp.melt), get_dstat(sp.melt), get_enab(sp.trade), get_dstat(sp.trade), get_enab(sp.dump), get_dstat(sp.dump), get_enab(sp.train), get_dstat(sp.train)))
+        has_melt_mastworks = has_melt_mastworks or sp.melt_masterworks
+        print(fmt:format(sp.stockpile_number, sp.name, get_enab(sp.melt, sp.melt_masterworks and 'X'), get_dstat(sp.melt),
+            get_enab(sp.trade), get_dstat(sp.trade), get_enab(sp.dump), get_dstat(sp.dump), get_enab(sp.train), get_dstat(sp.train)))
+    end
+    if has_melt_mastworks then
+        print()
+        print('An "X" in the "melt" column indicates that masterworks in the stockpile will be melted.')
     end
 end
 
@@ -101,7 +110,8 @@ local function do_add_stockpile_config(features, opts)
                     features.melt or config.melt == 1,
                     features.trade or config.trade == 1,
                     features.dump or config.dump == 1,
-                    features.train or config.train == 1)
+                    features.train or config.train == 1,
+                    not not opts.melt_masterworks)
             end
         end
     end)
@@ -125,6 +135,7 @@ local function process_args(opts, args)
 
     return argparse.processArgsGetopt(args, {
         {'h', 'help', handler=function() opts.help = true end},
+        {'m', 'melt-masterworks', handler=function() opts.melt_masterworks = true end},
         {'s', 'stockpile', hasArg=true, handler=function(arg) opts.sp = arg end},
     })
 end


### PR DESCRIPTION
- add persisted config elements per stockpile\
- add CLI support
- add GUI elements for setting option from `stockpiles` overlay
- add button to stockpiles overlay for showing help

![image](https://github.com/DFHack/dfhack/assets/977482/1f7ccb5e-f673-4cf8-bf0d-5a78a054091a)