### PR TITLE
[suspendmanager] don't unsuspend constructions blocked by an item

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -68,6 +68,7 @@ Template for new versions:
 - fix behavior of Linux Steam launcher on systems that don't support the inotify API
 - fix rendering of resize "notch" in lower right corner of resizable windows in ascii mode
 - `quickfort`: stockpiles can now be placed even if there is water covering the tile, as per vanilla behavior
+- `suspendmanager`: fix a cancellation spam when an item prevents a building to be completed
 
 ## Misc Improvements
 - `tailor`: allow turning off automatic confiscation of tattered clothing

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -68,7 +68,7 @@ Template for new versions:
 - fix behavior of Linux Steam launcher on systems that don't support the inotify API
 - fix rendering of resize "notch" in lower right corner of resizable windows in ascii mode
 - `quickfort`: stockpiles can now be placed even if there is water covering the tile, as per vanilla behavior
-- `suspendmanager`: fix a cancellation spam when an item prevents a building to be completed
+- `suspendmanager`: prevent cancellation spam when an item is preventing a building from being completed
 
 ## Misc Improvements
 - `tailor`: allow turning off automatic confiscation of tattered clothing

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -317,8 +317,8 @@ private:
         // Check for items on the building, look into all the map blocks overlapping
         // the building
         bool has_item = false;
-        for (size_t block_x = building->x1 >> 4; block_x <= building->x2 >> 4; ++block_x) {
-            for (size_t block_y = building->y1 >> 4; block_y <= building->y2 >> 4; ++block_y) {
+        for (int32_t block_x = building->x1 >> 4; block_x <= building->x2 >> 4; ++block_x) {
+            for (int32_t block_y = building->y1 >> 4; block_y <= building->y2 >> 4; ++block_y) {
                 auto block = Maps::getBlock(block_x,block_y,building->z);
                 if (!block)
                     continue;

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -77,7 +77,7 @@ enum Reason {
     DEADEND = 5,
     // Would cave in immediately on completion
     UNSUPPORTED = 6,
-    // Has an unmovable item in the same block that is part of a job
+    // Has an unmovable item on top of the building job
     ITEM_IN_JOB = 7,
 };
 

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -343,7 +343,10 @@ private:
         if (!has_item)
             return false;
 
-        // With an item, check for the surrounding of the building
+        // When there is an item on top of the building, check for the surrounding of the building
+        // for a place where the dwarves would be able to move the item to.
+        // The dwarves will move an item if there is a walkable space without any
+        // building planned, non-diagonally neighbouring the building.
         // The position of the item does not matter, in multi-tile buildings
         // dwarves will move the item multiple tiles if necessary
         for (auto x : {building->x1-1, building->x2+1}) {


### PR DESCRIPTION
When there is an item on top of a construction that the dwarves can't move, `suspendmanager` would always try to unsuspend it, only for the dwarves to suspend it again. This lead to a cancellation spam and quite a waste of time of dwarves trying to build the same thing again and again.

This change detects items that cannot be moved away, and register it as an "external suspension", so that `suspendmanager` will neither suspend nor unsuspend it while it's in this situation, with a message explaining on the suspended construction.

If an actual deadlock is there, it is not fixed, it will wait suspended for a user action. However, it makes some situations like building a floor on top of its scattered construction material much more efficient, where constructions are unsuspended as soon as they are buildable:

![image](https://github.com/DFHack/dfhack/assets/630159/8b43d8b6-4faf-4147-83dd-708a4cd0b2d1)


Fixes #4087
