### PR TITLE
[dwarfvet] properly initialize job id when linking into world

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -65,6 +65,7 @@ Template for new versions:
 
 ## Fixes
 - `zone`: don't show animal assignment link for cages and restraints linked to dungeon zones (which aren't normally assignable)
+- `dwarfvet`: fix invalid job id assigned to ``Rest`` job, which could cause crashes on reload
 
 ## Misc Improvements
 - `overlay`: allow ``overlay_onupdate_max_freq_seconds`` to be dynamically set to 0 for a burst of high-frequency updates

--- a/plugins/lua/dwarfvet.lua
+++ b/plugins/lua/dwarfvet.lua
@@ -92,13 +92,12 @@ function HospitalZone:assign_spot(unit, unit_pos)
     local pos = self:find_spot(unit_pos)
     if not pos then return false end
     local job = df.new(df.job)
-    dfhack.job.linkIntoWorld(job)
+    dfhack.job.linkIntoWorld(job, true)
     job.pos.x = pos.x
     job.pos.y = pos.y
     job.pos.z = pos.z
     job.flags.special = true
     job.job_type = df.job_type.Rest
-    job.wait_timer = 1600
     local gref = df.new(df.general_ref_unit_workerst)
     gref.unit_id = unit.id
     job.general_refs:insert('#', gref)


### PR DESCRIPTION
Fixes https://github.com/DFHack/dfhack/issues/3876

also removes reference to non-existent `wait_timer` field

tested on real injured animals. jobs look good, hospital visit was successful.