### PR TITLE
Fix dig-now not updating flags when channeling

### DIFF
--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -489,6 +489,7 @@ static bool dig_tile(color_ostream &out, MapExtras::MapCache &map,
                     if (td_below == df::tile_dig_designation::Default) {
                         dig_tile(out, map, pos_below, td_below, dug_tiles);
                     }
+                    propagate_vertical_flags(map, pos);
                     return true;
                 }
             } else {


### PR DESCRIPTION
Fixes #3808
Due to channel designations being handled with recursive calls and exiting early, propagate_vertical_flags() wasn't running on the position of the channel designation itself, but on the tile below. Adding a call to propagate_vertical_flags() before the early exit solved the issue.