### PR TITLE
propagate output flush through proxy

### DIFF
--- a/library/ColorText.cpp
+++ b/library/ColorText.cpp
@@ -196,6 +196,7 @@ void color_ostream_proxy::flush_proxy()
             target->add_text(it->first, it->second);
 
         target->end_batch();
+        target->flush_proxy();
     }
 
     buffer.clear();


### PR DESCRIPTION
when flushing an `color_ostream_proxy`, propagate the flush to the target stream

why this matters:

asynchronous output for stuff that runs during a tick gets written to a `color_ostream_proxy` that is created by the tick update handler, proxying the actual DFHack console object. this is typically debugging messages that we want displayed promptly, and so most of our handling routines are designed to flush this ostream fairly promptly so that output is displayed promptly

however, while flushing the proxy object causes all of the content in its buffer to be written to its "target" ostream, it does _not_ propagate the flush, which means that that output is simply stashed in that target ostream to be displayed "later" when some _other_ thing causes that stream to flush. this can delay debugging output for a considerable time or even cause output to appear to be lost

this PR simply makes the routine that pushes the buffered output in the proxy ostream up to to the target upstream to also force a flush on that upstream

this should not impact console locking: the implementation of `proxy_flush` in `DFHack::Console` includes lock management. in addition, i tested this code by throwing all sorts of output through it and was not able to get it to deadlock or otherwise misbehave