### PR TITLE
[buildingplan] display how many items are available on the planner panel

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `buildingplan`: display how many items are available on the planner panel
 
 ## Documentation
 

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -294,7 +294,7 @@ function ItemLine:get_item_line_text()
         uibs.building_type, uibs.building_subtype, uibs.custom_type, idx - 1)
     if self.available >= quantity then
         self.note_pen = COLOR_GREEN
-        self.note = ' Available now'
+        self.note = (' %d available now'):format(self.available)
     elseif self.available >= 0 then
         self.note_pen = COLOR_BROWN
         self.note = (' Will link next (need to make %d)'):format(quantity - self.available)


### PR DESCRIPTION
just like we display how many you'd need to make if you don't have enough
![image](https://github.com/DFHack/dfhack/assets/977482/c83bd443-6714-4253-87fd-9a2e6e964dd8)

Fixes https://github.com/DFHack/dfhack/issues/3903