### PR TITLE
[Gui] make focus string matching case sensitive

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -77,6 +77,7 @@ Template for new versions:
 - ``Units::paintTile``, ``Units::readTile``: now takes an optional field specification for reading and writing to specific map compositing layers
 
 ## Lua
+- ``dfhack.gui.matchFocusString``: focus string matching is now case sensitive (for performance reasons)
 
 ## Removed
 

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -899,19 +899,14 @@ void Gui::clearFocusStringCache() {
 }
 
 bool Gui::matchFocusString(std::string focus_string, df::viewscreen *top) {
-    focus_string = toLower_cp437(focus_string);
     if (!top)
         top = getCurViewscreen(true);
 
-    if (!cached_focus_strings.contains(top)) {
-        vector<string> focus_strings = getFocusStrings(top);
-        for (size_t i = 0; i < focus_strings.size(); ++i)
-            focus_strings[i] = toLower_cp437(focus_strings[i]);
-        cached_focus_strings[top] = focus_strings;
-    }
-    vector<string> &cached = cached_focus_strings[top];
+    if (!cached_focus_strings.contains(top))
+        cached_focus_strings[top] = getFocusStrings(top);
 
-    return std::find_if(cached.begin(), cached.end(), [&focus_string](std::string item) {
+    vector<string> &cached = cached_focus_strings[top];
+    return std::find_if(cached.begin(), cached.end(), [&focus_string](const std::string &item) {
         return prefix_matches(focus_string, item);
     }) != cached.end();
 }


### PR DESCRIPTION
this is a hot spot for performance, and streamlining the string comparisons is important. all library code sends in case-correct strings. 3rd party code *may* need to adjust.