### PR TITLE
[Items] fix trade price when item is in both buy and sell agreements

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 - `gui/launcher`: fix detection on Shift-Enter for running commands and autoclosing the launcher
 - `logistics`: don't send autotrade items to forbidden depots
 - `autoclothing`: don't produce clothes for dead units
+- `caravan`: fix trade price calculations when the same item was requested for both import and export
 
 ## Misc Improvements
 - `autobutcher`: prefer butchering partially trained animals and save fully domesticated animals to assist in wildlife domestication programs

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -2022,10 +2022,14 @@ int Items::getValue(df::item *item, df::caravan_state *caravan)
 
     // modify buy/sell prices
     if (caravan) {
-        value *= get_buy_request_multiplier(item, caravan->buy_prices);
-        value >>= 7;
-        value *= get_sell_request_multiplier(item, caravan);
-        value >>= 7;
+        int32_t buy_multiplier = get_buy_request_multiplier(item, caravan->buy_prices);
+        if (buy_multiplier == DEFAULT_AGREEMENT_MULTIPLIER) {
+            value *= get_sell_request_multiplier(item, caravan);;
+            value >>= 7;
+        } else {
+            value *= buy_multiplier;
+            value >>= 7;
+        }
     }
 
     // Boost value from stack size


### PR DESCRIPTION
from testing (see: https://discord.com/channels/793331351645323264/807444467140788254/1218139324818784257 ) items are *not* blindly multiplied both by buy and sell agreements like we previously thought. It receives a maximum of one multiplier.