### PR TITLE
[dig] only propagate autodig to tiles that vanilla doesn't

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 - `seedwatch`: do not include unplantable tree seeds in its status report
 - ``Buildings::containsTile``: fix result for buildings that are solid and have no extent structures
 - Mortal mode: prevent keybindings that run armok tools from being recognized when in mortal mode
+- `dig`: don't leave phantom dig designations behind when autodigging warm/damp designated tiles
 
 ## Misc Improvements
 - `blueprint`: capture track carving designations in addition to already-carved tracks

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -332,8 +332,10 @@ static void propagate_if_material_match(color_ostream& out, MapExtras::MapCache 
     if (!des || !occ || !is_wall(pos))
         return;
 
-    des->bits.dig = df::tile_dig_designation::Default;
-    occ->bits.dig_auto = true;
+    if (des->bits.hidden && ((warm && is_warm(pos)) || (damp && is_damp(pos)))) {
+        des->bits.dig = df::tile_dig_designation::Default;
+        occ->bits.dig_auto = true;
+    }
 
     if (warm) {
         if (auto warm_mask = World::getPersistentTilemask(warm_config, block, true))


### PR DESCRIPTION
prevents phantom dig designations from being left behind

Fixes: https://github.com/DFHack/dfhack/issues/4639