### PR TITLE
prevent armok keybindings from being recognized in mortal mode

### DIFF
--- a/ci/test.lua
+++ b/ci/test.lua
@@ -458,9 +458,7 @@ local function load_tests(file, tests)
     local targets = type(env.config.target) == 'table' and env.config.target or {env.config.target}
     for _,target in ipairs(targets) do
         if target == 'core' then goto continue end
-        if type(target) ~= 'string' or not helpdb.is_entry(target) or
-            helpdb.get_entry_tags(target).unavailable
-        then
+        if type(target) ~= 'string' or helpdb.has_tag(target, 'unavailable') then
             dfhack.printerr('Skipping tests for unavailable target: ' .. target)
             return true
         end

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,7 @@ Template for new versions:
 - `tiletypes`: make aquifers functional when adding the ``aquifer`` property
 - `seedwatch`: do not include unplantable tree seeds in its status report
 - ``Buildings::containsTile``: fix result for buildings that are solid and have no extent structures
+- Mortal mode: prevent keybindings that run armok tools from being recognized when in mortal mode
 
 ## Misc Improvements
 - `blueprint`: capture track carving designations in addition to already-carved tracks

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3950,6 +3950,10 @@ Each entry has several properties associated with it:
 
   Returns the set of tag names for the given entry.
 
+* ``helpdb.has_tag(entry, tag)``
+
+  Returns whether the given entry exists and has the specified tag.
+
 * ``helpdb.is_tag(str)``, ``helpdb.is_tag(list)``
 
   Returns whether the given string (or list of strings) is a (are all) valid tag

--- a/library/lua/dfhack.lua
+++ b/library/lua/dfhack.lua
@@ -963,7 +963,7 @@ local warned_scripts = {}
 function dfhack.run_script(name,...)
     if not warned_scripts[name] then
         local helpdb = require('helpdb')
-        if helpdb.is_entry(name) and helpdb.get_entry_tags(name).unavailable then
+        if helpdb.has_tag(name, 'unavailable') then
             warned_scripts[name] = true
             dfhack.printerr(('UNTESTED WARNING: the "%s" script has not been validated to work well with this version of DF.'):format(name))
             dfhack.printerr('It may not work as expected, or it may corrupt your game.')

--- a/library/lua/helpdb.lua
+++ b/library/lua/helpdb.lua
@@ -526,6 +526,11 @@ function get_entry_tags(entry)
     return get_db_property(entry, 'tags')
 end
 
+-- returns whether the given entry exists and has the specified tag
+function has_tag(entry, tag)
+    return is_entry(entry) and get_entry_tags(entry)[tag]
+end
+
 -- returns whether the given string (or list of strings) matches a tag name
 function is_tag(str)
     ensure_db()

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -16,9 +16,7 @@ end
 
 function should_hide_armok(cmdline)
     local command = get_command(cmdline)
-    return dfhack.getHideArmokTools() and
-            helpdb.is_entry(command) and
-            helpdb.get_entry_tags(command).armok
+    return dfhack.getHideArmokTools() and helpdb.has_tag(command, 'armok')
 end
 
 -- ----------------- --


### PR DESCRIPTION
also add a helpful helpdb api to facilitate the detection

as reported in [Discord](https://discord.com/channels/793331351645323264/807444467140788254/1246846660106256454)