### PR TITLE
[dig] warm/damp fixups

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,8 @@ Template for new versions:
 - `zone`: fix display of distance from cage for small pets in assignment dialog
 - `modtools/create-item`: now functions properly when the ``reaction-gloves`` tweak is active
 - `blueprint`: correctly record stockpile ("place") blueprints when there are adjacent non-rectangular stockpiles of identical types
+- `dig`: refresh count of tiles that will be modified by "mark all designated tiles on this z-level for warm/damp dig" when the z-level changes
+- `dig`: don't affect already-revealed tiles when marking z-level for warm/damp dig
 
 ## Misc Improvements
 - `caravan`: display who is in the cages you are selecting for trade and whether they are hostile
@@ -67,6 +69,7 @@ Template for new versions:
 - `regrass`: Can now add grass in map blocks where there hasn't been any, force specific grass type
 - `createitem`: refactored to use ``Items::createItem()`` API function
 - `dig`: warm/damp/aquifer status will now be shown in mining mode for tiles that your dwarves can see from the level below
+- `dig`: warm/damp/aquifer status will now be shown when in smoothing/engraving modes
 
 ## Documentation
 - Quickfort Blueprint Library: embed demo video for pump stack blueprint

--- a/docs/plugins/dig.rst
+++ b/docs/plugins/dig.rst
@@ -228,7 +228,9 @@ aquifer.
 If you have already designated a z-level when you realize you need warm or damp
 dig protection (e.g. you have run into a light aquifer and want to continue
 digging), the toolbar button gives you a shortcut to add the warm or damp dig
-marker to all designated tiles on the current z-level.
+marker to all designated tiles on the current z-level. Note that it only
+affects tiles that are not yet revealed since revealed tiles don't benefit from
+the warm or damp dig designations.
 
 Click on the new mining toolbar icon or hit :kbd:`Ctrl`:kbd:`D` to bring up the
 configuration submenu.
@@ -237,7 +239,7 @@ warmdamp
 ~~~~~~~~
 
 The ``dig.warmdamp`` overlay makes a number of tile properties visible when in
-mining mode:
+mining or smoothing mode:
 
 - In ASCII mode, it highlights warm tiles red and damp tiles in light blue. Box
   selection characters and the keyboard cursor will also change color as

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -2002,6 +2002,9 @@ static void toggle_cur_level(color_ostream &out, PersistentDataItem &config) {
         df::tile_bitmask *mask = NULL;
         for (uint32_t x = 0; x < 16; x++) for (uint32_t y = 0; y < 16; y++) {
             df::coord pos = block_pos + df::coord(x, y, 0);
+            if (!block->designation[x % 16][y % 16].bits.hidden)
+                continue;
+
             if (dig_jobs.contains(pos)) {
                 z_jobs.emplace(dig_jobs[pos]);
                 continue;
@@ -2043,6 +2046,8 @@ static int getCurLevelDesignatedCount(color_ostream &out) {
 
         const auto & block_pos = block->map_pos;
         for (uint32_t x = 0; x < 16; x++) for (uint32_t y = 0; y < 16; y++) {
+            if (!block->designation[x % 16][y % 16].bits.hidden)
+                continue;
             df::coord pos = block_pos + df::coord(x, y, 0);
             if (block->designation[x][y].bits.dig || dig_jobs.contains(pos))
                 ++count;

--- a/plugins/lua/dig.lua
+++ b/plugins/lua/dig.lua
@@ -29,7 +29,8 @@ WarmDampDigConfig.ATTRS {
 }
 
 function WarmDampDigConfig:init()
-    local dcount = getCurLevelDesignatedCount()
+    self.dcount = getCurLevelDesignatedCount()
+    self.z = df.global.window_z
 
     local panel = widgets.Panel{
         frame_style=gui.FRAME_MEDIUM,
@@ -66,7 +67,9 @@ function WarmDampDigConfig:init()
             widgets.Label{
                 text={
                     'Mark/unmark ',
-                    {text=dcount, pen=COLOR_YELLOW}, (' tile%s'):format(dcount == 1 and '' or 's'), NEWLINE,
+                    {text=function() return self.dcount end, pen=COLOR_YELLOW},
+                    {text=function() return (' tile%s'):format(self.dcount == 1 and '' or 's') end},
+                    NEWLINE,
                     'currently designated on', NEWLINE,
                     'this level for:'
                 },
@@ -92,6 +95,10 @@ end
 function WarmDampDigConfig:render(dc)
     self.subviews.damp:setOption(getDampPaintEnabled())
     self.subviews.warm:setOption(getWarmPaintEnabled())
+    if df.global.window_z ~= self.z then
+        self.dcount = getCurLevelDesignatedCount()
+        self.z = df.global.window_z
+    end
     WarmDampDigConfig.super.render(self, dc)
 end
 
@@ -261,6 +268,10 @@ WarmDampOverlay.ATTRS{
         'dwarfmode/Designate/DIG_FROM_MARKER',
         'dwarfmode/Designate/DIG_TO_MARKER',
         'dwarfmode/Designate/ERASE',
+        'dwarfmode/Designate/SMOOTH',
+        'dwarfmode/Designate/ENGRAVE',
+        'dwarfmode/Designate/TRACK',
+        'dwarfmode/Designate/FORTIFY',
     },
     default_enabled=true,
     overlay_only=true,


### PR DESCRIPTION
- refresh count of tiles that will be modified by "mark all designated tiles on this z-level for warm/damp dig" when the z-level changes
- don't affect already-revealed tiles when marking z-level for warm/damp dig
- warm/damp/aquifer status will now be shown when in smoothing/engraving modes
