### PR TITLE
Implement df::coord iterator and cuboid class 

### DIFF
--- a/library/modules/Maps.cpp
+++ b/library/modules/Maps.cpp
@@ -105,13 +105,109 @@ const char * DFHack::sa_feature(df::feature_type index)
     }
 };
 
+/*
+ * Cuboid class fns
+ */
+cuboid::cuboid(int16_t x1, int16_t y1, int16_t z1, int16_t x2, int16_t y2, int16_t z2)
+{
+    x_min = std::min(x1, x2);
+    x_max = std::max(x1, x2);
+    y_min = std::min(y1, y2);
+    y_max = std::max(y1, y2);
+    z_min = std::min(z1, z2);
+    z_max = std::max(z1, z2);
+}
+
+cuboid::cuboid(int16_t x, int16_t y, int16_t z)
+{
+    x_min = x_max = x;
+    y_min = y_max = y;
+    z_min = z_max = z;
+}
+
+bool cuboid::isValid() const
+{
+    return x_min >= 0 && y_min >= 0 && z_min >= 0 &&
+        x_max >= x_min && y_max >= y_min && z_max >= z_min;
+}
+
+bool cuboid::clamp(bool block)
+{
+    if (!Maps::IsValid() || x_min < 0 || y_min < 0 || z_min < 0 ||
+        x_max < 0 || y_max < 0 || z_max < 0)
+    {
+        return false;
+    }
+
+    int32_t xy_mult = block ? 1 : 16;
+    x_min = std::min(x_min, (int16_t)(world->map.x_count_block * xy_mult));
+    x_max = std::min(x_max, (int16_t)(world->map.x_count_block * xy_mult));
+    y_min = std::min(y_min, (int16_t)(world->map.y_count_block * xy_mult));
+    y_max = std::min(y_max, (int16_t)(world->map.y_count_block * xy_mult));
+    z_min = std::min(z_min, (int16_t)world->map.z_count_block);
+    z_max = std::min(z_max, (int16_t)world->map.z_count_block);
+
+    if (x_min > x_max) std::swap(x_min, x_max);
+    if (y_min > y_max) std::swap(y_min, y_max);
+    if (z_min > z_max) std::swap(z_min, z_max);
+
+    return true;
+}
+
+bool cuboid::addPos(int16_t x, int16_t y, int16_t z)
+{
+    if (x < 0 || y < 0 || z < 0 || (isValid() && containsPos(x, y, z)))
+        return false;
+
+    x_min = (x_min < 0 || x < x_min) ? x : x_min;
+    x_max = (x_max < 0 || x > x_max) ? x : x_max;
+
+    y_min = (y_min < 0 || y < y_min) ? y : y_min;
+    y_max = (y_max < 0 || y > y_max) ? y : y_max;
+
+    z_min = (z_min < 0 || z < z_min) ? z : z_min;
+    z_max = (z_max < 0 || z > z_max) ? z : z_max;
+
+    return true;
+}
+
+bool cuboid::containsPos(int16_t x, int16_t y, int16_t z) const
+{
+    return x >= x_min && y >= y_min && z >= z_min &&
+        x <= x_max && y <= y_max && z <= z_max;
+}
+
+void cuboid::forCoord(std::function<bool(df::coord)> fn)
+{
+    if (isValid()) // Only iterate if valid cuboid
+        Maps::forCoord(fn, x_min, y_min, z_max, x_max, y_max, z_min);
+}
+
+/*
+ * The Maps module
+ */
 bool Maps::IsValid ()
 {
     return (world->map.block_index != NULL);
 }
 
+void Maps::forCoord(std::function<bool(df::coord)> fn, int16_t x1, int16_t y1, int16_t z1,
+    int16_t x2, int16_t y2, int16_t z2)
+{
+    int16_t dx = x1 > x2 ? -1 : 1;
+    int16_t dy = y1 > y2 ? -1 : 1;
+    int16_t dz = z1 > z2 ? -1 : 1;
+
+    // Process z, y, then x
+    for (int16_t x = x1; x != x2 + dx; x += dx)
+        for (int16_t y = y1; y != y2 + dy; y += dy)
+            for (int16_t z = z1; z != z2 + dz; z += dz)
+                if (!fn(df::coord(x, y, z)))
+                    return;
+}
+
 // getter for map size in blocks
-inline void getSizeInline (int32_t& x, int32_t& y, int32_t& z)
+inline void getSizeInline (int32_t &x, int32_t &y, int32_t &z)
 {
     if (!Maps::IsValid())
     {
@@ -122,11 +218,11 @@ inline void getSizeInline (int32_t& x, int32_t& y, int32_t& z)
     y = world->map.y_count_block;
     z = world->map.z_count_block;
 }
-void Maps::getSize (int32_t& x, int32_t& y, int32_t& z)
+void Maps::getSize (int32_t &x, int32_t &y, int32_t &z)
 {
     getSizeInline(x, y, z);
 }
-void Maps::getSize (uint32_t& x, uint32_t& y, uint32_t& z) //todo: deprecate me
+void Maps::getSize (uint32_t &x, uint32_t &y, uint32_t &z) //todo: deprecate me
 {
     int32_t sx, sy, sz;
     getSizeInline(sx, sy, sz);
@@ -136,17 +232,17 @@ void Maps::getSize (uint32_t& x, uint32_t& y, uint32_t& z) //todo: deprecate me
 }
 
 // getter for map size in tiles
-inline void getTileSizeInline (int32_t& x, int32_t& y, int32_t& z)
+inline void getTileSizeInline (int32_t &x, int32_t &y, int32_t &z)
 {
     getSizeInline(x, y, z);
     x *= 16;
     y *= 16;
 }
-void Maps::getTileSize (int32_t& x, int32_t& y, int32_t& z)
+void Maps::getTileSize (int32_t &x, int32_t &y, int32_t &z)
 {
     getTileSizeInline(x, y, z);
 }
-void Maps::getTileSize (uint32_t& x, uint32_t& y, uint32_t& z) //todo: deprecate me
+void Maps::getTileSize (uint32_t &x, uint32_t &y, uint32_t &z) //todo: deprecate me
 {
     int32_t sx, sy, sz;
     getTileSizeInline(sx, sy, sz);
@@ -156,7 +252,7 @@ void Maps::getTileSize (uint32_t& x, uint32_t& y, uint32_t& z) //todo: deprecate
 }
 
 // getter for map position
-void Maps::getPosition (int32_t& x, int32_t& y, int32_t& z)
+void Maps::getPosition (int32_t &x, int32_t &y, int32_t &z)
 {
     if (!IsValid())
     {
@@ -405,7 +501,7 @@ bool GetLocalFeature(t_feature &feature, df::coord2d rgn_pos, int32_t index)
 
 inline bool ReadFeaturesInline(int32_t x, int32_t y, int32_t z, t_feature *local, t_feature *global)
 {
-    df::map_block* block = Maps::getBlock(x, y, z);
+    df::map_block *block = Maps::getBlock(x, y, z);
     if (!block)
         return false;
     return Maps::ReadFeatures(block, local, global);
@@ -443,8 +539,8 @@ bool Maps::ReadFeatures(df::map_block * block, t_feature * local, t_feature * gl
  * Block events
  */
 bool Maps::SortBlockEvents(df::map_block *block,
-    vector <df::block_square_event_mineralst *>* veins,
-    vector <df::block_square_event_frozen_liquidst *>* ices,
+    vector <df::block_square_event_mineralst *> *veins,
+    vector <df::block_square_event_frozen_liquidst *> *ices,
     vector <df::block_square_event_material_spatterst *> *materials,
     vector <df::block_square_event_grassst *> *grasses,
     vector <df::block_square_event_world_constructionst *> *constructions,
@@ -515,7 +611,7 @@ bool Maps::SortBlockEvents(df::map_block *block,
 
 inline bool RemoveBlockEventInline(int32_t x, int32_t y, int32_t z, df::block_square_event * which)
 {
-    df::map_block* block = Maps::getBlock(x, y, z);
+    df::map_block *block = Maps::getBlock(x, y, z);
     if (!block)
         return false;
     int idx = linear_index(block->block_events, which);
@@ -654,8 +750,8 @@ bool Maps::canStepBetween(df::coord pos1, df::coord pos2)
         pos2 = temp;
     }
 
-    df::map_block* block1 = getTileBlock(pos1);
-    df::map_block* block2 = getTileBlock(pos2);
+    df::map_block *block1 = getTileBlock(pos1);
+    df::map_block *block2 = getTileBlock(pos2);
 
     if ( !block1 || !block2 )
         return false;
@@ -671,8 +767,8 @@ bool Maps::canStepBetween(df::coord pos1, df::coord pos2)
     if ( dz == 0 )
         return true;
 
-    df::tiletype* type1 = Maps::getTileType(pos1);
-    df::tiletype* type2 = Maps::getTileType(pos2);
+    df::tiletype *type1 = Maps::getTileType(pos1);
+    df::tiletype *type2 = Maps::getTileType(pos2);
 
     df::tiletype_shape shape1 = ENUM_ATTR(tiletype,shape,*type1);
     df::tiletype_shape shape2 = ENUM_ATTR(tiletype,shape,*type2);
@@ -699,7 +795,7 @@ bool Maps::canStepBetween(df::coord pos1, df::coord pos2)
                 for ( int32_t y = -1; y <= 1; y++ ) {
                     if ( x == 0 && y == 0 )
                         continue;
-                    df::tiletype* type = Maps::getTileType(df::coord(pos1.x+x,pos1.y+y,pos1.z));
+                    df::tiletype *type = Maps::getTileType(df::coord(pos1.x+x,pos1.y+y,pos1.z));
                     df::tiletype_shape shape3 = ENUM_ATTR(tiletype,shape,*type);
                     if ( shape3 == tiletype_shape::WALL ) {
                         foundWall = true;
@@ -715,7 +811,7 @@ bool Maps::canStepBetween(df::coord pos1, df::coord pos2)
             if ( index_tile(block2->occupancy,pos2).bits.building != tile_building_occ::Dynamic )
                 return false;
             //note that forbidden hatches have Floored occupancy. unforbidden ones have dynamic occupancy
-            df::building* building = Buildings::findAtTile(pos2);
+            df::building *building = Buildings::findAtTile(pos2);
             if ( building == NULL ) {
                 out << __FILE__ << ", line " << __LINE__ << ": couldn't find hatch.\n";
                 return false;
@@ -736,7 +832,7 @@ bool Maps::canStepBetween(df::coord pos1, df::coord pos2)
             for ( int32_t y = -1; y <= 1; y++ ) {
                 if ( x == 0 && y == 0 )
                     continue;
-                df::tiletype* type = Maps::getTileType(df::coord(pos1.x+x,pos1.y+y,pos1.z));
+                df::tiletype *type = Maps::getTileType(df::coord(pos1.x+x,pos1.y+y,pos1.z));
                 df::tiletype_shape shape3 = ENUM_ATTR(tiletype,shape,*type);
                 if ( shape3 == tiletype_shape::WALL ) {
                     foundWall = true;
@@ -747,12 +843,12 @@ bool Maps::canStepBetween(df::coord pos1, df::coord pos2)
         }
         if ( !foundWall )
             return false; //unusable ramp
-        df::tiletype* typeUp = Maps::getTileType(up);
+        df::tiletype *typeUp = Maps::getTileType(up);
         df::tiletype_shape shapeUp = ENUM_ATTR(tiletype,shape,*typeUp);
         if ( shapeUp != tiletype_shape::RAMP_TOP )
             return false;
 
-        df::map_block* blockUp = getTileBlock(up);
+        df::map_block *blockUp = getTileBlock(up);
         if ( !blockUp )
             return false;
 
@@ -1006,17 +1102,17 @@ df::enums::biome_type::biome_type Maps::getBiomeTypeWithRef(int16_t region_x, in
 }
 
 bool Maps::isTileAquifer(int32_t x, int32_t y, int32_t z) {
-    df::tile_designation* des = Maps::getTileDesignation(x, y, z);
+    df::tile_designation *des = Maps::getTileDesignation(x, y, z);
     return des && des->bits.water_table;
 }
 
 bool Maps::isTileHeavyAquifer(int32_t x, int32_t y, int32_t z) {
-    df::tile_occupancy* occ = Maps::getTileOccupancy(x, y, z);
+    df::tile_occupancy *occ = Maps::getTileOccupancy(x, y, z);
     return occ && occ->bits.heavy_aquifer;
 }
 
 bool Maps::setTileAquifer(int32_t x, int32_t y, int32_t z, bool heavy) {
-    df::map_block* block = Maps::getTileBlock(x, y ,z);
+    df::map_block *block = Maps::getTileBlock(x, y ,z);
     if (!block)
         return false;
 
@@ -1033,7 +1129,7 @@ bool Maps::setTileAquifer(int32_t x, int32_t y, int32_t z, bool heavy) {
     return true;
 }
 
-int Maps::setAreaAquifer(df::coord pos1, df::coord pos2, bool heavy, std::function<bool(df::coord, df::map_block*)> filter) {
+int Maps::setAreaAquifer(df::coord pos1, df::coord pos2, bool heavy, std::function<bool(df::coord, df::map_block *)> filter) {
     df::coord minPos = df::coord(std::min(pos1.x, pos2.x), std::min(pos1.y, pos2.y), std::min(pos1.z, pos2.z));
     df::coord maxPos = df::coord(std::max(pos1.x, pos2.x), std::max(pos1.y, pos2.y), std::max(pos1.z, pos2.z));
 
@@ -1042,7 +1138,7 @@ int Maps::setAreaAquifer(df::coord pos1, df::coord pos2, bool heavy, std::functi
     for (int16_t z = minPos.z; z <= maxPos.z; z++) {
         for (int16_t blockX = (minPos.x >> 4) << 4; blockX <= maxPos.x; blockX += 16) {
             for (int16_t blockY = (minPos.y >> 4) << 4; blockY <= maxPos.y; blockY += 16) {
-                df::map_block* block = Maps::getTileBlock(blockX, blockY, z);
+                df::map_block *block = Maps::getTileBlock(blockX, blockY, z);
                 if (!block)
                     continue;
 
@@ -1078,7 +1174,7 @@ int Maps::setAreaAquifer(df::coord pos1, df::coord pos2, bool heavy, std::functi
 }
 
 bool Maps::removeTileAquifer(int32_t x, int32_t y, int32_t z) {
-    df::map_block* block = Maps::getTileBlock(x, y, z);
+    df::map_block *block = Maps::getTileBlock(x, y, z);
     if (!block)
         return false;
     if (!isTileAquifer(x, y, z))
@@ -1105,7 +1201,7 @@ bool Maps::removeTileAquifer(int32_t x, int32_t y, int32_t z) {
     return true;
 }
 
-int Maps::removeAreaAquifer(df::coord pos1, df::coord pos2, std::function<bool(df::coord, df::map_block*)> filter) {
+int Maps::removeAreaAquifer(df::coord pos1, df::coord pos2, std::function<bool(df::coord, df::map_block *)> filter) {
     df::coord minPos = df::coord(std::min(pos1.x, pos2.x), std::min(pos1.y, pos2.y), std::min(pos1.z, pos2.z));
     df::coord maxPos = df::coord(std::max(pos1.x, pos2.x), std::max(pos1.y, pos2.y), std::max(pos1.z, pos2.z));
 
@@ -1114,7 +1210,7 @@ int Maps::removeAreaAquifer(df::coord pos1, df::coord pos2, std::function<bool(d
     for (int16_t z = minPos.z; z <= maxPos.z; z++) {
         for (int16_t blockX = (minPos.x >> 4) << 4; blockX <= maxPos.x; blockX += 16) {
             for (int16_t blockY = (minPos.y >> 4) << 4; blockY <= maxPos.y; blockY += 16) {
-                df::map_block* block = Maps::getTileBlock(blockX, blockY, z);
+                df::map_block *block = Maps::getTileBlock(blockX, blockY, z);
                 if (!block)
                     continue;
 
@@ -1127,7 +1223,7 @@ int Maps::removeAreaAquifer(df::coord pos1, df::coord pos2, std::function<bool(d
                 // Loop through all tiles in the block
                 for (int16_t xOffset = 0; xOffset <= 15; xOffset++) {
                     for (int16_t yOffset = 0; yOffset <= 15; yOffset++) {
-                        df::tile_designation& des = block->designation[xOffset][yOffset];
+                        df::tile_designation &des = block->designation[xOffset][yOffset];
                         if (des.bits.water_table) {
                             if (xOffset >= startX && yOffset >= startY && xOffset <= endX && yOffset <= endY
                                 && filter(df::coord(blockX + xOffset, blockY + yOffset, z), block)

--- a/plugins/autochop.cpp
+++ b/plugins/autochop.cpp
@@ -248,7 +248,7 @@ static bool is_accessible_tree(const df::coord &pos, const vector<df::unit *> &c
 
 static bool is_valid_tree(const df::plant *plant) {
     // Skip all non-trees immediately.
-    if (plant->type == df::plant_type::DRY_PLANT || plant->type == df::plant_type::WET_PLANT)
+    if (!plant->tree_info)
         return false;
 
     // Skip plants with invalid tile.

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -495,13 +495,11 @@ command_result df_getplants(color_ostream& out, vector <string>& parameters) {
             if (!exclude)
                 continue;
         }
-        df::tiletype_shape shape = tileShape(cur->tiletype[x][y]);
-        df::tiletype_material material = tileMaterial(cur->tiletype[x][y]);
-        df::tiletype_special special = tileSpecial(cur->tiletype[x][y]);
-        bool is_shrub = plant->type == df::plant_type::DRY_PLANT || plant->type == df::plant_type::WET_PLANT;
-        if (is_shrub && (treesonly || !(shape == tiletype_shape::SHRUB && special != tiletype_special::DEAD)))
+        df::tiletype tt = cur->tiletype[x][y];
+        df::tiletype_material mat = tileMaterial(tt);
+        if ((treesonly || tt != tiletype::Shrub) && ENUM_ATTR(plant_type, is_shrub, plant->type))
             continue;
-        if (!is_shrub && (shrubsonly || !(material == tiletype_material::TREE)))
+        if ((shrubsonly || mat != tiletype_material::TREE) && !ENUM_ATTR(plant_type, is_shrub, plant->type))
             continue;
         if (cur->designation[x][y].bits.hidden)
             continue;

--- a/plugins/prospector.cpp
+++ b/plugins/prospector.cpp
@@ -289,8 +289,8 @@ struct EmbarkTileLayout {
 
 static df::world_region_details *get_details(df::world_data *data, df::coord2d pos)
 {
-    int d_idx = linear_index(data->region_details, &df::world_region_details::pos, pos);
-    return vector_get(data->region_details, d_idx);
+    int d_idx = linear_index(data->midmap_data.region_details, &df::world_region_details::pos, pos);
+    return vector_get(data->midmap_data.region_details, d_idx);
 }
 
 bool estimate_underground(color_ostream &out, EmbarkTileLayout &tile, df::world_region_details *details, int x, int y)
@@ -358,17 +358,19 @@ bool estimate_underground(color_ostream &out, EmbarkTileLayout &tile, df::world_
 
         float penalty = 1.0f;
         switch (layer->type) {
-        case df::world_underground_region::Cavern:
+        case df::feature_layer_type::SUBTERRANEAN:
             penalty = 0.75f;
             break;
-        case df::world_underground_region::MagmaSea:
+        case df::feature_layer_type::MAGMA_CORE:
             sea_found = true;
             tile.min_z = feature->min_z;
             for (int i = feature->min_z; i <= feature->max_z; i++)
                 tile.penalty[i] = 0.2 + 0.6f*(i-feature->min_z)/(feature->max_z-feature->min_z+1);
             break;
-        case df::world_underground_region::Underworld:
+        case df::feature_layer_type::UNDERWORLD:
             penalty = 0.0f;
+            break;
+        case df::feature_layer_type::NONE:
             break;
         }
 

--- a/plugins/prospector.cpp
+++ b/plugins/prospector.cpp
@@ -289,8 +289,8 @@ struct EmbarkTileLayout {
 
 static df::world_region_details *get_details(df::world_data *data, df::coord2d pos)
 {
-    int d_idx = linear_index(data->midmap_data.region_details, &df::world_region_details::pos, pos);
-    return vector_get(data->midmap_data.region_details, d_idx);
+    int d_idx = linear_index(data->region_details, &df::world_region_details::pos, pos);
+    return vector_get(data->region_details, d_idx);
 }
 
 bool estimate_underground(color_ostream &out, EmbarkTileLayout &tile, df::world_region_details *details, int x, int y)
@@ -358,19 +358,17 @@ bool estimate_underground(color_ostream &out, EmbarkTileLayout &tile, df::world_
 
         float penalty = 1.0f;
         switch (layer->type) {
-        case df::feature_layer_type::SUBTERRANEAN:
+        case df::world_underground_region::Cavern:
             penalty = 0.75f;
             break;
-        case df::feature_layer_type::MAGMA_CORE:
+        case df::world_underground_region::MagmaSea:
             sea_found = true;
             tile.min_z = feature->min_z;
             for (int i = feature->min_z; i <= feature->max_z; i++)
                 tile.penalty[i] = 0.2 + 0.6f*(i-feature->min_z)/(feature->max_z-feature->min_z+1);
             break;
-        case df::feature_layer_type::UNDERWORLD:
+        case df::world_underground_region::Underworld:
             penalty = 0.0f;
-            break;
-        case df::feature_layer_type::NONE:
             break;
         }
 
@@ -792,7 +790,7 @@ static command_result map_prospector(color_ostream &con,
                             loc = loc % 16;
                             if (options.hidden || !b->DesignationAt(loc).bits.hidden)
                             {
-                                if (plant.type == df::plant_type::DRY_PLANT || plant.type == df::plant_type::WET_PLANT)
+                                if (ENUM_ATTR(plant_type, is_shrub, plant.type))
                                     plantMats[plant.material].add(global_z);
                                 else
                                     treeMats[plant.material].add(global_z);


### PR DESCRIPTION
Implement an iterator that operates on all `df::coord`s within a cuboid box. Iterates in the direction of x/y/z provided (rather than always min to max.) By default iterates per z-level, but has an option to iterate in the z direction first.
Closes #4596

Cuboid class for defining a cuboid of tiles. Can test if a coord is inside itself. Can be expanded to contain a given coord. Has a method to call the above iterator using the defined cuboid.
Closes #4595

Also update plugins to use `plant_type` enum attrs, since we're removing the `cuboid` struct from `plugins/plant.cpp` in this PR anyway.