### PR TITLE
remove tags from unavailable tools

### DIFF
--- a/docs/Tools.rst
+++ b/docs/Tools.rst
@@ -3,8 +3,8 @@
 DFHack tools
 ============
 
-DFHack has **a lot** of tools. This page attempts to make it clearer what they
-are, how they work, and how to find the ones you want.
+DFHack comes with **a lot** of tools. This page attempts to make it clearer
+what they are, how they work, and how to find the ones you want.
 
 .. contents:: Contents
   :local:
@@ -35,6 +35,12 @@ categories are listed in the next few sections. Note that a tool can belong to
 more than one category. If you already know what you're looking for, try the
 `search` or Ctrl-F on this page. If you'd like to see the full list of tools in
 one flat list, please refer to the `annotated index <all-tag-index>`.
+
+Some tools are part of our back catalog and haven't been updated yet for v50 of
+Dwarf Fortress. These tools are tagged as
+`unavailable <unavailable-tag-index>`. They will still appear in the
+alphabetical list at the bottom of this page, but unavailable tools will not
+listed in any of the indices.
 
 DFHack tools by game mode
 -------------------------

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -75,6 +75,7 @@ Template for new versions:
 - `zone`: animals trained for war or hunting are now labeled as such in animal assignment screens
 
 ## Documentation
+- unavailable tools are no longer listed in the tag indices in the online docs
 
 ## API
 - Translate: will use DF's ``translate_name`` function, if available, instead of the DFHack emulation

--- a/docs/plugins/autogems.rst
+++ b/docs/plugins/autogems.rst
@@ -3,7 +3,7 @@ autogems
 
 .. dfhack-tool::
     :summary: Automatically cut rough gems.
-    :tags: unavailable fort auto workorders
+    :tags: unavailable
     :no-command:
 
 .. dfhack-command:: autogems-reload

--- a/docs/plugins/building-hacks.rst
+++ b/docs/plugins/building-hacks.rst
@@ -3,7 +3,7 @@ building-hacks
 
 .. dfhack-tool::
     :summary: Provides a Lua API for creating powered workshops.
-    :tags: unavailable fort gameplay buildings
+    :tags: unavailable
     :no-command:
 
 See `building-hacks-api` for more details.

--- a/docs/plugins/burrows.rst
+++ b/docs/plugins/burrows.rst
@@ -3,7 +3,7 @@ burrows
 
 .. dfhack-tool::
     :summary: Auto-expand burrows as you dig.
-    :tags: unavailable fort auto design productivity map units
+    :tags: unavailable
     :no-command:
 
 .. dfhack-command:: burrow

--- a/docs/plugins/digFlood.rst
+++ b/docs/plugins/digFlood.rst
@@ -3,7 +3,7 @@ digFlood
 
 .. dfhack-tool::
     :summary: Digs out veins as they are discovered.
-    :tags: unavailable fort auto map
+    :tags: unavailable
 
 Once you register specific vein types, this tool will automatically designate
 tiles of those types of veins for digging as your miners complete adjacent

--- a/docs/plugins/diggingInvaders.rst
+++ b/docs/plugins/diggingInvaders.rst
@@ -3,7 +3,7 @@ diggingInvaders
 
 .. dfhack-tool::
     :summary: Invaders dig and destroy to get to your dwarves.
-    :tags: unavailable fort gameplay military units
+    :tags: unavailable
 
 Usage
 -----

--- a/docs/plugins/dwarfmonitor.rst
+++ b/docs/plugins/dwarfmonitor.rst
@@ -3,7 +3,7 @@ dwarfmonitor
 
 .. dfhack-tool::
     :summary: Report on dwarf preferences and efficiency.
-    :tags: unavailable fort inspection jobs units
+    :tags: unavailable
 
 It can also show heads-up display widgets with live fort statistics.
 

--- a/docs/plugins/embark-assistant.rst
+++ b/docs/plugins/embark-assistant.rst
@@ -3,7 +3,7 @@ embark-assistant
 
 .. dfhack-tool::
     :summary: Embark site selection support.
-    :tags: unavailable embark fort interface
+    :tags: unavailable
 
 Run this command while the pre-embark screen is displayed to show extended (and
 reasonably correct) resource information for the embark rectangle as well as

--- a/docs/plugins/embark-tools.rst
+++ b/docs/plugins/embark-tools.rst
@@ -3,7 +3,7 @@ embark-tools
 
 .. dfhack-tool::
     :summary: Extend the embark screen functionality.
-    :tags: unavailable embark fort interface
+    :tags: unavailable
 
 Usage
 -----

--- a/docs/plugins/fix-unit-occupancy.rst
+++ b/docs/plugins/fix-unit-occupancy.rst
@@ -3,7 +3,7 @@ fix-unit-occupancy
 
 .. dfhack-tool::
     :summary: Fix phantom unit occupancy issues.
-    :tags: unavailable fort bugfix map
+    :tags: unavailable
 
 If you see "unit blocking tile" messages that you can't account for
 (:bug:`3499`), this tool can help.

--- a/docs/plugins/fixveins.rst
+++ b/docs/plugins/fixveins.rst
@@ -3,7 +3,7 @@ fixveins
 
 .. dfhack-tool::
     :summary: Restore missing mineral inclusions.
-    :tags: unavailable fort bugfix map
+    :tags: unavailable
 
 This tool can also remove invalid references to mineral inclusions if you broke
 your embark with tools like `tiletypes`.

--- a/docs/plugins/follow.rst
+++ b/docs/plugins/follow.rst
@@ -3,7 +3,7 @@ follow
 
 .. dfhack-tool::
     :summary: Make the screen follow the selected unit.
-    :tags: unavailable fort interface units
+    :tags: unavailable
 
 Once you exit from the current menu or cursor mode, the screen will stay
 centered on the unit. Handy for watching dwarves running around. Deactivated by

--- a/docs/plugins/forceequip.rst
+++ b/docs/plugins/forceequip.rst
@@ -3,7 +3,7 @@ forceequip
 
 .. dfhack-tool::
     :summary: Move items into a unit's inventory.
-    :tags: unavailable adventure fort animals items military units
+    :tags: unavailable
 
 This tool is typically used to equip specific clothing/armor items onto a dwarf,
 but can also be used to put armor onto a war animal or to add unusual items

--- a/docs/plugins/generated-creature-renamer.rst
+++ b/docs/plugins/generated-creature-renamer.rst
@@ -3,7 +3,7 @@ generated-creature-renamer
 
 .. dfhack-tool::
     :summary: Automatically renames generated creatures.
-    :tags: unavailable adventure fort legends units
+    :tags: unavailable
     :no-command:
 
 .. dfhack-command:: list-generated

--- a/docs/plugins/infiniteSky.rst
+++ b/docs/plugins/infiniteSky.rst
@@ -3,7 +3,7 @@ infiniteSky
 
 .. dfhack-tool::
     :summary: Automatically allocate new z-levels of sky
-    :tags: unavailable fort auto design map
+    :tags: unavailable
 
 If enabled, this plugin will automatically allocate new z-levels of sky at the
 top of the map as you build up. Or it can allocate one or many additional levels

--- a/docs/plugins/isoworldremote.rst
+++ b/docs/plugins/isoworldremote.rst
@@ -3,7 +3,7 @@ isoworldremote
 
 .. dfhack-tool::
     :summary: Provides a remote API used by Isoworld.
-    :tags: unavailable dev graphics
+    :tags: unavailable
     :no-command:
 
 See `remote` for related remote APIs.

--- a/docs/plugins/jobutils.rst
+++ b/docs/plugins/jobutils.rst
@@ -5,7 +5,7 @@ jobutils
 
 .. dfhack-tool::
     :summary: Provides commands for interacting with jobs.
-    :tags: unavailable fort inspection jobs
+    :tags: unavailable
     :no-command:
 
 .. dfhack-command:: job

--- a/docs/plugins/labormanager.rst
+++ b/docs/plugins/labormanager.rst
@@ -3,7 +3,7 @@ labormanager
 
 .. dfhack-tool::
     :summary: Automatically manage dwarf labors.
-    :tags: unavailable fort auto labors
+    :tags: unavailable
 
 Labormanager is derived from `autolabor` but uses a completely different
 approach to assigning jobs to dwarves. While autolabor tries to keep as many

--- a/docs/plugins/manipulator.rst
+++ b/docs/plugins/manipulator.rst
@@ -3,7 +3,7 @@ manipulator
 
 .. dfhack-tool::
     :summary: An in-game labor management interface.
-    :tags: unavailable fort productivity labors
+    :tags: unavailable
     :no-command:
 
 It is equivalent to the popular Dwarf Therapist utility.

--- a/docs/plugins/map-render.rst
+++ b/docs/plugins/map-render.rst
@@ -3,7 +3,7 @@ map-render
 
 .. dfhack-tool::
     :summary: Provides a Lua API for re-rendering portions of the map.
-    :tags: unavailable dev graphics
+    :tags: unavailable
     :no-command:
 
 See `map-render-api` for details.

--- a/docs/plugins/mode.rst
+++ b/docs/plugins/mode.rst
@@ -3,7 +3,7 @@ mode
 
 .. dfhack-tool::
     :summary: See and change the game mode.
-    :tags: unavailable armok dev gameplay
+    :tags: unavailable
 
 .. warning::
 

--- a/docs/plugins/mousequery.rst
+++ b/docs/plugins/mousequery.rst
@@ -3,7 +3,7 @@ mousequery
 
 .. dfhack-tool::
     :summary: Adds mouse controls to the DF interface.
-    :tags: unavailable fort productivity interface
+    :tags: unavailable
 
 Adds mouse controls to the DF interface. For example, with ``mousequery`` you
 can click on buildings to configure them, hold the mouse button to draw dig

--- a/docs/plugins/petcapRemover.rst
+++ b/docs/plugins/petcapRemover.rst
@@ -3,7 +3,7 @@ petcapRemover
 
 .. dfhack-tool::
     :summary: Modify the pet population cap.
-    :tags: unavailable fort auto animals
+    :tags: unavailable
 
 In vanilla DF, pets will not reproduce unless the population is below 50 and the
 number of children of that species is below a certain percentage. This plugin

--- a/docs/plugins/plants.rst
+++ b/docs/plugins/plants.rst
@@ -5,7 +5,7 @@ plants
 
 .. dfhack-tool::
     :summary: Provides commands that interact with plants.
-    :tags: unavailable adventure fort armok map plants
+    :tags: unavailable
     :no-command:
 
 .. dfhack-command:: plant

--- a/docs/plugins/power-meter.rst
+++ b/docs/plugins/power-meter.rst
@@ -3,7 +3,7 @@ power-meter
 
 .. dfhack-tool::
     :summary: Allow pressure plates to measure power.
-    :tags: unavailable fort gameplay buildings
+    :tags: unavailable
     :no-command:
 
 If you run `gui/power-meter` while building a pressure plate, the pressure

--- a/docs/plugins/rename.rst
+++ b/docs/plugins/rename.rst
@@ -3,7 +3,7 @@ rename
 
 .. dfhack-tool::
     :summary: Easily rename things.
-    :tags: unavailable adventure fort productivity buildings stockpiles units
+    :tags: unavailable
 
 Use `gui/rename` for an in-game interface.
 

--- a/docs/plugins/rendermax.rst
+++ b/docs/plugins/rendermax.rst
@@ -3,7 +3,7 @@ rendermax
 
 .. dfhack-tool::
     :summary: Modify the map lighting.
-    :tags: unavailable adventure fort gameplay graphics
+    :tags: unavailable
 
 This plugin provides a collection of OpenGL lighting filters that affect how the
 map is drawn to the screen.

--- a/docs/plugins/search.rst
+++ b/docs/plugins/search.rst
@@ -5,7 +5,7 @@ search
 
 .. dfhack-tool::
     :summary: Adds search capabilities to the UI.
-    :tags: unavailable fort productivity interface
+    :tags: unavailable
     :no-command:
 
 Search options are added to the Stocks, Animals, Trading, Stockpile, Noble

--- a/docs/plugins/siege-engine.rst
+++ b/docs/plugins/siege-engine.rst
@@ -3,7 +3,7 @@ siege-engine
 
 .. dfhack-tool::
     :summary: Extend the functionality and usability of siege engines.
-    :tags: unavailable fort gameplay buildings
+    :tags: unavailable
     :no-command:
 
 Siege engines in DF haven't been updated since the game was 2D, and can only aim

--- a/docs/plugins/steam-engine.rst
+++ b/docs/plugins/steam-engine.rst
@@ -3,7 +3,7 @@ steam-engine
 
 .. dfhack-tool::
     :summary: Allow modded steam engine buildings to function.
-    :tags: unavailable fort gameplay buildings
+    :tags: unavailable
     :no-command:
 
 The steam-engine plugin detects custom workshops with the string

--- a/docs/plugins/stockflow.rst
+++ b/docs/plugins/stockflow.rst
@@ -3,7 +3,7 @@ stockflow
 
 .. dfhack-tool::
     :summary: Queue manager jobs based on free space in stockpiles.
-    :tags: unavailable fort auto stockpiles workorders
+    :tags: unavailable
 
 With this plugin, the fortress bookkeeper can tally up free space in specific
 stockpiles and queue jobs through the manager to produce items to fill the free

--- a/docs/plugins/stocks.rst
+++ b/docs/plugins/stocks.rst
@@ -3,7 +3,7 @@ stocks
 
 .. dfhack-tool::
     :summary: Enhanced fortress stock management interface.
-    :tags: unavailable fort productivity items
+    :tags: unavailable
 
 When the plugin is enabled, two new hotkeys become available:
 

--- a/docs/plugins/title-folder.rst
+++ b/docs/plugins/title-folder.rst
@@ -3,7 +3,7 @@ title-folder
 
 .. dfhack-tool::
     :summary: Displays the DF folder name in the window title bar.
-    :tags: unavailable interface
+    :tags: unavailable
     :no-command:
 
 Usage

--- a/docs/plugins/trackstop.rst
+++ b/docs/plugins/trackstop.rst
@@ -3,7 +3,7 @@ trackstop
 
 .. dfhack-tool::
     :summary: Add dynamic configuration options for track stops.
-    :tags: unavailable fort gameplay buildings
+    :tags: unavailable
     :no-command:
 
 When enabled, this plugin adds a :kbd:`q` menu for track stops, which is

--- a/docs/plugins/tweak.rst
+++ b/docs/plugins/tweak.rst
@@ -3,7 +3,7 @@ tweak
 
 .. dfhack-tool::
     :summary: A collection of tweaks and bugfixes.
-    :tags: unavailable adventure fort armok bugfix fps interface
+    :tags: unavailable
 
 Usage
 -----

--- a/docs/plugins/workflow.rst
+++ b/docs/plugins/workflow.rst
@@ -3,7 +3,7 @@ workflow
 
 .. dfhack-tool::
     :summary: Manage automated item production rules.
-    :tags: unavailable fort auto jobs
+    :tags: unavailable
 
 Manage repeat jobs according to stock levels. `gui/workflow` provides a simple
 front-end integrated in the game UI.

--- a/docs/plugins/zone.rst
+++ b/docs/plugins/zone.rst
@@ -3,7 +3,7 @@ zone
 
 .. dfhack-tool::
     :summary: Manage activity zones, cages, and the animals therein.
-    :tags: unavailable fort productivity animals buildings interface
+    :tags: unavailable
 
 Usage
 -----

--- a/docs/sphinx_extensions/dfhack/tool_docs.py
+++ b/docs/sphinx_extensions/dfhack/tool_docs.py
@@ -140,7 +140,8 @@ class DFHackToolDirectiveBase(sphinx.directives.ObjectDescription):
         anchor = to_anchor(self.get_tool_name_from_docname())
         tags = self.env.domaindata['tag-repo']['doctags'][docname]
         indexdata = (name, self.options.get('summary', ''), '', docname, anchor, 0)
-        self.env.domaindata['all']['objects'].append(indexdata)
+        if 'unavailable' not in tags:
+            self.env.domaindata['all']['objects'].append(indexdata)
         for tag in tags:
             self.env.domaindata[tag]['objects'].append(indexdata)
 


### PR DESCRIPTION
https://github.com/DFHack/scripts/pull/863 but for plugins; more info in that PR

This PR also adds some explanatory text in the docs about how unavailable tools are listed.

Fixes https://github.com/DFHack/dfhack/issues/3503