### PR TITLE
`vector<int32_t>` and `vector<int16_t>`

### DIFF
--- a/library/DataIdentity.cpp
+++ b/library/DataIdentity.cpp
@@ -58,4 +58,7 @@ namespace df {
     OPAQUE_IDENTITY_TRAITS(std::weak_ptr<df::widget_container>);
 
     buffer_container_identity buffer_container_identity::base_instance;
+
+    DFHACK_EXPORT stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity("vector", identity_traits<int32_t>::get());
+    DFHACK_EXPORT stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity("vector", identity_traits<int16_t>::get());
 }

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -659,11 +659,11 @@ namespace df
     template<class T, int sz> struct identity_traits<T [sz]> {
         static container_identity *get();
     };
-#endif
 
     template<class T> struct identity_traits<std::vector<T> > {
         static container_identity *get();
     };
+#endif
 
     template<class T> struct identity_traits<std::vector<T*> > {
         static stl_ptr_vector_identity *get();

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -370,6 +370,7 @@ namespace df
             return ((uint8_t*)ptr) + idx * item->byte_size();
         }
     };
+#endif
 
     template<class T>
     class stl_container_identity : public container_identity {
@@ -406,6 +407,7 @@ namespace df
         }
     };
 
+#ifdef BUILD_DFHACK_LIB
     template<class T>
     class ro_stl_container_identity : public container_identity {
     protected:
@@ -657,15 +659,27 @@ namespace df
     template<class T, int sz> struct identity_traits<T [sz]> {
         static container_identity *get();
     };
+#endif
 
     template<class T> struct identity_traits<std::vector<T> > {
         static container_identity *get();
     };
-#endif
 
     template<class T> struct identity_traits<std::vector<T*> > {
         static stl_ptr_vector_identity *get();
     };
+
+    // explicit specializations for these two types
+    // for availability in plugins
+
+    template<> struct identity_traits<std::vector<int32_t> > {
+        static container_identity* get();
+    };
+
+    template<> struct identity_traits<std::vector<int16_t> > {
+        static container_identity* get();
+    };
+
 
 #ifdef BUILD_DFHACK_LIB
     template<class T> struct identity_traits<std::deque<T> > {
@@ -737,6 +751,19 @@ namespace df
     inline stl_ptr_vector_identity *identity_traits<std::vector<T*> >::get() {
         static stl_ptr_vector_identity identity(identity_traits<T>::get());
         return &identity;
+    }
+
+    // explicit specializations for these two types
+    // for availability in plugins
+
+    extern DFHACK_EXPORT stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity;
+    inline container_identity* identity_traits<std::vector<int32_t> >::get() {
+        return &stl_vector_int32_t_identity;
+    }
+
+    extern DFHACK_EXPORT stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity;
+    inline container_identity* identity_traits<std::vector<int16_t> >::get() {
+        return &stl_vector_int16_t_identity;
     }
 
 #ifdef BUILD_DFHACK_LIB


### PR DESCRIPTION
this makes identity traits for these two specializations available in plugins

with this change, the `stl_vector_identity` template will be visible to plugins, but the identity objects _themselves_ will not (except for `vector<int32_t>` and `vector<int16_t>`) so any attempt to actually use a `vector` other than one of these two types or of a pointer type (which is covered elsewhere by the `vector<T*>` specialization which is exported) will result in linkage errors

this is mainly intended to enable merging #4632 without #4591, since i don't think i want to pursue #4591 at this time