### PR TITLE
suspendmanager: fully suspend unbuildable dead-ends

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 - `dig`: don't affect already-revealed tiles when marking z-level for warm/damp dig
 - `zone`: refresh values in distance column when switching selected pastures when the assign animals dialog is open
 - `logistics`: also add trainers to semi-wild pets when autoretrain is enabled
+- `suspendmanager`: fully suspend unbuildable deadends
 
 ## Misc Improvements
 - `caravan`: display who is in the cages you are selecting for trade and whether they are hostile

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -556,7 +556,13 @@ private:
                 exit = impassiblePlan;
             }
 
-            if (!exit) return;
+            if (!exit) {
+                // there is no exit at all
+                // suspend the current construction job to leave the entire plan suspended
+                // and stop here
+                suspensions[job->id] = Reason::DEADEND;
+                return;
+            }
 
             // exit is the single exit point of this corridor, suspend its construction job...
             for (auto exit_job : exit->jobs) {


### PR DESCRIPTION
In situation like this:

![327988826-5ad7b9ca-66fb-4b48-b10d-9857196eb733](https://github.com/DFHack/dfhack/assets/630159/ea003878-b465-4da2-a2c3-593565f6d136)

or this:

![328079232-8992e7a8-a11c-42fe-910b-f4fdf3162680](https://github.com/DFHack/dfhack/assets/630159/6a6239c4-c485-4af4-a2c2-e0c8d484e6e4)

one tile was left unsuspendended because the dead end suspension routine was stopping at the last one when finding out that there was no exit, but it was not suspending it, leaving one unsuspended tile, which is especially confusing when combined with the "not constructible but accessible" nature of ramp tops. This PR suspend the last tile.

fixes #4558 