### PR TITLE
[buildingplan we can no longer build with ash, coal, or soap

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -65,6 +65,7 @@ Template for new versions:
 - `sort`: new search widgets for slab engraving menu; can filter for only units that need a slab to prevent rising as a ghost
 
 ## Fixes
+- `buildingplan`: remove bars of ash, coal, and soap as valid building materials to match v50 rules
 - `zone`: races without specific child or baby names will now get generic child/baby names instead of an empty string
 - `zone`: don't show animal assignment link for cages and restraints linked to dungeon zones (which aren't normally assignable)
 - `sort`: don't count mercenaries as appointed officials in the squad assignment screen

--- a/plugins/buildingplan/buildingplan_cycle.cpp
+++ b/plugins/buildingplan/buildingplan_cycle.cpp
@@ -59,11 +59,28 @@ static bool isAccessible(color_ostream& out, df::item* item) {
     return is_walkable;
 }
 
+// as of v50, soap, coal, and ash are no longer valid building materials
+static bool isUnusableBar(color_ostream& out, df::item* item) {
+    if (item->getType() != df::item_type::BAR)
+        return false;
+
+    MaterialInfo minfo(item);
+    string token = minfo.getToken();
+    if (token.starts_with("COAL:") || token == "ASH")
+        return true;
+
+    df::job_item_flags2 ok;
+    df::job_item_flags2 mask;
+    minfo.getMatchBits(ok, mask);
+    return ok.bits.soap;
+}
+
 bool itemPassesScreen(color_ostream& out, df::item* item) {
     static const BadFlags bad_flags;
     return !(item->flags.whole & bad_flags.whole)
         && !item->isAssignedToStockpile()
-        && isAccessible(out, item);
+        && isAccessible(out, item)
+        && !isUnusableBar(out, item);
 }
 
 bool matchesHeatSafety(int16_t mat_type, int32_t mat_index, HeatSafety heat) {


### PR DESCRIPTION
need to manually mask them out since they're still in the item vector

Fixes https://github.com/DFHack/dfhack/issues/3700