### PR TITLE
Fix _ENV typing for mkmodule

### DIFF
--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -199,6 +199,7 @@ function rawset_default(target,source)
     end
 end
 
+---@type any
 DEFAULT_NIL = DEFAULT_NIL or {} -- Unique token
 
 ---@generic T: table

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -149,7 +149,7 @@ end
 ---@nodiscard
 ---@param module string
 ---@param env? table|metatable
----@return table pkg
+---@return _G pkg
 function mkmodule(module,env)
     -- Verify that the module name is correct
     local _, rq_modname = find_required_module_arg()


### PR DESCRIPTION
This PR fixes an issue where any file with `_ENV` declared (modules) would lose the majority of typing capabilities by assigning the `_G` type to the return of `mkmodule`. This is not strictly accurate in terms of typing, but it is a significant win for ease of use when developing DFHack modules.

Setting `DEFAULT_NIL` to any prevents warnings from appearing when using it in place of things like tables. I didn't have a better idea for how to type it.