### PR TITLE
add a few missing const specifiers

### DIFF
--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -333,7 +333,7 @@ namespace DFHack
                 compound_identity *scope_parent, const char *dfhack_name,
                 struct_identity *parent, const struct_field_info *fields);
 
-        virtual identity_type type() { return IDTYPE_UNION; }
+        virtual identity_type type() const { return IDTYPE_UNION; }
 
         virtual void build_metatable(lua_State *state) const;
     };

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -473,7 +473,7 @@ namespace df
             : bit_container_identity(sizeof(container), &allocator_fn<container>, ienum)
         {}
 
-        const std::string getFullName(type_identity *item) const {
+        virtual const std::string getFullName(const type_identity *item) const {
             return "BitArray<>";
         }
 


### PR DESCRIPTION
that were causing warnings/errors on gcc 13.2

ref: https://github.com/DFHack/dfhack/pull/4702