### PR TITLE
[fastdwarf] persist state and refine tele logic

### DIFF
--- a/docs/plugins/fastdwarf.rst
+++ b/docs/plugins/fastdwarf.rst
@@ -2,7 +2,7 @@ fastdwarf
 =========
 
 .. dfhack-tool::
-    :summary: Dwarves teleport and/or finish jobs instantly.
+    :summary: Citizens walk fast and and finish jobs instantly.
     :tags: fort armok units
 
 Usage
@@ -11,28 +11,45 @@ Usage
 ::
 
     enable fastdwarf
-    fastdwarf <speed mode> [<tele mode>]
+    fastdwarf [status]
+    fastdwarf <fast mode> [<tele mode>]
 
 Examples
 --------
 
-``fastdwarf 1``
-    Make all your dwarves move and work at maximum speed.
+``enable fastdwarf`` or ``fastdwarf 1``
+    Make all your citizens move and work at maximum speed.
+``fastdwarf``
+    Print out current configuration.
 ``fastdwarf 1 1``
     In addition to working at maximum speed, dwarves also teleport to their
-    destinations.
+    destinations. It is possible that units end up in places they shouldn't be,
+    and you may need to `teleport` stranded units back to safety.
 
 Options
 -------
 
-Speed modes:
+Fast modes:
 
-:0: Dwarves move and work at normal rates.
-:1: Dwarves move and work at maximum speed.
-:2: ALL units move (and work) at maximum speed, including creatures and
-    hostiles.
+:0: Citizens move and work at normal rates.
+:1: Citizens move and work at maximum speed.
+:2: ALL units move (and work) at maximum speed, including creatures, visitors,
+    long-term residents, and hostiles.
 
 Tele modes:
 
 :0: No teleportation.
-:1: Dwarves teleport to their destinations.
+:1: Citizens teleport to their job destinations.
+
+Note that a dwarf will only teleport when:
+
+- They are not pushing anything (like a wheelbarrow)
+- They are not dragging anything/anyone or being dragged
+- They are not following anyone or being followed
+- They have a job with a valid destination
+
+So you may still see dwarves walking normally or just standing still if they do
+not have a job to teleport to. Since jobs get done so much faster, you will
+likely see groups of dwarves just standing around, with individual dwarves
+periodically disappaearing and reappearing moments later when they have a job
+to do.

--- a/plugins/fastdwarf.cpp
+++ b/plugins/fastdwarf.cpp
@@ -1,167 +1,216 @@
-#include "Core.h"
-#include "Console.h"
-#include "DataDefs.h"
-#include "Export.h"
+#include "Debug.h"
 #include "PluginManager.h"
-#include "modules/Units.h"
-#include "modules/Maps.h"
 
-#include "df/map_block.h"
-#include "df/unit.h"
-#include "df/unit_action.h"
+#include "modules/Maps.h"
+#include "modules/Persistence.h"
+#include "modules/Units.h"
+#include "modules/World.h"
+
 #include "df/unit_relationship_type.h"
-#include "df/units_other_id.h"
-#include "df/world.h"
-#include "df/unit_action_type_group.h"
 
 using std::string;
 using std::vector;
-
 using namespace DFHack;
-using namespace df::enums;
 
 DFHACK_PLUGIN("fastdwarf");
-DFHACK_PLUGIN_IS_ENABLED(active);
+DFHACK_PLUGIN_IS_ENABLED(is_enabled);
+
 REQUIRE_GLOBAL(world);
-using df::global::debug_turbospeed;  // not required
+using df::global::debug_turbospeed;  // soft dependency, so not REQUIRE_GLOBAL
 
-static bool enable_fastdwarf = false;
-static bool enable_teledwarf = false;
+namespace DFHack {
+    // for configuration-related logging
+    DBG_DECLARE(fastdwarf, config, DebugCategory::LINFO);
+    // for logging during the update cycle
+    DBG_DECLARE(fastdwarf, cycle, DebugCategory::LINFO);
+}
 
-DFhackCExport command_result plugin_shutdown ( color_ostream &out )
-{
-    if (debug_turbospeed)
-        *debug_turbospeed = false;
+static const string CONFIG_KEY = string(plugin_name) + "/config";
+static PersistentDataItem config;
+
+enum ConfigValues {
+    CONFIG_FAST = 0,
+    CONFIG_TELE = 1,
+};
+
+static int get_config_val(PersistentDataItem &c, int index) {
+    if (!c.isValid())
+        return -1;
+    return c.ival(index);
+}
+static void set_config_val(PersistentDataItem &c, int index, int value) {
+    if (c.isValid())
+        c.ival(index) = value;
+}
+
+static command_result do_command(color_ostream &out, vector<string> & parameters);
+
+DFhackCExport command_result plugin_init(color_ostream &out, std::vector<PluginCommand> & commands) {
+    DEBUG(config,out).print("initializing %s\n", plugin_name);
+
+    commands.push_back(PluginCommand(
+        "fastdwarf",
+        "Citizens walk fast and and finish jobs instantly.",
+        do_command));
+
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_onupdate ( color_ostream &out )
-{
-    // do we even need to do anything at all?
-    if (!enable_fastdwarf && !enable_teledwarf)
-        return CR_OK;
+static void set_state(color_ostream &out, int fast, int tele) {
+    DEBUG(config,out).print("setting state: fast=%d, tele=%d\n", fast, tele);
+    is_enabled = fast || tele;
+    set_config_val(config, CONFIG_FAST, fast);
+    set_config_val(config, CONFIG_TELE, tele);
 
-    // make sure the world is actually loaded
-    if (!world || !world->map.block_index)
-    {
-        enable_fastdwarf = enable_teledwarf = false;
-        return CR_OK;
+    if (debug_turbospeed)
+        *debug_turbospeed = fast == 2;
+    else if (fast == 2)
+        out.printerr("Speed level 2 not available.\n");
+}
+
+DFhackCExport command_result plugin_enable(color_ostream &out, bool enable) {
+    if (!Core::getInstance().isWorldLoaded()) {
+        out.printerr("Cannot enable %s without a loaded world.\n", plugin_name);
+        return CR_FAILURE;
     }
 
-    for (size_t i = 0; i < world->units.active.size(); i++)
-    {
-        df::unit *unit = world->units.active[i];
-        // citizens only
-        if (!Units::isCitizen(unit))
-            continue;
+    if (enable != is_enabled) {
+        set_state(out, enable ? 1 : 0, 0);
+    } else {
+        DEBUG(config,out).print("%s from the API, but already %s; no action\n",
+                                is_enabled ? "enabled" : "disabled",
+                                is_enabled ? "enabled" : "disabled");
+    }
+    return CR_OK;
+}
 
-        if (enable_teledwarf) do
-        {
-            // skip dwarves that are dragging creatures or being dragged
-            if ((unit->relationship_ids[df::unit_relationship_type::Draggee] != -1) ||
-                (unit->relationship_ids[df::unit_relationship_type::Dragger] != -1))
-                break;
+DFhackCExport command_result plugin_shutdown (color_ostream &out) {
+    DEBUG(config,out).print("shutting down %s\n", plugin_name);
 
-            // skip dwarves that are following other units
-            if (unit->following != 0)
-                break;
+    // make sure the debug flag doesn't get left on
+    if (debug_turbospeed)
+        *debug_turbospeed = false;
 
-            // skip unconscious units
-            if (unit->counters.unconscious > 0)
-                break;
+    return CR_OK;
+}
 
-            // don't do anything if the dwarf isn't going anywhere
-            if (!unit->pos.isValid() || !unit->path.dest.isValid() || unit->pos == unit->path.dest) {
-                break;
-            }
+DFhackCExport command_result plugin_load_data (color_ostream &out) {
+    config = World::GetPersistentData(CONFIG_KEY);
 
-            if (!Units::teleport(unit, unit->path.dest))
-                break;
+    if (!config.isValid()) {
+        DEBUG(config,out).print("no config found in this save; initializing\n");
+        config = World::AddPersistentData(CONFIG_KEY);
+        set_state(out, false, false);
+    } else {
+        is_enabled = get_config_val(config, CONFIG_FAST) || get_config_val(config, CONFIG_TELE);
+        DEBUG(config,out).print("loading persisted state: fast=%d, tele=%d\n",
+            get_config_val(config, CONFIG_FAST),
+            get_config_val(config, CONFIG_TELE));
+    }
 
-            unit->path.path.clear();
-        } while (0);
+    return CR_OK;
+}
 
-        if (enable_fastdwarf)
-        {
+DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_change_event event) {
+    if (event == DFHack::SC_WORLD_UNLOADED) {
+        if (is_enabled) {
+            DEBUG(config,out).print("world unloaded; disabling %s\n",
+                                    plugin_name);
+            is_enabled = false;
+        }
+    }
+    return CR_OK;
+}
+
+static void do_tele(color_ostream &out, df::unit * unit) {
+    // skip dwarves that are dragging creatures or being dragged
+    if ((unit->relationship_ids[df::unit_relationship_type::Draggee] != -1) ||
+        (unit->relationship_ids[df::unit_relationship_type::Dragger] != -1))
+        return;
+
+    // skip dwarves that are following other units
+    if (unit->following != 0)
+        return;
+
+    // skip unconscious units
+    if (unit->counters.unconscious > 0)
+        return;
+
+    // don't do anything if the dwarf isn't going anywhere
+    if (!unit->pos.isValid() || !unit->path.dest.isValid() || unit->pos == unit->path.dest)
+        return;
+
+    // skip units with no current job so they can still meander and fulfill needs
+    if (!unit->job.current_job)
+        return;
+
+    // don't do anything if the destination is in a different pathability group or is unrevealed
+    if (!Maps::canWalkBetween(unit->pos, unit->path.dest))
+        return;
+    if (!Maps::isTileVisible(unit->path.dest))
+        return;
+
+    DEBUG(cycle,out).print("teleporting unit %d\n", unit->id);
+
+    if (!Units::teleport(unit, unit->path.dest))
+        return;
+
+    unit->path.path.clear();
+}
+
+DFhackCExport command_result plugin_onupdate(color_ostream &out) {
+    DEBUG(cycle,out).print("running %s cycle\n", plugin_name);
+
+    // fast mode 2 is handled by DF itself
+    bool is_fast = get_config_val(config, CONFIG_FAST) == 1;
+    bool is_tele = get_config_val(config, CONFIG_TELE) == 1;
+
+    std::vector<df::unit *> citizens;
+    Units::getCitizens(citizens);
+    for (auto & unit : citizens) {
+        if (is_tele)
+            do_tele(out, unit);
+
+        if (is_fast) {
+            DEBUG(cycle,out).print("fastifying unit %d\n", unit->id);
             Units::setGroupActionTimers(out, unit, 1, df::unit_action_type_group::All);
         }
     }
+
     return CR_OK;
 }
 
-static command_result fastdwarf (color_ostream &out, vector <string> & parameters)
+/////////////////////////////////////////////////////
+// CLI logic
+//
+
+static command_result do_command(color_ostream &out, vector <string> & parameters)
 {
-    if (parameters.size() > 2)
+    const size_t num_params = parameters.size();
+
+    if (num_params > 2 || (num_params > 1 && parameters[0] == "help"))
         return CR_WRONG_USAGE;
 
-    if ((parameters.size() == 1) || (parameters.size() == 2))
-    {
-        if (parameters.size() == 2)
-        {
-            if (parameters[1] == "0")
-                enable_teledwarf = false;
-            else if (parameters[1] == "1")
-                enable_teledwarf = true;
-            else
-                return CR_WRONG_USAGE;
-        }
-        else
-            enable_teledwarf = false;
-        if (parameters[0] == "0")
-        {
-            enable_fastdwarf = false;
-            if (debug_turbospeed)
-                *debug_turbospeed = false;
-        }
-        else if (parameters[0] == "1")
-        {
-            enable_fastdwarf = true;
-            if (debug_turbospeed)
-                *debug_turbospeed = false;
-        }
-        else if (parameters[0] == "2")
-        {
-            if (debug_turbospeed)
-            {
-                enable_fastdwarf = false;
-                *debug_turbospeed = true;
-            }
-            else
-            {
-                out.print("Speed level 2 not available.\n");
-                return CR_FAILURE;
-            }
-        }
-        else
-            return CR_WRONG_USAGE;
+    if (num_params == 0 || parameters[0] == "status") {
+        out.print("Current state: fast = %d, teleport = %d.\n",
+            get_config_val(config, CONFIG_FAST),
+            get_config_val(config, CONFIG_TELE));
+        return CR_OK;
     }
 
-    active = enable_fastdwarf || enable_teledwarf;
+    int fast = string_to_int(parameters[0]);
+    int tele = num_params >= 2 ? string_to_int(parameters[1]) : 0;
 
-    out.print("Current state: fast = %d, teleport = %d.\n",
-        (debug_turbospeed && *debug_turbospeed) ? 2 : (enable_fastdwarf ? 1 : 0),
-        enable_teledwarf ? 1 : 0);
-
-    return CR_OK;
-}
-
-DFhackCExport command_result plugin_enable ( color_ostream &out, bool enable )
-{
-    if (active != enable)
-    {
-        active = enable_fastdwarf = enable;
-        enable_teledwarf = false;
+    if (fast < 0 || fast > 2) {
+        out.printerr("Invalid value for fast: '%s'", parameters[0].c_str());
+        return CR_WRONG_USAGE;
+    }
+    if (tele < 0 || tele > 1) {
+        out.printerr("Invalid value for tele: '%s'", parameters[1].c_str());
+        return CR_WRONG_USAGE;
     }
 
-    return CR_OK;
-}
-
-DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands)
-{
-    commands.push_back(PluginCommand(
-        "fastdwarf",
-        "Dwarves teleport and/or finish jobs instantly.",
-        fastdwarf));
+    set_state(out, fast, tele);
 
     return CR_OK;
 }


### PR DESCRIPTION
persist state with fort

add "status" command for printing state, API otherwise unchanged, despite the odd numeric syntax

behavior change: don't teleport if no job or if the destination is in a different pathability group or is on a hidden tile

Fixes: https://github.com/DFHack/dfhack/issues/4141
Fixes: https://github.com/DFHack/dfhack/issues/3998
Fixes: https://github.com/DFHack/dfhack/issues/2660
Fixes: https://github.com/DFHack/dfhack/issues/2623