### PR TITLE
[widgets.EditField] use new Shift-Enter keybinding name for 50.12

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -62,6 +62,7 @@ Template for new versions:
 - `autochop`: fix underestimation of log yield for cavern mushrooms
 - `gui/notify`: prevent notification overlay from showing up in arena mode
 - `logistics`: don't melt/trade/dump empty containers that happen to be sitting on the stockpile unless the stockpile accepts those item types
+- `gui/launcher`: fix detection on Shift-Enter for running commands and autoclosing the launcher
 
 ## Misc Improvements
 - `autobutcher`: prefer butchering partially trained animals and save fully domesticated animals to assist in wildlife domestication programs

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -790,11 +790,11 @@ function EditField:onInput(keys)
         return true
     end
 
-    if keys.SELECT or keys.CUSTOM_SHIFT_ENTER then
+    if keys.SELECT or keys.SELECT_ALL then
         if self.key then
             self:setFocus(false)
         end
-        if keys.CUSTOM_SHIFT_ENTER then
+        if keys.SELECT_ALL then
             if self.on_submit2 then
                 self.on_submit2(self.text)
                 return true


### PR DESCRIPTION
now that we have a shift-enter keybinding, this can work again