### PR TITLE
Make `dig-now` remove ramps for all dig modes.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -29,7 +29,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-- `dig-now`: now properly changes newly exposed areas to light/outside when digging around the surface.
+- `dig-now`: now properly removes ramps rendered unusable by digging and changes newly exposed areas to light/outside when digging around the surface.
 ## Misc Improvements
 
 ## Documentation

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -344,7 +344,11 @@ static void clean_ramp(MapExtras::MapCache &map, const DFCoord &pos) {
     if (is_wall(map, DFCoord(pos.x-1, pos.y, pos.z)) ||
             is_wall(map, DFCoord(pos.x+1, pos.y, pos.z)) ||
             is_wall(map, DFCoord(pos.x, pos.y-1, pos.z)) ||
-            is_wall(map, DFCoord(pos.x, pos.y+1, pos.z)))
+            is_wall(map, DFCoord(pos.x, pos.y+1, pos.z)) ||
+            is_wall(map, DFCoord(pos.x-1, pos.y-1, pos.z)) ||
+            is_wall(map, DFCoord(pos.x-1, pos.y+1, pos.z)) ||
+            is_wall(map, DFCoord(pos.x+1, pos.y-1, pos.z)) ||
+            is_wall(map, DFCoord(pos.x+1, pos.y+1, pos.z)))
         return;
 
     remove_ramp_top(map, DFCoord(pos.x, pos.y, pos.z+1));
@@ -359,6 +363,10 @@ static void clean_ramps(MapExtras::MapCache &map, const DFCoord &pos) {
     clean_ramp(map, DFCoord(pos.x+1, pos.y, pos.z));
     clean_ramp(map, DFCoord(pos.x, pos.y-1, pos.z));
     clean_ramp(map, DFCoord(pos.x, pos.y+1, pos.z));
+    clean_ramp(map, DFCoord(pos.x-1, pos.y-1, pos.z));
+    clean_ramp(map, DFCoord(pos.x-1, pos.y+1, pos.z));
+    clean_ramp(map, DFCoord(pos.x+1, pos.y-1, pos.z));
+    clean_ramp(map, DFCoord(pos.x+1, pos.y+1, pos.z));
 }
 
 // destroys any colonies located at pos
@@ -489,6 +497,7 @@ static bool dig_tile(color_ostream &out, MapExtras::MapCache &map,
                     if (td_below == df::tile_dig_designation::Default) {
                         dig_tile(out, map, pos_below, td_below, dug_tiles);
                     }
+                    clean_ramps(map, pos);
                     propagate_vertical_flags(map, pos);
                     return true;
                 }
@@ -552,6 +561,7 @@ static bool dig_tile(color_ostream &out, MapExtras::MapCache &map,
     TRACE(general).print("dig_tile: digging the designation tile at (" COORD ")\n",COORDARGS(pos));
     dig_type(map, pos, target_type);
 
+    clean_ramps(map, pos);
     return true;
 }
 


### PR DESCRIPTION
Fixes #4213 by looking for ramps for every designation type and adding the missing diagonal case to clean_ramp() and clean_ramps().