### PR TITLE
[docs] don't scan .git dirs for rst files

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -181,6 +181,7 @@ today_fmt = html_last_updated_fmt = '%Y-%m-%d'
 # directories to ignore when looking for source files.
 exclude_patterns = [
     'README.md',
+    '.git/*',
     'build*',
     'depends/*',
     'docs/html/*',


### PR DESCRIPTION
discovered when a PR branch name ended in `.rst`