### PR TITLE
use a blank, default ref when pushing to non DFHack repos

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Clone DFHack
         uses: actions/checkout@v3
         with:
-          repository: ${{ format('{0}/dfhack', inputs.dfhack_ref && github.repository_owner || 'DFHack') }}
+          repository: ${{ inputs.dfhack_ref && format('{0}/dfhack', github.repository_owner) || 'DFHack/dfhack' }}
           ref: ${{ inputs.dfhack_ref }}
           submodules: true
           fetch-depth: ${{ !inputs.platform-files && 1 || 0 }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Clone DFHack
         uses: actions/checkout@v3
         with:
-          repository: ${{ format('{0}/dfhack', inputs.dfhack_ref && github.repository_owner || 'DFHack') }}
+          repository: ${{ inputs.dfhack_ref && format('{0}/dfhack', github.repository_owner) || 'DFHack/dfhack' }}
           ref: ${{ inputs.dfhack_ref }}
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Clone DFHack
       uses: actions/checkout@v3
       with:
-        repository: ${{ format('{0}/dfhack', inputs.dfhack_ref && github.repository_owner || 'DFHack') }}
+        repository: ${{ inputs.dfhack_ref && format('{0}/dfhack', github.repository_owner) || 'DFHack/dfhack' }}
         ref: ${{ inputs.dfhack_ref }}
     - name: Get scripts submodule ref
       if: '!inputs.scripts_ref'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Clone DFHack
       uses: actions/checkout@v3
       with:
-        repository: ${{ format('{0}/dfhack', inputs.dfhack_ref && github.repository_owner || 'DFHack') }}
+        repository: ${{ inputs.dfhack_ref && format('{0}/dfhack', github.repository_owner) || 'DFHack/dfhack' }}
         ref: ${{ inputs.dfhack_ref }}
     - name: Detect DF version
       shell: bash


### PR DESCRIPTION
so forks still build against DFHack/dfhack/develop instead of their own (likely out of date and tagless) fork of develop

followup to https://github.com/DFHack/dfhack/pull/4232