### PR TITLE
[autonestbox] don't assign egg layers that might revert to wild

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `reveal`: automatically reset saved map state when a new save is loaded
+- `autonestbox`: don't automatically assign partially trained egg-layers to nestboxes if they don't have an ongoing trainer assigned since they might revert to wild
 
 ## Documentation
 

--- a/plugins/autonestbox.cpp
+++ b/plugins/autonestbox.cpp
@@ -247,11 +247,17 @@ static bool isAssigned(df::unit *unit) {
     return false;
 }
 
+static bool unlikely_to_revert_to_wild(df::unit *unit) {
+    if (Units::isDomesticated(unit))
+        return true;
+    return Units::isTame(unit) && Units::isMarkedForTraining(unit);
+}
+
 static bool isFreeEgglayer(df::unit *unit)
 {
     return Units::isActive(unit) && !Units::isUndead(unit)
         && Units::isFemale(unit)
-        && Units::isTame(unit)
+        && unlikely_to_revert_to_wild(unit)
         && Units::isOwnCiv(unit)
         && Units::isEggLayer(unit)
         && !isAssigned(unit)


### PR DESCRIPTION
I'd noticed this in-game before, but the logic error became obvious when I was refactoring the training code