### PR TITLE
Make changevein affect connected veins

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ Template for new versions:
 - `suspendmanager`: stop suspending single tile stair constructions
 
 ## Misc Improvements
+- `changevein`: affect connected veins even outside of the selected map block
 
 ## Documentation
 - `installing`: add instructions for how to use Steam DFHack with non-Steam DF (for DFHack auto-updates and cloud backups)

--- a/docs/plugins/changevein.rst
+++ b/docs/plugins/changevein.rst
@@ -5,9 +5,7 @@ changevein
     :summary: Change the material of a mineral inclusion.
     :tags: fort armok map
 
-You can change a vein to any inorganic material RAW id. Note that this command
-only affects tiles within the current 16x16 block - for large veins and
-clusters, you will need to use this command multiple times.
+You can change a vein to any inorganic material RAW id.
 
 You can use the `probe` command to discover the material RAW ids for existing
 veins that you want to duplicate.

--- a/plugins/changevein.cpp
+++ b/plugins/changevein.cpp
@@ -100,9 +100,8 @@ struct VeinEdgeBitmask
 
 static void ChangeSameBlockVeins(df::map_block* block, df::block_square_event_mineralst* event, VeinEdgeBitmask& mask, int32_t matIndex)
 {
-    for (size_t i = 0; i < block->block_events.size(); i++)
+    for (auto evt : block->block_events)
     {
-        df::block_square_event* evt = block->block_events[i];
         if (evt == event)
             continue;
         if (evt->getType() != block_square_event_type::mineral)
@@ -113,7 +112,7 @@ static void ChangeSameBlockVeins(df::map_block* block, df::block_square_event_mi
         {
             for (uint8_t j = 0; j < 15; j++)
             {
-                uint16_t bitmask = cur->tile_bitmask.bits[j] | cur->tile_bitmask.bits[std::max(j - 1, 0)] | cur->tile_bitmask.bits[std::min(j + 1, 15)];
+                uint16_t bitmask = cur->tile_bitmask.bits[j] | cur->tile_bitmask.bits[(j>0 ? j-1 : 0)] | cur->tile_bitmask.bits[std::min(j + 1, 15)];
                 bitmask |= (bitmask << 1) | (bitmask >> 1);
 
                 if (bitmask & event->tile_bitmask.bits[j])
@@ -150,9 +149,8 @@ static void ChangeSurroundingBlockVeins(df::map_block* block, VeinEdgeBitmask& m
         if (!newBlock)
             continue;
 
-        for (size_t j = 0; j < newBlock->block_events.size(); j++)
+        for (auto evt : newBlock->block_events)
         {
-            df::block_square_event* evt = newBlock->block_events[j];
             if (evt->getType() != block_square_event_type::mineral)
                 continue;
 
@@ -185,9 +183,8 @@ static void ChangeSurroundingBlockVeins(df::map_block* block, VeinEdgeBitmask& m
         if (!newBlock)
             continue;
 
-        for (size_t j = 0; j < newBlock->block_events.size(); j++)
+        for (auto evt : newBlock->block_events)
         {
-            df::block_square_event* evt = newBlock->block_events[j];
             if (evt->getType() != block_square_event_type::mineral)
                 continue;
 
@@ -246,9 +243,8 @@ command_result df_changevein (color_ostream &out, vector <string> & parameters)
     }
     df::block_square_event_mineralst *mineral = NULL;
     int tx = cursor->x % 16, ty = cursor->y % 16;
-    for (size_t j = 0; j < block->block_events.size(); j++)
+    for (auto evt : block->block_events)
     {
-        df::block_square_event *evt = block->block_events[j];
         if (evt->getType() != block_square_event_type::mineral)
             continue;
         df::block_square_event_mineralst *cur = (df::block_square_event_mineralst *)evt;

--- a/plugins/changevein.cpp
+++ b/plugins/changevein.cpp
@@ -24,6 +24,188 @@ DFHACK_PLUGIN("changevein");
 REQUIRE_GLOBAL(world);
 REQUIRE_GLOBAL(cursor);
 
+constexpr uint8_t NORTH = 0;
+constexpr uint8_t EAST = 1;
+constexpr uint8_t SOUTH = 2;
+constexpr uint8_t WEST = 3;
+constexpr uint8_t NORTHEAST = 0;
+constexpr uint8_t SOUTHEAST = 1;
+constexpr uint8_t SOUTHWEST = 2;
+constexpr uint8_t NORTHWEST = 3;
+
+static const df::coord2d DIRECTION_OFFSETS[] = { df::coord2d(0, -16), df::coord2d(16, 0), df::coord2d(0, 16), df::coord2d(-16, 0)  };
+static const df::coord2d DIAGONAL_OFFSETS[] = { df::coord2d(16, -16), df::coord2d(16, 16), df::coord2d(-16, -16), df::coord2d(-16, 16) };
+
+struct VeinEdgeBitmask
+{
+    int32_t mat;
+    // North: 0 | East: 1 | South: 2 | West: 3
+    uint16_t edges[4];
+    // NE: 0 | SE: 1 | SW: 2 | NW: 3
+    bool corners[4];
+
+    VeinEdgeBitmask(df::block_square_event_mineralst* event)
+    {
+        mat = event->inorganic_mat;
+
+        // North & South
+        edges[NORTH] = event->tile_bitmask.bits[0];
+        edges[SOUTH] = event->tile_bitmask.bits[15];
+
+        // East & West
+        edges[EAST] = 0;
+        edges[WEST] = 0;
+        for (uint8_t i = 0; i < 16; i++)
+        {
+            // East-most tile is represented by the largest bit
+            edges[EAST] |= (event->tile_bitmask.bits[i] & 0b1000000000000000) >> (15 - i);
+            // West-most tile is represented by the smallest bit
+            edges[WEST] |= (event->tile_bitmask.bits[i] & 0b0000000000000001) << i;
+        }
+
+        corners[NORTHEAST] = edges[NORTH] & 0b1000000000000000;
+        corners[SOUTHEAST] = edges[SOUTH] & 0b1000000000000000;
+        corners[SOUTHWEST] = edges[SOUTH] & 0b0000000000000001;
+        corners[NORTHWEST] = edges[NORTH] & 0b0000000000000001;
+    }
+
+    void SmudgeBitmask()
+    {
+        for (uint8_t i = 0; i < 4; i++)
+        {
+            edges[i] |= (edges[i] << 1) | (edges[i] >> 1);
+        }
+    }
+
+    bool Merge(VeinEdgeBitmask& other)
+    {
+        if (other.mat != this->mat)
+            return false;
+
+        for (uint8_t i = 0; i < 4; i++)
+        {
+            this->edges[i] |= other.edges[i];
+            this->corners[i] |= other.corners[i];
+        }
+
+        return true;
+    }
+
+    bool Merge(df::block_square_event_mineralst* event)
+    {
+        VeinEdgeBitmask temp = VeinEdgeBitmask(event);
+        return this->Merge(temp);
+    }
+};
+
+static void ChangeSameBlockVeins(df::map_block* block, df::block_square_event_mineralst* event, VeinEdgeBitmask& mask, int32_t matIndex)
+{
+    for (size_t i = 0; i < block->block_events.size(); i++)
+    {
+        df::block_square_event* evt = block->block_events[i];
+        if (evt == event)
+            continue;
+        if (evt->getType() != block_square_event_type::mineral)
+            continue;
+
+        df::block_square_event_mineralst* cur = (df::block_square_event_mineralst*)evt;
+        if (cur->inorganic_mat == mask.mat)
+        {
+            for (uint8_t j = 0; j < 15; j++)
+            {
+                uint16_t bitmask = cur->tile_bitmask.bits[j] | cur->tile_bitmask.bits[std::max(j - 1, 0)] | cur->tile_bitmask.bits[std::min(j + 1, 15)];
+                bitmask |= (bitmask << 1) | (bitmask >> 1);
+
+                if (bitmask & event->tile_bitmask.bits[j])
+                {
+                    mask.Merge(cur);
+                    cur->inorganic_mat = matIndex;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+static void ChangeSurroundingBlockVeins(df::map_block* block, VeinEdgeBitmask& mask, int32_t matIndex)
+{
+    if (!block)
+        return;
+
+    // For detecting diagonal connections
+    mask.SmudgeBitmask();
+
+    for (uint8_t i = 0; i < 4; i++)
+    {
+        const df::coord2d& offset = DIRECTION_OFFSETS[i];
+        const uint16_t edgeBitmask = mask.edges[i];
+        const uint8_t oppositeIndex = (i + 2) % 4;
+
+        if (!edgeBitmask)
+            continue;
+
+        df::coord pos = df::coord(block->map_pos.x + offset.x, block->map_pos.y + offset.y, block->map_pos.z);
+        df::map_block* newBlock = Maps::getTileBlock(pos);
+
+        if (!newBlock)
+            continue;
+
+        for (size_t j = 0; j < newBlock->block_events.size(); j++)
+        {
+            df::block_square_event* evt = newBlock->block_events[j];
+            if (evt->getType() != block_square_event_type::mineral)
+                continue;
+
+            df::block_square_event_mineralst* cur = (df::block_square_event_mineralst*)evt;
+            if (cur->inorganic_mat == mask.mat)
+            {
+                VeinEdgeBitmask newMask = VeinEdgeBitmask(cur);
+                if (newMask.edges[oppositeIndex] & edgeBitmask)
+                {
+                    cur->inorganic_mat = matIndex;
+                    ChangeSameBlockVeins(newBlock, cur, newMask, matIndex);
+                    ChangeSurroundingBlockVeins(newBlock, newMask, matIndex);
+                }
+            }
+        }
+    }
+
+    for (uint8_t i = 0; i < 4; i++)
+    {
+        const df::coord2d& offset = DIAGONAL_OFFSETS[i];
+        const bool cornerBit = mask.corners[i];
+        const uint8_t oppositeIndex = (i + 2) % 4;
+
+        if (!cornerBit)
+            continue;
+
+        df::coord pos = df::coord(block->map_pos.x + offset.x, block->map_pos.y + offset.y, block->map_pos.z);
+        df::map_block* newBlock = Maps::getTileBlock(pos);
+
+        if (!newBlock)
+            continue;
+
+        for (size_t j = 0; j < newBlock->block_events.size(); j++)
+        {
+            df::block_square_event* evt = newBlock->block_events[j];
+            if (evt->getType() != block_square_event_type::mineral)
+                continue;
+
+            df::block_square_event_mineralst* cur = (df::block_square_event_mineralst*)evt;
+            if (cur->inorganic_mat == mask.mat)
+            {
+                VeinEdgeBitmask newMask = VeinEdgeBitmask(cur);
+                if (newMask.corners[oppositeIndex] && cornerBit)
+                {
+                    cur->inorganic_mat = matIndex;
+                    ChangeSameBlockVeins(newBlock, cur, newMask, matIndex);
+                    ChangeSurroundingBlockVeins(newBlock, newMask, matIndex);
+                }
+            }
+        }
+    }
+}
+
 command_result df_changevein (color_ostream &out, vector <string> & parameters)
 {
     if (parameters.size() != 1)
@@ -78,7 +260,11 @@ command_result df_changevein (color_ostream &out, vector <string> & parameters)
         out.printerr("Selected tile does not contain a mineral vein.\n");
         return CR_FAILURE;
     }
+
+    VeinEdgeBitmask mask = VeinEdgeBitmask(mineral);
     mineral->inorganic_mat = mi.index;
+    ChangeSameBlockVeins(block, mineral, mask, mi.index);
+    ChangeSurroundingBlockVeins(block, mask, mi.index);
 
     return CR_OK;
 }


### PR DESCRIPTION
Fixes #4519
changevein will now convert any connected veins in the same tile and neighboring tiles.