### PR TITLE
Fix incorrect object:_field() usage docs

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -197,11 +197,12 @@ They implement the following features:
     are automatically exposed in their exact type, and the reverse
     rule would make access to superclass fields unreliable.
 
-* ``ref._field(field)``
+* ``ref:_field(field)``
 
   Returns a reference to a valid field. That is, unlike regular
   subscript, it returns a reference to the field within the structure
-  even for primitive typed fields and pointers.
+  even for primitive typed fields and pointers. Fails with an error
+  if the field is not found.
 
 * ``ref:vmethod(args...)``
 
@@ -246,7 +247,7 @@ Implemented features:
   may return a default value, or auto-resize instead for convenience.
   Currently this relaxed mode is implemented by df-flagarray aka BitArray.
 
-* ``ref._field(index)``
+* ``ref:_field(index)``
 
   Like with structs, returns a pointer to the array element, if possible.
   Flag and bit arrays cannot return such pointer, so it fails with an error.

--- a/library/LuaTypes.cpp
+++ b/library/LuaTypes.cpp
@@ -635,7 +635,7 @@ static int meta_struct_index(lua_State *state)
 static int meta_struct_field_reference(lua_State *state)
 {
     if (lua_gettop(state) != 2)
-        luaL_error(state, "Usage: object._field(name)");
+        luaL_error(state, "Usage: object:_field(name)");
     uint8_t *ptr = get_object_addr(state, 1, 2, "reference");
     auto field = (struct_field_info*)find_field(state, 2, "reference");
     if (!field)
@@ -660,7 +660,7 @@ static int meta_struct_field_reference(lua_State *state)
 static int meta_global_field_reference(lua_State *state)
 {
     if (lua_gettop(state) != 2)
-        luaL_error(state, "Usage: object._field(name)");
+        luaL_error(state, "Usage: object:_field(name)");
     auto field = (struct_field_info*)find_field(state, 2, "reference");
     if (!field)
         field_error(state, 2, "builtin property or method", "reference");
@@ -947,7 +947,7 @@ static int meta_container_index(lua_State *state)
 static int meta_container_field_reference(lua_State *state)
 {
     if (lua_gettop(state) != 2)
-        luaL_error(state, "Usage: object._field(index)");
+        luaL_error(state, "Usage: object:_field(index)");
     uint8_t *ptr = get_object_addr(state, 1, 2, "reference");
     int iidx = lookup_container_field(state, 2, "reference");
 


### PR DESCRIPTION
Looks like `ref.field(name)` was not documented properly.

```cpp
static int meta_struct_field_reference(lua_State *state)
{
    if (lua_gettop(state) != 2)
        luaL_error(state, "Usage: object._field(name)");
```

Both the struct and container versions require `self` (in Lua terms). Running either with the provided syntax results in an error prompting `Usage: object._field(index)` which is also incorrect.