### PR TITLE
[dialogs] extend yesno dialog so it can be used for more kinds of confirmations

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -107,9 +107,11 @@ Template for new versions:
 - ``dfhack.maps.setTileAquifer``: make tile into an aquifer
 - ``dfhack.maps.removeTileAquifer``: remove aquifer from tile
 - ``plugins.tiletypes.tiletypes_setTile``: can now accept a table with for access to previously unavailable options
+- ``dialogs.showYesNoPrompt``: extend options so the standard dialog can be used for `gui/confirm`-style confirmation prompts
 
 
 ## Removed
+- ``gui.FramedScreen``: this class is now deprecated; please use ``gui.ZScreen`` and ``widgets.Window`` instead
 
 # 50.13-r2
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4862,56 +4862,6 @@ A ZScreen convenience subclass that sets the attributes to something
 appropriate for modal dialogs. The game is force paused, and no input is passed
 through to the underlying viewscreens.
 
-FramedScreen class
-------------------
-
-A Screen subclass that paints a visible frame around its body.
-Most dialogs should inherit from this class.
-
-A framed screen has the following attributes:
-
-:frame_style: A table that defines a set of pens to draw various parts of the frame.
-:frame_title: A string to display in the middle of the top of the frame.
-:frame_width: Desired width of the client area. If *nil*, the screen will occupy the whole width.
-:frame_height: Likewise, for height.
-:frame_inset: The gap between the frame and the client area. Defaults to 0.
-:frame_background: The pen to fill in the frame with. Defaults to CLEAR_PEN.
-
-There are the following predefined frame style tables:
-
-* ``FRAME_WINDOW``
-
-  A frame suitable for a draggable, optionally resizable window.
-
-* ``FRAME_PANEL``
-
-  A frame suitable for a static (non-draggable, non-resizable) panel.
-
-* ``FRAME_MEDIUM``
-
-  A frame suitable for overlay widget panels.
-
-* ``FRAME_THIN``
-
-  A frame suitable for floating tooltip panels that need the DFHack signature.
-
-* ``FRAME_BOLD``
-
-  A frame suitable for a non-draggable panel meant to capture the user's focus,
-  like an important notification, confirmation dialog or error message.
-
-* ``FRAME_INTERIOR``
-
-  A frame suitable for light interior accent elements. This frame does *not*
-  have a visible ``DFHack`` signature on it, so it must not be used as the most
-  external frame for a DFHack-owned UI.
-
-* ``FRAME_INTERIOR_MEDIUM``
-
-  A copy of ``FRAME_MEDIUM`` that lacks the ``DFHack`` signature. Suitable for
-  panels that are part of a larger widget cluster. Must *not* be used as the
-  most external frame for a DFHack-owned UI.
-
 gui.widgets
 ===========
 
@@ -5047,10 +4997,44 @@ Has attributes:
 * ``frame_style``, ``frame_title`` (default: ``nil``)
 
   If defined, a frame will be drawn around the panel and subviews will be inset
-  by 1. The attributes are identical to what is defined in the
-  `FramedScreen class`_. When using the predefined frame styles in the ``gui``
-  module, remember to ``require`` the gui module and prefix the identifier with
-  ``gui.``, e.g. ``gui.GREY_LINE_FRAME``.
+  by 1. The following predefined frame styles are defined:
+
+  * ``FRAME_WINDOW``
+
+    A frame suitable for a draggable, optionally resizable window.
+
+  * ``FRAME_PANEL``
+
+    A frame suitable for a static (non-resizable) panel.
+
+  * ``FRAME_MEDIUM``
+
+    A frame suitable for overlay widget panels.
+
+  * ``FRAME_THIN``
+
+    A frame suitable for floating tooltip panels that need the DFHack signature.
+
+  * ``FRAME_BOLD``
+
+    A frame suitable for a non-draggable panel meant to capture the user's
+    focus, like an important notification, confirmation dialog or error message.
+
+  * ``FRAME_INTERIOR``
+
+    A frame suitable for light interior accent elements. This frame does *not*
+    have a visible ``DFHack`` signature on it, so it must not be used as the
+    external frame for a DFHack-owned UI.
+
+  * ``FRAME_INTERIOR_MEDIUM``
+
+    A copy of ``FRAME_MEDIUM`` that lacks the ``DFHack`` signature. Suitable for
+    panels that are part of a larger widget cluster. Must *not* be used as the
+    external frame for a DFHack-owned UI.
+
+  When using the predefined frame styles in the ``gui`` module, remember to
+  ``require`` the gui module and prefix the identifier with ``gui.``, e.g.
+  ``gui.FRAME_THIN``.
 
 * ``no_force_pause_badge`` (default: ``false``)
 

--- a/library/lua/gui/dialogs.lua
+++ b/library/lua/gui/dialogs.lua
@@ -10,28 +10,36 @@ local widgets = require('gui.widgets')
 --
 
 DialogWindow = defclass(DialogWindow, widgets.Window)
-DialogWindow.ATTRS {
+DialogWindow.ATTRS{
     frame={w=20, h=10},
-    label_params=DEFAULT_NIL,
-    accept_label=DEFAULT_NIL,
+    min_width=30,
+    extra_height=0,
+    message_label_attrs={},
+    accept_hotkey_label_attrs={},
     on_accept=DEFAULT_NIL,
     on_cancel=DEFAULT_NIL,
 }
 
-function DialogWindow:init(info)
+function DialogWindow:init()
+    local message_label_attrs = {
+        view_id='label',
+        auto_height=false,
+        frame={t=0, l=0, b=2},
+    }
+    for k,v in pairs(self.message_label_attrs) do message_label_attrs[k] = v end
+
+    local accept_hotkey_label_attrs = {
+        frame={b=0, l=0, r=0},
+        key='SELECT',
+        label='Ok',
+        auto_width=true,
+        on_activate=self:callback('accept'),
+    }
+    for k,v in pairs(self.accept_hotkey_label_attrs) do accept_hotkey_label_attrs[k] = v end
+
     self:addviews{
-        widgets.Label{
-            view_id='label',
-            frame={t=0, l=0, b=3},
-            text=self.label_params.text,
-        },
-        widgets.HotkeyLabel{
-            frame={b=0, l=0, r=0},
-            label=self.accept_label,
-            key='SELECT',
-            auto_width=true,
-            on_activate=self:callback('accept'),
-        },
+        widgets.Label(message_label_attrs),
+        widgets.HotkeyLabel(accept_hotkey_label_attrs),
     }
 end
 
@@ -50,18 +58,18 @@ function DialogWindow:cancel()
 end
 
 function DialogWindow:computeFrame()
-    local min_width = math.max(self.frame.w or 0, 20, #(self.frame_title or '') + 4)
+    local min_width = math.max(self.frame.w or 0, 20, self.min_width, #(self.frame_title or '') + 4)
 
     local label = self.subviews.label
     local text_area_width = label:getTextWidth() + 1
     local text_height = label:getTextHeight()
     local sw, sh = dfhack.screen.getWindowSize()
-    if text_height >= sh - 6 then
+    if text_height >= sh - (6 + self.extra_height) then
         -- account for scrollbar
         text_area_width = text_area_width + 2
     end
 
-    local fw, fh = math.max(min_width, text_area_width), text_height + 3
+    local fw, fh = math.max(min_width, text_area_width), text_height + 3 + self.extra_height
     return gui.compute_frame_body(sw, sh, {w=fw, h=fh}, 1, 1, true)
 end
 
@@ -73,26 +81,31 @@ function DialogWindow:onInput(keys)
 end
 
 DialogScreen = defclass(DialogScreen, gui.ZScreenModal)
-DialogScreen.ATTRS {
-    focus_path='MessageBox',
+DialogScreen.ATTRS{
+    focus_path='dialogs/message',
     title=DEFAULT_NIL,
-    label_params={},
-    accept_label='Ok',
+    min_width=DEFAULT_NIL,
+    extra_height=DEFAULT_NIL,
+    message_label_attrs=DEFAULT_NIL,
+    accept_hotkey_label_attrs=DEFAULT_NIL,
     on_accept=DEFAULT_NIL,
     on_cancel=DEFAULT_NIL,
     on_close=DEFAULT_NIL,
 }
 
-function DialogScreen:init()
-    self:addviews{
-        DialogWindow{
-            frame_title=self.title,
-            accept_label=self.accept_label,
-            label_params=self.label_params,
-            on_accept=self.on_accept,
-            on_cancel=self.on_cancel,
-        }
+function DialogScreen:init(args)
+    local window = DialogWindow{
+        frame_title=self.title,
+        min_width=self.min_width,
+        extra_height=self.extra_height,
+        message_label_attrs=self.message_label_attrs,
+        accept_hotkey_label_attrs=self.accept_hotkey_label_attrs,
+        on_accept=self.on_accept,
+        on_cancel=self.on_cancel,
+        subviews=self.subviews,
     }
+    window:addviews(args.subviews)
+    self:addviews{window}
 end
 
 function DialogScreen:onDismiss()
@@ -108,7 +121,7 @@ end
 function showMessage(title, text, tcolor, on_close)
     return DialogScreen{
         title=title,
-        label_params={
+        message_label_attrs={
             text=text,
             text_pen=tcolor,
         },
@@ -116,17 +129,49 @@ function showMessage(title, text, tcolor, on_close)
     }:show()
 end
 
-function showYesNoPrompt(title, text, tcolor, on_accept, on_cancel)
-    return DialogScreen{
+function showYesNoPrompt(title, text, tcolor, on_accept, on_cancel, on_pause, on_settings)
+    local dialog
+    local subviews = {
+        widgets.HotkeyLabel{
+            frame={b=2, r=0},
+            label='Settings',
+            key='CUSTOM_SHIFT_S',
+            auto_width=true,
+            on_activate=function()
+                dialog:dismiss()
+                on_settings()
+            end,
+            visible=not not on_settings,
+        },
+        widgets.HotkeyLabel{
+            frame={b=2, l=0},
+            label='Pause confirmations',
+            key='CUSTOM_SHIFT_P',
+            auto_width=true,
+            on_activate=function()
+                dialog:dismiss()
+                on_pause()
+            end,
+            visible=not not on_pause,
+        },
+    }
+    dialog = DialogScreen{
         title=title,
-        label_params={
+        message_label_attrs={
+            frame=(on_pause or on_settings) and {t=0, l=0, b=4} or nil,
             text=text,
             text_pen=tcolor,
         },
-        accept_label='Yes, proceed',
+        accept_hotkey_label_attrs={
+            label='Yes, proceed',
+        },
         on_accept=on_accept,
         on_cancel=on_cancel,
-    }:show()
+        min_width=on_settings and 35 or nil,
+        extra_height=(on_pause or on_settings) and 2 or 0,
+        subviews=subviews,
+    }
+    return dialog:show()
 end
 
 ------------------------


### PR DESCRIPTION
like the `gui/confirm` prompt and file deletion confirmations

in preparation for deleting blueprints from the `gui/quickfort` blueprint list