### PR TITLE
New MiscUtils.h functions: random_index, vector_get_random, capitalize_string_words, grab_token_string_pos

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -73,8 +73,12 @@ Template for new versions:
 - `modding-guide`: Add examples for script-only and blueprint-only mods that you can upload to DF's Steam Workshop
 
 ## API
+- ``random_index``, ``vector_get_random``: new ``MiscUtils`` functions, for getting a random entry in a vector
+- ``capitalize_string_words``: new ``MiscUtils`` function, returns string with all words capitalized
+- ``grab_token_string_pos``: new ``MiscUtils`` function, used for parsing tokens
 
 ## Lua
+- ``dfhack.capitalizeStringWords``: new function, returns string with all words capitalized
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -941,6 +941,10 @@ can be omitted.
   Note that the returned string may be longer than the input string. For
   example, ``ä`` is replaced with ``a``, and ``æ`` is replaced with ``ae``.
 
+* ``dfhack.capitalizeStringWords(string)``
+
+  Return a version of the string with each word capitalized.
+
 * ``dfhack.run_command(command[, ...])``
 
   Run an arbitrary DFHack command, with the core suspended, and send output to

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1905,7 +1905,6 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, isDemon),
     WRAPM(Units, isDanger),
     WRAPM(Units, isGreatDanger),
-    WRAPM(Units, getUnitFromHFID),
     WRAPM(Units, teleport),
     WRAPM(Units, getGeneralRef),
     WRAPM(Units, getSpecificRef),

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1450,6 +1450,7 @@ static std::string df2utf(std::string s) { return DF2UTF(s); }
 static std::string utf2df(std::string s) { return UTF2DF(s); }
 static std::string df2console(color_ostream &out, std::string s) { return DF2CONSOLE(out, s); }
 static std::string toSearchNormalized(std::string s) { return to_search_normalized(s); }
+static std::string capitalizeStringWords(std::string s) { return capitalize_string_words(s); }
 
 #define WRAP_VERSION_FUNC(name, function) WRAPN(name, DFHack::Version::function)
 
@@ -1468,6 +1469,7 @@ static const LuaWrapper::FunctionReg dfhack_module[] = {
     WRAP(utf2df),
     WRAP(df2console),
     WRAP(toSearchNormalized),
+    WRAP(capitalizeStringWords),
     WRAP_VERSION_FUNC(getDFHackVersion, dfhack_version),
     WRAP_VERSION_FUNC(getDFHackRelease, dfhack_release),
     WRAP_VERSION_FUNC(getDFHackBuildID, dfhack_build_id),
@@ -1903,6 +1905,7 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, isDemon),
     WRAPM(Units, isDanger),
     WRAPM(Units, isGreatDanger),
+    WRAPM(Units, getUnitFromHFID),
     WRAPM(Units, teleport),
     WRAPM(Units, getGeneralRef),
     WRAPM(Units, getSpecificRef),

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -177,7 +177,7 @@ std::string to_search_normalized(const std::string &str)
 }
 
 std::string capitalize_string_words(const std::string& str)
-{	// Cleaned up from g_src/basics.cpp, and returns new string
+{   // Cleaned up from g_src/basics.cpp, and returns new string
     std::string out = str;
     bool starting = true;
     int32_t bracket_count = 0;
@@ -294,7 +294,7 @@ bool word_wrap(std::vector<std::string> *out, const std::string &str, size_t lin
 }
 
 std::string grab_token_string_pos(const std::string& source, int32_t pos, char compc)
-{	// Cleaned up from g_src/basics.cpp, return string instead of bool
+{   // Cleaned up from g_src/basics.cpp, return string instead of bool
     std::string out;
 
     // Go until you hit compc, ']', or the end

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -183,7 +183,7 @@ std::string capitalize_string_words(const std::string& str)
     int32_t bracket_count = 0;
     bool conf;
 
-    for (int32_t s = 0; s < out.length(); s++)
+    for (size_t s = 0; s < out.length(); s++)
     {
         if (out[s] == '[') { ++bracket_count; continue; }
         else if (out[s] == ']') { --bracket_count; continue; }

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -61,6 +61,8 @@ namespace DFHack {
     class color_ostream;
 }
 
+DFHACK_EXPORT int random_int(int max);
+
 template <typename T>
 void print_bits ( T val, std::ostream& out )
 {
@@ -178,6 +180,17 @@ inline int binsearch_index(const std::vector<CT*> &vec, typename CT::key_pointer
     return CT::binsearch_index(vec, key, exact);
 }
 
+template <typename FT>
+int random_index(const std::vector<FT>& vec)
+{
+    if (vec.empty())
+        return -1;
+    else if (vec.size() == 1)
+        return 0;
+
+    return random_int(vec.size());
+}
+
 template<typename FT, typename KT>
 inline bool vector_contains(const std::vector<FT> &vec, KT key)
 {
@@ -197,6 +210,12 @@ inline T vector_get(const std::vector<T> &vec, unsigned idx, const T &defval = T
         return vec[idx];
     else
         return defval;
+}
+
+template<typename T>
+inline T vector_get_random(const std::vector<T>& vec, const T& defval = T())
+{
+    return vector_get(vec, random_index(vec), defval);
 }
 
 template<typename T>
@@ -401,6 +420,7 @@ inline std::string join_strings(const std::string &separator, T &items) {
 DFHACK_EXPORT std::string toUpper(const std::string &str);
 DFHACK_EXPORT std::string toLower(const std::string &str);
 DFHACK_EXPORT std::string to_search_normalized(const std::string &str);
+DFHACK_EXPORT std::string capitalize_string_words(const std::string& str);
 
 static inline std::string int_to_string(const int n) {
     std::ostringstream ss;
@@ -444,6 +464,13 @@ DFHACK_EXPORT bool word_wrap(std::vector<std::string> *out,
                              const std::string &str,
                              size_t line_length = 80,
                              word_wrap_whitespace_mode mode = WSMODE_KEEP_ALL);
+/**
+* Function to assist in parsing tokens. Returns string from source pos until next compc, ']', or end.
+* pos should be set to position after '[' to start with, then incremented by the result's size+1 before subsequent calls.
+* compc is usually ':', but can be '.' for parsing number ranges.
+* Based on Bay12's g_src/basics.cpp
+*/
+std::string grab_token_string_pos(const std::string& source, int32_t pos, char compc = ':');
 
 inline bool bits_match(unsigned required, unsigned ok, unsigned mask)
 {
@@ -456,8 +483,6 @@ inline T clip_range(T a, T1 minv, T2 maxv) {
     if (a > maxv) return maxv;
     return a;
 }
-
-DFHACK_EXPORT int random_int(int max);
 
 /**
  * Returns the amount of milliseconds elapsed since the UNIX epoch.


### PR DESCRIPTION
Add new functions to `MiscUtils.h`.

`random_index` and `vector_get_random` are for getting a random entry from a vector. Common use case  is to fill up a temp vector with possible results (e.g., raws matching conditions) then need to choose one at random.

`capitalize_string_words` and `grab_token_string_pos` are from `g_src/basics.cpp` and have been tidied up to return strings (instead of modifying the existing string in the case of `capitalize_string_words`.)

Moved `random_int` up in `MiscUtils.h` so I could use it in `random_index`. (Trying to implement `random_index` in `MiscUtils.cpp` is a nightmare of cryptic errors related to `#include` that I've given up on.)