### PR TITLE
Fix ramp autocorrect and rename surroundings to autocorrect

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -76,7 +76,7 @@ Template for new versions:
 - `regrass`: now accepts numerical IDs for grass raws; ``regrass --list`` replaces ``regrass --plant ""``
 - `tiletypes`: performance improvements when affecting tiles over a large range
 - `tiletypes`: support for heavy aquifers
-- `tiletypes`: new ``surroundings`` property for maintaining valid tile surroundings
+- `tiletypes`: new ``autocorrect`` property for maintaining valid tile surroundings
 - Dreamfort: add a full complement of beds and chests to both barracks
 - Dreamfort: redesign guildhall/temple/library level for better accessibility
 - Dreamfort: walkthough documentation refresh

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -6674,7 +6674,7 @@ tiletypes
   - ``subterranean``: -1, 0, or 1
   - ``skyview``: -1, 0, or 1
   - ``aquifer``: -1, 0, 1, or 2
-  - ``surroundings``: 0 or 1
+  - ``autocorrect``: 0 or 1
   - ``stone_material``: integer material id
   - ``vein_type``: ``df.inclusion_type``
 

--- a/docs/plugins/tiletypes.rst
+++ b/docs/plugins/tiletypes.rst
@@ -149,8 +149,8 @@ The options identify the property of the tile and the value of that property:
     Whether a tile is marked as "Outside". A value of ``0`` means "inside".
 ``aqua``, ``aquifer 0|1|2``
     Whether a tile is marked as an aquifer. A value of ``2`` means "heavy aquifer".
-``surr``, ``surroundings 0|1``
-    Whether the tile's surroundings should be validated, e.g., adding bottoms/tops
+``ac``, ``autocorrect 0|1``
+    Whether the tile's surroundings should be autocorrected, e.g., adding bottoms/tops
     to tiles that span multiple Z levels and updating liquids. A value of ``1``
     means to do so.
 ``stone <stone type>``


### PR DESCRIPTION
Fixes autocorrect leaving ramp tops after erasing ramps.
Renames `surroundings` to `autocorrect`.