### PR TITLE
constify identities

### DIFF
--- a/library/DataDefs.cpp
+++ b/library/DataDefs.cpp
@@ -42,44 +42,44 @@ distribution.
 using namespace DFHack;
 
 
-void *type_identity::do_allocate_pod() {
+void *type_identity::do_allocate_pod() const {
     size_t sz = byte_size();
     void *p = malloc(sz);
     memset(p, 0, sz);
     return p;
 }
 
-void type_identity::do_copy_pod(void *tgt, const void *src) {
+void type_identity::do_copy_pod(void *tgt, const void *src) const {
     memmove(tgt, src, byte_size());
 };
 
-bool type_identity::do_destroy_pod(void *obj) {
+bool type_identity::do_destroy_pod(void *obj) const {
     free(obj);
     return true;
 }
 
-void *type_identity::allocate() {
+void *type_identity::allocate() const {
     if (can_allocate())
         return do_allocate();
     else
         return NULL;
 }
 
-bool type_identity::copy(void *tgt, const void *src) {
+bool type_identity::copy(void *tgt, const void *src) const {
     if (can_allocate() && tgt && src)
         return do_copy(tgt, src);
     else
         return false;
 }
 
-bool type_identity::destroy(void *obj) {
+bool type_identity::destroy(void *obj) const {
     if (can_allocate() && obj)
         return do_destroy(obj);
     else
         return false;
 }
 
-void *enum_identity::do_allocate() {
+void *enum_identity::do_allocate() const {
     size_t sz = byte_size();
     void *p = malloc(sz);
     memcpy(p, &first_item_value, std::min(sz, sizeof(int64_t)));
@@ -92,11 +92,11 @@ void *enum_identity::do_allocate() {
  * initialized by the loader in the initial mmap.
  */
 compound_identity *compound_identity::list = NULL;
-std::vector<compound_identity*> compound_identity::top_scope;
+std::vector<const compound_identity*> compound_identity::top_scope;
 
 compound_identity::compound_identity(size_t size, TAllocateFn alloc,
-                                     compound_identity *scope_parent, const char *dfhack_name)
-    : constructed_identity(size, alloc), dfhack_name(dfhack_name), scope_parent(scope_parent)
+    const compound_identity *scope_parent, const char *dfhack_name)
+    : constructed_identity(size, alloc), dfhack_name(dfhack_name), scope_parent(const_cast<compound_identity*>(scope_parent)) // fixme
 {
     next = list; list = this;
 }
@@ -109,7 +109,7 @@ void compound_identity::doInit(Core *)
         top_scope.push_back(this);
 }
 
-std::string compound_identity::getFullName()
+const std::string compound_identity::getFullName() const
 {
     if (scope_parent)
         return scope_parent->getFullName() + "." + getName();
@@ -131,19 +131,19 @@ void compound_identity::Init(Core *core)
 }
 
 bitfield_identity::bitfield_identity(size_t size,
-                                     compound_identity *scope_parent, const char *dfhack_name,
+                                     const compound_identity *scope_parent, const char *dfhack_name,
                                      int num_bits, const bitfield_item_info *bits)
     : compound_identity(size, NULL, scope_parent, dfhack_name), bits(bits), num_bits(num_bits)
 {
 }
 
 enum_identity::enum_identity(size_t size,
-                             compound_identity *scope_parent, const char *dfhack_name,
-                             type_identity *base_type,
+    const compound_identity *scope_parent, const char *dfhack_name,
+    const type_identity *base_type,
                              int64_t first_item_value, int64_t last_item_value,
                              const char *const *keys,
                              const ComplexData *complex,
-                             const void *attrs, struct_identity *attr_type)
+                             const void *attrs, const struct_identity *attr_type)
     : compound_identity(size, NULL, scope_parent, dfhack_name),
       keys(keys), complex(complex),
       first_item_value(first_item_value), last_item_value(last_item_value),
@@ -158,7 +158,7 @@ enum_identity::enum_identity(size_t size,
     }
 }
 
-enum_identity::enum_identity(enum_identity *base_enum, type_identity *override_base_type)
+enum_identity::enum_identity(const enum_identity *base_enum, const type_identity *override_base_type)
     : enum_identity(override_base_type->byte_size(), base_enum->getScopeParent(),
                     base_enum->getName(), override_base_type, base_enum->first_item_value,
                     base_enum->last_item_value, base_enum->keys, base_enum->complex,
@@ -177,10 +177,10 @@ enum_identity::ComplexData::ComplexData(std::initializer_list<int64_t> values)
 }
 
 struct_identity::struct_identity(size_t size, TAllocateFn alloc,
-                                 compound_identity *scope_parent, const char *dfhack_name,
-                                 struct_identity *parent, const struct_field_info *fields)
+    const compound_identity *scope_parent, const char *dfhack_name,
+    const struct_identity *parent, const struct_field_info *fields)
     : compound_identity(size, alloc, scope_parent, dfhack_name),
-      parent(parent), has_children(false), fields(fields)
+      parent(const_cast<struct_identity*>(parent)), has_children(false), fields(fields)
 {
 }
 
@@ -194,7 +194,7 @@ void struct_identity::doInit(Core *core)
     }
 }
 
-bool struct_identity::is_subclass(struct_identity *actual)
+bool struct_identity::is_subclass(const struct_identity *actual) const
 {
     if (!has_children && actual != this)
         return false;
@@ -205,42 +205,42 @@ bool struct_identity::is_subclass(struct_identity *actual)
     return false;
 }
 
-std::string pointer_identity::getFullName()
+const std::string pointer_identity::getFullName() const
 {
     return (target ? target->getFullName() : std::string("void")) + "*";
 }
 
-std::string container_identity::getFullName(type_identity *item)
+const std::string container_identity::getFullName(const type_identity *item) const
 {
     return '<' + (item ? item->getFullName() : std::string("void")) + '>';
 }
 
-std::string ptr_container_identity::getFullName(type_identity *item)
+const std::string ptr_container_identity::getFullName(const type_identity *item) const
 {
     return '<' + (item ? item->getFullName() : std::string("void")) + std::string("*>");
 }
 
-std::string bit_container_identity::getFullName(type_identity *)
+const std::string bit_container_identity::getFullName(const type_identity *) const
 {
     return "<bool>";
 }
 
-std::string df::buffer_container_identity::getFullName(type_identity *item)
+const std::string df::buffer_container_identity::getFullName(const type_identity *item) const
 {
     return (item ? item->getFullName() : std::string("void")) +
            (size > 0 ? stl_sprintf("[%d]", size) : std::string("[]"));
 }
 
-union_identity::union_identity(size_t size, TAllocateFn alloc,
+union_identity::union_identity(size_t size, const TAllocateFn alloc,
         compound_identity *scope_parent, const char *dfhack_name,
         struct_identity *parent, const struct_field_info *fields)
     : struct_identity(size, alloc, scope_parent, dfhack_name, parent, fields)
 {
 }
 
-virtual_identity::virtual_identity(size_t size, TAllocateFn alloc,
+virtual_identity::virtual_identity(size_t size, const TAllocateFn alloc,
                                    const char *dfhack_name, const char *original_name,
-                                   virtual_identity *parent, const struct_field_info *fields,
+                                   const virtual_identity *parent, const struct_field_info *fields,
                                    bool is_plugin)
     : struct_identity(size, alloc, NULL, dfhack_name, parent, fields), original_name(original_name),
       vtable_ptr(NULL), is_plugin(is_plugin)
@@ -462,7 +462,7 @@ void DFHack::flagarrayToString(std::vector<std::string> *pvec, const void *p,
     }
 }
 
-static const struct_field_info *find_union_tag_candidate(struct_identity *structure, const struct_field_info *union_field)
+static const struct_field_info *find_union_tag_candidate(const struct_identity *structure, const struct_field_info *union_field)
 {
     if (union_field->extra && union_field->extra->union_tag_field)
     {
@@ -502,7 +502,7 @@ static const struct_field_info *find_union_tag_candidate(struct_identity *struct
     return nullptr;
 }
 
-const struct_field_info *DFHack::find_union_tag(struct_identity *structure, const struct_field_info *union_field)
+const struct_field_info *DFHack::find_union_tag(const struct_identity *structure, const struct_field_info *union_field)
 {
     CHECK_NULL_POINTER(structure);
     CHECK_NULL_POINTER(union_field);
@@ -538,7 +538,7 @@ const struct_field_info *DFHack::find_union_tag(struct_identity *structure, cons
         return nullptr;
     }
 
-    auto container_type = static_cast<container_identity *>(union_field->type);
+    auto container_type = static_cast<const container_identity *>(union_field->type);
     if (container_type->getFullName(nullptr) != "vector<void>" ||
             !container_type->getItemType() ||
             container_type->getItemType()->type() != IDTYPE_UNION)
@@ -555,7 +555,7 @@ const struct_field_info *DFHack::find_union_tag(struct_identity *structure, cons
         return nullptr;
     }
 
-    auto tag_container_type = static_cast<container_identity *>(tag_candidate->type);
+    auto tag_container_type = static_cast<const container_identity *>(tag_candidate->type);
     if (tag_container_type->getFullName(nullptr) == "vector<void>" &&
             tag_container_type->getItemType() &&
             tag_container_type->getItemType()->type() == IDTYPE_ENUM)

--- a/library/DataIdentity.cpp
+++ b/library/DataIdentity.cpp
@@ -15,11 +15,11 @@
 
 namespace df {
 #define NUMBER_IDENTITY_TRAITS(category, type, name) \
-    category##_identity<type> identity_traits<type>::identity(name);
+    const category##_identity<type> identity_traits<type>::identity(name);
 #define INTEGER_IDENTITY_TRAITS(type, name) NUMBER_IDENTITY_TRAITS(integer, type, name)
 #define FLOAT_IDENTITY_TRAITS(type) NUMBER_IDENTITY_TRAITS(float, type, #type)
 #define OPAQUE_IDENTITY_TRAITS_NAME(name, ...) \
-    opaque_identity identity_traits<__VA_ARGS__ >::identity(sizeof(__VA_ARGS__), allocator_noassign_fn<__VA_ARGS__ >, name)
+    const opaque_identity identity_traits<__VA_ARGS__ >::identity(sizeof(__VA_ARGS__), allocator_noassign_fn<__VA_ARGS__ >, name)
 #define OPAQUE_IDENTITY_TRAITS(...) OPAQUE_IDENTITY_TRAITS_NAME(#__VA_ARGS__, __VA_ARGS__ )
 
     INTEGER_IDENTITY_TRAITS(char,               "char");
@@ -36,14 +36,14 @@ namespace df {
     FLOAT_IDENTITY_TRAITS(float);
     FLOAT_IDENTITY_TRAITS(double);
 
-    bool_identity identity_traits<bool>::identity;
-    stl_string_identity identity_traits<std::string>::identity;
-    ptr_string_identity identity_traits<char*>::identity;
-    ptr_string_identity identity_traits<const char*>::identity;
-    pointer_identity identity_traits<void*>::identity;
-    stl_ptr_vector_identity identity_traits<std::vector<void*> >::identity;
-    stl_bit_vector_identity identity_traits<std::vector<bool> >::identity;
-    bit_array_identity identity_traits<BitArray<int> >::identity;
+    const bool_identity identity_traits<bool>::identity;
+    const stl_string_identity identity_traits<std::string>::identity;
+    const ptr_string_identity identity_traits<char*>::identity;
+    const ptr_string_identity identity_traits<const char*>::identity;
+    const pointer_identity identity_traits<void*>::identity;
+    const stl_ptr_vector_identity identity_traits<std::vector<void*> >::identity;
+    const stl_bit_vector_identity identity_traits<std::vector<bool> >::identity;
+    const bit_array_identity identity_traits<BitArray<int> >::identity;
 
     OPAQUE_IDENTITY_TRAITS(std::condition_variable);
     OPAQUE_IDENTITY_TRAITS(std::fstream);
@@ -57,8 +57,8 @@ namespace df {
     OPAQUE_IDENTITY_TRAITS(std::variant<std::string, std::function<void()> >);
     OPAQUE_IDENTITY_TRAITS(std::weak_ptr<df::widget_container>);
 
-    buffer_container_identity buffer_container_identity::base_instance;
+    const buffer_container_identity buffer_container_identity::base_instance;
 
-    DFHACK_EXPORT stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity("vector", identity_traits<int32_t>::get());
-    DFHACK_EXPORT stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity("vector", identity_traits<int16_t>::get());
+    DFHACK_EXPORT const stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity("vector", identity_traits<int32_t>::get());
+    DFHACK_EXPORT const stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity("vector", identity_traits<int16_t>::get());
 }

--- a/library/DataIdentity.cpp
+++ b/library/DataIdentity.cpp
@@ -59,6 +59,6 @@ namespace df {
 
     const buffer_container_identity buffer_container_identity::base_instance;
 
-    DFHACK_EXPORT const stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity("vector", identity_traits<int32_t>::get());
-    DFHACK_EXPORT const stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity("vector", identity_traits<int16_t>::get());
+    const stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity("vector", identity_traits<int32_t>::get());
+    const stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity("vector", identity_traits<int16_t>::get());
 }

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -226,12 +226,12 @@ int DFHack::Lua::PushPosXY(lua_State *state, const df::coord2d &pos)
  * Public DF object reference handling API
  */
 
-void DFHack::Lua::PushDFObject(lua_State *state, type_identity *type, void *ptr)
+void DFHack::Lua::PushDFObject(lua_State *state, const type_identity *type, void *ptr)
 {
     push_object_internal(state, type, ptr, false);
 }
 
-void *DFHack::Lua::GetDFObject(lua_State *state, type_identity *type, int val_index, bool exact_type)
+void *DFHack::Lua::GetDFObject(lua_State *state, const type_identity *type, int val_index, bool exact_type)
 {
     return get_object_internal(state, type, val_index, exact_type, false);
 }
@@ -248,7 +248,7 @@ static void check_valid_ptr_index(lua_State *state, int val_index)
 }
 
 static void signal_typeid_error(color_ostream *out, lua_State *state,
-                                type_identity *type, const char *msg,
+    const type_identity *type, const char *msg,
                                 int val_index, bool perr, bool signal)
 {
     std::string typestr = type ? type->getFullName() : "any pointer";
@@ -273,7 +273,7 @@ static void signal_typeid_error(color_ostream *out, lua_State *state,
 }
 
 
-void *DFHack::Lua::CheckDFObject(lua_State *state, type_identity *type, int val_index, bool exact_type)
+void *DFHack::Lua::CheckDFObject(lua_State *state, const type_identity *type, int val_index, bool exact_type)
 {
     check_valid_ptr_index(state, val_index);
 

--- a/library/LuaTypes.cpp
+++ b/library/LuaTypes.cpp
@@ -62,22 +62,22 @@ size_t strnlen (const char *str, size_t max)
  * Identity object read/write methods *
  **************************************/
 
-void function_identity_base::lua_read(lua_State *state, int fname_idx, void *ptr)
+void function_identity_base::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     field_error(state, fname_idx, "executable code", "read");
 }
 
-void function_identity_base::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void function_identity_base::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     field_error(state, fname_idx, "executable code", "write");
 }
 
-void constructed_identity::lua_read(lua_State *state, int fname_idx, void *ptr)
+void constructed_identity::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     push_object_internal(state, this, ptr);
 }
 
-static void invoke_assign(lua_State *state, type_identity *id, void *ptr, int val_index)
+static void invoke_assign(lua_State *state, const type_identity *id, void *ptr, int val_index)
 {
     lua_getfield(state, LUA_REGISTRYINDEX, DFHACK_ASSIGN_NAME);
     push_object_internal(state, id, ptr);
@@ -85,7 +85,7 @@ static void invoke_assign(lua_State *state, type_identity *id, void *ptr, int va
     lua_call(state, 2, 0);
 }
 
-void constructed_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void constructed_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     if (lua_istable(state, val_index))
     {
@@ -104,22 +104,22 @@ void constructed_identity::lua_write(lua_State *state, int fname_idx, void *ptr,
         field_error(state, fname_idx, "complex object", "write");
 }
 
-void enum_identity::lua_read(lua_State *state, int fname_idx, void *ptr)
+void enum_identity::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     base_type->lua_read(state, fname_idx, ptr);
 }
 
-void enum_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void enum_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     base_type->lua_write(state, fname_idx, ptr, val_index);
 }
 
-void df::integer_identity_base::lua_read(lua_State *state, int fname_idx, void *ptr)
+void df::integer_identity_base::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     lua_pushinteger(state, read(ptr));
 }
 
-void df::integer_identity_base::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void df::integer_identity_base::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     int is_num = 0;
     auto value = lua_tointegerx(state, val_index, &is_num);
@@ -128,12 +128,12 @@ void df::integer_identity_base::lua_write(lua_State *state, int fname_idx, void 
     write(ptr, value);
 }
 
-void df::float_identity_base::lua_read(lua_State *state, int fname_idx, void *ptr)
+void df::float_identity_base::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     lua_pushnumber(state, read(ptr));
 }
 
-void df::float_identity_base::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void df::float_identity_base::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     if (!lua_isnumber(state, val_index))
         field_error(state, fname_idx, "number expected", "write");
@@ -141,12 +141,12 @@ void df::float_identity_base::lua_write(lua_State *state, int fname_idx, void *p
     write(ptr, lua_tonumber(state, val_index));
 }
 
-void df::bool_identity::lua_read(lua_State *state, int fname_idx, void *ptr)
+void df::bool_identity::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     lua_pushboolean(state, *(bool*)ptr);
 }
 
-void df::bool_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void df::bool_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     char *pb = (char*)ptr;
 
@@ -158,7 +158,7 @@ void df::bool_identity::lua_write(lua_State *state, int fname_idx, void *ptr, in
         field_error(state, fname_idx, "boolean or number expected", "write");
 }
 
-void df::ptr_string_identity::lua_read(lua_State *state, int fname_idx, void *ptr)
+void df::ptr_string_identity::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     auto pstr = (char**)ptr;
     if (*pstr)
@@ -167,18 +167,18 @@ void df::ptr_string_identity::lua_read(lua_State *state, int fname_idx, void *pt
         lua_pushnil(state);
 }
 
-void df::ptr_string_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void df::ptr_string_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     field_error(state, fname_idx, "raw pointer string", "write");
 }
 
-void df::stl_string_identity::lua_read(lua_State *state, int fname_idx, void *ptr)
+void df::stl_string_identity::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     auto pstr = (std::string*)ptr;
     lua_pushlstring(state, pstr->data(), pstr->size());
 }
 
-void df::stl_string_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void df::stl_string_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     size_t size;
     const char *bytes = lua_tolstring(state, val_index, &size);
@@ -188,18 +188,18 @@ void df::stl_string_identity::lua_write(lua_State *state, int fname_idx, void *p
     *(std::string*)ptr = std::string(bytes, size);
 }
 
-void df::pointer_identity::lua_read(lua_State *state, int fname_idx, void *ptr, type_identity *target)
+void df::pointer_identity::lua_read(lua_State *state, int fname_idx, void *ptr, const type_identity *target)
 {
     push_object_internal(state, target, *(void**)ptr);
 }
 
-void df::pointer_identity::lua_read(lua_State *state, int fname_idx, void *ptr)
+void df::pointer_identity::lua_read(lua_State *state, int fname_idx, void *ptr) const
 {
     lua_read(state, fname_idx, ptr, target);
 }
 
 static void autovivify_ptr(lua_State *state, int fname_idx, void **pptr,
-                          type_identity *target, int val_index)
+    const type_identity *target, int val_index)
 {
     lua_getfield(state, val_index, "new");
 
@@ -213,7 +213,7 @@ static void autovivify_ptr(lua_State *state, int fname_idx, void **pptr,
         int top = lua_gettop(state);
 
         // Verify new points to a reasonable type of object
-        type_identity *suggested = get_object_identity(state, top, "autovivify", true, true);
+        const type_identity *suggested = get_object_identity(state, top, "autovivify", true, true);
 
         if (!is_type_compatible(state, target, 0, suggested, top+1, false))
             field_error(state, fname_idx, "incompatible suggested autovivify type", "write");
@@ -258,7 +258,7 @@ static bool is_null(lua_State *state, int val_index)
 }
 
 void df::pointer_identity::lua_write(lua_State *state, int fname_idx, void *ptr,
-                                     type_identity *target, int val_index)
+                                     const type_identity *target, int val_index)
 {
     auto pptr = (void**)ptr;
 
@@ -281,12 +281,12 @@ void df::pointer_identity::lua_write(lua_State *state, int fname_idx, void *ptr,
     }
 }
 
-void df::pointer_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index)
+void df::pointer_identity::lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const
 {
     lua_write(state, fname_idx, ptr, target, val_index);
 }
 
-int container_identity::lua_item_count(lua_State *state, void *ptr, CountMode mode)
+int container_identity::lua_item_count(lua_State *state, void *ptr, CountMode mode) const
 {
     if (lua_isnumber(state, UPVAL_ITEM_COUNT))
         return lua_tointeger(state, UPVAL_ITEM_COUNT);
@@ -294,21 +294,21 @@ int container_identity::lua_item_count(lua_State *state, void *ptr, CountMode mo
         return item_count(ptr, mode);
 }
 
-void container_identity::lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx)
+void container_identity::lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx) const
 {
     auto id = (type_identity*)lua_touserdata(state, UPVAL_ITEM_ID);
     void *pitem = item_pointer(id, ptr, idx);
     push_object_internal(state, id, pitem);
 }
 
-void container_identity::lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx)
+void container_identity::lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx) const
 {
     auto id = (type_identity*)lua_touserdata(state, UPVAL_ITEM_ID);
     void *pitem = item_pointer(id, ptr, idx);
     id->lua_read(state, fname_idx, pitem);
 }
 
-void container_identity::lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index)
+void container_identity::lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const
 {
     if (is_readonly())
         field_error(state, fname_idx, "container is read-only", "write");
@@ -318,7 +318,7 @@ void container_identity::lua_item_write(lua_State *state, int fname_idx, void *p
     id->lua_write(state, fname_idx, pitem, val_index);
 }
 
-bool container_identity::lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index)
+bool container_identity::lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const
 {
     auto id = (type_identity*)lua_touserdata(state, UPVAL_ITEM_ID);
 
@@ -343,28 +343,28 @@ bool container_identity::lua_insert2(lua_State *state, int fname_idx, void *ptr,
     return insert(ptr, idx, pitem);
 }
 
-void ptr_container_identity::lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx)
+void ptr_container_identity::lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx) const
 {
     auto id = (type_identity*)lua_touserdata(state, UPVAL_ITEM_ID);
     void *pitem = item_pointer(id, ptr, idx);
     push_adhoc_pointer(state, pitem, id);
 }
 
-void ptr_container_identity::lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx)
+void ptr_container_identity::lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx) const
 {
     auto id = (type_identity*)lua_touserdata(state, UPVAL_ITEM_ID);
     void *pitem = item_pointer(&df::identity_traits<void*>::identity, ptr, idx);
     df::pointer_identity::lua_read(state, fname_idx, pitem, id);
 }
 
-void ptr_container_identity::lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index)
+void ptr_container_identity::lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const
 {
     auto id = (type_identity*)lua_touserdata(state, UPVAL_ITEM_ID);
     void *pitem = item_pointer(&df::identity_traits<void*>::identity, ptr, idx);
     df::pointer_identity::lua_write(state, fname_idx, pitem, id, val_index);
 }
 
-bool ptr_container_identity::lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index)
+bool ptr_container_identity::lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const
 {
     auto id = (type_identity*)lua_touserdata(state, UPVAL_ITEM_ID);
 
@@ -374,17 +374,17 @@ bool ptr_container_identity::lua_insert2(lua_State *state, int fname_idx, void *
     return insert(ptr, idx, pitem);
 }
 
-void bit_container_identity::lua_item_reference(lua_State *state, int, void *, int)
+void bit_container_identity::lua_item_reference(lua_State *state, int, void *, int) const
 {
     lua_pushnil(state);
 }
 
-void bit_container_identity::lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx)
+void bit_container_identity::lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx) const
 {
     lua_pushboolean(state, get_item(ptr, idx));
 }
 
-void bit_container_identity::lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index)
+void bit_container_identity::lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const
 {
     if (lua_isboolean(state, val_index) || lua_isnil(state, val_index))
         set_item(ptr, idx, lua_toboolean(state, val_index));
@@ -1313,7 +1313,7 @@ namespace IndexFieldsFlags {
         RAW     = 1 << 1,
     };
 }
-static void IndexFields(lua_State *state, int base, struct_identity *pstruct, int flags)
+static void IndexFields(lua_State *state, int base, const struct_identity *pstruct, int flags)
 {
     if (pstruct->getParent())
         IndexFields(state, base, pstruct->getParent(), flags);
@@ -1393,7 +1393,7 @@ static void PushFieldInfoSubTable(lua_State *state, const struct_field_info *fie
     if (field->type) {
         Lua::TableInsert(state, "type_name", field->type->getFullName());
 
-        lua_pushlightuserdata(state, field->type);
+        lua_pushlightuserdata(state, const_cast<type_identity*>(field->type));
         lua_setfield(state, -2, "type_identity");
 
         PushTypeIdentity(state, field->type);
@@ -1532,7 +1532,7 @@ void LuaWrapper::IndexStatics(lua_State *state, int meta_idx, int ftable_idx, st
 {
     // stack: metatable fieldtable
     AddFieldInfoTable(state, ftable_idx, pstruct);
-    for (struct_identity *p = pstruct; p; p = p->getParent())
+    for (const struct_identity *p = pstruct; p; p = p->getParent())
     {
         auto fields = p->getFields();
         if (!fields)
@@ -1557,7 +1557,7 @@ void LuaWrapper::IndexStatics(lua_State *state, int meta_idx, int ftable_idx, st
 /**
  * Make a struct-style object metatable.
  */
-static void MakeFieldMetatable(lua_State *state, struct_identity *pstruct,
+static void MakeFieldMetatable(lua_State *state, const struct_identity *pstruct,
                                lua_CFunction reader, lua_CFunction writer,
                                lua_CFunction iterator, bool globals = false)
 {
@@ -1587,7 +1587,7 @@ static void MakeFieldMetatable(lua_State *state, struct_identity *pstruct,
 /**
  * Make a primitive-style metatable
  */
-static void MakePrimitiveMetatable(lua_State *state, type_identity *type)
+static void MakePrimitiveMetatable(lua_State *state, const type_identity *type)
 {
     int base = lua_gettop(state);
 
@@ -1600,7 +1600,7 @@ static void MakePrimitiveMetatable(lua_State *state, type_identity *type)
 
     if (type->type() != IDTYPE_OPAQUE)
     {
-        EnableMetaField(state, base+2, "value", type);
+        EnableMetaField(state, base+2, "value", const_cast<type_identity*>(type));
         AssociateId(state, base+3, 1, "value");
 
         EnableMetaField(state, base+2, "ref_target", NULL);
@@ -1621,7 +1621,7 @@ static void MakePrimitiveMetatable(lua_State *state, type_identity *type)
 
 static void AddContainerMethodFun(lua_State *state, int meta_idx, int field_idx,
                                   lua_CFunction function, const char *name,
-                                  type_identity *container, type_identity *item, int count)
+                                  const type_identity *container, const type_identity *item, int count)
 {
     lua_pushfstring(state, "%s()", name);
     SetContainerMethod(state, meta_idx, lua_gettop(state), function, name, container, item, count);
@@ -1633,8 +1633,8 @@ static void AddContainerMethodFun(lua_State *state, int meta_idx, int field_idx,
 /**
  * Make a container-style object metatable.
  */
-static void MakeContainerMetatable(lua_State *state, container_identity *type,
-                                   type_identity *item, int count, type_identity *ienum)
+static void MakeContainerMetatable(lua_State *state, const container_identity *type,
+                                   const type_identity *item, int count, const type_identity *ienum)
 {
     int base = lua_gettop(state);
 
@@ -1647,7 +1647,7 @@ static void MakeContainerMetatable(lua_State *state, container_identity *type,
     lua_setfield(state, base+1, "__metatable");
     lua_setfield(state, base+1, "_type");
 
-    lua_pushlightuserdata(state, item);
+    lua_pushlightuserdata(state, const_cast<type_identity*>(item));
     lua_setfield(state, base+1, "_field_identity");
 
     if (count >= 0)
@@ -1680,17 +1680,17 @@ static void MakeContainerMetatable(lua_State *state, container_identity *type,
 /*
  * Metatable construction identity methods.
  */
-void type_identity::build_metatable(lua_State *state)
+void type_identity::build_metatable(lua_State *state) const
 {
     MakePrimitiveMetatable(state, this);
 }
 
-void container_identity::build_metatable(lua_State *state)
+void container_identity::build_metatable(lua_State *state) const
 {
     MakeContainerMetatable(state, this, getItemType(), -1, getIndexEnumType());
 }
 
-void bitfield_identity::build_metatable(lua_State *state)
+void bitfield_identity::build_metatable(lua_State *state) const
 {
     int base = lua_gettop(state);
 
@@ -1711,10 +1711,10 @@ void bitfield_identity::build_metatable(lua_State *state)
 
     lua_pop(state, 1);
 
-    EnableMetaField(state, base+2, "whole", this);
+    EnableMetaField(state, base+2, "whole", const_cast<bitfield_identity*>(this));
 }
 
-void struct_identity::build_metatable(lua_State *state)
+void struct_identity::build_metatable(lua_State *state) const
 {
     int base = lua_gettop(state);
     MakeFieldMetatable(state, this, meta_struct_index, meta_struct_newindex, meta_struct_next);
@@ -1722,7 +1722,7 @@ void struct_identity::build_metatable(lua_State *state)
     SetPtrMethods(state, base+1, base+2);
 }
 
-void union_identity::build_metatable(lua_State *state)
+void union_identity::build_metatable(lua_State *state) const
 {
     int base = lua_gettop(state);
     MakeFieldMetatable(state, this, meta_struct_index, meta_struct_newindex, meta_union_next);
@@ -1730,14 +1730,14 @@ void union_identity::build_metatable(lua_State *state)
     SetPtrMethods(state, base+1, base+2);
 }
 
-void other_vectors_identity::build_metatable(lua_State *state)
+void other_vectors_identity::build_metatable(lua_State *state) const
 {
     int base = lua_gettop(state);
     MakeFieldMetatable(state, this, meta_struct_index, meta_struct_newindex, meta_struct_next);
 
     EnableMetaField(state, base+2, "_enum");
 
-    LookupInTable(state, index_enum, &DFHACK_TYPEID_TABLE_TOKEN);
+    LookupInTable(state, const_cast<enum_identity*>(index_enum), &DFHACK_TYPEID_TABLE_TOKEN);
     lua_setfield(state, base+1, "_enum");
 
     auto keys = &index_enum->getKeys()[-index_enum->getFirstItem()];
@@ -1752,7 +1752,7 @@ void other_vectors_identity::build_metatable(lua_State *state)
     SetPtrMethods(state, base+1, base+2);
 }
 
-void global_identity::build_metatable(lua_State *state)
+void global_identity::build_metatable(lua_State *state) const
 {
     int base = lua_gettop(state);
     MakeFieldMetatable(state, this, meta_global_index, meta_global_newindex, meta_struct_next, true);
@@ -1804,7 +1804,7 @@ static void GetAdHocMetatable(lua_State *state, const struct_field_info *field)
     }
 }
 
-void LuaWrapper::push_adhoc_pointer(lua_State *state, void *ptr, type_identity *target)
+void LuaWrapper::push_adhoc_pointer(lua_State *state, void *ptr, const type_identity *target)
 {
     if (!target)
     {
@@ -1812,7 +1812,7 @@ void LuaWrapper::push_adhoc_pointer(lua_State *state, void *ptr, type_identity *
         return;
     }
 
-    LookupInTable(state, target, &DFHACK_PTR_IDTABLE_TOKEN);
+    LookupInTable(state, const_cast<type_identity*>(target), &DFHACK_PTR_IDTABLE_TOKEN);
 
     type_identity *id = (type_identity*)lua_touserdata(state, -1);
     lua_pop(state, 1);
@@ -1828,7 +1828,7 @@ void LuaWrapper::push_adhoc_pointer(lua_State *state, void *ptr, type_identity *
         void *newobj = lua_newuserdata(state, sizeof(pointer_identity));
         id = new (newobj) pointer_identity(target);
 
-        SaveInTable(state, target, &DFHACK_PTR_IDTABLE_TOKEN);
+        SaveInTable(state, const_cast<type_identity*>(target), &DFHACK_PTR_IDTABLE_TOKEN);
         lua_pop(state, 1);
     }
 

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -78,88 +78,88 @@ namespace DFHack
     typedef void *(*TAllocateFn)(void*,const void*);
 
     class DFHACK_EXPORT type_identity {
-        size_t size;
+        const size_t size;
 
     protected:
         type_identity(size_t size) : size(size) {};
 
-        void *do_allocate_pod();
-        void do_copy_pod(void *tgt, const void *src);
-        bool do_destroy_pod(void *obj);
+        void *do_allocate_pod() const;
+        void do_copy_pod(void *tgt, const void *src) const;
+        bool do_destroy_pod(void *obj) const;
 
-        virtual bool can_allocate() { return true; }
-        virtual void *do_allocate() { return do_allocate_pod(); }
-        virtual bool do_copy(void *tgt, const void *src) { do_copy_pod(tgt, src); return true; }
-        virtual bool do_destroy(void *obj) { return do_destroy_pod(obj); }
+        virtual bool can_allocate() const { return true; }
+        virtual void *do_allocate() const { return do_allocate_pod(); }
+        virtual bool do_copy(void *tgt, const void *src) const { do_copy_pod(tgt, src); return true; }
+        virtual bool do_destroy(void *obj) const { return do_destroy_pod(obj); }
 
     public:
         virtual ~type_identity() {}
 
-        virtual size_t byte_size() { return size; }
+        virtual size_t byte_size() const { return size; }
 
-        virtual identity_type type() = 0;
+        virtual identity_type type() const = 0;
 
-        virtual std::string getFullName() = 0;
+        virtual const std::string getFullName() const = 0;
 
         // For internal use in the lua wrapper
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) = 0;
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) = 0;
-        virtual void build_metatable(lua_State *state);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const = 0;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const = 0;
+        virtual void build_metatable(lua_State *state) const;
 
         // lua_read doesn't just return a reference to the object
-        virtual bool isPrimitive() { return true; }
+        virtual bool isPrimitive() const { return true; }
         // needs constructor/destructor
-        virtual bool isConstructed() { return false; }
+        virtual bool isConstructed() const { return false; }
         // inherits from container_identity
-        virtual bool isContainer() { return false; }
+        virtual bool isContainer() const { return false; }
 
-        void *allocate();
-        bool copy(void *tgt, const void *src);
-        bool destroy(void *obj);
+        void *allocate() const;
+        bool copy(void* tgt, const void* src) const;
+        bool destroy(void *obj) const;
     };
 
     class DFHACK_EXPORT constructed_identity : public type_identity {
-        TAllocateFn allocator;
+        const TAllocateFn allocator;
 
     protected:
-        constructed_identity(size_t size, TAllocateFn alloc)
+        constructed_identity(size_t size, const TAllocateFn alloc)
             : type_identity(size), allocator(alloc) {};
 
-        virtual bool can_allocate() { return (allocator != NULL); }
-        virtual void *do_allocate() { return allocator(NULL,NULL); }
-        virtual bool do_copy(void *tgt, const void *src) { return allocator(tgt,src) == tgt; }
-        virtual bool do_destroy(void *obj) { return allocator(NULL,obj) == obj; }
+        virtual bool can_allocate() const { return (allocator != NULL); }
+        virtual void *do_allocate() const { return allocator(NULL,NULL); }
+        virtual bool do_copy(void *tgt, const void *src) const { return allocator(tgt,src) == tgt; }
+        virtual bool do_destroy(void *obj) const { return allocator(NULL,obj) == obj; }
     public:
-        virtual bool isPrimitive() { return false; }
-        virtual bool isConstructed() { return true; }
+        virtual bool isPrimitive() const { return false; }
+        virtual bool isConstructed() const { return true; }
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
 
     class DFHACK_EXPORT compound_identity : public constructed_identity {
         static compound_identity *list;
-        compound_identity *next;
+        mutable compound_identity *next;
 
         const char *dfhack_name;
-        compound_identity *scope_parent;
-        std::vector<compound_identity*> scope_children;
-        static std::vector<compound_identity*> top_scope;
+        mutable compound_identity *scope_parent;
+        mutable std::vector<const compound_identity*> scope_children;
+        static std::vector<const compound_identity*> top_scope;
 
     protected:
         compound_identity(size_t size, TAllocateFn alloc,
-                          compound_identity *scope_parent, const char *dfhack_name);
+            const compound_identity *scope_parent, const char *dfhack_name);
 
         virtual void doInit(Core *core);
 
     public:
-        const char *getName() { return dfhack_name; }
+        const char *getName() const { return dfhack_name; }
 
-        virtual std::string getFullName();
+        virtual const std::string getFullName() const;
 
-        compound_identity *getScopeParent() { return scope_parent; }
-        const std::vector<compound_identity*> &getScopeChildren() { return scope_children; }
-        static const std::vector<compound_identity*> &getTopScope() { return top_scope; }
+        const compound_identity *getScopeParent() const { return scope_parent; }
+        const std::vector<const compound_identity*> &getScopeChildren() const { return scope_children; }
+        static const std::vector<const compound_identity*> &getTopScope() { return top_scope; }
 
         static void Init(Core *core);
     };
@@ -177,27 +177,27 @@ namespace DFHack
 
     class DFHACK_EXPORT bitfield_identity : public compound_identity {
         const bitfield_item_info *bits;
-        int num_bits;
+        const int num_bits;
 
     protected:
-        virtual bool can_allocate() { return true; }
-        virtual void *do_allocate() { return do_allocate_pod(); }
-        virtual bool do_copy(void *tgt, const void *src) { do_copy_pod(tgt, src); return true; }
-        virtual bool do_destroy(void *obj) { return do_destroy_pod(obj); }
+        virtual bool can_allocate() const { return true; }
+        virtual void *do_allocate() const { return do_allocate_pod(); }
+        virtual bool do_copy(void *tgt, const void *src) const { do_copy_pod(tgt, src); return true; }
+        virtual bool do_destroy(void *obj) const { return do_destroy_pod(obj); }
 
     public:
         bitfield_identity(size_t size,
-                          compound_identity *scope_parent, const char *dfhack_name,
+            const compound_identity *scope_parent, const char *dfhack_name,
                           int num_bits, const bitfield_item_info *bits);
 
-        virtual identity_type type() { return IDTYPE_BITFIELD; }
+        virtual identity_type type() const { return IDTYPE_BITFIELD; }
 
-        virtual bool isConstructed() { return false; }
+        virtual bool isConstructed() const { return false; }
 
-        int getNumBits() { return num_bits; }
-        const bitfield_item_info *getBits() { return bits; }
+        int getNumBits() const { return num_bits; }
+        const bitfield_item_info *getBits() const { return bits; }
 
-        virtual void build_metatable(lua_State *state);
+        virtual void build_metatable(lua_State *state) const;
     };
 
     class struct_identity;
@@ -220,44 +220,44 @@ namespace DFHack
         int64_t last_item_value;
         int count;
 
-        type_identity *base_type;
+        const type_identity *base_type;
 
         const void *attrs;
-        struct_identity *attr_type;
+        const struct_identity *attr_type;
 
     protected:
-        virtual bool can_allocate() { return true; }
-        virtual void *do_allocate();
-        virtual bool do_copy(void *tgt, const void *src) { do_copy_pod(tgt, src); return true; }
-        virtual bool do_destroy(void *obj) { return do_destroy_pod(obj); }
+        virtual bool can_allocate() const { return true; }
+        virtual void *do_allocate() const;
+        virtual bool do_copy(void *tgt, const void *src) const { do_copy_pod(tgt, src); return true; }
+        virtual bool do_destroy(void *obj) const { return do_destroy_pod(obj); }
 
     public:
         enum_identity(size_t size,
-                      compound_identity *scope_parent, const char *dfhack_name,
-                      type_identity *base_type,
+            const compound_identity *scope_parent, const char *dfhack_name,
+            const type_identity *base_type,
                       int64_t first_item_value, int64_t last_item_value,
                       const char *const *keys,
                       const ComplexData *complex,
-                      const void *attrs, struct_identity *attr_type);
-        enum_identity(enum_identity *enum_type, type_identity *override_base_type);
+                      const void *attrs, const struct_identity *attr_type);
+        enum_identity(const enum_identity *enum_type, const type_identity *override_base_type);
 
-        virtual identity_type type() { return IDTYPE_ENUM; }
+        virtual identity_type type() const { return IDTYPE_ENUM; }
 
-        int64_t getFirstItem() { return first_item_value; }
-        int64_t getLastItem() { return last_item_value; }
-        int getCount() { return count; }
-        const char *const *getKeys() { return keys; }
-        const ComplexData *getComplex() { return complex; }
+        int64_t getFirstItem() const { return first_item_value; }
+        int64_t getLastItem() const { return last_item_value; }
+        int getCount() const { return count; }
+        const char *const *getKeys() const { return keys; }
+        const ComplexData *getComplex() const { return complex; }
 
-        type_identity *getBaseType() { return base_type; }
-        const void *getAttrs() { return attrs; }
-        struct_identity *getAttrType() { return attr_type; }
+        const type_identity *getBaseType() const { return base_type; }
+        const void *getAttrs() const { return attrs; }
+        const struct_identity *getAttrType() const { return attr_type; }
 
-        virtual bool isPrimitive() { return true; }
-        virtual bool isConstructed() { return false; }
+        virtual bool isPrimitive() const { return true; }
+        virtual bool isConstructed() const { return false; }
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
 
     struct struct_field_info_extra {
@@ -284,14 +284,14 @@ namespace DFHack
         Mode mode;
         const char *name;
         size_t offset;
-        type_identity *type;
+        const type_identity *type;
         size_t count;
         const struct_field_info_extra *extra;
     };
 
     class DFHACK_EXPORT struct_identity : public compound_identity {
-        struct_identity *parent;
-        std::vector<struct_identity*> children;
+        mutable struct_identity *parent;
+        mutable std::vector<const struct_identity*> children;
         bool has_children;
 
         const struct_field_info *fields;
@@ -301,20 +301,20 @@ namespace DFHack
 
     public:
         struct_identity(size_t size, TAllocateFn alloc,
-                compound_identity *scope_parent, const char *dfhack_name,
-                struct_identity *parent, const struct_field_info *fields);
+            const compound_identity *scope_parent, const char *dfhack_name,
+            const struct_identity *parent, const struct_field_info *fields);
 
-        virtual identity_type type() { return IDTYPE_STRUCT; }
+        virtual identity_type type() const { return IDTYPE_STRUCT; }
 
-        struct_identity *getParent() { return parent; }
-        const std::vector<struct_identity*> &getChildren() { return children; }
-        bool hasChildren() { return has_children; }
+        const struct_identity *getParent() const { return parent; }
+        const std::vector<const struct_identity*> &getChildren() const { return children; }
+        bool hasChildren() const { return has_children; }
 
-        const struct_field_info *getFields() { return fields; }
+        const struct_field_info *getFields() const { return fields; }
 
-        bool is_subclass(struct_identity *subtype);
+        bool is_subclass(const struct_identity *subtype) const;
 
-        virtual void build_metatable(lua_State *state);
+        virtual void build_metatable(lua_State *state) const;
     };
 
     class DFHACK_EXPORT global_identity : public struct_identity {
@@ -322,9 +322,9 @@ namespace DFHack
         global_identity(const struct_field_info *fields)
             : struct_identity(0,NULL,NULL,"global",NULL,fields) {}
 
-        virtual identity_type type() { return IDTYPE_GLOBAL; }
+        virtual identity_type type() const { return IDTYPE_GLOBAL; }
 
-        virtual void build_metatable(lua_State *state);
+        virtual void build_metatable(lua_State *state) const;
     };
 
     class DFHACK_EXPORT union_identity : public struct_identity {
@@ -335,24 +335,24 @@ namespace DFHack
 
         virtual identity_type type() { return IDTYPE_UNION; }
 
-        virtual void build_metatable(lua_State *state);
+        virtual void build_metatable(lua_State *state) const;
     };
 
     class DFHACK_EXPORT other_vectors_identity : public struct_identity {
-        enum_identity *index_enum;
+        const enum_identity *index_enum;
 
     public:
-        other_vectors_identity(size_t size, TAllocateFn alloc,
-                compound_identity *scope_parent, const char *dfhack_name,
-                struct_identity *parent, const struct_field_info *fields,
-                enum_identity *index_enum) :
+        other_vectors_identity(size_t size, const TAllocateFn alloc,
+            const compound_identity *scope_parent, const char *dfhack_name,
+            const struct_identity *parent, const struct_field_info *fields,
+            const enum_identity *index_enum) :
             struct_identity(size, alloc, scope_parent, dfhack_name, parent, fields),
             index_enum(index_enum)
         {}
 
-        enum_identity *getIndexEnum() { return index_enum; }
+        const enum_identity *getIndexEnum() const { return index_enum; }
 
-        virtual void build_metatable(lua_State *state);
+        virtual void build_metatable(lua_State *state) const;
     };
 
 #ifdef _MSC_VER
@@ -369,33 +369,33 @@ namespace DFHack
 
         const char *original_name;
 
-        void *vtable_ptr;
+        mutable void *vtable_ptr;
 
         bool is_plugin;
 
         friend class VMethodInterposeLinkBase;
-        std::map<int,VMethodInterposeLinkBase*> interpose_list;
+        mutable std::map<int,VMethodInterposeLinkBase*> interpose_list;
 
     protected:
         virtual void doInit(Core *core);
 
         static void *get_vtable(virtual_ptr instance_ptr) { return *(void**)instance_ptr; }
 
-        bool can_allocate() { return struct_identity::can_allocate() && (vtable_ptr != NULL); }
+        bool can_allocate() const { return struct_identity::can_allocate() && (vtable_ptr != NULL); }
 
-        void *get_vmethod_ptr(int index);
-        bool set_vmethod_ptr(MemoryPatcher &patcher, int index, void *ptr);
+        void *get_vmethod_ptr(int index) const;
+        bool set_vmethod_ptr(MemoryPatcher &patcher, int index, void *ptr) const;
 
     public:
-        virtual_identity(size_t size, TAllocateFn alloc,
+        virtual_identity(size_t size, const TAllocateFn alloc,
                          const char *dfhack_name, const char *original_name,
-                         virtual_identity *parent, const struct_field_info *fields,
+            const virtual_identity *parent, const struct_field_info *fields,
                          bool is_plugin = false);
         ~virtual_identity();
 
-        virtual identity_type type() { return IDTYPE_CLASS; }
+        virtual identity_type type() const { return IDTYPE_CLASS; }
 
-        const char *getOriginalName() { return original_name ? original_name : getName(); }
+        const char *getOriginalName() const { return original_name ? original_name : getName(); }
 
     public:
         static virtual_identity *get(virtual_ptr instance_ptr);
@@ -403,7 +403,7 @@ namespace DFHack
         static virtual_identity *find(void *vtable);
         static virtual_identity *find(const std::string &name);
 
-        bool is_instance(virtual_ptr instance_ptr) {
+        bool is_instance(virtual_ptr instance_ptr) const {
             if (!instance_ptr) return false;
             if (vtable_ptr) {
                 void *vtable = get_vtable(instance_ptr);
@@ -413,7 +413,7 @@ namespace DFHack
             return is_subclass(get(instance_ptr));
         }
 
-        bool is_direct_instance(virtual_ptr instance_ptr) {
+        bool is_direct_instance(virtual_ptr instance_ptr) const {
             if (!instance_ptr) return false;
             return vtable_ptr ? (vtable_ptr == get_vtable(instance_ptr))
                               : (this == get(instance_ptr));
@@ -445,7 +445,7 @@ namespace DFHack
 
 #define STRICT_VIRTUAL_CAST_VAR(var,type,input) type *var = strict_virtual_cast<type>(input)
 
-    void InitDataDefGlobals(Core *core);
+void InitDataDefGlobals(Core *core);
 
     template<class T>
     T *ifnull(T *a, T *b) { return a ? a : b; }
@@ -876,7 +876,7 @@ namespace DFHack {
      * As a special case, a container-type union can have a tag field that is
      * a bit vector if it has exactly two members.
      */
-    DFHACK_EXPORT const struct_field_info *find_union_tag(struct_identity *structure, const struct_field_info *union_field);
+    DFHACK_EXPORT const struct_field_info *find_union_tag(const struct_identity *structure, const struct_field_info *union_field);
 }
 
 #define ENUM_ATTR(enum,attr,val) (df::enum_traits<df::enum>::attrs(val).attr)

--- a/library/include/DataFuncs.h
+++ b/library/include/DataFuncs.h
@@ -153,7 +153,7 @@ namespace df {
         function_identity(T ptr, bool vararg)
             : function_identity_base(wrapper::num_args, vararg), ptr(ptr) {};
 
-        virtual void invoke(lua_State *state, int base) { wrapper::execute(state, base, ptr); }
+        virtual void invoke(lua_State *state, int base) const { wrapper::execute(state, base, ptr); }
     };
 
     template<typename T>

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -53,142 +53,142 @@ namespace df {
 namespace DFHack
 {
     class DFHACK_EXPORT function_identity_base : public type_identity {
-        int num_args;
-        bool vararg;
+        const int num_args;
+        const bool vararg;
 
     public:
         function_identity_base(int num_args, bool vararg = false)
             : type_identity(0), num_args(num_args), vararg(vararg) {};
 
-        virtual identity_type type() { return IDTYPE_FUNCTION; }
+        virtual identity_type type() const { return IDTYPE_FUNCTION; }
 
-        int getNumArgs() { return num_args; }
-        bool adjustArgs() { return vararg; }
+        int getNumArgs() const { return num_args; }
+        bool adjustArgs() const { return vararg; }
 
-        std::string getFullName() { return "function"; }
+        const std::string getFullName() const { return "function"; }
 
-        virtual void invoke(lua_State *state, int base) = 0;
+        virtual void invoke(lua_State *state, int base) const = 0;
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
 
     class DFHACK_EXPORT primitive_identity : public type_identity {
     public:
         primitive_identity(size_t size) : type_identity(size) {};
 
-        virtual identity_type type() { return IDTYPE_PRIMITIVE; }
+        virtual identity_type type() const { return IDTYPE_PRIMITIVE; }
     };
 
     class DFHACK_EXPORT opaque_identity : public constructed_identity {
-        std::string name;
+        const std::string name;
 
     public:
         opaque_identity(size_t size, TAllocateFn alloc, const std::string &name)
           : constructed_identity(size, alloc), name(name) {};
 
-        virtual std::string getFullName() { return name; }
-        virtual identity_type type() { return IDTYPE_OPAQUE; }
+        virtual const std::string getFullName() const { return name; }
+        virtual identity_type type() const { return IDTYPE_OPAQUE; }
     };
 
     class DFHACK_EXPORT pointer_identity : public primitive_identity {
-        type_identity *target;
+        const type_identity *target;
 
     public:
-        pointer_identity(type_identity *target = NULL)
+        pointer_identity(const type_identity *target = NULL)
             : primitive_identity(sizeof(void*)), target(target) {};
 
-        virtual identity_type type() { return IDTYPE_POINTER; }
+        virtual identity_type type() const { return IDTYPE_POINTER; }
 
-        type_identity *getTarget() { return target; }
+        const type_identity *getTarget() const { return target; }
 
-        std::string getFullName();
+        const std::string getFullName() const;
 
-        static void lua_read(lua_State *state, int fname_idx, void *ptr, type_identity *target);
-        static void lua_write(lua_State *state, int fname_idx, void *ptr, type_identity *target, int val_index);
+        static void lua_read(lua_State *state, int fname_idx, void *ptr, const type_identity *target);
+        static void lua_write(lua_State *state, int fname_idx, void *ptr, const type_identity *target, int val_index);
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
 
     class DFHACK_EXPORT container_identity : public constructed_identity {
-        type_identity *item;
-        enum_identity *ienum;
+        const type_identity *item;
+        const enum_identity *ienum;
 
     public:
-        container_identity(size_t size, TAllocateFn alloc, type_identity *item, enum_identity *ienum = NULL)
+        container_identity(size_t size, const TAllocateFn alloc, const type_identity *item, const enum_identity *ienum = NULL)
             : constructed_identity(size, alloc), item(item), ienum(ienum) {};
 
-        virtual identity_type type() { return IDTYPE_CONTAINER; }
+        virtual identity_type type() const { return IDTYPE_CONTAINER; }
 
-        std::string getFullName() { return getFullName(item); }
+        const std::string getFullName() const { return getFullName(item); }
 
-        virtual void build_metatable(lua_State *state);
-        virtual bool isContainer() { return true; }
+        virtual void build_metatable(lua_State *state) const;
+        virtual bool isContainer() const { return true; }
 
-        type_identity *getItemType() { return item; }
-        type_identity *getIndexEnumType() { return ienum; }
+        const type_identity *getItemType() const { return item; }
+        const type_identity *getIndexEnumType() const { return ienum; }
 
-        virtual std::string getFullName(type_identity *item);
+        virtual const std::string getFullName(const type_identity *item) const;
 
         enum CountMode {
             COUNT_LEN, COUNT_READ, COUNT_WRITE
         };
 
-        int lua_item_count(lua_State *state, void *ptr, CountMode cnt);
+        int lua_item_count(lua_State *state, void *ptr, CountMode cnt) const;
 
-        virtual void lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx);
-        virtual void lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx);
-        virtual void lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index);
+        virtual void lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx) const;
+        virtual void lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx) const;
+        virtual void lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const;
 
-        virtual bool is_readonly() { return false; }
+        virtual bool is_readonly() const { return false; }
 
-        virtual bool resize(void *ptr, int size) { return false; }
-        virtual bool erase(void *ptr, int index) { return false; }
-        virtual bool insert(void *ptr, int index, void *pitem) { return false; }
+        virtual bool resize(void *ptr, int size) const { return false; }
+        virtual bool erase(void *ptr, int index) const { return false; }
+        virtual bool insert(void *ptr, int index, void *pitem) const { return false; }
 
-        virtual bool lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index);
+        virtual bool lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const;
 
     protected:
-        virtual int item_count(void *ptr, CountMode cnt) = 0;
-        virtual void *item_pointer(type_identity *item, void *ptr, int idx) = 0;
+        virtual int item_count(void *ptr, CountMode cnt) const = 0;
+        virtual void *item_pointer(const type_identity *item, void *ptr, int idx) const = 0;
     };
 
     class DFHACK_EXPORT ptr_container_identity : public container_identity {
     public:
         ptr_container_identity(size_t size, TAllocateFn alloc,
-                               type_identity *item, enum_identity *ienum = NULL)
+            const type_identity *item, const enum_identity *ienum = NULL)
             : container_identity(size, alloc, item, ienum) {};
 
-        virtual identity_type type() { return IDTYPE_PTR_CONTAINER; }
+        virtual identity_type type() const { return IDTYPE_PTR_CONTAINER; }
 
-        std::string getFullName(type_identity *item);
+        const std::string getFullName(const type_identity *item) const;
 
-        virtual void lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx);
-        virtual void lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx);
-        virtual void lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index);
+        virtual void lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx) const;
+        virtual void lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx) const;
+        virtual void lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const;
 
-        virtual bool lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index);
+        virtual bool lua_insert2(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const;
     };
 
     class DFHACK_EXPORT bit_container_identity : public container_identity {
     public:
-        bit_container_identity(size_t size, TAllocateFn alloc, enum_identity *ienum = NULL)
+        bit_container_identity(size_t size, TAllocateFn alloc, const enum_identity *ienum = NULL)
             : container_identity(size, alloc, NULL, ienum) {};
 
-        virtual identity_type type() { return IDTYPE_BIT_CONTAINER; }
+        virtual identity_type type() const { return IDTYPE_BIT_CONTAINER; }
 
-        std::string getFullName(type_identity *item);
+        const std::string getFullName(const type_identity *item) const;
 
-        virtual void lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx);
-        virtual void lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx);
-        virtual void lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index);
+        virtual void lua_item_reference(lua_State *state, int fname_idx, void *ptr, int idx) const;
+        virtual void lua_item_read(lua_State *state, int fname_idx, void *ptr, int idx) const;
+        virtual void lua_item_write(lua_State *state, int fname_idx, void *ptr, int idx, int val_index) const;
 
     protected:
-        virtual void *item_pointer(type_identity *, void *, int) { return NULL; }
+        virtual void *item_pointer(const type_identity *, void *, int) const { return NULL; }
 
-        virtual bool get_item(void *ptr, int idx) = 0;
-        virtual void set_item(void *ptr, int idx, bool val) = 0;
+        virtual bool get_item(void *ptr, int idx) const = 0;
+        virtual void set_item(void *ptr, int idx, bool val) const = 0;
     };
 }
 
@@ -209,10 +209,10 @@ namespace df
         number_identity_base(size_t size, const char *name)
             : primitive_identity(size), name(name) {};
 
-        std::string getFullName() { return name; }
+        const std::string getFullName() const { return name; }
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) = 0;
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) = 0;
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const = 0;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const = 0;
 
     };
 
@@ -221,12 +221,12 @@ namespace df
         integer_identity_base(size_t size, const char *name)
             : number_identity_base(size, name) {}
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
 
     protected:
-        virtual int64_t read(void *ptr) = 0;
-        virtual void write(void *ptr, int64_t val) = 0;
+        virtual int64_t read(void *ptr) const = 0;
+        virtual void write(void *ptr, int64_t val) const = 0;
     };
 
     class DFHACK_EXPORT float_identity_base : public number_identity_base {
@@ -234,12 +234,12 @@ namespace df
         float_identity_base(size_t size, const char *name)
             : number_identity_base(size, name) {}
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
 
     protected:
-        virtual double read(void *ptr) = 0;
-        virtual void write(void *ptr, double val) = 0;
+        virtual double read(void *ptr) const = 0;
+        virtual void write(void *ptr, double val) const = 0;
     };
 
     template<class T>
@@ -248,8 +248,8 @@ namespace df
         integer_identity(const char *name) : integer_identity_base(sizeof(T), name) {}
 
     protected:
-        virtual int64_t read(void *ptr) { return int64_t(*(T*)ptr); }
-        virtual void write(void *ptr, int64_t val) { *(T*)ptr = T(val); }
+        virtual int64_t read(void *ptr) const { return int64_t(*(T*)ptr); }
+        virtual void write(void *ptr, int64_t val) const { *(T*)ptr = T(val); }
     };
 
     template<class T>
@@ -258,28 +258,28 @@ namespace df
         float_identity(const char *name) : float_identity_base(sizeof(T), name) {}
 
     protected:
-        virtual double read(void *ptr) { return double(*(T*)ptr); }
-        virtual void write(void *ptr, double val) { *(T*)ptr = T(val); }
+        virtual double read(void *ptr) const { return double(*(T*)ptr); }
+        virtual void write(void *ptr, double val) const { *(T*)ptr = T(val); }
     };
 
     class DFHACK_EXPORT bool_identity : public primitive_identity {
     public:
         bool_identity() : primitive_identity(sizeof(bool)) {};
 
-        std::string getFullName() { return "bool"; }
+        const std::string getFullName() const { return "bool"; }
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
 
     class DFHACK_EXPORT ptr_string_identity : public primitive_identity {
     public:
         ptr_string_identity() : primitive_identity(sizeof(char*)) {};
 
-        std::string getFullName() { return "char*"; }
+        const std::string getFullName() const { return "char*"; }
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
 
     class DFHACK_EXPORT stl_string_identity : public DFHack::constructed_identity {
@@ -288,14 +288,14 @@ namespace df
             : constructed_identity(sizeof(std::string), &allocator_fn<std::string>)
         {};
 
-        std::string getFullName() { return "string"; }
+        const std::string getFullName() const { return "string"; }
 
-        virtual DFHack::identity_type type() { return DFHack::IDTYPE_PRIMITIVE; }
+        virtual DFHack::identity_type type() const { return DFHack::IDTYPE_PRIMITIVE; }
 
-        virtual bool isPrimitive() { return true; }
+        virtual bool isPrimitive() const { return true; }
 
-        virtual void lua_read(lua_State *state, int fname_idx, void *ptr);
-        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index);
+        virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
+        virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
 
     class DFHACK_EXPORT stl_ptr_vector_identity : public ptr_container_identity {
@@ -307,36 +307,36 @@ namespace df
          * in layout and behavior to std::vector<void*> for any T.
          */
 
-        stl_ptr_vector_identity(type_identity *item = NULL, enum_identity *ienum = NULL)
-            : ptr_container_identity(sizeof(container),allocator_fn<container>,item, ienum)
+        stl_ptr_vector_identity(const type_identity *item = NULL, const enum_identity *ienum = NULL)
+            : ptr_container_identity(sizeof(container), &df::allocator_fn<container>, item, ienum)
         {};
 
-        std::string getFullName(type_identity *item) {
+        const std::string getFullName(const type_identity *item) const {
             return "vector" + ptr_container_identity::getFullName(item);
         }
 
-        virtual DFHack::identity_type type() { return DFHack::IDTYPE_STL_PTR_VECTOR; }
+        virtual DFHack::identity_type type() const { return DFHack::IDTYPE_STL_PTR_VECTOR; }
 
-        virtual bool resize(void *ptr, int size) {
+        virtual bool resize(void *ptr, int size) const {
             (*(container*)ptr).resize(size);
             return true;
         }
-        virtual bool erase(void *ptr, int size) {
+        virtual bool erase(void *ptr, int size) const {
             auto &ct = *(container*)ptr;
             ct.erase(ct.begin()+size);
             return true;
         }
-        virtual bool insert(void *ptr, int idx, void *item) {
+        virtual bool insert(void *ptr, int idx, void *item) const {
             auto &ct = *(container*)ptr;
             ct.insert(ct.begin()+idx, item);
             return true;
         }
 
     protected:
-        virtual int item_count(void *ptr, CountMode) {
+        virtual int item_count(void *ptr, CountMode) const {
             return (int)((container*)ptr)->size();
         };
-        virtual void *item_pointer(type_identity *, void *ptr, int idx) {
+        virtual void *item_pointer(const type_identity *, void *ptr, int idx) const {
             return &(*(container*)ptr)[idx];
         }
     };
@@ -351,22 +351,22 @@ namespace df
             : container_identity(0, NULL, NULL, NULL), size(0)
         {}
 
-        buffer_container_identity(int size, type_identity *item, enum_identity *ienum = NULL)
+        buffer_container_identity(int size, const type_identity *item, const enum_identity *ienum = NULL)
             : container_identity(0, NULL, item, ienum), size(size)
         {}
 
-        size_t byte_size() { return getItemType()->byte_size()*size; }
+        size_t byte_size() const { return getItemType()->byte_size()*size; }
 
-        std::string getFullName(type_identity *item);
-        int getSize() { return size; }
+        const std::string getFullName(const type_identity *item) const;
+        int getSize() const { return size; }
 
-        virtual DFHack::identity_type type() { return DFHack::IDTYPE_BUFFER; }
+        virtual DFHack::identity_type type() const { return DFHack::IDTYPE_BUFFER; }
 
-        static buffer_container_identity base_instance;
+        static const buffer_container_identity base_instance;
 
     protected:
-        virtual int item_count(void *ptr, CountMode) { return size; }
-        virtual void *item_pointer(type_identity *item, void *ptr, int idx) {
+        virtual int item_count(void *ptr, CountMode) const { return size; }
+        virtual void *item_pointer(const type_identity *item, void *ptr, int idx) const {
             return ((uint8_t*)ptr) + idx * item->byte_size();
         }
     };
@@ -377,32 +377,32 @@ namespace df
         const char *name;
 
     public:
-        stl_container_identity(const char *name, type_identity *item, enum_identity *ienum = NULL)
+        stl_container_identity(const char *name, const type_identity *item, const enum_identity *ienum = NULL)
             : container_identity(sizeof(T), &allocator_fn<T>, item, ienum), name(name)
         {}
 
-        std::string getFullName(type_identity *item) {
+        const std::string getFullName(type_identity *item) const {
             return name + container_identity::getFullName(item);
         }
 
-        virtual bool resize(void *ptr, int size) {
+        virtual bool resize(void *ptr, int size) const {
             (*(T*)ptr).resize(size);
             return true;
         }
-        virtual bool erase(void *ptr, int size) {
+        virtual bool erase(void *ptr, int size) const {
             auto &ct = *(T*)ptr;
             ct.erase(ct.begin()+size);
             return true;
         }
-        virtual bool insert(void *ptr, int idx, void *item) {
+        virtual bool insert(void *ptr, int idx, void *item) const {
             auto &ct = *(T*)ptr;
             ct.insert(ct.begin()+idx, *(typename T::value_type*)item);
             return true;
         }
 
     protected:
-        virtual int item_count(void *ptr, CountMode) { return (int)((T*)ptr)->size(); }
-        virtual void *item_pointer(type_identity *item, void *ptr, int idx) {
+        virtual int item_count(void *ptr, CountMode) const { return (int)((T*)ptr)->size(); }
+        virtual void *item_pointer(const type_identity *item, void *ptr, int idx) const {
             return &(*(T*)ptr)[idx];
         }
     };
@@ -414,22 +414,22 @@ namespace df
         const char *name;
 
     public:
-        ro_stl_container_identity(const char *name, type_identity *item, enum_identity *ienum = NULL)
+        ro_stl_container_identity(const char *name, const type_identity *item, const enum_identity *ienum = NULL)
             : container_identity(sizeof(T), &allocator_fn<T>, item, ienum), name(name)
         {}
 
-        std::string getFullName(type_identity *item) {
+        const std::string getFullName(const type_identity *item) const {
             return name + container_identity::getFullName(item);
         }
 
-        virtual bool is_readonly() { return true; }
-        virtual bool resize(void *ptr, int size) { return false; }
-        virtual bool erase(void *ptr, int size) { return false; }
-        virtual bool insert(void *ptr, int idx, void *item) { return false; }
+        virtual bool is_readonly() const { return true; }
+        virtual bool resize(void *ptr, int size) const { return false; }
+        virtual bool erase(void *ptr, int size) const { return false; }
+        virtual bool insert(void *ptr, int idx, void *item) const { return false; }
 
     protected:
-        virtual int item_count(void *ptr, CountMode) { return (int)((T*)ptr)->size(); }
-        virtual void *item_pointer(type_identity *item, void *ptr, int idx) {
+        virtual int item_count(void *ptr, CountMode) const { return (int)((T*)ptr)->size(); }
+        virtual void *item_pointer(const type_identity *item, void *ptr, int idx) const {
             auto iter = (*(T*)ptr).begin();
             for (; idx > 0; idx--) ++iter;
             return (void*)&*iter;
@@ -438,22 +438,22 @@ namespace df
 
     template<class T>
     class ro_stl_assoc_container_identity : public ro_stl_container_identity<T> {
-        type_identity *key_identity;
-        type_identity *item_identity;
+        const type_identity *key_identity;
+        const type_identity *item_identity;
 
     public:
-        ro_stl_assoc_container_identity(const char *name, type_identity *key, type_identity *item)
+        ro_stl_assoc_container_identity(const char *name, const type_identity *key, const type_identity *item)
             : ro_stl_container_identity<T>(name, item),
               key_identity(key),
               item_identity(item)
         {}
 
-        virtual std::string getFullName(type_identity*) override {
+        virtual const std::string getFullName(const type_identity*) const override {
             return std::string(ro_stl_assoc_container_identity<T>::name) + "<" + key_identity->getFullName() + ", " + item_identity->getFullName() + ">";
         }
 
     protected:
-        virtual void *item_pointer(type_identity *item, void *ptr, int idx) override {
+        virtual void *item_pointer(const type_identity *item, void *ptr, int idx) const override {
             auto iter = (*(T*)ptr).begin();
             for (; idx > 0; idx--) ++iter;
             return (void*)&iter->second;
@@ -469,27 +469,27 @@ namespace df
 
         typedef BitArray<int> container;
 
-        bit_array_identity(enum_identity *ienum = NULL)
+        bit_array_identity(const enum_identity *ienum = NULL)
             : bit_container_identity(sizeof(container), &allocator_fn<container>, ienum)
         {}
 
-        std::string getFullName(type_identity *item) {
+        const std::string getFullName(type_identity *item) const {
             return "BitArray<>";
         }
 
-        virtual bool resize(void *ptr, int size) {
+        virtual bool resize(void *ptr, int size) const {
             ((container*)ptr)->resize((size+7)/8);
             return true;
         }
 
     protected:
-        virtual int item_count(void *ptr, CountMode cnt) {
+        virtual int item_count(void *ptr, CountMode cnt) const {
             return cnt == COUNT_LEN ? ((container*)ptr)->size * 8 : -1;
         }
-        virtual bool get_item(void *ptr, int idx) {
+        virtual bool get_item(void *ptr, int idx) const {
             return ((container*)ptr)->is_set(idx);
         }
-        virtual void set_item(void *ptr, int idx, bool val) {
+        virtual void set_item(void *ptr, int idx, bool val) const {
             ((container*)ptr)->set(idx, val);
         }
     };
@@ -499,27 +499,27 @@ namespace df
     public:
         typedef std::vector<bool> container;
 
-        stl_bit_vector_identity(enum_identity *ienum = NULL)
-            : bit_container_identity(sizeof(container), &allocator_fn<container>, ienum)
+        stl_bit_vector_identity(const enum_identity *ienum = NULL)
+            : bit_container_identity(sizeof(container), &df::allocator_fn<container>, ienum)
         {}
 
-        std::string getFullName(type_identity *item) {
+        const std::string getFullName(const type_identity *item) const {
             return "vector" + bit_container_identity::getFullName(item);
         }
 
-        virtual bool resize(void *ptr, int size) {
+        virtual bool resize(void *ptr, int size) const {
             (*(container*)ptr).resize(size);
             return true;
         }
 
     protected:
-        virtual int item_count(void *ptr, CountMode) {
+        virtual int item_count(void *ptr, CountMode) const {
             return (int)((container*)ptr)->size();
         }
-        virtual bool get_item(void *ptr, int idx) {
+        virtual bool get_item(void *ptr, int idx) const {
             return (*(container*)ptr)[idx];
         }
-        virtual void set_item(void *ptr, int idx, bool val) {
+        virtual void set_item(void *ptr, int idx, bool val) const {
             (*(container*)ptr)[idx] = val;
         }
     };
@@ -530,19 +530,19 @@ namespace df
     public:
         typedef enum_list_attr<T> container;
 
-        enum_list_attr_identity(type_identity *item)
+        enum_list_attr_identity(const type_identity *item)
             : container_identity(sizeof(container), NULL, item, NULL)
         {}
 
-        std::string getFullName(type_identity *item) {
+        const std::string getFullName(const type_identity *item) const {
             return "enum_list_attr" + container_identity::getFullName(item);
         }
 
     protected:
-        virtual int item_count(void *ptr, CountMode cm) {
+        virtual int item_count(void *ptr, CountMode cm) const {
             return cm == COUNT_WRITE ? 0 : (int)((container*)ptr)->size;
         }
-        virtual void *item_pointer(type_identity *item, void *ptr, int idx) {
+        virtual void *item_pointer(const type_identity *item, void *ptr, int idx) const {
             return (void*)&((container*)ptr)->items[idx];
         }
     };
@@ -551,8 +551,8 @@ namespace df
 #define NUMBER_IDENTITY_TRAITS(category, type) \
     template<> struct DFHACK_EXPORT identity_traits<type> { \
         static const bool is_primitive = true; \
-        static category##_identity<type> identity; \
-        static category##_identity_base *get() { return &identity; } \
+        static const category##_identity<type> identity; \
+        static const category##_identity_base *get() { return &identity; } \
     };
 
 #define INTEGER_IDENTITY_TRAITS(type) NUMBER_IDENTITY_TRAITS(integer, type)
@@ -563,8 +563,8 @@ namespace df
 
 #define OPAQUE_IDENTITY_TRAITS(...) \
     template<> struct DFHACK_EXPORT identity_traits<__VA_ARGS__ > { \
-        static opaque_identity identity; \
-        static opaque_identity *get() { return &identity; } \
+        static const opaque_identity identity; \
+        static const opaque_identity *get() { return &identity; } \
     };
 
     INTEGER_IDENTITY_TRAITS(char);
@@ -606,42 +606,42 @@ namespace df
 
     template<> struct DFHACK_EXPORT identity_traits<bool> {
         static const bool is_primitive = true;
-        static bool_identity identity;
-        static bool_identity *get() { return &identity; }
+        static const bool_identity identity;
+        static const bool_identity *get() { return &identity; }
     };
 
     template<> struct DFHACK_EXPORT identity_traits<std::string> {
         static const bool is_primitive = true;
-        static stl_string_identity identity;
-        static stl_string_identity *get() { return &identity; }
+        static const stl_string_identity identity;
+        static const stl_string_identity *get() { return &identity; }
     };
 
     template<> struct DFHACK_EXPORT identity_traits<char*> {
         static const bool is_primitive = true;
-        static ptr_string_identity identity;
-        static ptr_string_identity *get() { return &identity; }
+        static const ptr_string_identity identity;
+        static const ptr_string_identity *get() { return &identity; }
     };
 
     template<> struct DFHACK_EXPORT identity_traits<const char*> {
         static const bool is_primitive = true;
-        static ptr_string_identity identity;
-        static ptr_string_identity *get() { return &identity; }
+        static const ptr_string_identity identity;
+        static const ptr_string_identity *get() { return &identity; }
     };
 
     template<> struct DFHACK_EXPORT identity_traits<void*> {
         static const bool is_primitive = true;
-        static pointer_identity identity;
-        static pointer_identity *get() { return &identity; }
+        static const pointer_identity identity;
+        static const pointer_identity *get() { return &identity; }
     };
 
     template<> struct DFHACK_EXPORT identity_traits<std::vector<void*> > {
-        static stl_ptr_vector_identity identity;
-        static stl_ptr_vector_identity *get() { return &identity; }
+        static const stl_ptr_vector_identity identity;
+        static const stl_ptr_vector_identity *get() { return &identity; }
     };
 
     template<> struct DFHACK_EXPORT identity_traits<std::vector<bool> > {
-        static stl_bit_vector_identity identity;
-        static stl_bit_vector_identity *get() { return &identity; }
+        static const stl_bit_vector_identity identity;
+        static const stl_bit_vector_identity *get() { return &identity; }
     };
 
 #undef NUMBER_IDENTITY_TRAITS
@@ -653,73 +653,73 @@ namespace df
 
 #ifdef BUILD_DFHACK_LIB
     template<class Enum, class FT> struct identity_traits<enum_field<Enum,FT> > {
-        static enum_identity *get();
+        static const enum_identity *get();
     };
 #endif
 
     template<class T> struct identity_traits<T *> {
         static const bool is_primitive = true;
-        static pointer_identity *get();
+        static const pointer_identity *get();
     };
 
 #ifdef BUILD_DFHACK_LIB
     template<class T, int sz> struct identity_traits<T [sz]> {
-        static container_identity *get();
+        static const container_identity *get();
     };
 
     template<class T> struct identity_traits<std::vector<T> > {
-        static container_identity *get();
+        static const container_identity *get();
     };
 #endif
 
     template<class T> struct identity_traits<std::vector<T*> > {
-        static stl_ptr_vector_identity *get();
+        static const stl_ptr_vector_identity *get();
     };
 
     // explicit specializations for these two types
     // for availability in plugins
 
     template<> struct identity_traits<std::vector<int32_t> > {
-        static container_identity* get();
+        static const container_identity* get();
     };
 
     template<> struct identity_traits<std::vector<int16_t> > {
-        static container_identity* get();
+        static const container_identity* get();
     };
 
 
 #ifdef BUILD_DFHACK_LIB
     template<class T> struct identity_traits<std::deque<T> > {
-        static container_identity *get();
+        static const container_identity *get();
     };
 
     template<class T> struct identity_traits<std::set<T> > {
-        static container_identity *get();
+        static const container_identity *get();
     };
 
     template<class KT, class T> struct identity_traits<std::map<KT, T>> {
-        static container_identity *get();
+        static const container_identity *get();
     };
 
     template<class KT, class T> struct identity_traits<std::unordered_map<KT, T>> {
-        static container_identity *get();
+        static const container_identity *get();
     };
 
     template<> struct identity_traits<BitArray<int> > {
-        static bit_array_identity identity;
-        static bit_container_identity *get() { return &identity; }
+        static const bit_array_identity identity;
+        static const bit_container_identity *get() { return &identity; }
     };
 
     template<class T> struct identity_traits<BitArray<T> > {
-        static bit_container_identity *get();
+        static const bit_container_identity *get();
     };
 
     template<class T> struct identity_traits<DfArray<T> > {
-        static container_identity *get();
+        static const container_identity *get();
     };
 
     template<class T> struct identity_traits<enum_list_attr<T> > {
-        static container_identity *get();
+        static const container_identity *get();
     };
 #endif
 
@@ -727,97 +727,97 @@ namespace df
 
 #ifdef BUILD_DFHACK_LIB
     template<class Enum, class FT>
-    inline enum_identity *identity_traits<enum_field<Enum,FT> >::get() {
-        static enum_identity identity(identity_traits<Enum>::get(), identity_traits<FT>::get());
+    inline const enum_identity *identity_traits<enum_field<Enum,FT> >::get() {
+        static const enum_identity identity(identity_traits<Enum>::get(), identity_traits<FT>::get());
         return &identity;
     }
 #endif
 
     template<class T>
-    inline pointer_identity *identity_traits<T *>::get() {
-        static pointer_identity identity(identity_traits<T>::get());
+    inline const pointer_identity *identity_traits<T *>::get() {
+        static const pointer_identity identity(identity_traits<T>::get());
         return &identity;
     }
 
 #ifdef BUILD_DFHACK_LIB
     template<class T, int sz>
-    inline container_identity *identity_traits<T [sz]>::get() {
-        static buffer_container_identity identity(sz, identity_traits<T>::get());
+    inline const container_identity *identity_traits<T [sz]>::get() {
+        static const buffer_container_identity identity(sz, identity_traits<T>::get());
         return &identity;
     }
 
     template<class T>
-    inline container_identity *identity_traits<std::vector<T> >::get() {
+    inline const container_identity *identity_traits<std::vector<T> >::get() {
         typedef std::vector<T> container;
-        static stl_container_identity<container> identity("vector", identity_traits<T>::get());
+        static const stl_container_identity<container> identity("vector", identity_traits<T>::get());
         return &identity;
     }
 #endif
 
     template<class T>
-    inline stl_ptr_vector_identity *identity_traits<std::vector<T*> >::get() {
-        static stl_ptr_vector_identity identity(identity_traits<T>::get());
+    inline const stl_ptr_vector_identity *identity_traits<std::vector<T*> >::get() {
+        static const stl_ptr_vector_identity identity(identity_traits<T>::get());
         return &identity;
     }
 
     // explicit specializations for these two types
     // for availability in plugins
 
-    extern DFHACK_EXPORT stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity;
-    inline container_identity* identity_traits<std::vector<int32_t> >::get() {
+    extern const DFHACK_EXPORT stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity;
+    inline const container_identity* identity_traits<std::vector<int32_t> >::get() {
         return &stl_vector_int32_t_identity;
     }
 
-    extern DFHACK_EXPORT stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity;
-    inline container_identity* identity_traits<std::vector<int16_t> >::get() {
+    extern const DFHACK_EXPORT stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity;
+    inline const container_identity* identity_traits<std::vector<int16_t> >::get() {
         return &stl_vector_int16_t_identity;
     }
 
 #ifdef BUILD_DFHACK_LIB
     template<class T>
-    inline container_identity *identity_traits<std::deque<T> >::get() {
+    inline const container_identity *identity_traits<std::deque<T> >::get() {
         typedef std::deque<T> container;
-        static stl_container_identity<container> identity("deque", identity_traits<T>::get());
+        static const stl_container_identity<container> identity("deque", identity_traits<T>::get());
         return &identity;
     }
 
     template<class T>
-    inline container_identity *identity_traits<std::set<T> >::get() {
+    inline const container_identity *identity_traits<std::set<T> >::get() {
         typedef std::set<T> container;
-        static ro_stl_container_identity<container> identity("set", identity_traits<T>::get());
+        static const ro_stl_container_identity<container> identity("set", identity_traits<T>::get());
         return &identity;
     }
 
     template<class KT, class T>
-    inline container_identity *identity_traits<std::map<KT, T>>::get() {
+    inline const container_identity *identity_traits<std::map<KT, T>>::get() {
         typedef std::map<KT, T> container;
-        static ro_stl_assoc_container_identity<container> identity("map", identity_traits<KT>::get(), identity_traits<T>::get());
+        static const ro_stl_assoc_container_identity<container> identity("map", identity_traits<KT>::get(), identity_traits<T>::get());
         return &identity;
     }
 
     template<class KT, class T>
-    inline container_identity *identity_traits<std::unordered_map<KT, T>>::get() {
+    inline const container_identity *identity_traits<std::unordered_map<KT, T>>::get() {
         typedef std::unordered_map<KT, T> container;
-        static ro_stl_assoc_container_identity<container> identity("unordered_map", identity_traits<KT>::get(), identity_traits<T>::get());
+        static const ro_stl_assoc_container_identity<container> identity("unordered_map", identity_traits<KT>::get(), identity_traits<T>::get());
         return &identity;
     }
 
     template<class T>
-    inline bit_container_identity *identity_traits<BitArray<T> >::get() {
-        static bit_array_identity identity(identity_traits<T>::get());
+    inline const bit_container_identity *identity_traits<BitArray<T> >::get() {
+        static const bit_array_identity identity(identity_traits<T>::get());
         return &identity;
     }
 
     template<class T>
-    inline container_identity *identity_traits<DfArray<T> >::get() {
+    inline const container_identity *identity_traits<DfArray<T> >::get() {
         typedef DfArray<T> container;
-        static stl_container_identity<container> identity("DfArray", identity_traits<T>::get());
+        static const stl_container_identity<container> identity("DfArray", identity_traits<T>::get());
         return &identity;
     }
 
     template<class T>
-    inline container_identity *identity_traits<enum_list_attr<T> >::get() {
-        static enum_list_attr_identity<T> identity(identity_traits<T>::get());
+    inline const container_identity *identity_traits<enum_list_attr<T> >::get() {
+        static const enum_list_attr_identity<T> identity(identity_traits<T>::get());
         return &identity;
     }
 #endif

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -381,7 +381,7 @@ namespace df
             : container_identity(sizeof(T), &allocator_fn<T>, item, ienum), name(name)
         {}
 
-        const std::string getFullName(type_identity *item) const {
+        const std::string getFullName(const type_identity *item) const {
             return name + container_identity::getFullName(item);
         }
 

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -112,18 +112,18 @@ namespace DFHack {namespace Lua {
     /**
      * Push the pointer onto the stack as a wrapped DF object of the given type.
      */
-    DFHACK_EXPORT void PushDFObject(lua_State *state, type_identity *type, void *ptr);
+    DFHACK_EXPORT void PushDFObject(lua_State *state, const type_identity *type, void *ptr);
 
     /**
      * Check that the value is a wrapped DF object of the given type, and if so return the pointer.
      */
-    DFHACK_EXPORT void *GetDFObject(lua_State *state, type_identity *type, int val_index, bool exact_type = false);
+    DFHACK_EXPORT void *GetDFObject(lua_State *state, const type_identity *type, int val_index, bool exact_type = false);
 
     /**
      * Check that the value is a wrapped DF object of the given type, and if so return the pointer.
      * Otherwise throw an argument type error.
      */
-    DFHACK_EXPORT void *CheckDFObject(lua_State *state, type_identity *type, int val_index, bool exact_type = false);
+    DFHACK_EXPORT void *CheckDFObject(lua_State *state, const type_identity *type, int val_index, bool exact_type = false);
 
     /**
      * Assign the value at val_index to the target of given identity using df.assign().

--- a/library/include/LuaWrapper.h
+++ b/library/include/LuaWrapper.h
@@ -147,10 +147,10 @@ namespace LuaWrapper {
     /*
      * If is_method is true, these use UPVAL_TYPETABLE to save a hash lookup.
      */
-    void push_object_internal(lua_State *state, type_identity *type, void *ptr, bool in_method = true);
-    void *get_object_internal(lua_State *state, type_identity *type, int val_index, bool exact_type, bool in_method = true);
+    void push_object_internal(lua_State *state, const type_identity *type, void *ptr, bool in_method = true);
+    void *get_object_internal(lua_State *state, const type_identity *type, int val_index, bool exact_type, bool in_method = true);
 
-    void push_adhoc_pointer(lua_State *state, void *ptr, type_identity *target);
+    void push_adhoc_pointer(lua_State *state, void *ptr, const type_identity *target);
 
     /**
      * Verify that the object is a DF ref with UPVAL_METATABLE.
@@ -158,11 +158,11 @@ namespace LuaWrapper {
      */
     DFHACK_EXPORT uint8_t *get_object_addr(lua_State *state, int obj, int field, const char *mode);
 
-    bool is_type_compatible(lua_State *state, type_identity *type1, int meta1,
-                            type_identity *type2, int meta2, bool exact_equal);
+    bool is_type_compatible(lua_State *state, const type_identity *type1, int meta1,
+        const type_identity *type2, int meta2, bool exact_equal);
 
     DFHACK_EXPORT
-    type_identity *get_object_identity(lua_State *state, int objidx,
+    const type_identity *get_object_identity(lua_State *state, int objidx,
                                        const char *ctx, bool allow_type = false,
                                        bool keep_metatable = false);
 
@@ -181,7 +181,7 @@ namespace LuaWrapper {
     /**
      * Make a metatable with most common fields, and an empty table for UPVAL_FIELDTABLE.
      */
-    void MakeMetatable(lua_State *state, type_identity *type, const char *kind);
+    void MakeMetatable(lua_State *state, const type_identity *type, const char *kind);
     /**
      * Enable a metafield by injecting an entry into a UPVAL_FIELDTABLE.
      */
@@ -209,18 +209,18 @@ namespace LuaWrapper {
      */
     void PushContainerMethod(lua_State *state, int meta_idx, int ftable_idx,
                              lua_CFunction function,
-                             type_identity *container, type_identity *item, int count);
+        const type_identity *container, const type_identity *item, int count);
     /**
      * Add a 6 upvalue metamethod to the metatable.
      */
     void SetContainerMethod(lua_State *state, int meta_idx, int ftable_idx,
                             lua_CFunction function, const char *name,
-                            type_identity *container, type_identity *item, int count);
+                            const type_identity *container, const type_identity *item, int count);
     /**
      * If ienum refers to a valid enum, attach its keys to UPVAL_FIELDTABLE,
      * and the enum itself to the _enum metafield. Pushes the key table on the stack.
      */
-    void AttachEnumKeys(lua_State *state, int meta_idx, int ftable_idx, type_identity *ienum);
+    void AttachEnumKeys(lua_State *state, int meta_idx, int ftable_idx, const type_identity *ienum);
 
     /**
      * Push a closure invoking the given function.

--- a/library/include/PluginStatics.h
+++ b/library/include/PluginStatics.h
@@ -18,13 +18,13 @@ namespace DFHack {
 struct DFHACK_EXPORT xlsx_file_handle_identity : public compound_identity {
     xlsx_file_handle_identity()
         :compound_identity(0, nullptr, nullptr, "xlsx_file_handle") {};
-    DFHack::identity_type type() override { return IDTYPE_OPAQUE; }
+    DFHack::identity_type type() const override { return IDTYPE_OPAQUE; }
 };
 
 struct DFHACK_EXPORT xlsx_sheet_handle_identity : public compound_identity {
     xlsx_sheet_handle_identity()
         :compound_identity(0, nullptr, nullptr, "xlsx_sheet_handle") {};
-    DFHack::identity_type type() override { return IDTYPE_OPAQUE; }
+    DFHack::identity_type type() const override { return IDTYPE_OPAQUE; }
 };
 
 struct DFHACK_EXPORT xlsx_file_handle {

--- a/library/include/VTableInterpose.h
+++ b/library/include/VTableInterpose.h
@@ -160,7 +160,7 @@ namespace DFHack
         */
         friend class virtual_identity;
 
-        virtual_identity *host; // Class with the vtable
+        const virtual_identity *host; // Class with the vtable
         int vmethod_idx;        // Index of the interposed method in the vtable
         void *interpose_method; // Pointer to the code of the interposing method
         void *chain_mptr;       // Pointer to the chain field in the subclass below
@@ -173,18 +173,18 @@ namespace DFHack
         // Chain of hooks within the same host
         VMethodInterposeLinkBase *next, *prev;
         // Subclasses that inherit this topmost hook directly
-        std::set<virtual_identity*> child_hosts;
+        std::set<const virtual_identity*> child_hosts;
         // Hooks within subclasses that branch off this topmost hook
         std::set<VMethodInterposeLinkBase*> child_next;
         // (See the cpp file for a more detailed description of these links)
 
         void set_chain(void *chain);
-        void on_host_delete(virtual_identity *host);
+        void on_host_delete(const virtual_identity *host);
 
-        VMethodInterposeLinkBase *get_first_interpose(virtual_identity *id);
-        bool find_child_hosts(virtual_identity *cur, void *vmptr);
+        VMethodInterposeLinkBase *get_first_interpose(const virtual_identity *id);
+        bool find_child_hosts(const virtual_identity *cur, void *vmptr);
     public:
-        VMethodInterposeLinkBase(virtual_identity *host, int vmethod_idx, void *interpose_method, void *chain_mptr, int priority, const char *name);
+        VMethodInterposeLinkBase(const virtual_identity *host, int vmethod_idx, void *interpose_method, void *chain_mptr, int priority, const char *name);
         ~VMethodInterposeLinkBase();
 
         bool is_applied() { return applied; }

--- a/plugins/devel/check-structures-sanity/check-structures-sanity.h
+++ b/plugins/devel/check-structures-sanity/check-structures-sanity.h
@@ -31,16 +31,16 @@ struct QueueItem
 };
 struct CheckedStructure
 {
-    type_identity *identity;
+    const type_identity *identity;
     size_t count;
     size_t allocated_count;
-    enum_identity *eid;
+    const enum_identity *eid;
     bool ptr_is_array;
     bool inside_structure;
 
     CheckedStructure();
-    explicit CheckedStructure(type_identity *, size_t = 0);
-    CheckedStructure(type_identity *, size_t, enum_identity *, bool);
+    explicit CheckedStructure(const type_identity *, size_t = 0);
+    CheckedStructure(const type_identity *, size_t, const enum_identity *, bool);
     CheckedStructure(const struct_field_info *);
 
     size_t full_size() const;
@@ -109,7 +109,7 @@ public:
 
         return *reinterpret_cast<const T *>(item.ptr);
     }
-    int64_t get_int_value(const QueueItem & item, type_identity *type, bool quiet = false);
+    int64_t get_int_value(const QueueItem & item, const type_identity *type, bool quiet = false);
     const char *get_vtable_name(const QueueItem & item, const CheckedStructure & cs, bool quiet = false);
     std::pair<const void *, CheckedStructure> validate_vector_size(const QueueItem & item, const CheckedStructure & cs, bool quiet = false);
     size_t get_allocated_size(const QueueItem & item);
@@ -117,8 +117,8 @@ public:
     // this function doesn't make sense on windows, where std::string is not pointer-sized.
     const std::string *validate_stl_string_pointer(const void *const*);
 #endif
-    static const char *const *get_enum_item_key(enum_identity *identity, int64_t value);
-    static const char *const *get_enum_item_attr_or_key(enum_identity *identity, int64_t value, const char *attr_name);
+    static const char *const *get_enum_item_key(const enum_identity *identity, int64_t value);
+    static const char *const *get_enum_item_attr_or_key(const enum_identity *identity, int64_t value, const char *attr_name);
 
 private:
     color_ostream & fail(int, const QueueItem &, const CheckedStructure &);
@@ -132,7 +132,7 @@ private:
     void dispatch_bitfield(const QueueItem &, const CheckedStructure &);
     void dispatch_enum(const QueueItem &, const CheckedStructure &);
     void dispatch_struct(const QueueItem &, const CheckedStructure &);
-    void dispatch_field(const QueueItem &, const CheckedStructure &, struct_identity *, const struct_field_info *);
+    void dispatch_field(const QueueItem &, const CheckedStructure &, const struct_identity *, const struct_field_info *);
     void dispatch_class(const QueueItem &, const CheckedStructure &);
     void dispatch_buffer(const QueueItem &, const CheckedStructure &);
     void dispatch_stl_ptr_vector(const QueueItem &, const CheckedStructure &);
@@ -140,15 +140,15 @@ private:
     void dispatch_tagged_union_vector(const QueueItem &, const QueueItem &, const CheckedStructure &, const CheckedStructure &, const char *);
     void dispatch_untagged_union(const QueueItem &, const CheckedStructure &);
     void check_unknown_pointer(const QueueItem &);
-    void check_stl_vector(const QueueItem &, type_identity *, type_identity *);
+    void check_stl_vector(const QueueItem &, const type_identity *, const type_identity *);
     void check_stl_string(const QueueItem &);
-    void check_stl_map(const QueueItem &, container_identity *);
-    void check_stl_unordered_map(const QueueItem &, container_identity *);
+    void check_stl_map(const QueueItem &, const container_identity *);
+    void check_stl_unordered_map(const QueueItem &, const container_identity *);
     void check_possible_pointer(const QueueItem &, const CheckedStructure &);
 
     friend struct CheckedStructure;
-    static type_identity *wrap_in_pointer(type_identity *);
-    static type_identity *wrap_in_stl_ptr_vector(type_identity *);
+    static const type_identity *wrap_in_pointer(const type_identity *);
+    static const type_identity *wrap_in_stl_ptr_vector(const type_identity *);
 };
 
 #define FAIL(message) \

--- a/plugins/devel/check-structures-sanity/types.cpp
+++ b/plugins/devel/check-structures-sanity/types.cpp
@@ -18,11 +18,11 @@ CheckedStructure::CheckedStructure() :
     CheckedStructure(nullptr, 0)
 {
 }
-CheckedStructure::CheckedStructure(type_identity *identity, size_t count) :
+CheckedStructure::CheckedStructure(const type_identity *identity, size_t count) :
     CheckedStructure(identity, count, nullptr, false)
 {
 }
-CheckedStructure::CheckedStructure(type_identity *identity, size_t count, enum_identity *eid, bool inside_structure) :
+CheckedStructure::CheckedStructure(const type_identity *identity, size_t count, const enum_identity *eid, bool inside_structure) :
     identity(identity),
     count(count),
     allocated_count(0),
@@ -122,11 +122,11 @@ bool CheckedStructure::has_type_at_offset(const CheckedStructure & type, size_t 
 
     if (identity->type() == IDTYPE_BUFFER)
     {
-        auto target = static_cast<container_identity *>(identity)->getItemType();
+        auto target = static_cast<const container_identity *>(identity)->getItemType();
         return CheckedStructure(target, 0).has_type_at_offset(type, offset % target->byte_size());
     }
 
-    auto st = dynamic_cast<struct_identity *>(identity);
+    auto st = dynamic_cast<const struct_identity *>(identity);
     if (!st)
     {
         return false;
@@ -154,9 +154,9 @@ bool CheckedStructure::has_type_at_offset(const CheckedStructure & type, size_t 
     return false;
 }
 
-type_identity *Checker::wrap_in_stl_ptr_vector(type_identity *base)
+const type_identity *Checker::wrap_in_stl_ptr_vector(const type_identity *base)
 {
-    static std::map<type_identity *, std::unique_ptr<df::stl_ptr_vector_identity>> wrappers;
+    static std::map<const type_identity *, std::unique_ptr<const df::stl_ptr_vector_identity>> wrappers;
     auto it = wrappers.find(base);
     if (it != wrappers.end())
     {
@@ -165,15 +165,15 @@ type_identity *Checker::wrap_in_stl_ptr_vector(type_identity *base)
     return (wrappers[base] = std::make_unique<df::stl_ptr_vector_identity>(base, nullptr)).get();
 }
 
-type_identity *Checker::wrap_in_pointer(type_identity *base)
+const type_identity *Checker::wrap_in_pointer(const type_identity *base)
 {
-    static std::map<type_identity *, std::unique_ptr<df::pointer_identity>> wrappers;
+    static std::map<const type_identity *, std::unique_ptr<const df::pointer_identity>> wrappers;
     auto it = wrappers.find(base);
     if (it != wrappers.end())
     {
         return it->second.get();
     }
-    return (wrappers[base] = std::make_unique<df::pointer_identity>(base)).get();
+    return (wrappers[base] = std::make_unique<const df::pointer_identity>(base)).get();
 }
 
 std::map<size_t, std::vector<std::string>> known_types_by_size;

--- a/plugins/devel/check-structures-sanity/validate.cpp
+++ b/plugins/devel/check-structures-sanity/validate.cpp
@@ -105,7 +105,7 @@ bool Checker::is_valid_dereference(const QueueItem & item, const CheckedStructur
 #undef FAIL_PTR
 }
 
-int64_t Checker::get_int_value(const QueueItem & item, type_identity *type, bool quiet)
+int64_t Checker::get_int_value(const QueueItem & item, const type_identity *type, bool quiet)
 {
     if (type == df::identity_traits<int32_t>::get())
     {
@@ -388,12 +388,12 @@ const std::string *Checker::validate_stl_string_pointer(const void *const* base)
 }
 #endif
 
-const char *const *Checker::get_enum_item_key(enum_identity *identity, int64_t value)
+const char *const *Checker::get_enum_item_key(const enum_identity *identity, int64_t value)
 {
     return get_enum_item_attr_or_key(identity, value, nullptr);
 }
 
-const char *const *Checker::get_enum_item_attr_or_key(enum_identity *identity, int64_t value, const char *attr_name)
+const char *const *Checker::get_enum_item_attr_or_key(const enum_identity *identity, int64_t value, const char *attr_name)
 {
     size_t index;
     if (auto cplx = identity->getComplex())


### PR DESCRIPTION
This PR marks all of the core data identity classes as `const` to reflect that these types are effectively immutable. 

As noted elsewhere, `compound_identity` has a small degree of technical mutability due to lazy initialization, and `virtual_identity` has mutability due to its dual purpose for implementing vtable interposes; these are both accommodated by marking the related class members as `mutable`. This results in some `const_cast`s, in the `compound_identity` and `struct_identity` constructors, and in a couple of places in code related to virtual identities. There are also several `const_cast`s associated with storing type identity pointers into Lua metatables and lightuserdata objects, which are downcasts into `void*` and thus have to be `const_cast`ed to maintain correctness. Some of these are arguably code smells arguing for a redesign of the code in question, but that's for a future PR.

I also rewrote a couple of methods in `VMethodInterposeLinkBase` to avoid using `map::operator[]` (because the latter breaks `const`ness); this has the side effect that searching for a vmethod by index will no longer insert an empty pointer into a virtual class's vtable interpose map on a lookup for a previously undefined index.

While these changes will enable making a significant fraction of `data_identity` instances `constinit` or `constexpr` (which has advantages in terms of more predictable static initialization, faster startup, and possibly other optimizations), such changes are not included in this PR.