### PR TITLE
include fast z movement as a map movement key

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -62,6 +62,7 @@ Template for new versions:
 - `sort`: fix mouse clicks falling through the squad assignment overlay panel when clicking on the panel but not on a clickable widget
 - `sort`: fix potential crash when removing jobs directly from the Tasks info screen
 - `misery`: fix error when changing the misery factor
+- When passing map movement keys through to the map from DFHack tool windows, also pass fast z movements (shift-scroll by default)
 
 ## Misc Improvements
 - `autochop`: better error output when target burrows are not specified on the commandline

--- a/library/lua/gui/dwarfmode.lua
+++ b/library/lua/gui/dwarfmode.lua
@@ -219,6 +219,7 @@ MOVEMENT_KEYS = {
     CURSOR_UPLEFT_FAST = { -1, -1, 0, true }, CURSOR_UPRIGHT_FAST = { 1, -1, 0, true },
     CURSOR_DOWNLEFT_FAST = { -1, 1, 0, true }, CURSOR_DOWNRIGHT_FAST = { 1, 1, 0, true },
     CURSOR_UP_Z = { 0, 0, 1 }, CURSOR_DOWN_Z = { 0, 0, -1 },
+    CURSOR_UP_Z_FAST = { 0, 0, 1, true }, CURSOR_DOWN_Z_FAST = { 0, 0, -1, true },
     CURSOR_UP_Z_AUX = { 0, 0, 1 }, CURSOR_DOWN_Z_AUX = { 0, 0, -1 },
 }
 


### PR DESCRIPTION
it was just missing. this meant that shift scroll was not being passed through to the map when `pass_movement_keys` was set to true