### PR TITLE
fix getMouseFramePos() for nested widgets

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 - `warn-stranded`: don't complain about units that aren't on the map (e.g.  soldiers out on raids)
 - `autoclothing`: Fix enabled behavior
 - ``Gui::makeAnnouncement``, ``Gui::autoDFAnnouncement``: don't display popup for all announcement types
+- ``gui.View:getMouseFramePos``: function now detects the correct coordinates even when the widget is nested within other frames
 
 ## Misc Improvements
 - `regrass`: also regrow depleted cavern moss

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -509,7 +509,14 @@ function View:getMousePos(view_rect)
 end
 
 function View:getMouseFramePos()
-    return self:getMousePos(ViewRect{rect=self.frame_rect})
+    return self:getMousePos(ViewRect{
+        rect=mkdims_wh(
+            self.frame_rect.x1+self.frame_parent_rect.x1,
+            self.frame_rect.y1+self.frame_parent_rect.y1,
+            self.frame_rect.width,
+            self.frame_rect.height
+        )
+    })
 end
 
 function View:computeFrame(parent_rect)

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -536,7 +536,6 @@ function Panel:postUpdateLayout()
         end
         ::continue::
     end
-    self.frame_rect.height = y
 
     -- let widgets adjust to their new positions
     self:updateSubviewLayout()


### PR DESCRIPTION
still works for top-level widgets, of course