### PR TITLE
Fix makeButtonLabel pen tables again (+Safer `safe_index`)

### DIFF
--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -514,11 +514,12 @@ end
 ---@param ... number|string
 ---@return any obj
 function safe_index(obj,idx,...)
-    if obj == nil or idx == nil then
+    local obj_type = type(obj)
+    if obj == nil or idx == nil or (obj_type ~= "table" and obj_type ~= "userdata") then
         return nil
     end
     if type(idx) == 'number' and
-            type(obj) == 'userdata' and -- this check is only relevant for c++
+            obj_type == 'userdata' and -- this check is only relevant for c++
             (idx < 0 or idx >= #obj)
     then
         return nil

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1708,9 +1708,9 @@ end
 local function get_button_token_base_pens(spec, x, y)
     local pen, pen_hover = COLOR_GRAY, COLOR_WHITE
     if spec.pens then
-        pen = type(spec.pens) == 'table' and safe_index(spec.pens, y, x) or spec.pens[y] or spec.pens
+        pen = type(spec.pens) == 'table' and (safe_index(spec.pens, y, x) or spec.pens[y]) or spec.pens
         if spec.pens_hover then
-            pen_hover = type(spec.pens_hover) == 'table' and safe_index(spec.pens_hover, y, x) or spec.pens_hover[y] or spec.pens_hover
+            pen_hover = type(spec.pens_hover) == 'table' and (safe_index(spec.pens_hover, y, x) or spec.pens_hover[y]) or spec.pens_hover
         else
             pen_hover = pen
         end


### PR DESCRIPTION
Takes into account extra cases not considered by #4622 
In doing this, also adds a check to `safe_index` to verify that the passed object is a table/userdata, to prevent issues with invocations such as: `safe_index({ A= { B= 5 } }, 'A', 'B', 'C')`

Extra cases:
```
pens=COLOR_YELLOW
```
```
pens={
    {{fg=COLOR_YELLOW, bg=COLOR_LIGHTRED},{fg=COLOR_BLUE, bg=COLOR_DARKGRAY}},
    COLOR_LIGHTRED,
}
```
```
pens={COLOR_YELLOW,{fg=COLOR_BLUE, bg=COLOR_DARKGRAY}}
```