### PR TITLE
commandline options for controlling launchdf behavior

### DIFF
--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -310,19 +310,48 @@ Commandline options
 ===================
 
 In addition to `Using an OS terminal`_ to execute commands on startup, DFHack
-also recognizes a single commandline option that can be specified on the
-commandline:
+also recognizes a few commandline options.
 
-- ``--disable-dfhack``: If this option is passed on the Dwarf Fortress
-  commandline, then DFHack will be disabled for the session. You will have to
-  restart Dwarf Fortress without specifying this option in order to use DFHack.
-  If you are launching Dwarf Fortress from Steam, you can enter the option in
-  the "Launch Options" text box in the properties for the Dwarf Fortress app.
-  Note that if you do this, DFHack will be disabled regardless of whether you
-  run Dwarf Fortress from its own app or DFHack's. You will have to clear the
-  DF Launch Options in order to use DFHack again. Note that even if DFHack is
-  disabled, :file:`stdout.txt` and :file:`stderr.txt` will still be redirected
-  to :file:`stdout.log` and :file:`stderr.log`, respectively.
+Options passed to Dwarf Fortress
+--------------------------------
+
+These options can be passed to Dwarf Fortress and will be intercepted by
+DFHack. If you are launching Dwarf Fortress from Steam, you can set your
+options in the "Launch Options" text box in the properties for the Dwarf
+Fortress app (**NOT the DFHack app**). Note that these launch options will be
+used regardless of whether you run Dwarf Fortress from its own app or DFHack's.
+
+- ``--disable-dfhack``: If set, then DFHack will be disabled for the session.
+  You will have to restart Dwarf Fortress without specifying this option in
+  order to use DFHack. Note that even if DFHack is disabled, :file:`stdout.txt`
+  and :file:`stderr.txt` will still be redirected to :file:`stdout.log` and
+  :file:`stderr.log`, respectively.
+
+- ``--nosteam-dfhack``: If set, then the DFHack stub launcher will not execute
+  when you launch DF from its own app in the Steam client. This will prevent
+  your settings from being restored or backed up with Steam Cloud Save. This is
+  probably not what you want. If you want to just not have the DFHack playtime
+  counted towards your hours, see the DFHack stub launcher ``--nowait`` option
+  below.
+
+Options passed to the DFHack Steam stub launcher
+------------------------------------------------
+
+These options can be passed to the DFHack stub launcher that executes when you
+run the DFHack app from the Steam client. You can set your options in the
+"Launch Options" text box in the properties for the DFHack app (**NOT the Dwarf
+Fortress app**). Note that these launch options will be used regardless of
+whether you run Dwarf Fortress from its own app or DFHack's.
+
+- ``--nowait``: If set, the DFHack stub launcher will not wait for DF to exit
+  before exiting itself. This may be desired by players who do not want their
+  playtime "double counted". However, using this option means that your DFHack
+  settings that get backed up to the cloud will always be out of sync. The stub
+  launcher normally downloads updated settings from Steam Cloud Save when DF
+  launches, and then backs up changed settings when DF exits. If this option is
+  used, then your settings  will still be reconciled when DF launches, but
+  changes made during your play session will not be saved when DF exits. Please
+  use with caution -- you may lose data.
 
 .. _env-vars:
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -54,6 +54,7 @@ Template for new versions:
 ## New Tools
 
 ## New Features
+- DFHack and the Dwarf Fortress translation project can now both be run at the same time
 
 ## Fixes
 - `zone`: fix display of distance from cage for small pets in assignment dialog
@@ -71,6 +72,7 @@ Template for new versions:
 - `dig`: warm/damp/aquifer status will now be shown in mining mode for tiles that your dwarves can see from the level below
 - `dig`: warm/damp/aquifer status will now be shown when in smoothing/engraving modes
 - `stockpiles`: import and export "desired items" configuration for route stops
+- New commandline options for controlling the Cloud Save coprocess when launching from Steam. See the `dfhack-core` documentation for details.
 
 ## Documentation
 - Quickfort Blueprint Library: embed demo video for pump stack blueprint

--- a/library/modules/DFSteam.cpp
+++ b/library/modules/DFSteam.cpp
@@ -5,6 +5,8 @@
 #include "Debug.h"
 #include "PluginManager.h"
 
+#include "df/gamest.h"
+
 namespace DFHack
 {
     DBG_DECLARE(core, dfsteam, DebugCategory::LINFO);
@@ -220,6 +222,12 @@ void DFSteam::launchSteamDFHackIfNecessary(color_ostream& out) {
             !g_SteamInternal_FindOrCreateUserInterface ||
             !g_SteamAPI_ISteamApps_BIsAppInstalled) {
         DEBUG(dfsteam, out).print("required Steam API calls are unavailable\n");
+        return;
+    }
+
+    const std::string & cmdline = df::global::game->command_line.original;
+    if (cmdline.find("--nosteam-dfhack") != std::string::npos) {
+        WARN(dfsteam, out).print("--nosteam-dfhack specified on commandline; not launching DFHack coprocess\n");
         return;
     }
 

--- a/package/launchdf.cpp
+++ b/package/launchdf.cpp
@@ -11,8 +11,11 @@
 
 #include <string>
 
-const uint32 DFHACK_STEAM_APPID = 2346660;
-const uint32 DF_STEAM_APPID = 975370;
+#define xstr(s) str(s)
+#define str(s) #s
+
+#define DFHACK_STEAM_APPID 2346660
+#define DF_STEAM_APPID 975370
 
 #ifdef WIN32
 
@@ -28,7 +31,7 @@ static BOOL is_running_on_wine() {
 }
 
 static LPCWSTR launch_via_steam_posix() {
-    const char* argv[] = { "/bin/sh", "-c", "\"steam -applaunch 975370\"", NULL };
+    const char* argv[] = { "/bin/sh", "-c", "\"steam -applaunch " xstr(DF_STEAM_APPID) "\"", NULL };
 
     // does not return on success
     _execv(argv[0], argv);
@@ -53,7 +56,7 @@ static LPCWSTR launch_via_steam() {
     if (retCode != ERROR_SUCCESS)
         return L"Could not find Steam client executable";
 
-    WCHAR commandLine[1024] = L"steam.exe -applaunch 975370";
+    WCHAR commandLine[1024] = L"steam.exe -applaunch " xstr(DF_STEAM_APPID);
 
     BOOL res = CreateProcessW(steamPath, commandLine,
         NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
@@ -64,15 +67,15 @@ static LPCWSTR launch_via_steam() {
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
         return NULL;
-    } else {
-        return L"Could not launch Dwarf Fortress";
     }
+
+    return L"Could not launch Dwarf Fortress";
 }
 
 #else
 
 static const char * launch_via_steam() {
-    static const char * command = "steam -applaunch 975370";
+    static const char * command = "steam -applaunch " xstr(DF_STEAM_APPID);
     if (system(command) != 0)
         return "failed to launch DF via steam";
     return NULL;
@@ -93,8 +96,7 @@ static LPCWSTR launch_direct() {
     BOOL res = CreateProcessW(L"Dwarf Fortress.exe",
             NULL, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
 
-    if (res)
-    {
+    if (res) {
         WaitForSingleObject(pi.hProcess, INFINITE);
 
         CloseHandle(pi.hProcess);
@@ -177,11 +179,14 @@ DWORD findDwarfFortressProcess() {
     return -1;
 }
 
-bool waitForDF() {
+bool waitForDF(bool nowait) {
     DWORD df_pid = findDwarfFortressProcess();
 
     if (df_pid == -1)
         return false;
+
+    if (nowait)
+        return true;
 
     HANDLE hDF = OpenProcess(PROCESS_QUERY_INFORMATION | SYNCHRONIZE, FALSE, df_pid);
 
@@ -213,15 +218,18 @@ static pid_t findDwarfFortressProcess() {
     return strtoul(buf, NULL, 10);
 }
 
-bool waitForDF() {
+bool waitForDF(bool nowait) {
     pid_t df_pid = findDwarfFortressProcess();
 
     if (df_pid <= 0)
         return false;
 
-    char path[64];
-    snprintf(path, 64, "tail --pid=%i -f /dev/null", df_pid);
-    return 0 == system(path);
+    if (nowait)
+        return true;
+
+    char cmd[64];
+    snprintf(cmd, 64, "tail --pid=%i -f /dev/null", df_pid);
+    return 0 == system(cmd);
 }
 
 #endif
@@ -236,7 +244,19 @@ int main(int argc, char* argv[]) {
         exit(0);
     }
 
-    if (waitForDF())
+    bool nowait = false;
+#ifdef WIN32
+    std::wstring cmdline(lpCmdLine);
+    if (cmdline.find(L"--nowait") != cmdline::npos)
+        nowait = true;
+#else
+    for (int idx = 0; idx < argc; ++idx) {
+        if (strcmp(argv[idx], "--nowait") == 0)
+            nowait = true;
+    }
+#endif
+
+    if (waitForDF(nowait))
         exit(0);
 
     if (!SteamAPI_Init()) {
@@ -290,14 +310,11 @@ int main(int argc, char* argv[]) {
         exit(1);
     }
 
-    if (waitForDF())
-        exit(0);
-
     if (!wrap_launch(launch_via_steam))
         exit(1);
 
     int counter = 0;
-    while (!waitForDF()) {
+    while (!waitForDF(nowait)) {
         if (counter++ > 60) {
 #ifdef WIN32
             MessageBoxW(NULL, L"Dwarf Fortress took too long to launch, aborting", NULL, 0);


### PR DESCRIPTION
adds `--nowait` option to make the coprocess exit immediately after detecting DF and `--nosteam-dfhack` option for disabling the coprocess entirely.

Fixes https://github.com/DFHack/dfhack/issues/4461