### PR TITLE
Add "flask-contents" tweak

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 
 ## New Features
 - `cleanowned`: Add a "nodump" option to allow for confiscating items without dumping
+- `tweak`: Add "flask-contents", makes flasks/vials/waterskins be named according to their contents
 
 ## Fixes
 

--- a/docs/plugins/tweak.rst
+++ b/docs/plugins/tweak.rst
@@ -35,6 +35,10 @@ Commands
     temperature is crossed in no more than 100 ticks when updating from the
     environment temperature. This reduces the time it takes for temperature to
     reach equilibrium and improves FPS when there are many items.
+``flask-contents``
+    Names filled waterskins, flasks, and vials according to their contents,
+    the same way other containers such as barrels, bins, and cages are named.
+    (:bug:`4914`)
 ``partial-items``
     Displays percentages on partially-consumed items such as hospital cloth.
 ``reaction-gloves``

--- a/plugins/tweak/tweak.cpp
+++ b/plugins/tweak/tweak.cpp
@@ -16,6 +16,7 @@ using namespace DFHack;
 #include "tweaks/craft-age-wear.h"
 #include "tweaks/eggs-fertile.h"
 #include "tweaks/fast-heat.h"
+#include "tweaks/flask-contents.h"
 #include "tweaks/partial-items.h"
 #include "tweaks/reaction-gloves.h"
 
@@ -56,6 +57,8 @@ DFhackCExport command_result plugin_init(color_ostream &out, vector<PluginComman
     TWEAK_HOOK("fast-heat", fast_heat_hook, updateTempFromMap);
     TWEAK_HOOK("fast-heat", fast_heat_hook, updateTemperature);
     TWEAK_HOOK("fast-heat", fast_heat_hook, adjustTemperature);
+
+    TWEAK_HOOK("flask-contents", flask_contents_hook, getItemDescription);
 
     TWEAK_HOOK("partial-items", partial_items_hook_bar, getItemDescription);
     TWEAK_HOOK("partial-items", partial_items_hook_drink, getItemDescription);

--- a/plugins/tweak/tweaks/flask-contents.h
+++ b/plugins/tweak/tweaks/flask-contents.h
@@ -1,0 +1,39 @@
+// Make flask item names indicate what's inside them (e.g. "liquid fire vial (green glass)")
+
+#include "df/item_flaskst.h"
+#include "df/builtin_mats.h"
+#include "modules/Items.h"
+
+struct flask_contents_hook : df::item_flaskst {
+    typedef df::item_flaskst interpose_base;
+    DEFINE_VMETHOD_INTERPOSE(void, getItemDescription, (std::string *str, int8_t plurality)) {
+        std::vector<df::item*> contents;
+        Items::getContainedItems(this, &contents);
+
+        if (contents.size() == 0)
+        {
+            INTERPOSE_NEXT(getItemDescription)(str, plurality);
+            return;
+        }
+        MaterialInfo mat(mat_type, mat_index);
+        if (contents.size() == 1)
+        {
+            if ((mat.material->flags.is_set(df::material_flags::LEATHER)) && (contents[0]->getMaterial() == df::builtin_mats::WATER))
+                str->append("Filled");
+            else
+                contents[0]->getItemDescription(str, 1);
+        }
+        else
+            str->append("Mixed");
+
+        if (mat.material->flags.is_set(df::material_flags::LEATHER))
+            str->append(" waterskin (");
+        else if (mat.material->flags.is_set(df::material_flags::IS_GLASS))
+            str->append(" vial (");
+        else
+            str->append(" flask (");
+        str->append(mat.toString());
+        str->append(")");
+    }
+};
+IMPLEMENT_VMETHOD_INTERPOSE(flask_contents_hook, getItemDescription);


### PR DESCRIPTION
Makes flasks, vials, and waterskins display the name of their contents, just like other containers do (e.g. barrels, bins, and cages).