### PR TITLE
[Gui::revealInDwarfmodeMap] optionally highlight the zoom target tile

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -65,8 +65,10 @@ Template for new versions:
 ## Documentation
 
 ## API
+- ``Gui::revealInDwarfmodeMap``: gained ``highlight`` parameter to control setting the tile highlight on the zoom target
 
 ## Lua
+- ``dfhack.gui.revealInDwarfmodeMap``: gained ``highlight`` parameter to control setting the tile highlight on the zoom target
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1053,11 +1053,13 @@ Fortress mode
   Same as ``resetDwarfmodeView``, but also recenter if position is valid. If ``pause`` is false, skip pausing. Respects
   ``RECENTER_INTERFACE_SHUTDOWN_MS`` in DF's ``init.txt`` (the delay before input is recognized when a recenter occurs.)
 
-* ``dfhack.gui.revealInDwarfmodeMap(pos[,center])``
-  ``dfhack.gui.revealInDwarfmodeMap(x,y,z[,center])``
+* ``dfhack.gui.revealInDwarfmodeMap(pos[,center[,highlight]])``
+  ``dfhack.gui.revealInDwarfmodeMap(x,y,z[,center[,highlight]])``
 
-  Centers the view on the given coordinates. If ``center`` is true, make sure the
-  position is in the exact center of the view, else just bring it on screen.
+  Centers the view on the given coordinates. If ``center`` is true, make sure
+  the position is in the exact center of the view, else just bring it on screen.
+  If ``highlight`` is true, then mark the target tile with a pulsing highlight
+  until the player clicks somewhere else.
 
   ``pos`` can be a ``df.coord`` instance or a table assignable to a ``df.coord`` (see `lua-api-table-assignment`),
   e.g.::

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1660,11 +1660,19 @@ static int gui_revealInDwarfmodeMap(lua_State *state)
     switch (lua_gettop(state))
     {
         default:
+        case 5:
+            rv = Gui::revealInDwarfmodeMap(CheckCoordXYZ(state, 1, false), lua_toboolean(state, 4), lua_toboolean(state, 5));
+            break;
         case 4:
             rv = Gui::revealInDwarfmodeMap(CheckCoordXYZ(state, 1, false), lua_toboolean(state, 4));
             break;
         case 3:
-            rv = Gui::revealInDwarfmodeMap(CheckCoordXYZ(state, 1, false));
+            if (lua_isboolean(state, 3)) {
+                Lua::CheckDFAssign(state, &p, 1);
+                rv = Gui::revealInDwarfmodeMap(p, lua_toboolean(state, 2), lua_toboolean(state, 3));
+            }
+            else
+                rv = Gui::revealInDwarfmodeMap(CheckCoordXYZ(state, 1, false));
             break;
         case 2:
             Lua::CheckDFAssign(state, &p, 1);

--- a/library/include/modules/Gui.h
+++ b/library/include/modules/Gui.h
@@ -165,8 +165,8 @@ namespace DFHack
         DFHACK_EXPORT DwarfmodeDims getDwarfmodeViewDims();
 
         DFHACK_EXPORT void resetDwarfmodeView(bool pause = false);
-        DFHACK_EXPORT bool revealInDwarfmodeMap(int32_t x, int32_t y, int32_t z, bool center = false);
-        DFHACK_EXPORT inline bool revealInDwarfmodeMap(df::coord pos, bool center = false) { return revealInDwarfmodeMap(pos.x, pos.y, pos.z, center); };
+        DFHACK_EXPORT bool revealInDwarfmodeMap(int32_t x, int32_t y, int32_t z, bool center = false, bool highlight = false);
+        DFHACK_EXPORT inline bool revealInDwarfmodeMap(df::coord pos, bool center = false, bool highlight = false) { return revealInDwarfmodeMap(pos.x, pos.y, pos.z, center, highlight); };
         DFHACK_EXPORT bool pauseRecenter(int32_t x, int32_t y, int32_t z, bool pause = true);
         DFHACK_EXPORT inline bool pauseRecenter(df::coord pos, bool pause = true) { return pauseRecenter(pos.x, pos.y, pos.z, pause); };
         DFHACK_EXPORT bool refreshSidebar();

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -2094,13 +2094,13 @@ void Gui::resetDwarfmodeView(bool pause)
         *df::global::pause_state = true;
 }
 
-bool Gui::revealInDwarfmodeMap(int32_t x, int32_t y, int32_t z, bool center)
+bool Gui::revealInDwarfmodeMap(int32_t x, int32_t y, int32_t z, bool center, bool highlight)
 {   // Reverse-engineered from DF announcement and scrolling code
     using df::global::window_x;
     using df::global::window_y;
     using df::global::window_z;
 
-    if (!window_x || !window_y || !window_z || !world)
+    if (!window_x || !window_y || !window_z || !world || !game)
         return false;
 
     auto dims = getDwarfmodeViewDims();
@@ -2136,6 +2136,12 @@ bool Gui::revealInDwarfmodeMap(int32_t x, int32_t y, int32_t z, bool center)
     *window_z = clip_range(new_win_z, 0, (world->map.z_count - 1));
     game->minimap.update = true;
     game->minimap.mustmake = true;
+
+    if (highlight) {
+        game->main_interface.recenter_indicator_m.x = x;
+        game->main_interface.recenter_indicator_m.y = y;
+        game->main_interface.recenter_indicator_m.z = z;
+    }
 
     return true;
 }


### PR DESCRIPTION
take advantage of the tile highlight mechanism that vanilla uses when zooming to a unit/item