### PR TITLE
Make Items::createItem handle multiple output

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,7 +57,6 @@ Template for new versions:
 
 ## Fixes
 - `zone`: fix display of distance from cage for small pets in assignment dialog
-- Fixed misidentification of visitors from your own civ as residents; affects all tools that iterate through citizens/residents
 - `modtools/create-item`: now functions properly when the ``reaction-gloves`` tweak is active
 
 ## Misc Improvements

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,17 +57,21 @@ Template for new versions:
 
 ## Fixes
 - `zone`: fix display of distance from cage for small pets in assignment dialog
+- Fixed misidentification of visitors from your own civ as residents; affects all tools that iterate through citizens/residents
+- `modtools/create-item`: now functions properly when the ``reaction-gloves`` tweak is active
 
 ## Misc Improvements
 - `caravan`: display who is in the cages you are selecting for trade and whether they are hostile
 - `regrass`: Can now add grass to stairs, ramps, ashes, buildings, muddy stone, shrubs, and trees
 - `regrass`: Can now restrict regrass effect to specified tile, block, cuboid, or z-levels
 - `regrass`: Can now add grass in map blocks where there hasn't been any, force specific grass type
+- `createitem`: refactored to use ``Items::createItem()`` API function
 
 ## Documentation
 
 ## API
 - ``dfhack.items.getReadableDescription()``: easy API for getting a human-readable item description with useful annotations and information (like tattered markers or who is in a cage)
+- ``Items::createItem``: now returns a list of item pointers rather than a single ID, moved creator parameter to beginning, added growth_print and no_floor parameters at end
 
 ## Lua
 - ``dfhack.internal.setClipboardTextCp437Multiline``: for copying multiline text to the system clipboard

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1917,7 +1917,7 @@ Items module
   Returns whether a caravan will pay extra for the given item. If caravan_state
   is not given, checks all active caravans.
 
-* ``dfhack.items.createItem(item_type, item_subtype, mat_type, mat_index, unit)``
+* ``dfhack.items.createItem(unit, item_type, item_subtype, mat_type, mat_index, growth_print, no_floor)``
 
   Creates an item, similar to the `createitem` plugin.
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -83,6 +83,7 @@ distribution.
 #include "df/inorganic_raw.h"
 #include "df/item.h"
 #include "df/itemdef.h"
+#include "df/item_type.h"
 #include "df/job.h"
 #include "df/job_item.h"
 #include "df/job_material_category.h"
@@ -2288,7 +2289,6 @@ static const LuaWrapper::FunctionReg dfhack_items_module[] = {
     WRAPM(Items, getItemBaseValue),
     WRAPM(Items, getValue),
     WRAPM(Items, isRequestedTradeGood),
-    WRAPM(Items, createItem),
     WRAPM(Items, checkMandates),
     WRAPM(Items, canTrade),
     WRAPM(Items, canTradeWithContents),
@@ -2359,12 +2359,27 @@ static int items_moveToBuilding(lua_State *state)
     return 1;
 }
 
+static int items_createItem(lua_State *state)
+{
+    auto unit = Lua::CheckDFObject<df::unit>(state, 1);
+    df::item_type item_type = (df::item_type)lua_tointeger(state, 2);
+    auto item_subtype = lua_tointeger(state, 3);
+    auto mat_type = lua_tointeger(state, 4);
+    auto mat_index = lua_tointeger(state, 5);
+    int growth_print = luaL_optint(state, 6, -1);
+    bool no_floor = lua_toboolean(state, 7);
+    std::vector<df::item *> out_items;
+    Items::createItem(out_items, unit, item_type, item_subtype, mat_type, mat_index, growth_print, no_floor);
+    Lua::PushVector(state, out_items);
+    return 1;
+}
 
 static const luaL_Reg dfhack_items_funcs[] = {
     { "getPosition", items_getPosition },
     { "getOuterContainerRef", items_getOuterContainerRef },
     { "getContainedItems", items_getContainedItems },
     { "moveToBuilding", items_moveToBuilding },
+    { "createItem", items_createItem },
     { NULL, NULL }
 };
 

--- a/library/include/modules/Items.h
+++ b/library/include/modules/Items.h
@@ -174,7 +174,7 @@ DFHACK_EXPORT int getItemBaseValue(int16_t item_type, int16_t item_subtype, int1
 /// Gets the value of a specific item, taking into account civ values and trade agreements if a caravan is given
 DFHACK_EXPORT int getValue(df::item *item, df::caravan_state *caravan = NULL);
 
-DFHACK_EXPORT int32_t createItem(df::item_type type, int16_t item_subtype, int16_t mat_type, int32_t mat_index, df::unit* creator);
+DFHACK_EXPORT bool createItem(std::vector<df::item *> &out_items, df::unit* creator, df::item_type type, int16_t item_subtype, int16_t mat_type, int32_t mat_index, int32_t growth_print = -1, bool no_floor = false);
 
 /// Returns true if the item is free from mandates, or false if mandates prevent trading the item
 DFHACK_EXPORT bool checkMandates(df::item *item);


### PR DESCRIPTION
This changes the function signature to return a list of created items via the first parameter and a boolean "success" code. It also moves the "unit" parameter to the beginning and adds "growth_print" to the end (which is required for PLANT_GROWTH items).

Should fix #2063