### PR TITLE
Add painting tiles to the world map port

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2860,6 +2860,34 @@ static int screen_readTile(lua_State *L)
     return 1;
 }
 
+static int screen_paintTileMapPort(lua_State *L)
+{
+    Pen pen;
+    Lua::CheckPen(L, &pen, 1);
+    int x = luaL_checkint(L, 2);
+    int y = luaL_checkint(L, 3);
+    if (lua_gettop(L) >= 4 && !lua_isnil(L, 4))
+    {
+        if (lua_type(L, 4) == LUA_TSTRING)
+            pen.ch = lua_tostring(L, 4)[0];
+        else
+            pen.ch = luaL_checkint(L, 4);
+    }
+    if (lua_gettop(L) >= 5 && !lua_isnil(L, 5))
+        pen.tile = luaL_checkint(L, 5);
+    lua_pushboolean(L, Screen::paintTileMapPort(pen, x, y));
+    return 1;
+}
+
+// static int screen_readTileMapPort(lua_State *L)
+// {
+//     int x = luaL_checkint(L, 1);
+//     int y = luaL_checkint(L, 2);
+//     Pen pen = Screen::readTileMapPort(x, y);
+//     Lua::Push(L, pen);
+//     return 1;
+// }
+
 static int screen_paintString(lua_State *L)
 {
     Pen pen;
@@ -3047,6 +3075,7 @@ static const luaL_Reg dfhack_screen_funcs[] = {
     { "getWindowSize", screen_getWindowSize },
     { "paintTile", screen_paintTile },
     { "readTile", screen_readTile },
+    { "paintTileMapPort", screen_paintTileMapPort },
     { "paintString", screen_paintString },
     { "fillRect", screen_fillRect },
     { "findGraphicsTile", screen_findGraphicsTile },

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -35,6 +35,7 @@ distribution.
 
 #include "df/viewscreen.h"
 #include "df/graphic_viewportst.h"
+#include "df/graphic_map_portst.h"
 
 #include <set>
 #include <memory>
@@ -203,6 +204,12 @@ namespace DFHack
         /// Retrieves one screen tile from the buffer
         DFHACK_EXPORT Pen readTile(int x, int y, bool map = false, int32_t * df::graphic_viewportst::*texpos_field = NULL);
 
+        /// Paint one world map tile with the given pen
+        DFHACK_EXPORT bool paintTileMapPort(const Pen &pen, int x, int y, int32_t * df::graphic_map_portst::*texpos_field = NULL);
+
+        /// Retrieves one world map tile from the buffer
+        // DFHACK_EXPORT Pen readTile(int x, int y, int32_t * df::graphic_map_portst::*texpos_field = NULL);
+
         /// Paint a string onto the screen. Ignores ch and tile of pen.
         DFHACK_EXPORT bool paintString(const Pen &pen, int x, int y, const std::string &text, bool map = false);
 
@@ -315,6 +322,8 @@ namespace DFHack
         namespace Hooks {
             GUI_HOOK_DECLARE(get_tile, Pen, (int x, int y, bool map, int32_t * df::graphic_viewportst::*texpos_field));
             GUI_HOOK_DECLARE(set_tile, bool, (const Pen &pen, int x, int y, bool map, int32_t * df::graphic_viewportst::*texpos_field));
+            // GUI_HOOK_DECLARE(get_tile_map_port, Pen, (int x, int y, int32_t * df::graphic_map_portst::*texpos_field));
+            GUI_HOOK_DECLARE(set_tile_map_port, bool, (const Pen &pen, int x, int y, int32_t * df::graphic_map_portst::*texpos_field));
         }
 
         //! Temporary hide a screen until destructor is called


### PR DESCRIPTION
You are now able to paint world map tiles!

![image](https://github.com/DFHack/dfhack/assets/3470436/1455e289-be0d-4320-b533-8e16aa689f8a)

missing: getTileMapPort

Closes https://github.com/DFHack/dfhack/issues/4703