### PR TITLE
[suspendmanager] fix buildingplan integration

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ Template for new versions:
 
 ## Misc Improvements
 - When launched from the Steam client on Linux, both Dwarf Fortress and DFHack will be shown as "Running". This ensures that DF has proper accounting for Linux player usage.
+- `suspendmanager`: port to C++ to decrease impact on framerate
 
 ## Documentation
 

--- a/plugins/lua/buildingplan.lua
+++ b/plugins/lua/buildingplan.lua
@@ -53,8 +53,7 @@ function parse_commandline(...)
 end
 
 function is_suspendmanager_enabled()
-    local ok, sm = pcall(reqscript, 'suspendmanager')
-    return ok and sm.isEnabled()
+    return require('plugins.suspendmanager').isEnabled()
 end
 
 function get_num_filters(btype, subtype, custom)

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -685,10 +685,12 @@ DFhackCExport command_result plugin_enable(color_ostream &out, bool enable) {
                                 is_enabled ? "enabled" : "disabled");
         config.set_bool(CONFIG_IS_ENABLED, is_enabled);
         if (enable) {
-             EventManager::registerListener(EventManager::EventType::JOB_COMPLETED, *eventhandler_instance, plugin_self);
-             do_cycle(out);
+            EventManager::registerListener(EventManager::EventType::JOB_COMPLETED, *eventhandler_instance, plugin_self);
+            EventManager::registerListener(EventManager::EventType::JOB_INITIATED, *eventhandler_instance, plugin_self);
+            do_cycle(out);
         } else {
-             EventManager::unregister(EventManager::EventType::JOB_COMPLETED, *eventhandler_instance, plugin_self);
+            EventManager::unregister(EventManager::EventType::JOB_COMPLETED, *eventhandler_instance, plugin_self);
+            EventManager::unregister(EventManager::EventType::JOB_COMPLETED, *eventhandler_instance, plugin_self);
         }
 
     } else {


### PR DESCRIPTION
Make `buildingplan` properly detect `suspendmanager` and run `suspendmanager` also on initiated jobs. Fixes a regression of the C++ port. 