### PR TITLE
[buildingplan] improve interface for single-tile stairs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `buildingplan`: display how many items are available on the planner panel
+- `buildingplan`: clarify interface when building single-tile staircases
 - `sort`: allow searching by profession on the squad assignment page
 - `sort`: add search for work animal assignment screen; allow filtering by miltary/civilian
 - `dreamfort`: Inside+ and Clearcutting burrows now automatically created and managed

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -171,6 +171,18 @@ local function is_stairs()
             and uibs.building_subtype == df.construction_type.UpDownStair
 end
 
+local function is_single_level_stairs()
+    if not is_stairs() then return false end
+    local _, _, dimz = get_cur_area_dims()
+    return dimz == 1
+end
+
+local function is_multi_level_stairs()
+    if not is_stairs() then return false end
+    local _, _, dimz = get_cur_area_dims()
+    return dimz > 1
+end
+
 local direction_panel_frame = {t=4, h=13, w=46, r=28}
 
 local direction_panel_types = utils.invert{
@@ -435,10 +447,10 @@ function PlannerOverlay:init()
         },
         widgets.CycleHotkeyLabel{
             view_id='stairs_top_subtype',
-            frame={b=5, l=23, w=30},
+            frame={b=7, l=1, w=30},
             key='CUSTOM_R',
-            label='Top Stair Type:   ',
-            visible=is_stairs,
+            label='Top stair type:   ',
+            visible=is_multi_level_stairs,
             options={
                 {label='Auto', value='auto'},
                 {label='UpDown', value=df.construction_type.UpDownStair},
@@ -447,14 +459,26 @@ function PlannerOverlay:init()
         },
         widgets.CycleHotkeyLabel {
             view_id='stairs_bottom_subtype',
-            frame={b=4, l=23, w=30},
+            frame={b=6, l=1, w=30},
             key='CUSTOM_B',
             label='Bottom Stair Type:',
-            visible=is_stairs,
+            visible=is_multi_level_stairs,
             options={
                 {label='Auto', value='auto'},
                 {label='UpDown', value=df.construction_type.UpDownStair},
                 {label='Up', value=df.construction_type.UpStair},
+            },
+        },
+        widgets.CycleHotkeyLabel{
+            view_id='stairs_only_subtype',
+            frame={b=7, l=1, w=30},
+            key='CUSTOM_R',
+            label='Single level stair:',
+            visible=is_single_level_stairs,
+            options={
+                {label='Up', value=df.construction_type.UpStair},
+                {label='UpDown', value=df.construction_type.UpDownStair},
+                {label='Down', value=df.construction_type.DownStair},
             },
         },
         widgets.CycleHotkeyLabel {  -- TODO: this thing also needs a slider
@@ -910,7 +934,8 @@ end
 function PlannerOverlay:get_stairs_subtype(pos, bounds)
     local subtype = uibs.building_subtype
     if pos.z == bounds.z1 then
-        local opt = self.subviews.stairs_bottom_subtype:getOptionValue()
+        local opt = bounds.z1 == bounds.z2 and self.subviews.stairs_only_subtype:getOptionValue() or
+            self.subviews.stairs_bottom_subtype:getOptionValue()
         if opt == 'auto' then
             local tt = dfhack.maps.getTileType(pos)
             local shape = df.tiletype.attrs[tt].shape


### PR DESCRIPTION
it wasn't obvious whether you needed to modify the "top" or the "bottom" stair config when building a single level of stairs. now a separate, more clearly labeled option appears when there is only one level of stairs to build

also moved the options to the left so they don't overwrite the dimensions label