### PR TITLE
Document enum type next_item function

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -71,6 +71,7 @@ Template for new versions:
 - pump stack blueprint: now designates in warm and damp dig mode for uninterrupted digging through warm and damp tiles
 
 ## Documentation
+- ``Lua API.rst``: added previously undocumented ``next_item(index)`` function for enum types
 
 ## API
 - ``Units::citizensRange``: c++-20 range for citizen units

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -356,6 +356,10 @@ bi-directional mapping between key strings and values, and
 also map ``_first_item`` and ``_last_item`` to the min and
 max values.
 
+Enum types also support the ``type.next_item(index)`` function,
+which returns the next valid index of the enum (returning the
+first value if index is greater than or equal to the max value).
+
 Struct and class types with an instance-vector attribute in the XML also support:
 
 * ``type.find(key)``

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -357,8 +357,9 @@ also map ``_first_item`` and ``_last_item`` to the min and
 max values.
 
 Enum types also support the ``type.next_item(index)`` function,
-which returns the next valid index of the enum (returning the
-first value if index is greater than or equal to the max value).
+which returns the next valid numeric value of the enum. It
+Returns the first enum value if ``index`` is greater than or
+equal to the max enum value.
 
 Struct and class types with an instance-vector attribute in the XML also support:
 


### PR DESCRIPTION
Looks like another silently missing function that is exposed to Lua.