### PR TITLE
add multiline clipboard API

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -70,6 +70,7 @@ Template for new versions:
 - ``dfhack.items.getReadableDescription()``: easy API for getting a human-readable item description with useful annotations and information (like tattered markers or who is in a cage)
 
 ## Lua
+- ``dfhack.internal.setClipboardTextCp437Multiline``: for copying multiline text to the system clipboard
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3149,6 +3149,11 @@ and are only documented here for completeness:
 
   Sets the system clipboard text from a CP437 string.
 
+* ``dfhack.internal.setClipboardTextCp437Multiline(text)``
+
+  Sets the system clipboard text from a CP437 string. Character 0x10 is
+  interpreted as a newline instead of the usual CP437 glyph.
+
 * ``dfhack.internal.getSuppressDuplicateKeyboardEvents()``
 * ``dfhack.internal.setSuppressDuplicateKeyboardEvents(suppress)``
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3316,6 +3316,7 @@ static const LuaWrapper::FunctionReg dfhack_internal_module[] = {
     WRAPN(msizeAddress, msize_address),
     WRAP(getClipboardTextCp437),
     WRAP(setClipboardTextCp437),
+    WRAP(setClipboardTextCp437Multiline),
     { NULL, NULL }
 };
 

--- a/library/include/modules/DFSDL.h
+++ b/library/include/modules/DFSDL.h
@@ -64,4 +64,7 @@ DFHACK_EXPORT int DFSDL_SetClipboardText(const char *text);
 DFHACK_EXPORT std::string getClipboardTextCp437();
 DFHACK_EXPORT bool setClipboardTextCp437(std::string text);
 
+// interprets 0xa as newline instead of usual CP437 char
+DFHACK_EXPORT bool setClipboardTextCp437Multiline(std::string text);
+
 }

--- a/library/modules/DFSDL.cpp
+++ b/library/modules/DFSDL.cpp
@@ -12,16 +12,18 @@ namespace DFHack {
 }
 
 using namespace DFHack;
+using std::string;
+using std::vector;
 
 static DFLibrary *g_sdl_handle = nullptr;
 static DFLibrary *g_sdl_image_handle = nullptr;
-static const std::vector<std::string> SDL_LIBS {
+static const vector<string> SDL_LIBS {
     "SDL2.dll",
     "SDL.framework/Versions/A/SDL",
     "SDL.framework/SDL",
     "libSDL2-2.0.so.0"
 };
-static const std::vector<std::string> SDL_IMAGE_LIBS {
+static const vector<string> SDL_IMAGE_LIBS {
     "SDL2_image.dll",
     "SDL_image.framework/Versions/A/SDL_image",
     "SDL_image.framework/SDL_image",
@@ -167,7 +169,7 @@ int DFSDL::DFSDL_ShowSimpleMessageBox(uint32_t flags, const char *title, const c
     return g_SDL_ShowSimpleMessageBox(flags, title, message, window);
 }
 
-DFHACK_EXPORT std::string DFHack::getClipboardTextCp437() {
+DFHACK_EXPORT string DFHack::getClipboardTextCp437() {
     if (!g_sdl_handle || g_SDL_HasClipboardText() != SDL_TRUE)
         return "";
     char *text = g_SDL_GetClipboardText();
@@ -176,13 +178,28 @@ DFHACK_EXPORT std::string DFHack::getClipboardTextCp437() {
         if (*c == '\t')
             *c = ' ';
     }
-    std::string textcp437 = UTF2DF(text);
+    string textcp437 = UTF2DF(text);
     DFHack::DFSDL::DFSDL_free(text);
     return textcp437;
 }
 
-DFHACK_EXPORT bool DFHack::setClipboardTextCp437(std::string text) {
+DFHACK_EXPORT bool DFHack::setClipboardTextCp437(string text) {
     if (!g_sdl_handle)
         return false;
     return 0 == DFHack::DFSDL::DFSDL_SetClipboardText(DF2UTF(text).c_str());
+}
+
+DFHACK_EXPORT bool DFHack::setClipboardTextCp437Multiline(string text) {
+    if (!g_sdl_handle)
+        return false;
+    vector<string> lines;
+    if (!split_string(&lines, text, "\n"))
+        return false;
+    std::ostringstream str;
+    for (size_t idx = 0; idx < lines.size(); ++idx) {
+        str << DF2UTF(lines[idx]);
+        if (idx < lines.size() - 1)
+            str << "\n";
+    }
+    return 0 == DFHack::DFSDL::DFSDL_SetClipboardText(str.str().c_str());
 }


### PR DESCRIPTION
Add dfhack.internal.setClipboardTextCp437Multiline for copying multiline text to the system clipboard

Fixes: https://github.com/DFHack/dfhack/issues/3987