### PR TITLE
revise tag descriptions

### DIFF
--- a/docs/Tags.rst
+++ b/docs/Tags.rst
@@ -13,25 +13,23 @@ for the tag assignment spreadsheet.
 
 "when" tags
 -----------
-- `adventure <adventure-tag-index>`: Tools that are useful while in adventure mode. Note that some tools only tagged with "fort" might also work in adventure mode, but not always in expected ways. Feel free to experiment, though!
-- `dfhack <dfhack-tag-index>`: Tools that you use to run DFHack commands or interact with the DFHack library. This tag also includes tools that help you manage the DF game itself (e.g. quicksave, etc.)
+- `adventure <adventure-tag-index>`: Tools that are useful while in adventure mode.
+- `dfhack <dfhack-tag-index>`: Tools that you use to run DFHack commands or interact with the DFHack or DF system.
 - `embark <embark-tag-index>`: Tools that are useful while on the fort embark screen or while creating an adventurer.
 - `fort <fort-tag-index>`: Tools that are useful while in fort mode.
 - `legends <legends-tag-index>`: Tools that are useful while in legends mode.
 
 "why" tags
 ----------
-- `armok <armok-tag-index>`: Tools which give the player god-like powers of any variety, such as control over game events, creating items from thin air, or viewing information the game intentionally keeps hidden. Players that do not wish to see these tools listed in DFHack command lists can hide them in the ``Preferences`` tab of `gui/control-panel`.
-
-
+- `armok <armok-tag-index>`: Tools which give the player god-like powers or the ability to access information the game intentionally keeps hidden. Players that do not wish to see these tools can hide them in the ``Preferences`` tab of `gui/control-panel`.
 - `auto <auto-tag-index>`: Tools that run in the background and automatically manage routine, toilsome aspects of your fortress.
 - `bugfix <bugfix-tag-index>`: Tools that fix specific bugs, either permanently or on-demand.
-- `design <design-tag-index>`: Tools that help you design your fort.
-- `dev <dev-tag-index>`: Tools that are useful when developing scripts or mods.
-- `fps <fps-tag-index>`: Tools that help you manage FPS drop.
+- `design <design-tag-index>`: Tools that help you with fort layout.
+- `dev <dev-tag-index>`: Tools that are useful when debugging or developing mods.
+- `fps <fps-tag-index>`: Tools that help you prevent impact to your FPS.
 - `gameplay <gameplay-tag-index>`: Tools that introduce new gameplay elements.
 - `inspection <inspection-tag-index>`: Tools that let you view information that is otherwise difficult to find.
-- `productivity <productivity-tag-index>`: Tools that help you do things that you could do manually, but using the tool is better and faster.
+- `productivity <productivity-tag-index>`: Tools that help you perform common tasks quickly and easily.
 
 "what" tags
 -----------
@@ -42,7 +40,7 @@ for the tag assignment spreadsheet.
 - `items <items-tag-index>`: Tools that interact with in-game items.
 - `jobs <jobs-tag-index>`: Tools that interact with jobs.
 - `labors <labors-tag-index>`: Tools that deal with labor assignment.
-- `map <map-tag-index>`: Tools  that interact with the game map.
+- `map <map-tag-index>`: Tools that interact with the game map.
 - `military <military-tag-index>`: Tools that interact with the military.
 - `plants <plants-tag-index>`: Tools that interact with trees, shrubs, and crops.
 - `stockpiles <stockpiles-tag-index>`: Tools that interact with stockpiles.


### PR DESCRIPTION
make the really long ones shorter so they can fit in the new `gui/launcher` UI