### PR TITLE
load vtables with library base offsets

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3172,6 +3172,10 @@ static int internal_getMemRanges(lua_State *L)
     for(size_t i = 0; i < ranges.size(); i++)
     {
         lua_newtable(L);
+        if (ranges[i].base) {
+            lua_pushinteger(L, (uintptr_t)ranges[i].base);
+            lua_setfield(L, -2, "base_addr");
+        }
         lua_pushinteger(L, (uintptr_t)ranges[i].start);
         lua_setfield(L, -2, "start_addr");
         lua_pushinteger(L, (uintptr_t)ranges[i].end);

--- a/library/Process-darwin.cpp
+++ b/library/Process-darwin.cpp
@@ -161,6 +161,9 @@ void Process::getMemRanges( vector<t_memrange> & ranges )
     kr = KERN_SUCCESS;
     address = 0;
 
+    string cur_name;
+    void * cur_base = nullptr;
+
     do {
 #ifdef DFHACK64
         flavor = VM_REGION_BASIC_INFO_64;
@@ -189,6 +192,11 @@ void Process::getMemRanges( vector<t_memrange> & ranges )
             t_memrange temp;
             strncpy( temp.name, dlinfo.dli_fname, 1023 );
             temp.name[1023] = 0;
+            if (cur_name != temp.name) {
+                cur_name = temp.name;
+                cur_base = (void *) address;
+            }
+            temp.base = cur_base;
             temp.start = (void *) address;
             temp.end = (void *) (address+vmsize);
             temp.read = (info.protection & VM_PROT_READ);

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -134,6 +134,9 @@ void Process::getMemRanges( vector<t_memrange> & ranges )
 
     size_t start, end, offset, device1, device2, node;
 
+    string cur_name;
+    void * cur_base = nullptr;
+
     while (fgets(buffer, 1024, mapFile))
     {
         t_memrange temp;
@@ -144,6 +147,11 @@ void Process::getMemRanges( vector<t_memrange> & ranges )
                (char*)&permissions,
                &offset, &device1, &device2, &node,
                (char*)temp.name);
+        if (cur_name != temp.name) {
+            cur_name = temp.name;
+            cur_base = (void *) start;
+        }
+        temp.base = cur_base;
         temp.start = (void *) start;
         temp.end = (void *) end;
         temp.read = permissions[0] == 'r';

--- a/library/Process-windows.cpp
+++ b/library/Process-windows.cpp
@@ -188,10 +188,12 @@ void Process::getMemRanges( vector<t_memrange> & ranges )
 
     ranges.clear();
 
+    HANDLE my_handle = GetCurrentProcess();
+
     // enumerate heaps
     // HeapNodes(d->my_pid, heaps);
     // go through all the VM regions, convert them to our internal format
-    while (VirtualQueryEx(d->my_handle, (const void*) (movingStart), &MBI, sizeof(MBI)) == sizeof(MBI))
+    while (VirtualQueryEx(my_handle, (const void*) (movingStart), &MBI, sizeof(MBI)) == sizeof(MBI))
     {
         movingStart = ((uint64_t)MBI.BaseAddress + MBI.RegionSize);
         if(movingStart % PageSize != 0)
@@ -242,7 +244,7 @@ void Process::getMemRanges( vector<t_memrange> & ranges )
 
 #if 1
         // Find the mapped file name
-        if (GetMappedFileName(d->my_handle, temp.start, temp.name, 1024))
+        if (GetMappedFileName(my_handle, temp.start, temp.name, 1024))
         {
             int vsize = strlen(temp.name);
 

--- a/library/include/MemAccess.h
+++ b/library/include/MemAccess.h
@@ -51,6 +51,7 @@ namespace DFHack
      */
     struct DFHACK_EXPORT t_memrange
     {
+        void * base;
         void * start;
         void * end;
         // memory range name (if any)
@@ -69,7 +70,6 @@ namespace DFHack
             return false;
         }
         bool valid;
-        uint8_t * buffer;
     };
 
     /**
@@ -244,8 +244,9 @@ namespace DFHack
             {
                 return identified;
             };
+
             /// get virtual memory ranges of the process (what is mapped where)
-            void getMemRanges(std::vector<t_memrange> & ranges );
+            static void getMemRanges(std::vector<t_memrange> & ranges);
 
             /// get the symbol table extension of this process
             std::shared_ptr<DFHack::VersionInfo> getDescriptor()


### PR DESCRIPTION
required to load vtables found only in g_src on Linux

Pairs well with https://github.com/DFHack/scripts/pull/965 and https://github.com/DFHack/df-structures/pull/715