### PR TITLE
add `Buildings::getName`

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -79,6 +79,7 @@ Template for new versions:
 
 ## API
 - Focus strings have moved for stockpile states: ``dwarfmode/CustomStockpile`` is now ``dwarfmode/Stockpile/Some/Customize`` and similar for ``dwarfmode/StockpileTools`` and ``dwarfmode/StockpileLink``
+- ``Buildings::getName``: get a building's name, convenience method for easier use from Lua
 - ``Maps::isTileAquifer``: check if tile is an aquifer
 - ``Maps::isTileHeavyAquifer``: check if tile is a heavy aquifer
 - ``Maps::setTileAquifer``: make tile into an aquifer

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2235,6 +2235,10 @@ General
   Replaces the owner of the civzone. If unit is *nil*, removes ownership.
   Returns *false* in case of error.
 
+  ``dfhack.buildings.getName(building)``
+
+  Returns the name of the building as it would appear in game.
+
 * ``dfhack.buildings.getSize(building)``
 
   Returns *width, height, centerx, centery*.

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2663,6 +2663,7 @@ static const LuaWrapper::FunctionReg dfhack_buildings_module[] = {
     WRAPM(Buildings, isPitPond),
     WRAPM(Buildings, isActive),
     WRAPM(Buildings, completeBuild),
+    WRAPM(Buildings, getName),
     { NULL, NULL }
 };
 

--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -113,6 +113,11 @@ DFHACK_EXPORT df::specific_ref *getSpecificRef(df::building *building, df::speci
 DFHACK_EXPORT bool setOwner(df::building_civzonest *building, df::unit *owner);
 
 /**
+ * Get the building's name (convenience method)
+ */
+DFHACK_EXPORT std::string getName(df::building* building);
+
+/**
  * Find the building located at the specified tile.
  * Does not work on civzones.
  */

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -355,6 +355,15 @@ df::specific_ref *Buildings::getSpecificRef(df::building *building, df::specific
     return findRef(building->specific_refs, type);
 }
 
+std::string Buildings::getName(df::building* building)
+{
+    CHECK_NULL_POINTER(building);
+
+    std::string tmp;
+    building->getName(&tmp);
+    return tmp;
+}
+
 bool Buildings::setOwner(df::building_civzonest *bld, df::unit *unit)
 {
     CHECK_NULL_POINTER(bld);


### PR DESCRIPTION
convenience method mainly intended for use from Lua, since calling the native DF vmethod from Lua is difficult and nonobvious