### PR TITLE
Adjusted `buildingplan` filter reset hotkey to ctrl-d 'delete'

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -83,7 +83,7 @@ Template for new versions:
 - `caravan`: price of vermin swarms correctly adjusted down. a stack of 10000 bees is worth 10, not 10000
 - `sort`: when filtering out already-established temples in the location assignment screen, also filter out the "No specific deity" option if a non-denominational temple has already been established
 - RemoteServer: continue to accept connections as long as the listening socket is valid instead of closing the socket after the first disconnect
-- `buildingplan`: edit filter interface now uses ctrl-x to reset the filter to avoid conflict with increasing the filter's minimum quality (shift-x)
+- `buildingplan`: overlay and filter editor gui now uses ctrl-d to delete the filter to avoid conflict with increasing the filter's minimum quality (shift-x)
 
 ## Misc Improvements
 - `buildingplan`: display how many items are available on the planner panel

--- a/plugins/lua/buildingplan/filterselection.lua
+++ b/plugins/lua/buildingplan/filterselection.lua
@@ -232,9 +232,9 @@ function QualityAndMaterialsPage:init()
                 },
                 widgets.HotkeyLabel{
                     frame={l=30, t=2},
-                    label='Reset filter',
+                    label='Delete filter',
                     auto_width=true,
-                    key='CUSTOM_CTRL_X',
+                    key='CUSTOM_CTRL_D',
                     on_activate=self:callback('clear_filter'),
                 },
             },

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -550,8 +550,8 @@ function PlannerOverlay:init()
                 },
                 widgets.HotkeyLabel{
                     frame={b=0, l=1, w=22},
-                    key='CUSTOM_X',
-                    label='Clear filter',
+                    key='CUSTOM_CTRL_D',
+                    label='Delete filter',
                     on_activate=function() self:clear_filter(self.selected) end,
                     enabled=function()
                         return buildingplan.hasFilter(uibs.building_type, uibs.building_subtype, uibs.custom_type, self.selected - 1)


### PR DESCRIPTION
Due to ctrl-x conflicting with field entry clearing.