### PR TITLE
add option to ``unsuspend`` that unsuspends all construction jobs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -82,7 +82,7 @@ Template for new versions:
 - `autobutcher`: do not butcher pregnant (or brooding) females
 - `quickfort`: support buildable instruments
 - `nestboxes`: increase the scanning frequency for fertile eggs to reduce the chance that they get snarfed by eager dwarves
-- `suspendmanager`: add option to ``unsuspend`` that unsuspends all construction jobs
+- `suspendmanager`: add option to ``unsuspend`` that unsuspends all jobs, regardless of potential issues
 
 ## Documentation
 - `installing`: add instructions for how to use Steam DFHack with non-Steam DF (for DFHack auto-updates and cloud backups)

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -82,6 +82,7 @@ Template for new versions:
 - `autobutcher`: do not butcher pregnant (or brooding) females
 - `quickfort`: support buildable instruments
 - `nestboxes`: increase the scanning frequency for fertile eggs to reduce the chance that they get snarfed by eager dwarves
+- `suspendmanager`: add option to ``unsuspend`` that unsuspends all construction jobs
 
 ## Documentation
 - `installing`: add instructions for how to use Steam DFHack with non-Steam DF (for DFHack auto-updates and cloud backups)

--- a/docs/plugins/suspendmanager.rst
+++ b/docs/plugins/suspendmanager.rst
@@ -32,7 +32,7 @@ Usage
 ``suspendmanager set preventblocking (true|false)``
     Prevent construction jobs from blocking each others (enabled by default). See `suspend`.
 
-``unsuspend [-s|--skipblocking] [-q|--quiet]``
+``unsuspend [-s|--skipblocking] [-q|--quiet] [-f|--force]``
     Perform a single cycle, suspending and unsuspending jobs as described above,
     regardless of whether `suspendmanager` is enabled.
 
@@ -48,6 +48,10 @@ Options
 
 ``-s``, ``--skipblocking``
     Also resume jobs that may block other jobs.
+
+``-f``, ``--force``
+    Resume all construction jobs, even if they are submerged or will collapse on
+    completion; implies ``--skipblocking``.
 
 Overlay
 -------

--- a/plugins/lua/suspendmanager.lua
+++ b/plugins/lua/suspendmanager.lua
@@ -26,21 +26,22 @@ function isBuildingPlanJob(job)
     return suspendmanager_isBuildingPlanJob(job)
 end
 
-function runOnce(prevent_blocking, quiet)
-    suspendmanager_runOnce(prevent_blocking)
+function runOnce(prevent_blocking, quiet, unsuspend_everything)
+    suspendmanager_runOnce(prevent_blocking, unsuspend_everything)
     if (not quiet) then
         print(suspendmanager_getStatus())
     end
 end
 
 function unsuspend_command(...)
-    local quiet, skipblocking = false, false
+    local quiet, skipblocking, unsuspend_everything = false, false, false
     argparse.processArgsGetopt({ ... }, {
         { 'q', 'quiet',        handler = function() quiet = true end },
         { 's', 'skipblocking', handler = function() skipblocking = true end },
+        { 'f', 'force', handler = function() unsuspend_everything = true end },
     })
 
-    runOnce(not skipblocking, quiet)
+    runOnce(not skipblocking, quiet, unsuspend_everything)
 end
 
 

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -684,8 +684,13 @@ public:
         DEBUG(cycle,out).print("finished refresh: found %zu reasons for suspension\n",suspensions.size());
     }
 
-    void do_cycle (color_ostream &out) {
-        refresh(out);
+    void do_cycle (color_ostream &out, bool unsuspend_everything = false)
+    {
+        if (unsuspend_everything){
+            suspensions.clear();
+        } else {
+            refresh(out);
+        }
         num_suspend = 0, num_unsuspend = 0;
 
         Reason reason;
@@ -904,6 +909,7 @@ static command_result do_command(color_ostream &out, vector<string> &parameters)
 }
 
 static command_result do_unsuspend_command(color_ostream &out, vector<string> &parameters) {
+    CoreSuspender suspend;
     auto ok = Lua::CallLuaModuleFunction(out, "plugins.suspendmanager", "unsuspend_command", parameters);
     return ok ? CR_OK : CR_FAILURE;
 }
@@ -957,10 +963,10 @@ static bool suspendmanager_isKeptSuspended(df::job *job) {
     }
 }
 
-static void suspendmanager_runOnce(color_ostream &out, bool blocking) {
+static void suspendmanager_runOnce(color_ostream &out, bool blocking, bool unsuspend_everything) {
     auto save = suspendmanager_instance->prevent_blocking;
     suspendmanager_instance->prevent_blocking = blocking;
-    do_cycle(out);
+    suspendmanager_instance->do_cycle(out, unsuspend_everything);
     suspendmanager_instance->prevent_blocking = save;
 }
 


### PR DESCRIPTION
Note 1: also fixes a missing core suspension in `do_unsuspend_command`
Note 2: running `unsuspend` no longer resets the counter for the next regular cycle. Running `unsuspend` while `suspendmanager` is enabled, doesn't make sense anyway.