### PR TITLE
Fix `dig-now` creating portals to the underworld when digging downstairs in tiles containing plants.

### DIFF
--- a/library/TileTypes.cpp
+++ b/library/TileTypes.cpp
@@ -291,8 +291,6 @@ namespace DFHack
         assert(is_valid_enum_item(sourceTileType));
         #endif
 
-
-
         // Special case for smooth pillars.
         // When you want a smooth wall, no need to search for best match.  Just use a pillar instead.
         // Choosing the right direction would require knowing neighbors.

--- a/library/TileTypes.cpp
+++ b/library/TileTypes.cpp
@@ -291,6 +291,8 @@ namespace DFHack
         assert(is_valid_enum_item(sourceTileType));
         #endif
 
+
+
         // Special case for smooth pillars.
         // When you want a smooth wall, no need to search for best match.  Just use a pillar instead.
         // Choosing the right direction would require knowing neighbors.
@@ -340,6 +342,11 @@ namespace DFHack
                 // Direction is medium value match
                 if (cur_direction == tileDirection(tt))
                     value |= 4;
+                
+                // If the material is a plant, consider soil an acceptable alternative
+                if (cur_material == tiletype_material::PLANT and tileMaterial(tt) == tiletype_material::SOIL) {
+                    value |= 2;
+                }
 
                 // Variant is low-value match
                 if (cur_variant == tileVariant(tt))


### PR DESCRIPTION
Give some points to matching plants with soil in `findSimilarTileType()`, which should avoid matching plants with esoteric materials.