### PR TITLE
expose unit creation DF endpoint to C++ and Lua

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -96,7 +96,7 @@ Template for new versions:
 - ``Maps::setAreaAquifer``: make all tiles in a cuboid into aquifers, with the option to provide a filter
 - ``Maps::removeTileAquifer``: remove aquifer from tile
 - ``Maps::removeAreaAquifer``: remove aquifers from all tiles in a cuboid, with the option to provide a filter
-- ``Units::makeown``: API to use bay12-provided entry point for "makeown" operation
+- ``Units::create``, ``Units::makeown``: new APIs to use bay12-provided entry points for low-level operations
 
 ## Lua
 - ``dfhack.gui.getSelectedJob``: can now return the job with a destination under the keyboard cursor (e.g. digging/carving/engraving jobs)
@@ -113,6 +113,7 @@ Template for new versions:
 - ``dfhack.maps.removeTileAquifer``: remove aquifer from tile
 - ``plugins.tiletypes.tiletypes_setTile``: can now accept a table for access to previously unavailable options
 - ``dialogs.showYesNoPrompt``: extend options so the standard dialog can be used for `gui/confirm`-style confirmation prompts
+- ``dfhack.units.create``, ``dfhack.units.makeown``: Lua access to new module API
 
 ## Removed
 - `plants`: renamed to `plant`

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1629,10 +1629,19 @@ Units module
 
   Returns the nemesis record of the unit if it has one, or *nil*.
 
-  ``dfhack.units.makeown(unit)``
+* ``dfhack.units.makeown(unit)``
 
   Makes the selected unit a member of the current fortress and site.
   Note that this operation may silently fail for any of several reasons, so it may be prudent to check if the operation has succeeded by using ``dfhack.units.isOwnCiv`` or another appropriate predicate on the unit in question.
+
+* ``dfhack.units.create(race, caste)``
+
+  Creates a new unit from scratch. The unit will be added to the
+  ``world.units.all`` vector, but not to the ``world.units.active`` vector. The
+  unit will not have an associated historical figure, nemesis record, map
+  position, labors, or any group associations. The unit *will* have a race,
+  caste, name, soul, and initialized body and mind (including personality). The
+  unit must be configured further as needed and put into play by the client.
 
 * ``dfhack.units.getPhysicalAttrValue(unit, attr_type)``
 * ``dfhack.units.getMentalAttrValue(unit, attr_type)``

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2053,6 +2053,7 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, getIdentity),
     WRAPM(Units, getNemesis),
     WRAPM(Units, makeown),
+    WRAPM(Units, create),
     WRAPM(Units, getPhysicalAttrValue),
     WRAPM(Units, getMentalAttrValue),
     WRAPM(Units, casteFlagSet),

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -203,6 +203,7 @@ DFHACK_EXPORT df::nemesis_record *getNemesis(df::unit *unit);
 // note: this function may fail for any of several reasons, all of which are silent
 // if needed, use isOwnCiv or another relevant predicate after invoking to determine if that the makeown operation was successful
 DFHACK_EXPORT void makeown(df::unit* unit);
+DFHACK_EXPORT df::unit * create(int16_t race, int16_t caste);
 
 DFHACK_EXPORT int getPhysicalAttrValue(df::unit *unit, df::physical_attribute_type attr);
 DFHACK_EXPORT int getMentalAttrValue(df::unit *unit, df::mental_attribute_type attr);

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -1143,6 +1143,14 @@ void Units::makeown(df::unit* unit)
     (*f)(unit);
 }
 
+df::unit * Units::create(int16_t race, int16_t caste) {
+    auto fp = df::global::unitst_more_convenient_create;
+    CHECK_NULL_POINTER(fp);
+
+    using FT = std::function<df::unit * (int16_t, int16_t)>;
+    auto f = reinterpret_cast<FT*>(fp);
+    return (*f)(race, caste);
+}
 
 int Units::getPhysicalAttrValue(df::unit *unit, df::physical_attribute_type attr)
 {


### PR DESCRIPTION
opens the door for `spawnunit`, `modtools/create-unit`, and other potential future tools, like `force siege`