### PR TITLE
Update Installing.rst

### DIFF
--- a/docs/Installing.rst
+++ b/docs/Installing.rst
@@ -11,9 +11,8 @@ Requirements
 ============
 
 DFHack supports all operating systems and platforms that Dwarf Fortress itself
-supports, which at the moment is just 64-bit Windows. However, the Windows
-build of DFHack works well under ``wine`` (or ``Proton``, Steam's fork of
-``wine``) on other operating systems.
+supports, which at the moment is the 64-bit version of Windows and Linux. However, the Windows
+build of DFHack works well under ``wine`` for other platforms.
 
 .. _installing-df-version:
 


### PR DESCRIPTION
Added Linux as a supported version. Removed the `Proton` reference since Proton does not support MacOS. I don't actually know if DFHack works under wine for MacOS or if it works under the new Arm chips with Rosetta, so I just left that in.