### PR TITLE
[Screen] fix vanilla top_of_text/bottom_of_text flags bleeding through

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 - When passing map movement keys through to the map from DFHack tool windows, also pass fast z movements (shift-scroll by default)
 - `getplants`: fix crash when processing mod-added plants with invalid materials
 - Dreamfort: fix holes in the "Inside+" burrow on the farming level (burrow autoexpand is interrupted by the pre-dug miasma vents to the surface)
+- DFHack tabs (e.g. in `gui/control-panel`) are now rendered correctly when there is a vanilla tab behind them
 
 ## Misc Improvements
 - `autochop`: better error output when target burrows are not specified on the commandline

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -203,6 +203,7 @@ static bool doSetTile_default(const Pen &pen, int x, int y, bool map)
 
         if (pen.top_of_text || pen.bottom_of_text) {
             screen[0] = uint8_t(pen.ch);
+            *flag &= ~0x18;
             if (pen.top_of_text)
                 *flag |= 0x8;
             if (pen.bottom_of_text)


### PR DESCRIPTION
noticed when using the control panel when the vanilla info tabs are visible