### PR TITLE
[buildingplan] refresh the overlay state when toggling minimize

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 
 ## Fixes
 - `buildingplan`: remove bars of ash, coal, and soap as valid building materials to match v50 rules
+- `buildingplan`: fix incorrect required items being displayed sometimes when switching the planner overlay on and off
 - `zone`: races without specific child or baby names will now get generic child/baby names instead of an empty string
 - `zone`: don't show animal assignment link for cages and restraints linked to dungeon zones (which aren't normally assignable)
 - `sort`: don't count mercenaries as appointed officials in the squad assignment screen

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -652,6 +652,7 @@ end
 function PlannerOverlay:toggle_minimized()
     self.state.minimized = not self.state.minimized
     config:write()
+    self:reset()
 end
 
 function PlannerOverlay:draw_divider_h(dc)


### PR DESCRIPTION
since the items may have changed

Fixes https://github.com/DFHack/dfhack/issues/3539