### PR TITLE
use new lookup for adventurer

### DIFF
--- a/docs/plugins/createitem.rst
+++ b/docs/plugins/createitem.rst
@@ -5,9 +5,10 @@ createitem
     :summary: Create arbitrary items.
     :tags: adventure fort armok items
 
-You can create new items of any type and made of any material. A unit must be
-selected in-game to use this command. By default, items created are spawned at
-the feet of the selected unit.
+You can create new items of any type and made of any material. By default,
+items created are spawned at the feet of the selected unit. If no unit is
+selected, the first citizen will be used as the creator unit and the items
+will be spawned at the location of the keyboard cursor.
 
 Specify the item and material information as you would indicate them in custom
 reaction raws, with the following differences:

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -1831,7 +1831,9 @@ DFHACK_EXPORT int Gui::makeAnnouncement(df::announcement_type type, df::announce
     if (flags.bits.PAUSE || flags.bits.RECENTER)
         pauseRecenter((flags.bits.RECENTER ? pos : df::coord()), flags.bits.PAUSE); // Does nothing if not dwarf mode
 
-    bool adv_unconscious = (*gamemode == game_mode::ADVENTURE && !world->units.active.empty() && world->units.active[0]->counters.unconscious > 0);
+    bool adv_unconscious = false;
+    if (auto adv = World::getAdventurer())
+        adv_unconscious = adv->counters.unconscious > 0;
 
     if (flags.bits.DO_MEGA && !adv_unconscious)
         showPopupAnnouncement(message, color, bright);
@@ -2065,19 +2067,19 @@ bool Gui::autoDFAnnouncement(df::announcement_infost info, string message)
     // Check if the announcement will actually be used and written to gamelog
     if (*gamemode == game_mode::ADVENTURE)
     {
-        // TODO: Expect this check when adventure mode is re-added; sound and gamelog will happen otherwise
-        /*if (!a_flags.bits.A_DISPLAY && !a_flags.bits.DO_MEGA)
+        if (!a_flags.bits.A_DISPLAY && !a_flags.bits.DO_MEGA)
         {
             DEBUG(gui).print("Skipped announcement not enabled at all for adventure mode:\n%s\n", message.c_str());
             return false;
-        }*/
+        }
+
         if (info.pos.x >= 0 &&
             info.type != announcement_type::CREATURE_SOUND &&
             info.type != announcement_type::REGULAR_CONVERSATION &&
             info.type != announcement_type::CONFLICT_CONVERSATION &&
             info.type != announcement_type::MECHANISM_SOUND)
         {   // If not sound, make sure we can see pos if we're not involved
-            if (world->units.active.empty() || (info.unit_a != world->units.active[0] && info.unit_d != world->units.active[0]))
+            if (auto adv = World::getAdventurer(); info.unit_a != adv && info.unit_d != adv)
             {   // Adventure mode reuses a dwarf mode digging designation bit to determine current visibility
                 if (!Maps::isValidTilePos(info.pos) || (Maps::getTileDesignation(info.pos)->whole & 0x10) == 0x0)
                 {
@@ -2124,7 +2126,9 @@ bool Gui::autoDFAnnouncement(df::announcement_infost info, string message)
     if (a_flags.bits.PAUSE || a_flags.bits.RECENTER)
         pauseRecenter((a_flags.bits.RECENTER ? info.pos : df::coord()), a_flags.bits.PAUSE); // Does nothing if not dwarf mode
 
-    bool adv_unconscious = (*gamemode == game_mode::ADVENTURE && !world->units.active.empty() && world->units.active[0]->counters.unconscious > 0);
+    bool adv_unconscious = false;
+    if (auto adv = World::getAdventurer())
+        adv_unconscious = adv->counters.unconscious > 0;
 
     if (a_flags.bits.DO_MEGA && !adv_unconscious)
         showPopupAnnouncement(message, info.color, info.bright);

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -314,7 +314,7 @@ bool Units::isHidden(df::unit *unit)
 
     if (*gamemode == game_mode::ADVENTURE)
     {
-        if (unit == world->units.active[0])
+        if (unit == World::getAdventurer())
             return false;
         else if (unit->flags1.bits.hidden_in_ambush)
             return true;
@@ -2000,8 +2000,8 @@ std::string Units::getCasteProfessionName(int race, int casteid, df::profession 
     if (pid < (df::profession)0 || !is_valid_enum_item(pid))
         return "";
     int16_t current_race = df::global::plotinfo->race_id;
-    if (df::global::gamemode && *df::global::gamemode == df::game_mode::ADVENTURE)
-        current_race = world->units.active[0]->race;
+    if (auto adv = World::getAdventurer())
+        current_race = adv->race;
     bool use_race_prefix = (race >= 0 && race != current_race);
 
     if (auto creature = df::creature_raw::find(race))

--- a/plugins/createitem.cpp
+++ b/plugins/createitem.cpp
@@ -12,6 +12,7 @@
 #include "modules/Gui.h"
 #include "modules/Items.h"
 #include "modules/Materials.h"
+#include "modules/Units.h"
 #include "modules/World.h"
 
 #include "df/building.h"
@@ -444,15 +445,20 @@ command_result df_createitem (color_ostream &out, vector <string> & parameters)
         if (*gametype == game_type::ADVENTURE_ARENA || World::isAdventureMode())
         {
             // Use the adventurer unit
-            unit = world->units.active[0];
+            unit = World::getAdventurer();
         }
-        else if (!world->units.active.empty() && cursor->x >= 0)
+        else if (cursor->x >= 0)
         {
-            // Use the first possible unit and the cursor position
-            unit = world->units.active[0];
+            // Use the first possible citizen if possible, otherwise the first unit
+            for (auto u : Units::citizensRange(world->units.active)) {
+                unit = u;
+                break;
+            }
+            if (!unit && world->units.active.size())
+                unit = world->units.active[0];
             move_to_cursor = true;
         }
-        else
+        if (!unit)
         {
             out.printerr("No unit selected!\n");
             return CR_FAILURE;

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -853,9 +853,9 @@ static DFCoord simulate_fall(const DFCoord &pos) {
 
 static void create_boulders(color_ostream &out,
                 const item_coords_t &item_coords,
-                const dig_now_options &options) {
-    df::unit *unit = world->units.active[0];
-    df::historical_entity *civ = df::historical_entity::find(unit->civ_id);
+                const dig_now_options &options,
+                df::unit * creator) {
+    df::historical_entity *civ = df::historical_entity::find(creator->civ_id);
     df::world_site *site = World::isFortressMode() ?
             df::world_site::find(plotinfo->site_id) : NULL;
 
@@ -891,7 +891,7 @@ static void create_boulders(color_ostream &out,
                                           static_cast<size_t>(INT16_MAX));
             prod->count = batch_size;
             remaining_items -= batch_size;
-            prod->produce(unit, &out_products, &out_items, &in_reag, &in_items,
+            prod->produce(creator, &out_products, &out_items, &in_reag, &in_items,
                           1, job_skill::NONE, 0, civ, site, NULL);
         }
 
@@ -1036,7 +1036,7 @@ bool dig_now_impl(color_ostream &out, const dig_now_options &options) {
     item_coords_t item_coords;
 
     do_dig(out, dug_coords, item_coords, options);
-    create_boulders(out, item_coords, options);
+    create_boulders(out, item_coords, options, world->units.active[0]);
     post_process_dug_tiles(out, dug_coords);
 
     // force the game to recompute its walkability cache

--- a/plugins/remotefortressreader/remotefortressreader.cpp
+++ b/plugins/remotefortressreader/remotefortressreader.cpp
@@ -1872,8 +1872,8 @@ static command_result GetViewInfo(color_ostream &stream, const EmptyMessage *in,
     out->set_cursor_pos_y(cy);
     out->set_cursor_pos_z(cz);
 
-    if (gamemode && *gamemode == GameMode::ADVENTURE)
-        out->set_follow_unit_id(world->units.active[0]->id);
+    if (auto adv = World::getAdventurer())
+        out->set_follow_unit_id(adv->id);
     else
         out->set_follow_unit_id(plotinfo->follow_unit);
     out->set_follow_item_id(plotinfo->follow_item);

--- a/plugins/sort.cpp
+++ b/plugins/sort.cpp
@@ -79,7 +79,7 @@ static int32_t our_filter_idx(df::widget_unit_list *unitlist) {
     if (world->units.active.empty())
         return true;
 
-    df::unit *u = world->units.active[0];
+    df::unit *u = world->units.active[0]; // any unit will do; we just need a sentinel
     if (!u)
         return true;
 


### PR DESCRIPTION
among other things fixes, the report from Steam where createitem wasn't selecting the adventurer by default (even though the docs say you have to select a unit before use)

Fixes: https://github.com/DFHack/dfhack/issues/4603