### PR TITLE
Fix thread-safety issues around armok mode logic

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2382,10 +2382,12 @@ void Core::setSuppressDuplicateKeyboardEvents(bool suppress) {
 }
 
 void Core::setMortalMode(bool value) {
+    std::lock_guard<std::mutex> lock(HotkeyMutex);
     mortal_mode = value;
 }
 
 void Core::setArmokTools(const std::vector<std::string> &tool_names) {
+    std::lock_guard<std::mutex> lock(HotkeyMutex);
     armok_tools.clear();
     armok_tools.insert(tool_names.begin(), tool_names.end());
 }

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -122,6 +122,7 @@ void DFHack::Lua::Push(lua_State *state, const df::coord2d &pos)
 
 void DFHack::Lua::GetVector(lua_State *state, std::vector<std::string> &pvec, int idx)
 {
+    luaL_checktype(state, idx, LUA_TTABLE);
     lua_pushnil(state);   // first key
     while (lua_next(state, idx) != 0)
     {


### PR DESCRIPTION
Followup to feedback in #4674.

I verified that `dfhack.internal.setArmokTools()` and `dfhack.setMortalMode()` can still be called from the `lua` interpreter without deadlocking. I haven't seen meaningful changes occur from calling them, though, so my testing may not be exhaustive.