### PR TITLE
centralize logic for getting an item description

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,10 +58,12 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `caravan`: display who is in the cages you are selecting for trade and whether they are hostile
 
 ## Documentation
 
 ## API
+- ``dfhack.items.getReadableDescription()``: easy API for getting a human-readable item description with useful annotations and information (like tattered markers or who is in a cage)
 
 ## Lua
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1815,6 +1815,12 @@ Items module
   Returns the string description of the item, as produced by the ``getItemDescription``
   method. If decorate is true, also adds markings for quality and improvements.
 
+* ``dfhack.items.getReadableDescription(item)``
+
+  Returns a string generally fit to usefully describe the item to the player.
+  When the item description appears anywhere in a script output or in the UI,
+  this is usually the string you should use.
+
 * ``dfhack.items.getGeneralRef(item, type)``
 
   Searches for a general_ref with the given type.

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2281,6 +2281,7 @@ static const LuaWrapper::FunctionReg dfhack_items_module[] = {
     WRAPM(Items, getHolderUnit),
     WRAPM(Items, getBookTitle),
     WRAPM(Items, getDescription),
+    WRAPM(Items, getReadableDescription),
     WRAPM(Items, isCasteMaterial),
     WRAPM(Items, getSubtypeCount),
     WRAPM(Items, getSubtypeDef),

--- a/library/include/modules/Items.h
+++ b/library/include/modules/Items.h
@@ -153,6 +153,8 @@ DFHACK_EXPORT std::string getBookTitle(df::item *item);
 /// Returns the description string of the item.
 DFHACK_EXPORT std::string getDescription(df::item *item, int type = 0, bool decorate = false);
 
+DFHACK_EXPORT std::string getReadableDescription(df::item *item);
+
 DFHACK_EXPORT bool moveToGround(MapExtras::MapCache &mc, df::item *item, df::coord pos);
 DFHACK_EXPORT bool moveToContainer(MapExtras::MapCache &mc, df::item *item, df::item *container);
 DFHACK_EXPORT bool moveToBuilding(MapExtras::MapCache &mc, df::item *item, df::building_actual *building,

--- a/plugins/lua/buildingplan/itemselection.lua
+++ b/plugins/lua/buildingplan/itemselection.lua
@@ -21,27 +21,12 @@ function get_automaterial_selection(building_type)
     return tracker.list[#tracker.list]
 end
 
-local function get_artifact_name(item)
-    local gref = dfhack.items.getGeneralRef(item, df.general_ref_type.IS_ARTIFACT)
-    if not gref then return end
-    local artifact = df.artifact_record.find(gref.artifact_id)
-    if not artifact then return end
-    return dfhack.TranslateName(artifact.name)
-end
-
 function get_item_description(item_id, item, safety_label)
     item = item or df.item.find(item_id)
     if not item then
         return ('No %s safe mechanisms available'):format(safety_label:lower())
     end
-    local desc = item.flags.artifact and get_artifact_name(item) or
-        dfhack.items.getDescription(item, 0, true)
-    local wear_level = item:getWear()
-    if wear_level == 1 then desc = ('x%sx'):format(desc)
-    elseif wear_level == 2 then desc = ('X%sX'):format(desc)
-    elseif wear_level == 3 then desc = ('XX%sXX'):format(desc)
-    end
-    return desc
+    return dfhack.items.getReadableDescription(item)
 end
 
 local function sort_by_type(a, b)


### PR DESCRIPTION
affects all dialogs where item descriptions are shown, such as the trade screens and the output of `item`

@vallode new API alert!