### PR TITLE
[zone] don't count dangling references when retiring zones

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -55,6 +55,7 @@ Template for new versions:
 
 ## New Features
 - `sort`: search and sort for the "choose unit to elevate to the barony" screen. units are sorted by the number of item preferences they have and the units are annotated with the items that they have preferences for
+- `zone`: add button to location details page for retiring unused locations
 - `gui/mass-remove`: new global keybinding: Ctrl-M while on the fort map
 
 ## Fixes

--- a/plugins/lua/zone.lua
+++ b/plugins/lua/zone.lua
@@ -1168,10 +1168,17 @@ end
 function RetireLocationOverlay:confirm_retire()
     local details = mi.location_details
     local location = details.selected_ab
-    local num_occupations, num_zones = 0, #location.contents.building_ids
+    local num_occupations, num_zones = 0, 0
     for _, occupation in ipairs(location.occupations) do
         if occupation.histfig_id ~= -1 then
             num_occupations = num_occupations + 1
+        end
+    end
+    for _, zone_id in ipairs(location.contents.building_ids) do
+        -- there can be dangling references in this list; only count
+        -- "attached" zones that actually exist
+        if df.building.find(zone_id) then
+            num_zones = num_zones + 1
         end
     end
     if num_occupations + num_zones > 0 then


### PR DESCRIPTION
if you remove a zone that has a location attached to it, the backref in the location to the zone is not cleaned up. don't count those dangling refs when determining if the location is still in use.