### PR TITLE
return untranslated name as the readable name

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -76,6 +76,7 @@ Template for new versions:
 ## API
 - ``Gui::revealInDwarfmodeMap``: gained ``highlight`` parameter to control setting the tile highlight on the zoom target
 - ``Maps::getWalkableGroup``: get the walkability group of a tile
+- ``Units::getReadableName``: now returns the *untranslated* name
 
 ## Lua
 - ``dfhack.gui.revealInDwarfmodeMap``: gained ``highlight`` parameter to control setting the tile highlight on the zoom target

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1282,7 +1282,7 @@ string Units::getReadableName(df::unit* unit) {
         race_name = "hunter " + race_name;
     if (isWar(unit))
         race_name = "war " + race_name;
-    string name = Translation::TranslateName(getVisibleName(unit));
+    string name = Translation::TranslateName(getVisibleName(unit), false);
     if (name.empty()) {
         name = race_name;
     } else {


### PR DESCRIPTION
as was originally intended. At the time, I didn't realize that TranslateName did the English translation by default