### PR TITLE
[Gui] give non-fortress modes a focus string

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ Template for new versions:
 
 ## Fixes
 - `autochop`: fix underestimation of log yield for cavern mushrooms
+- `gui/notify`: prevent notification overlay from showing up in arena mode
 
 ## Misc Improvements
 - `autobutcher`: prefer butchering partially trained animals and save fully domesticated animals to assist in wildlife domestication programs

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -284,7 +284,12 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
 {
     std::string newFocusString;
 
-    if(game->main_interface.main_designation_selected != -1) {
+    if (df::global::gametype && !World::isFortressMode()) {
+        newFocusString = baseFocus;
+        newFocusString += '/' + enum_item_key(*df::global::gametype);
+        focusStrings.push_back(newFocusString);
+    }
+    if (game->main_interface.main_designation_selected != -1) {
         newFocusString = baseFocus;
         newFocusString += "/Designate/" + enum_item_key(game->main_interface.main_designation_selected);
         focusStrings.push_back(newFocusString);


### PR DESCRIPTION
so it doesn't end up as dwarfmode/Default

this stops the `gui/notify` overlay from showing up in arena mode