### PR TITLE
[orders] only recheck orders that have conditions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `overlay`: allow ``overlay_onupdate_max_freq_seconds`` to be dynamically set to 0 for a burst of high-frequency updates
+- `orders`: ``recheck`` command now only resets orders that have conditions that can be rechecked
 
 ## Documentation
 

--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -18,12 +18,13 @@ Usage
 ``orders clear``
     Deletes all manager orders in the current embark.
 ``orders recheck [this]``
-    Sets the status to ``Checking`` (from ``Active``) for all work orders. if the
-    "this" option is passed, only sets the status for the workorder whose condition
-    details page is open. This makes the manager reevaluate its conditions.
-    This is especially useful for an order that had its conditions met when it
-    was started, but the requisite items have since disappeared and the workorder
-    is now generating job cancellation spam.
+    Sets the status to ``Checking`` (from ``Active``) for all work orders that
+    have conditions that can be re-checked. If the "this" option is passed,
+    only sets the status for the workorder whose condition details page is
+    open. This makes the manager reevaluate its conditions. This is especially
+    useful for an order that had its conditions met when it was started, but
+    the requisite items have since disappeared and the workorder is now
+    generating job cancellation spam.
 ``orders sort``
     Sorts current manager orders by repeat frequency so repeating orders don't
     prevent one-time orders from ever being completed. The sorting order is:

--- a/plugins/lua/orders.lua
+++ b/plugins/lua/orders.lua
@@ -71,7 +71,7 @@ OrdersOverlay.ATTRS{
     default_pos={x=53,y=-6},
     default_enabled=true,
     viewscreens='dwarfmode/Info/WORK_ORDERS/Default',
-    frame={w=46, h=4},
+    frame={w=43, h=4},
 }
 
 function OrdersOverlay:init()
@@ -99,7 +99,7 @@ function OrdersOverlay:init()
             },
             widgets.HotkeyLabel{
                 frame={t=0, l=15},
-                label='recheck',
+                label='recheck conditions',
                 key='CUSTOM_CTRL_K',
                 auto_width=true,
                 on_activate=do_recheck,
@@ -112,7 +112,7 @@ function OrdersOverlay:init()
                 on_activate=do_sort,
             },
             widgets.HotkeyLabel{
-                frame={t=0, l=31},
+                frame={t=1, l=28},
                 label='clear',
                 key='CUSTOM_CTRL_C',
                 auto_width=true,
@@ -179,10 +179,10 @@ local function set_current_inactive()
     end
 end
 
-local function is_current_active()
+local function can_recheck()
     local scrConditions = df.global.game.main_interface.info.work_orders.conditions
     local order = scrConditions.wq
-    return order.status.active
+    return order.status.active and #order.item_conditions > 0
 end
 
 -- -------------------
@@ -197,7 +197,7 @@ RecheckOverlay.ATTRS{
     default_enabled=true,
     viewscreens=focusString,
     -- width is the sum of lengths of `[` + `Ctrl+A` + `: ` + button.label + `]`
-    frame={w=1 + 6 + 2 + 16 + 1, h=3},
+    frame={w=1 + 6 + 2 + 19 + 1, h=3},
 }
 
 local function areTabsInTwoRows()
@@ -226,10 +226,10 @@ function RecheckOverlay:init()
         widgets.TextButton{
             view_id = 'button',
             -- frame={t=0, l=0, r=0, h=1}, -- is set in `updateTextButtonFrame()`
-            label='request re-check',
+            label='re-check conditions',
             key='CUSTOM_CTRL_A',
             on_activate=set_current_inactive,
-            enabled=is_current_active,
+            enabled=can_recheck,
         },
     }
 

--- a/plugins/orders.cpp
+++ b/plugins/orders.cpp
@@ -1036,11 +1036,15 @@ static command_result orders_sort_command(color_ostream & out)
 
 static command_result orders_recheck_command(color_ostream & out)
 {
-    for (auto it : world->manager_orders)
-    {
-        it->status.bits.active = false;
-        it->status.bits.validated = false;
+    size_t count = 0;
+    for (auto it : world->manager_orders) {
+        if (it->item_conditions.size() && it->status.bits.active) {
+            ++count;
+            it->status.bits.active = false;
+            it->status.bits.validated = false;
+        }
     }
+    out << "Re-checking conditions for " << count << " manager orders." << std::endl;
     return CR_OK;
 }
 


### PR DESCRIPTION
it is not useful to reset orders that do not have item conditions

also rearrange the overlay buttons a little to be more compact