### PR TITLE
Add attrs and _attr_entry_type documentation

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -355,15 +355,29 @@ Types excluding the global object also support:
   ``nil``, NULL or non-wrapper value as object; in this case the
   method returns ``nil``.
 
+Enum types support the following:
+
+* ``type.next_item(index)``
+
+  Returns the next valid numeric value of the enum. It  returns the
+  first enum value if ``index`` is greater than or equal to the max
+  enum value.
+
+* ``type.attrs``
+
+  A mapping of enum keys (usually integers) and values (usually strings) to
+  their attributes. e.g ``df.goal_type.attrs.STAY_ALIVE`` returns 
+  ``{ short_name: "Stay Alive", achieved_short_name: "Stayed Alive" } }``
+
+* ``type._attr_entry_type``
+
+  Returns the named ``struct-type`` type representing the table returned
+  by ``type.attrs``.
+
 In addition to this, enum and bitfield types contain a
 bi-directional mapping between key strings and values, and
 also map ``_first_item`` and ``_last_item`` to the min and
 max values.
-
-Enum types also support the ``type.next_item(index)`` function,
-which returns the next valid numeric value of the enum. It
-Returns the first enum value if ``index`` is greater than or
-equal to the max enum value.
 
 Struct and class types with an instance-vector attribute in the XML also support:
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -366,7 +366,7 @@ Enum types support the following:
 * ``type.attrs``
 
   A mapping of enum keys (usually integers) and values (usually strings) to
-  their attributes. e.g ``df.goal_type.attrs.STAY_ALIVE`` returns 
+  their attributes. e.g ``df.goal_type.attrs.STAY_ALIVE`` returns
   ``{ short_name: "Stay Alive", achieved_short_name: "Stayed Alive" } }``
 
 * ``type._attr_entry_type``


### PR DESCRIPTION
This PR aims to add missing information about the enum `attrs` field.

Closes #1802 