### PR TITLE
[buildingplan] fix planned buildings getting bumped to the front of the line on load

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,7 +66,8 @@ Template for new versions:
 - When passing map movement keys through to the map from DFHack tool windows, also pass fast z movements (shift-scroll by default)
 - `getplants`: fix crash when processing mod-added plants with invalid materials
 - Dreamfort: fix holes in the "Inside+" burrow on the farming level (burrow autoexpand is interrupted by the pre-dug miasma vents to the surface)
-- DFHack tabs (e.g. in `gui/control-panel`) are now rendered correctly when there is a vanilla tab behind them
+- DFHack tabs (e.g. in `gui/control-panel`) are now rendered correctly when there are certain vanilla screen elements behind them
+- `buildingplan`: when you save a game and load it again, newly planned buildings are now correctly placed in line after existing planned buildings of the same type
 
 ## Misc Improvements
 - `autochop`: better error output when target burrows are not specified on the commandline

--- a/plugins/buildingplan/plannedbuilding.cpp
+++ b/plugins/buildingplan/plannedbuilding.cpp
@@ -77,8 +77,10 @@ static set<string> get_specials(color_ostream &out, PersistentDataItem &bld_conf
         return ret;
     vector<string> specials;
     split_string(&specials, rawstrs[2], ",");
-    for (auto & special : specials)
-        ret.emplace(special);
+    for (auto & special : specials) {
+        if (special.size())
+            ret.emplace(special);
+    }
     return ret;
 }
 


### PR DESCRIPTION
this has been irking me forever. the fix was stupid simple.

PlannedBuilding state was subtly different depending on whether the state was created in this game session or loaded from disk. The difference was that one had a non-empty "specials" list, but the length of the string in that list was 0, so it was never obvious from the debug output what was going on. The fix is to not add a special entry if the input string is 0 length.

Fixes: https://github.com/DFHack/dfhack/issues/4188