### PR TITLE
Fix makeButtonLabelText pen tables

### DIFF
--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1708,9 +1708,9 @@ end
 local function get_button_token_base_pens(spec, x, y)
     local pen, pen_hover = COLOR_GRAY, COLOR_WHITE
     if spec.pens then
-        pen = type(spec.pens) == 'table' and spec.pens[y][x] or spec.pens
+        pen = type(spec.pens) == 'table' and #spec.pens > 0 and (#spec.pens[y] > 0 and spec.pens[y][x] or spec.pens[y]) or spec.pens
         if spec.pens_hover then
-            pen_hover = type(spec.pens_hover) == 'table' and spec.pens_hover[y][x] or spec.pens_hover
+            pen_hover = type(spec.pens_hover) == 'table' and #spec.pens_hover > 0 and (#spec.pens_hover[y] > 0 and spec.pens_hover[y][x] or spec.pens_hover[y]) or spec.pens_hover
         else
             pen_hover = pen
         end

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1708,7 +1708,7 @@ end
 local function get_button_token_base_pens(spec, x, y)
     local pen, pen_hover = COLOR_GRAY, COLOR_WHITE
     if spec.pens then
-        pen = type(spec.pens) == 'table' and #spec.pens > 0 and (#spec.pens[y] > 0 and spec.pens[y][x] or spec.pens[y]) or spec.pens
+        pen = type(spec.pens) == 'table' and safe_index(spec.pens, y, x) or spec.pens[y] or spec.pens
         if spec.pens_hover then
             pen_hover = type(spec.pens_hover) == 'table' and #spec.pens_hover > 0 and (#spec.pens_hover[y] > 0 and spec.pens_hover[y][x] or spec.pens_hover[y]) or spec.pens_hover
         else

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1710,7 +1710,7 @@ local function get_button_token_base_pens(spec, x, y)
     if spec.pens then
         pen = type(spec.pens) == 'table' and safe_index(spec.pens, y, x) or spec.pens[y] or spec.pens
         if spec.pens_hover then
-            pen_hover = type(spec.pens_hover) == 'table' and #spec.pens_hover > 0 and (#spec.pens_hover[y] > 0 and spec.pens_hover[y][x] or spec.pens_hover[y]) or spec.pens_hover
+            pen_hover = type(spec.pens_hover) == 'table' and safe_index(spec.pens_hover, y, x) or spec.pens_hover[y] or spec.pens_hover
         else
             pen_hover = pen
         end


### PR DESCRIPTION
Fixes #4621 

Allows for passing in values such as:
```
pens={
    {{fg=COLOR_YELLOW, bg=COLOR_LIGHTRED},{fg=COLOR_BLUE, bg=COLOR_DARKGRAY}},
    {{fg=COLOR_BLACK, bg=COLOR_LIGHTRED},{fg=COLOR_BLACK, bg=COLOR_LIGHTRED}},
},
```
```
pens={
    {{fg=COLOR_YELLOW, bg=COLOR_LIGHTRED},{fg=COLOR_BLUE, bg=COLOR_DARKGRAY}},
    {fg=COLOR_BLACK, bg=COLOR_LIGHTRED},
},
```
```
pens={fg=COLOR_BLACK, bg=COLOR_LIGHTRED},
```
