### PR TITLE
[autobutcher] small edits

### DIFF
--- a/docs/plugins/autobutcher.rst
+++ b/docs/plugins/autobutcher.rst
@@ -6,12 +6,10 @@ autobutcher
     :tags: fort auto fps animals
 
 This plugin monitors how many pets you have of each gender and age and assigns
-excess livestock for slaughter. It requires that you add the target race(s) to a
-watch list. Units will be ignored if they are:
+excess livestock for slaughter. Units will be ignored if they are:
 
 * Untamed
-* Nicknamed (for custom protection; you can use the `rename` ``unit`` tool
-  individually, or `zone` ``nick`` for groups)
+* Nicknamed
 * Caged, if and only if the cage is in a zone (to protect zoos)
 * Trained for war or hunting
 
@@ -20,8 +18,7 @@ opposite sex or have been gelded) will be butchered before those who will.
 Older adults and younger children will be butchered first if the population
 is above the target (defaults are: 2 male kids, 4 female kids, 2 male adults,
 4 female adults). Note that you may need to set a target above 1 to have a
-reliable breeding population due to asexuality etc. See `fix-ster` if this is a
-problem.
+reliable breeding population due to asexuality etc.
 
 Usage
 -----
@@ -31,6 +28,9 @@ Usage
     no races are watched by default. You have to add the ones you want to
     monitor with ``autobutcher watch``, ``autobutcher target`` or
     ``autobutcher autowatch``.
+``autobutcher [list]``
+    Print status and current settings, including the watchlist. This is the
+    default command if autobutcher is run without parameters.
 ``autobutcher autowatch``
     Automatically add all new races (animals you buy from merchants, tame
     yourself, or get from migrants) to the watch list using the default target
@@ -50,9 +50,6 @@ Usage
     future watch commands without changing your current watchlist. Otherwise,
     all space separated races listed will be modified (or added to the watchlist
     if they aren't there already).
-``autobutcher ticks <ticks>``
-    Change the number of ticks between scanning cycles when the plugin is
-    enabled. By default, a cycle happens every 6000 ticks (about 8 game days).
 ``autobutcher watch all|<race> [<race> ...]``
     Start watching the listed races. If they aren't already in your watchlist,
     then they will be added with the default target counts. If you specify the
@@ -64,9 +61,10 @@ Usage
 ``autobutcher forget all|<race> [<race> ...]``
     Unwatch the specified race(s) (or all races on your watchlist if ``all`` is
     given) and forget target settings for it/them.
-``autobutcher [list]``
-    Print status and current settings, including the watchlist. This is the
-    default command if autobutcher is run without parameters.
+``autobutcher now``
+    Process all livestock according to the current watchlist configuration,
+    even if the plugin is not currently enabled, and thus not doing automatic
+    periodic scans.
 ``autobutcher list_export``
     Print commands required to set the current settings in another fort.
 
@@ -104,7 +102,7 @@ fortress::
     enable autobutcher
     autobutcher target 2 2 2 2 DOG
     autobutcher target 1 1 2 2 CAT
-    autobutcher target 50 50 14 2 BIRD_GOOSE
+    autobutcher target 10 10 14 2 BIRD_GOOSE
     autobutcher target 2 2 4 2 ALPACA SHEEP LLAMA
     autobutcher target 5 5 6 2 PIG
     autobutcher target 0 0 0 0 new

--- a/plugins/lua/autobutcher.lua
+++ b/plugins/lua/autobutcher.lua
@@ -65,13 +65,6 @@ function parse_commandline(opts, ...)
         opts.fa = check_nonnegative_int(positionals[4])
         opts.ma = check_nonnegative_int(positionals[5])
         process_races(opts, positionals, 6)
-    elseif command == 'ticks' then
-        local ticks = tonumber(positionals[2])
-        if not is_positive_int(ticks) then
-            qerror('number of ticks must be a positive integer: ' .. ticks)
-        else
-            opts.ticks = ticks
-        end
     else
         qerror(('unrecognized command: "%s"'):format(command))
     end


### PR DESCRIPTION
- remove ticks config (this does not benefit the user and clutters the API)
- document "now" command (was already implemented, but not documented)
- run cycle on autowatch enable (so new races appear immediately)
- remove references to unavailable tools in docs

just small things found while prepping for https://github.com/DFHack/dfhack/issues/4004