### PR TITLE
Fix List widget on_submit2

### DIFF
--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -2098,7 +2098,7 @@ function List:onInput(keys)
     end
     if keys.SELECT then
         return self:submit()
-    elseif keys.CUSTOM_SHIFT_ENTER then
+    elseif keys.SELECT_ALL then
         return self:submit2()
     elseif keys._MOUSE_L then
         local idx = self:getIdxUnderMouse()


### PR DESCRIPTION
Use v50.12's `SELECT_ALL` keybinding instead of non-existent `CUSTOM_SHIFT_ENTER`.