### PR TITLE
don't designate pseudo constructions for removal

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -107,6 +107,7 @@ Template for new versions:
 - ``Persistence``: persistent keys are now namespaced by an entity_id (e.g. a player fort site ID)
 - ``Persistence``: data is now stored one file per entity ID (plus one for the global world) in the DF savegame directory
 - ``Units.isDanger``: now returns true for agitated wildlife
+- ``Constructions::designateRemove``: no longer designates the non-removable "pseudo" construtions that represent the top of walls
 
 ## Lua
 - ``dfhack.capitalizeStringWords``: new function, returns string with all words capitalized

--- a/library/modules/Constructions.cpp
+++ b/library/modules/Constructions.cpp
@@ -43,6 +43,7 @@ using namespace std;
 
 #include "df/building_constructionst.h"
 #include "df/building_type.h"
+#include "df/construction.h"
 #include "df/job_item.h"
 #include "df/map_block.h"
 #include "df/world.h"
@@ -142,6 +143,11 @@ bool Constructions::designateRemove(df::coord pos, bool *immediate)
 
     if (tileMaterial(ttype) == tiletype_material::CONSTRUCTION)
     {
+        // don't designate pseudo-constructions
+        auto constr = df::construction::find(pos);
+        if (constr->flags.bits.top_of_wall)
+            return false;
+
         auto &dsgn = block->designation[pos.x&15][pos.y&15];
         dsgn.bits.dig = tile_dig_designation::Default;
         block->flags.bits.designated = true;

--- a/library/modules/Constructions.cpp
+++ b/library/modules/Constructions.cpp
@@ -145,7 +145,7 @@ bool Constructions::designateRemove(df::coord pos, bool *immediate)
     {
         // don't designate pseudo-constructions
         auto constr = df::construction::find(pos);
-        if (constr->flags.bits.top_of_wall)
+        if (!constr || constr->flags.bits.top_of_wall)
             return false;
 
         auto &dsgn = block->designation[pos.x&15][pos.y&15];


### PR DESCRIPTION
fixes `gui/mass-remove` designating tops of walls for deconstruction