### PR TITLE
Update Units::getVisibleName

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 - `tweak`: Add "flask-contents", makes flasks/vials/waterskins be named according to their contents
 
 ## Fixes
+- ``Units::getVisibleName``: Use ``impersonated_hf`` field of identity
 
 ## Misc Improvements
 - `regrass`: also regrow depleted cavern moss

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1087,7 +1087,7 @@ df::language_name *Units::getVisibleName(df::unit *unit)
     if (identity)
     {
         auto imp_hf = df::historical_figure::find(identity->impersonated_hf);
-        return (imp_hf != NULL && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
+        return (imp_hf && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
     }
 
     return &hf->name;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1087,7 +1087,7 @@ df::language_name *Units::getVisibleName(df::unit *unit)
     if (identity)
     {
         auto imp_hf = df::historical_figure::find(identity->impersonated_hf);
-        return (imp_hf && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
+        return (imp_hf != NULL && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
     }
 
     return &hf->name;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1086,7 +1086,7 @@ df::language_name *Units::getVisibleName(df::unit *unit)
     auto identity = getFigureIdentity(hf);
     if (identity)
     {
-        auto imp_hf = df::historical_figure.find(identity->impersonated_hf);
+        auto imp_hf = df::historical_figure::find(identity->impersonated_hf);
         return (imp_hf && imp_hf->has_name) ? &imp_hf->name : &identity->name;
     }
 

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1087,7 +1087,7 @@ df::language_name *Units::getVisibleName(df::unit *unit)
     if (identity)
     {
         auto imp_hf = df::historical_figure::find(identity->impersonated_hf);
-        return (imp_hf && imp_hf->name && imp_hf->name->has_name) ? &imp_hf->name : &identity->name;
+        return (imp_hf && imp_hf->name && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
     }
 
     return &hf->name;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1087,7 +1087,7 @@ df::language_name *Units::getVisibleName(df::unit *unit)
     if (identity)
     {
         auto imp_hf = df::historical_figure::find(identity->impersonated_hf);
-        return (imp_hf && imp_hf->has_name) ? &imp_hf->name : &identity->name;
+        return (imp_hf && imp_hf->name && imp_hf->name->has_name) ? &imp_hf->name : &identity->name;
     }
 
     return &hf->name;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1079,11 +1079,18 @@ df::language_name *Units::getVisibleName(df::unit *unit)
 {
     CHECK_NULL_POINTER(unit);
 
-    // as of 0.44.11, identity names take precedence over associated histfig names
-    if (auto identity = getIdentity(unit))
-        return &identity->name;
+    auto hf = df::historical_figure::find(unit->hist_figure_id);
+    if (!hf)
+        return &unit->name;
 
-    return &unit->name;
+    auto identity = getFigureIdentity(hf);
+    if (identity)
+    {
+        auto imp_hf = df::historical_figure.find(identity->impersonated_hf);
+        return (imp_hf && imp_hf->has_name) ? &imp_hf->name : &identity->name;
+    }
+
+    return &hf->name;
 }
 
 df::nemesis_record *Units::getNemesis(df::unit *unit)

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1087,7 +1087,7 @@ df::language_name *Units::getVisibleName(df::unit *unit)
     if (identity)
     {
         auto imp_hf = df::historical_figure::find(identity->impersonated_hf);
-        return (imp_hf && imp_hf->name && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
+        return (imp_hf && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
     }
 
     return &hf->name;


### PR DESCRIPTION
Needs to use `impersonated_hf`, if exists.

Based on reverse engineering of v50.11, and is trivial to confirm just by changing the id of `impersonated_hf` and watching the unit's name change in the UI.