### PR TITLE
[Gui] distinguish between linked building view and item view

### DIFF
--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -504,6 +504,10 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
                     df::building_trapst* trap = strict_virtual_cast<df::building_trapst>(bld);
                     newFocusString += '/' + enum_item_key(trap->trap_type);
                 }
+                if (game->main_interface.view_sheets.show_linked_buildings)
+                    newFocusString += "/LinkedBuildings";
+                else
+                    newFocusString += "/Items";
             }
             break;
         default:


### PR DESCRIPTION
viewing items will append an `/Items` suffix on the focus string. viewing linked buildings will append a `/LinkedBuildings` on the focus string

In service of https://github.com/DFHack/scripts/pull/1016