### PR TITLE
Fix Enabled Behavior autoclothing

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -62,6 +62,7 @@ Template for new versions:
 - ``Units::getVisibleName``: don't reveal the true identities of units that are impersonating other historical figures
 - ``Gui::revealInDwarfmodeMap``: properly center the zoom even when the target tile is near the edge of the map
 - `warn-stranded`: don't complain about units that aren't on the map (e.g.  soldiers out on raids)
+- `autoclothing`: Fix enabled behavior
 
 ## Misc Improvements
 - `regrass`: also regrow depleted cavern moss

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -237,16 +237,16 @@ DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_chan
 
 DFhackCExport command_result plugin_load_site_data (color_ostream &out) {
     cycle_timestamp = 0;
-    auto enabled = World::GetPersistentSiteData("autoclothing/enabled");
-    if (enabled.get_bool(0))
-    {
-        out << "autoclothing enabled" << endl;
-        is_enabled = true;
+    auto enabled = World::GetPersistentSiteData(CONFIG_KEY);
+    if (!enabled.isValid()) {
+        DEBUG(control, out).print("no config found in this save; initializing\n");
+        enabled = World::AddPersistentSiteData(CONFIG_KEY);
+        enabled.set_bool(CONFIG_IS_ENABLED, is_enabled);
     }
-    else
-    {
-        is_enabled = false;
-    }
+
+    is_enabled = enabled.get_bool(CONFIG_IS_ENABLED);
+    DEBUG(control, out).print("loading persisted enabled state: %s\n",
+        is_enabled ? "true" : "false");
 
     // Parse constraints
     vector<PersistentDataItem> items;
@@ -303,7 +303,7 @@ DFhackCExport command_result plugin_enable(color_ostream& out, bool enable) {
     }
 
     if (enable != is_enabled) {
-        auto enabled = World::GetPersistentSiteData("autoclothing/enabled");
+        auto enabled = World::GetPersistentSiteData(CONFIG_KEY);
         is_enabled = enable;
         DEBUG(control, out).print("%s from the API; persisting\n",
             is_enabled ? "enabled" : "disabled");


### PR DESCRIPTION
Noticed `autoclothing` was not staying enabled for my fort after saving, quitting, and then reloading. Used tailor.cpp as a reference for the fix.

Tested fix and appears to work.