### PR TITLE
Add trap type to focus string

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -83,6 +83,7 @@ Template for new versions:
 - ``Units::getReadableName``: now returns the *untranslated* name
 - ``Burrows::setAssignedUnit``: now properly handles inactive burrows
 - ``Gui::getMousePos``: now takes an optional ``allow_out_of_bounds`` parameter so coordinates can be returned for mouse positions outside of the game map (i.e. in the blank space around the map)
+- Gui focus strings will now include the trap type for traps (e.g. dwarfmode/ViewSheets/BUILDING/Trap/StoneFallTrap)
 
 ## Lua
 - ``dfhack.gui.revealInDwarfmodeMap``: gained ``highlight`` parameter to control setting the tile highlight on the zoom target

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -380,8 +380,14 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
         case df::view_sheet_type::BUILDING:
             if (game->main_interface.view_sheets.linking_lever)
                 newFocusString = baseFocus + "/LinkingLever";
-            else if (auto bld = df::building::find(game->main_interface.view_sheets.viewing_bldid))
-                newFocusString += '/' + enum_item_key(bld->getType());
+            else if (auto bld = df::building::find(game->main_interface.view_sheets.viewing_bldid)) {
+                std::string buildingType = enum_item_key(bld->getType());
+                newFocusString += '/' + buildingType;
+                if (buildingType == "Trap") {
+                    df::building_trapst* trap = strict_virtual_cast<df::building_trapst>(bld);
+                    newFocusString += '/' + enum_item_key(trap->trap_type);
+                }
+            }
             break;
         default:
             break;

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -381,9 +381,8 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
             if (game->main_interface.view_sheets.linking_lever)
                 newFocusString = baseFocus + "/LinkingLever";
             else if (auto bld = df::building::find(game->main_interface.view_sheets.viewing_bldid)) {
-                std::string buildingType = enum_item_key(bld->getType());
-                newFocusString += '/' + buildingType;
-                if (buildingType == "Trap") {
+                newFocusString += '/' + enum_item_key(bld->getType());
+                if (bld->getType() == df::enums::building_type::Trap) {
                     df::building_trapst* trap = strict_virtual_cast<df::building_trapst>(bld);
                     newFocusString += '/' + enum_item_key(trap->trap_type);
                 }


### PR DESCRIPTION
When building type is trap, add the trap type to the focus string:

![image](https://github.com/DFHack/dfhack/assets/2104555/1cc01bb4-969d-424e-a86f-82dbeba72f53)

![image](https://github.com/DFHack/dfhack/assets/2104555/a0cb943d-07f3-4b20-83e0-ac826a232e08)

![image](https://github.com/DFHack/dfhack/assets/2104555/16ebdd18-b6d7-4840-9505-6d064e47eac5)
