### PR TITLE
[sort] reset state whenever we leave the local info context

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `sort`: fix potential crash when switching between info tabs
 
 ## Misc Improvements
 - `reveal`: automatically reset saved map state when a new save is loaded

--- a/plugins/lua/sort/info.lua
+++ b/plugins/lua/sort/info.lua
@@ -192,7 +192,21 @@ InfoOverlay = defclass(InfoOverlay, sortoverlay.SortOverlay)
 InfoOverlay.ATTRS{
     desc='Adds search and filter functionality to most info panels.',
     default_pos={x=64, y=8},
-    viewscreens='dwarfmode/Info',
+    viewscreens={
+        'dwarfmode/Info/CREATURES/CITIZEN',
+        'dwarfmode/Info/CREATURES/PET',
+        'dwarfmode/Info/CREATURES/AddingTrainer',
+        'dwarfmode/Info/CREATURES/AssignWorkAnimal',
+        'dwarfmode/Info/CREATURES/OverallTraining',
+        'dwarfmode/Info/CREATURES/OTHER',
+        'dwarfmode/Info/CREATURES/DECEASED',
+        'dwarfmode/Info/JOBS',
+        'dwarfmode/Info/Labor/WORK_DETAILS',
+        'dwarfmode/Info/ARTIFACTS/ARTIFACTS',
+        'dwarfmode/Info/ARTIFACTS/SYMBOLS',
+        'dwarfmode/Info/ARTIFACTS/NAMED_OBJECTS',
+        'dwarfmode/Info/ARTIFACTS/WRITTEN_CONTENT',
+    },
     frame={w=40, h=6},
 }
 

--- a/plugins/lua/sort/sortoverlay.lua
+++ b/plugins/lua/sort/sortoverlay.lua
@@ -55,11 +55,20 @@ local function do_cleanup(handlers, key, data)
     data.saved_original = nil
 end
 
+local function get_in_scope(scopes)
+    if type(scopes) == 'string' then scopes = {scopes} end
+    local scr = dfhack.gui.getDFViewscreen(true)
+    for _,scope in ipairs(scopes) do
+        if dfhack.gui.matchFocusString(scope, scr) then
+            return true
+        end
+    end
+end
+
 -- handles reset and clean up when the player exits the handled scope
 function SortOverlay:overlay_onupdate()
-    if self.overlay_onupdate_max_freq_seconds == 0 and
-        not dfhack.gui.matchFocusString(self.viewscreens, dfhack.gui.getDFViewscreen(true))
-    then
+    if self.overlay_onupdate_max_freq_seconds ~= 0 then return end
+    if not get_in_scope(self.viewscreens) then
         for key,data in pairs(self.state) do
             if type(data) == 'table' then
                 do_cleanup(self.handlers, key, data)


### PR DESCRIPTION
prevents a potential crash when DF refreshes the underlying lists and we're still referencing old, deleted data

Fixes: https://github.com/DFHack/dfhack/issues/4218