### PR TITLE
Update autoclothing.cpp

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `autochop`: better error output when target burrows are not specified on the commandline
+- `autoclothing` : now does not consider worn (x) clothing as usable/available, should help with using with `tailor` at same time
 - wherever units are listed in DFHack tools, properties like "agitated" or (-trained-) are now shown
 - `work-now`: now saves its enabled status with the fort
 - `fastdwarf`: now saves its state with the fort

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -573,6 +573,8 @@ static void find_needed_clothing_items()
                     continue;
                 if (item->getSubtype() != clothingOrder.item_subtype)
                     continue;
+                if (item->getWear() >= 1)
+                    continue;
 
                 MaterialInfo matInfo;
                 matInfo.decode(item);
@@ -599,6 +601,9 @@ static void remove_available_clothing()
     {
         //skip any owned items.
         if (getOwner(item))
+            continue;
+        //skip any worn or more items
+        if (item->getWear() >= 1)
             continue;
 
         //again, for each item, find if any clothing order matches
@@ -792,7 +797,7 @@ static bool isAvailableItem(df::item* item)
     if ((item->flags.whole & badFlags.whole) != 0)
         return false;
 
-    if (item->getWear() > 1)
+    if (item->getWear() >= 1)
         return false;
     if (!item->isClothing())
         return false;


### PR DESCRIPTION
(find_needed_clothing_items) Add check to skip items that are worn or more

(remove_available_clothing) Add check to skip items that are worn or more

(isAvailableItem) Change check on wear level to not include worn (x) items as available

I was running into an issue where autoclothing would not make new clothes and then tailor would have to start its own orders to clothe my dwarves (with clothes I didn't want them to wear). What has appeared to fix this is by having autoclothing not consider worn clothing as available/usable.

Any insight/feedback on this would be appreciated.