### PR TITLE
suspendmanager: take in account wall plans on the tile below

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,7 +59,7 @@ Template for new versions:
 
 ## Misc Improvements
 
-- `suspendmanager`: Take in account walls planned on the z-layer below to determine accessibility to a job
+- `suspendmanager`: Account for walls planned on the z-layer below when determining accessibility to a job
 
 ## Documentation
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,8 @@ Template for new versions:
 
 ## Misc Improvements
 
+- `suspendmanager`: Take in account walls planned on the z-layer below to determine accessibility to a job
+
 ## Documentation
 
 ## API

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -111,7 +111,7 @@ static const std::bitset<64> construction_impassible = std::bitset<64>()
     .set(construction_type::Wall)
     .set(construction_type::Fortification);
 
-// constructions that can be stand on the tile above
+// constructions that allow walking on the tile above
 static const std::bitset<64> construction_stand_above = std::bitset<64>()
     .set(construction_type::Wall)
     .set(construction_type::UpStair)
@@ -390,7 +390,8 @@ private:
             return true;
 
         auto below = Buildings::findAtTile(coord(pos.x,pos.y,pos.z-1));
-        if (below && below->getType() == df::building_type::Construction && construction_stand_above[below->getSubtype()])
+        if (below && below->getType() == df::building_type::Construction &&
+            construction_stand_above[below->getSubtype()])
             return true;
 
         return false;

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -111,12 +111,6 @@ static const std::bitset<64> construction_impassible = std::bitset<64>()
     .set(construction_type::Wall)
     .set(construction_type::Fortification);
 
-// constructions that allow walking on the tile above
-static const std::bitset<64> construction_stand_above = std::bitset<64>()
-    .set(construction_type::Wall)
-    .set(construction_type::UpStair)
-    .set(construction_type::UpDownStair);
-
 // constructions requiring same support as walls
 static const std::bitset<64> construction_wall_support = std::bitset<64>()
     .set(construction_type::Wall)
@@ -389,9 +383,10 @@ private:
         if (isSuitableAccess(pos))
             return true;
 
+        // if a wall is being constructed below, the tile will be suitable
         auto below = Buildings::findAtTile(coord(pos.x,pos.y,pos.z-1));
         if (below && below->getType() == df::building_type::Construction &&
-            construction_stand_above[below->getSubtype()])
+            below->getSubtype() == construction_type::Wall)
             return true;
 
         return false;


### PR DESCRIPTION
`suspendmanager` now consider wall being built below. Before, it would sometimes consider that a construction is not at risk of blocking another, since it is not walkable. This would lead it allowing some construction even if they are blocking another, since at the time of the construction the other is unreachable.

It now looks below to consider tiles that are "potentially walkable", to keep access to constructions, even if they are not yet reachable.

Fixes #3600 
Fixes #4466 
