### PR TITLE
Add `Units::isNobleFromOtherSite`

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1304,6 +1304,14 @@ Units module
 
   The unit belongs to the player's race.
 
+* ``dfhack.units.isNobleFromOtherSite(unit[, include_own])``
+
+  The unit is a noble (landholder) ruling a site that is not the
+  player's fortress. This includes monarchs if your fortress is not
+  a capital yet. You can include your local rulers if they somehow
+  hold a concurrent position as ruler of another site by passing
+  ``true`` as the optional second parameter. 
+
 * ``dfhack.units.isAlive(unit)``
 
   The unit isn't dead or undead.

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1363,7 +1363,7 @@ Units module
   player's fortress. This includes monarchs if your fortress is not
   a capital yet. You can include your local rulers if they somehow
   hold a concurrent position as ruler of another site by passing
-  ``true`` as the optional second parameter. 
+  ``true`` as the optional second parameter.
 
 * ``dfhack.units.isAlive(unit)``
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1719,6 +1719,7 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, isFortControlled),
     WRAPM(Units, isOwnCiv),
     WRAPM(Units, isOwnGroup),
+    WRAPM(Units, isNobleFromOtherSite),
     WRAPM(Units, isOwnRace),
     WRAPM(Units, isAlive),
     WRAPM(Units, isDead),

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -81,6 +81,7 @@ DFHACK_EXPORT bool isFortControlled(df::unit *unit);
 DFHACK_EXPORT bool isOwnCiv(df::unit* unit);
 DFHACK_EXPORT bool isOwnGroup(df::unit* unit);
 DFHACK_EXPORT bool isOwnRace(df::unit* unit);
+DFHACK_EXPORT bool isNobleFromOtherSite(df::unit* unit);
 
 DFHACK_EXPORT bool isAlive(df::unit *unit);
 DFHACK_EXPORT bool isDead(df::unit *unit);

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -81,7 +81,7 @@ DFHACK_EXPORT bool isFortControlled(df::unit *unit);
 DFHACK_EXPORT bool isOwnCiv(df::unit* unit);
 DFHACK_EXPORT bool isOwnGroup(df::unit* unit);
 DFHACK_EXPORT bool isOwnRace(df::unit* unit);
-DFHACK_EXPORT bool isNobleFromOtherSite(df::unit* unit, bool ignore_own = true);
+DFHACK_EXPORT bool isNobleFromOtherSite(df::unit* unit, bool include_own = false);
 
 DFHACK_EXPORT bool isAlive(df::unit *unit);
 DFHACK_EXPORT bool isDead(df::unit *unit);

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -81,7 +81,7 @@ DFHACK_EXPORT bool isFortControlled(df::unit *unit);
 DFHACK_EXPORT bool isOwnCiv(df::unit* unit);
 DFHACK_EXPORT bool isOwnGroup(df::unit* unit);
 DFHACK_EXPORT bool isOwnRace(df::unit* unit);
-DFHACK_EXPORT bool isNobleFromOtherSite(df::unit* unit, bool ignore_own = false);
+DFHACK_EXPORT bool isNobleFromOtherSite(df::unit* unit, bool ignore_own = true);
 
 DFHACK_EXPORT bool isAlive(df::unit *unit);
 DFHACK_EXPORT bool isDead(df::unit *unit);

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -81,7 +81,7 @@ DFHACK_EXPORT bool isFortControlled(df::unit *unit);
 DFHACK_EXPORT bool isOwnCiv(df::unit* unit);
 DFHACK_EXPORT bool isOwnGroup(df::unit* unit);
 DFHACK_EXPORT bool isOwnRace(df::unit* unit);
-DFHACK_EXPORT bool isNobleFromOtherSite(df::unit* unit);
+DFHACK_EXPORT bool isNobleFromOtherSite(df::unit* unit, bool ignore_own = false);
 
 DFHACK_EXPORT bool isAlive(df::unit *unit);
 DFHACK_EXPORT bool isDead(df::unit *unit);

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -221,7 +221,7 @@ bool Units::isOwnRace(df::unit* unit)
 }
 
 // check if creature holds a landholder appointment from site that is not the player's fort
-bool Units::isNobleFromOtherSite(df::unit* unit, bool ignore_own)
+bool Units::isNobleFromOtherSite(df::unit* unit, bool include_own)
 {
     CHECK_NULL_POINTER(unit);
 
@@ -239,7 +239,7 @@ bool Units::isNobleFromOtherSite(df::unit* unit, bool ignore_own)
         bool rules_this_site = (pos.entity->id == plotinfo->group_id) ||
                                (pos.entity->id == plotinfo->civ_id && plotinfo->king_arrived);
 
-        if (ignore_own && rules_this_site)
+        if (include_own && rules_this_site)
             return false;
 
         if (!rules_this_site)

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -236,20 +236,14 @@ bool Units::isNobleFromOtherSite(df::unit* unit, bool ignore_own)
             continue;
 
         // (landholder rules this site) or (site is capital and landholder is monarch)
-        bool is_this_site = (pos.entity->id == plotinfo->group_id) ||
-                            (pos.entity->id == plotinfo->civ_id && plotinfo->king_arrived);
+        bool rules_this_site = (pos.entity->id == plotinfo->group_id) ||
+                               (pos.entity->id == plotinfo->civ_id && plotinfo->king_arrived);
         
-        if (ignore_own && is_this_site)
-        {
-            result = false;
-            break;
-        }
+        if (ignore_own && rules_this_site)
+            return false;
 
-        if (!is_this_site) 
-        {
+        if (!rules_this_site)
             result = true;
-            break;
-        }
     }
 
     return result;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -220,7 +220,8 @@ bool Units::isOwnRace(df::unit* unit)
     return unit->race == plotinfo->race_id;
 }
 
-bool Units::isNobleFromOtherSite(df::unit* unit)
+// check if creature holds a landholder appointment from site that is not the player's fort
+bool Units::isNobleFromOtherSite(df::unit* unit, bool ignore_own)
 {
     CHECK_NULL_POINTER(unit);
 
@@ -234,11 +235,21 @@ bool Units::isNobleFromOtherSite(df::unit* unit)
         if (!pos.position->flags.is_set(entity_position_flags::IS_LAW_MAKER))
             continue;
 
-        if (pos.entity->id != plotinfo->group_id)
-            result = true; // is landholder and of a site not of the fort
+        // (landholder rules this site) or (site is capital and landholder is monarch)
+        bool is_this_site = (pos.entity->id == plotinfo->group_id) ||
+                            (pos.entity->id == plotinfo->civ_id && plotinfo->king_arrived);
         
-        break; // is landholder but of the site, i.e. not of another site
-        // TODO: handle monarchy
+        if (ignore_own && is_this_site)
+        {
+            result = false;
+            break;
+        }
+
+        if (!is_this_site) 
+        {
+            result = true;
+            break;
+        }
     }
 
     return result;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -228,7 +228,7 @@ bool Units::isNobleFromOtherSite(df::unit* unit, bool ignore_own)
     std::vector<NoblePosition> np;
     if (!getNoblePositions(&np, unit))
         return false;
-    
+
     bool result = false;
     for (auto const &pos : np)
     {
@@ -238,7 +238,7 @@ bool Units::isNobleFromOtherSite(df::unit* unit, bool ignore_own)
         // (landholder rules this site) or (site is capital and landholder is monarch)
         bool rules_this_site = (pos.entity->id == plotinfo->group_id) ||
                                (pos.entity->id == plotinfo->civ_id && plotinfo->king_arrived);
-        
+
         if (ignore_own && rules_this_site)
             return false;
 

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -220,6 +220,29 @@ bool Units::isOwnRace(df::unit* unit)
     return unit->race == plotinfo->race_id;
 }
 
+bool Units::isNobleFromOtherSite(df::unit* unit)
+{
+    CHECK_NULL_POINTER(unit);
+
+    std::vector<NoblePosition> np;
+    if (!getNoblePositions(&np, unit))
+        return false;
+    
+    bool result = false;
+    for (auto const &pos : np)
+    {
+        if (!pos.position->flags.is_set(entity_position_flags::IS_LAW_MAKER))
+            continue;
+
+        if (pos.entity->id != plotinfo->group_id)
+            result = true; // is landholder and of a site not of the fort
+        
+        break; // is landholder but of the site, i.e. not of another site
+        // TODO: handle monarchy
+    }
+
+    return result;
+}
 
 bool Units::isAlive(df::unit *unit)
 {


### PR DESCRIPTION
Function checks if a unit is a resident of your fort holding a landholder position belonging to another site. To be used for an upcoming Lua script to emigrate such nobility to avoid mandate hell and immigrate rulers that may be elsewhere due to succession.

I'll request a review for merge when that script is ready, in the meantime I don't think people may need this just yet.

TODO: Figure out how to do finding local rulers.