### PR TITLE
[Gui] make stockpile focus strings correspond better to UI state

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -67,6 +67,7 @@ Template for new versions:
 - `installing`: add instructions for how to use Steam DFHack with non-Steam DF (for DFHack auto-updates and cloud backups)
 
 ## API
+- Focus strings have moved for stockpile states: ``dwarfmode/CustomStockpile`` is now ``dwarfmode/Stockpile/Some/Customize`` and similar for ``dwarfmode/StockpileTools`` and ``dwarfmode/StockpileLink``
 
 ## Lua
 - ``dfhack.gui.getSelectedJob``: can now return the job with a destination under the keyboard cursor (e.g. digging/carving/engraving jobs)

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -587,6 +587,14 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
             newFocusString += "/Stockpile";
             if (game->main_interface.stockpile.cur_bld) {
                 newFocusString += "/Some";
+                if (game->main_interface.stockpile_link.open)
+                    newFocusString += "/Links";
+                else if (game->main_interface.stockpile_tools.open)
+                    newFocusString += "/Containers";
+                else if (game->main_interface.custom_stockpile.open)
+                    newFocusString += "/Customize";
+                else
+                    newFocusString += "/Default";
             }
             break;
         case df::enums::main_bottom_mode_type::STOCKPILE_PAINT:
@@ -800,21 +808,6 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
     if (game->main_interface.assign_vehicle.open) {
         newFocusString = baseFocus;
         newFocusString += "/AssignVehicle";
-        focusStrings.push_back(newFocusString);
-    }
-    if (game->main_interface.stockpile_link.open) {
-        newFocusString = baseFocus;
-        newFocusString += "/StockpileLink";
-        focusStrings.push_back(newFocusString);
-    }
-    if (game->main_interface.stockpile_tools.open) {
-        newFocusString = baseFocus;
-        newFocusString += "/StockpileTools";
-        focusStrings.push_back(newFocusString);
-    }
-    if (game->main_interface.custom_stockpile.open) {
-        newFocusString = baseFocus;
-        newFocusString += "/CustomStockpile";
         focusStrings.push_back(newFocusString);
     }
     if (game->main_interface.create_squad.open) {


### PR DESCRIPTION
- dwarfmode/CustomStockpile -> dwarfmode/Stockpile/Some/Customize
- dwarfmode/StockpileTools -> dwarfmode/Stockpile/Some/Containers
- dwarfmode/StockpileLink -> dwarfmode/Stockpile/Some/Links

Just a stockpile selected on the map is now dwarfmode/Stockpile/Some/Default
