### PR TITLE
Add USE_SYSTEM_SDL2 CMake option, defaulting to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,21 +289,28 @@ endif()
 find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIRS})
 
+set(USE_SYSTEM_SDL2 OFF CACHE BOOL "Set to ON to use the system SDL2 headers.")
+
 if(BUILD_LIBRARY)
-    # Download SDL release and extract into depends in the build dir
-    # all we need are the header files (including generated headers), so the same release package
-    # will work for all platforms
-    # (the above statement is untested for OSX)
-    set(SDL_VERSION 2.26.2)
-    set(SDL_ZIP_MD5 574daf26d48de753d0b1e19823c9d8bb)
-    set(SDL_ZIP_FILE SDL2-devel-${SDL_VERSION}-VC.zip)
-    set(SDL_ZIP_PATH ${dfhack_SOURCE_DIR}/depends/SDL2/)
-    download_file("https://github.com/libsdl-org/SDL/releases/download/release-${SDL_VERSION}/${SDL_ZIP_FILE}"
-        ${SDL_ZIP_PATH}${SDL_ZIP_FILE}
-        ${SDL_ZIP_MD5})
-    file(ARCHIVE_EXTRACT INPUT ${SDL_ZIP_PATH}${SDL_ZIP_FILE}
-        DESTINATION ${SDL_ZIP_PATH})
-    include_directories(${SDL_ZIP_PATH}/SDL2-${SDL_VERSION}/include)
+    if(USE_SYSTEM_SDL2)
+        find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)
+        include_directories(${SDL2_INCLUDE_DIRS})
+    else()
+        # Download SDL release and extract into depends in the build dir
+        # all we need are the header files (including generated headers), so the same release package
+        # will work for all platforms
+        # (the above statement is untested for OSX)
+        set(SDL_VERSION 2.26.2)
+        set(SDL_ZIP_MD5 574daf26d48de753d0b1e19823c9d8bb)
+        set(SDL_ZIP_FILE SDL2-devel-${SDL_VERSION}-VC.zip)
+        set(SDL_ZIP_PATH ${dfhack_SOURCE_DIR}/depends/SDL2/)
+        download_file("https://github.com/libsdl-org/SDL/releases/download/release-${SDL_VERSION}/${SDL_ZIP_FILE}"
+            ${SDL_ZIP_PATH}${SDL_ZIP_FILE}
+            ${SDL_ZIP_MD5})
+        file(ARCHIVE_EXTRACT INPUT ${SDL_ZIP_PATH}${SDL_ZIP_FILE}
+            DESTINATION ${SDL_ZIP_PATH})
+        include_directories(${SDL_ZIP_PATH}/SDL2-${SDL_VERSION}/include)
+    endif()
 endif()
 
 if(APPLE)


### PR DESCRIPTION
Since systems like nixpkgs change the search path of Dwarf Fortress, we should be able to use the same SDL2 instead of resorting to horrible hacks to work around the file downloading or using mismatched library versions between Dwarf Fortress and dfhack.