### PR TITLE
Suspendmanager: fix over-suspending single tile

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `suspendmanager`: stop suspending single tile stair constructions
 
 ## Misc Improvements
 

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -556,7 +556,6 @@ private:
                 exit = impassiblePlan;
             }
 
-
             if (!exit) {
                 // there is no exit at all
                 if (isImpassable(building)) {

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -556,11 +556,14 @@ private:
                 exit = impassiblePlan;
             }
 
+
             if (!exit) {
                 // there is no exit at all
-                // suspend the current construction job to leave the entire plan suspended
+                if (isImpassable(building)) {
+                    // suspend the current construction job to leave the entire plan suspended
+                    suspensions[job->id] = Reason::DEADEND;
+                }
                 // and stop here
-                suspensions[job->id] = Reason::DEADEND;
                 return;
             }
 


### PR DESCRIPTION
#4566 introduced a regression where suspendmanager would suspend single tile stairs with no access around.

This happens because the logic that tries to suspend the whole section when a construction is enclosed was blindly suspending the last checked tile with no exit. This being part of the "dead-end" exploration loop, non-blocking construction where usually filtered out by the previous iteration. But in the case of a single tile situation, it actually never checked that is was a blocking construction before suspending it.

Fixes #4580 

@myk002 I'm making the fix first to ensure it's in for the next release, but that's right, this whole thing is complex enough that it needs non-regression tests, I'll try to get some tests in too in a further PR
