### PR TITLE
[overlay] add perf timers

### DIFF
--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -38,6 +38,9 @@ function print_timers()
     print(('elapsed time: %d ms (%dm %ds)'):format(
         elapsed, elapsed // 60000, (elapsed % 60000) // 1000
     ))
+    print (('total widget processing time: %d ms (%.2f%% of elapsed time)'):format(
+        sum, (sum * 100) / elapsed
+    ))
 end
 
 -- ---------------- --

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -12,6 +12,8 @@ local GLOBAL_KEY = 'OVERLAY'
 
 local DEFAULT_X_POS, DEFAULT_Y_POS = -2, -2
 
+timers = {}
+
 -- ---------------- --
 -- state and config --
 -- ---------------- --
@@ -413,7 +415,9 @@ end
 local function detect_frame_change(widget, fn)
     local frame = widget.frame
     local w, h = frame.w, frame.h
+    local now_ms = dfhack.getTickCount()
     local ret = fn()
+    timers[widget.name] = (timers[widget.name] or 0) + (dfhack.getTickCount() - now_ms)
     if w ~= frame.w or h ~= frame.h then
         widget:updateLayout()
     end

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -24,6 +24,8 @@ function print_timers()
     for _,timer in pairs(timers) do
         sum = sum + timer
     end
+    if elapsed <= 0 then elapsed = 1 end
+    if sum <= 0 then sum = 1 end
     local sorted = {}
     for name,timer in pairs(timers) do
         table.insert(sorted, {name=name, ms=timer})
@@ -35,10 +37,10 @@ function print_timers()
         ))
     end
     print()
-    print(('elapsed time: %d ms (%dm %ds)'):format(
+    print(('elapsed time: %8d ms (%dm %ds)'):format(
         elapsed, elapsed // 60000, (elapsed % 60000) // 1000
     ))
-    print (('total widget processing time: %d ms (%.2f%% of elapsed time)'):format(
+    print(('widget time:  %8d ms (%.2f%% of elapsed time)'):format(
         sum, (sum * 100) / elapsed
     ))
 end

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -13,6 +13,9 @@ local GLOBAL_KEY = 'OVERLAY'
 local DEFAULT_X_POS, DEFAULT_Y_POS = -2, -2
 
 timers = {}
+function reset_timers()
+    timers = {}
+end
 
 -- ---------------- --
 -- state and config --

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -12,9 +12,32 @@ local GLOBAL_KEY = 'OVERLAY'
 
 local DEFAULT_X_POS, DEFAULT_Y_POS = -2, -2
 
-timers = {}
+local timers = {}
+local timers_start_ms = dfhack.getTickCount()
 function reset_timers()
     timers = {}
+    timers_start_ms = dfhack.getTickCount()
+end
+function print_timers()
+    local elapsed = dfhack.getTickCount() - timers_start_ms
+    local sum = 0
+    for _,timer in pairs(timers) do
+        sum = sum + timer
+    end
+    local sorted = {}
+    for name,timer in pairs(timers) do
+        table.insert(sorted, {name=name, ms=timer})
+    end
+    table.sort(sorted, function(a, b) return a.ms > b.ms end)
+    for _, elem in ipairs(sorted) do
+        print(('%45s %8d ms  %6.2f%% overlay  %6.2f%% overall'):format(
+            elem.name, elem.ms, (elem.ms * 100) / sum, (elem.ms * 100) / elapsed
+        ))
+    end
+    print()
+    print(('elapsed time: %d ms (%dm %ds)'):format(
+        elapsed, elapsed // 60000, (elapsed % 60000) // 1000
+    ))
 end
 
 -- ---------------- --

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -37,10 +37,10 @@ function print_timers()
         ))
     end
     print()
-    print(('elapsed time: %8d ms (%dm %ds)'):format(
+    print(('elapsed time: %10d ms (%dm %ds)'):format(
         elapsed, elapsed // 60000, (elapsed % 60000) // 1000
     ))
-    print(('widget time:  %8d ms (%.2f%% of elapsed time)'):format(
+    print(('widget time:  %10d ms (%.2f%% of elapsed time)'):format(
         sum, (sum * 100) / elapsed
     ))
 end


### PR DESCRIPTION
To use:

when you're ready to begin measurement, run:

`:lua require('plugins.overlay').reset_timers()`

then just let the overlay run. to get the measurements, run:

`:lua require('plugins.overlay').print_timers()`