### PR TITLE
allow getAnyJob to return the job under the cursor

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -67,6 +67,7 @@ Template for new versions:
 ## API
 
 ## Lua
+- ``dfhack.gui.getSelectedJob``: can now return the job with a destination under the keyboard cursor (e.g. digging/carving/engraving jobs)
 
 ## Removed
 

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -1077,11 +1077,23 @@ df::job *Gui::getAnyJob(df::viewscreen *top) {
         return cri_job.size() ? cri_job[0]->jb : NULL;
     }
 
-    if (auto unit = getAnyUnit(top)) {
+    if (auto unit = getAnyUnit(top))
         return unit->job.current_job;
+
+    if (auto job = getAnyWorkshopJob(top))
+        return job;
+
+    if (auto cursor = getCursorPos(); cursor.isValid()) {
+        for (auto *link = world->jobs.list.next; link; link = link->next) {
+            df::job *job = link->item;
+            if (!job)
+                continue;
+            if (job->pos == cursor)
+                return job;
+        }
     }
 
-    return getAnyWorkshopJob(top);
+    return NULL;
 }
 
 df::job *Gui::getSelectedJob(color_ostream &out, bool quiet)


### PR DESCRIPTION
useful when examining digging/carving jobs