### PR TITLE
Use defclass/mkinstance types in dfhack.lua

### DIFF
--- a/library/lua/class.lua
+++ b/library/lua/class.lua
@@ -15,6 +15,10 @@ reserved_names = { super = true, ATTRS = true }
 attrs_meta = attrs_meta or {}
 
 -- Create or updates a class; a class has metamethods and thus own metatable.
+---@generic T: table
+---@param class? T
+---@param parent? table
+---@return table|T
 function defclass(class,parent)
     class = class or {}
 
@@ -39,6 +43,10 @@ function defclass(class,parent)
 end
 
 -- An instance uses the class as metatable
+---@generic T: table
+---@param class table
+---@param table? T
+---@return table|T
 function mkinstance(class,table)
     table = table or {}
     setmetatable(table, class)

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -166,9 +166,21 @@ end
 
 DEFAULT_NIL = DEFAULT_NIL or {} -- Unique token
 
-local class = require('class')
-defclass = class.defclass
-mkinstance = class.mkinstance
+---@generic T: table
+---@param class? T
+---@param parent? table
+---@return table|T
+function defclass(class,parent)
+    return require('class').defclass(class,parent)
+end
+
+---@generic T: table
+---@param class table
+---@param table? T
+---@return table|T
+function mkinstance(class,table)
+    return require('class').mkinstance(class,table)
+end
 
 -- Misc functions
 

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -166,13 +166,9 @@ end
 
 DEFAULT_NIL = DEFAULT_NIL or {} -- Unique token
 
-function defclass(...)
-    return require('class').defclass(...)
-end
-
-function mkinstance(...)
-    return require('class').mkinstance(...)
-end
+local class = require('class')
+defclass = class.defclass
+mkinstance = class.mkinstance
 
 -- Misc functions
 


### PR DESCRIPTION
Removes the unnecessary (imo) function declaration in dfhack.lua in favour of an alias and gives the class methods types.