### PR TITLE
[orders] Add labor restrictions overlay for workshops

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ Template for new versions:
 - `stocks`: add button/hotkey for removing empty categories from the stocks list
 - `sort`: updated and reinstated military status/squad membership/burrow membership filter for work animal assignment screen
 - `logistics`: ``autoretrain`` will automatically assign trainers to your partially-trained (but not yet domesticated) livestock. this prevents children of partially-trained parents from reverting to wild if you don't notice they were born
+- `orders`: add overlay for configuring labor restrictions for workshops
 
 ## Fixes
 - `autochop`: fix underestimation of log yield for cavern mushrooms

--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -51,16 +51,40 @@ Examples
 Overlay
 -------
 
-Orders plugin functionality is directly available when the manager orders screen
-is open via an `overlay` widget. There are hotkeys assigned to export, import,
-sort, and clear. You can also click on the hotkey hints as if they were buttons.
-Clearing will ask for confirmation before acting.
+Orders plugin functionality is directly available via an `overlay` widget when
+the manager orders screen is open. There are hotkeys assigned to export, import,
+sort, clear, and recheck conditions. You can also click on the hotkey hints as
+if they were buttons. Clearing will ask for confirmation before acting.
 
-If you want to change where the overlay panel appears, you can move it via
-`gui/overlay`. If you just need to get the overlay out of the way temporarily,
-for example to read a long description of a historical figure when choosing a
-subject for a statue, click on the small arrow in the upper right corner of the
-overlay panel. Click on the arrow again to restore the panel.
+When you open the conditions screen for a manager order, there is also a small
+overlay that allows you to recheck conditions for just that order. This is
+useful for when the conditions were true when the order started, but they have
+become false and now you're just getting repeated cancellation spam as the
+order cannot be fulfilled.
+
+Finally, an overlay is added to the "Workers" tab for workshop and furnace
+buildings that support orders that can be categorized by labor type. On the
+overlay, you can configure the workshop to only accept general work orders that
+pertain to specific labors (the list of allowed labors is different for every
+workshop).
+
+For example, by default, all weapon, armor, and blacksmithing general manager
+orders get sent to all forges. With labor restrictions, you can designate
+specific forges to handle just weapons, just armor, or just metalsmithing.
+Then, you can assign appropriate legendary masters to each forge, and they will
+only receive orders for appropriate products.
+
+Simiarly, you can set up Craftsdwarf's workshops to specialize in stone, wood,
+or bone.
+
+:kbd:`Ctrl`:kbd:`A` will toggle all labors on or off.
+
+Veteran players may remember this as a vanilla feature in pre-v50 Dwarf
+Fortress. This is actually still the case. The DFHack overlay simply provides a
+UI for the vanilla feature hiding beneath the surface.
+
+If you want to change where the overlay panels appear, you can move them with
+`gui/overlay`.
 
 The orders library
 ------------------


### PR DESCRIPTION
restores pre-v50 configurability for the labor restrictions in the workshop profile

Fixes: https://github.com/DFHack/dfhack/issues/3449