### PR TITLE
Jobs and references

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -129,6 +129,8 @@ Template for new versions:
 - ``Units::create``, ``Units::makeown``: new APIs to use bay12-provided entry points for low-level operations
 - ``format_number``: format numbers according to the configured player formatting preference
 - ``Items::remove``: now cancels related jobs and marks the item as hidden and forbidden until it can be garbage collected
+- ``Job::addGeneralRef``: new easy API for creating general references and adding them to a Job
+- ``Job::addWorker``: new API function for assigning a job to unit
 
 ## Lua
 - ``dfhack.gui.getSelectedJob``: can now return the job with a destination under the keyboard cursor (e.g. digging/carving/engraving jobs)

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1290,6 +1290,11 @@ Job module
 
   Cancels a job, cleans up all references to it, and removes it from the world.
 
+* ``dfhack.job.addGeneralRef(job, type, id)``
+
+  Create a general reference of the given type, pointing to the object with the
+  specified id, and add the created general reference to the provided job.
+
 * ``dfhack.job.getGeneralRef(job, type)``
 
   Searches for a general_ref with the given type.
@@ -1311,6 +1316,11 @@ Job module
   Prevent the worker from taking jobs at the specified workshop for the
   specified cooldown period (in ticks). This doesn't decrease the cooldown
   period in any circumstances.
+
+* ``dfhack.job.addWorker(job, unit)``
+
+  Assign the specified job to the provided unit, unless the unit already has an
+  active job. Also cleans up a potential job posting for the provided job.
 
 * ``dfhack.job.removeWorker(job,cooldown)``
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -173,6 +173,7 @@ set(MODULE_HEADERS
     include/modules/Once.h
     include/modules/Persistence.h
     include/modules/Random.h
+    include/modules/References.h
     include/modules/Renderer.h
     include/modules/Screen.h
     include/modules/Textures.h
@@ -202,6 +203,7 @@ set(MODULE_SOURCES
     modules/Once.cpp
     modules/Persistence.cpp
     modules/Random.cpp
+    modules/References.cpp
     modules/Renderer.cpp
     modules/Screen.cpp
     modules/Textures.cpp

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -1862,6 +1862,8 @@ static bool jobItemEqual(const df::job_item *job1, const df::job_item *job2)
 }
 
 static const LuaWrapper::FunctionReg dfhack_job_module[] = {
+    WRAPM(Job,addGeneralRef),
+    WRAPM(Job,addWorker),
     WRAPM(Job,attachJobItem),
     WRAPM(Job,cloneJobStruct),
     WRAPM(Job,printItemDetails),

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -50,6 +50,10 @@ namespace DFHack
     class color_ostream;
 
     namespace Job {
+
+        // add a general reference with the specified general type and id
+        DFHACK_EXPORT bool addGeneralRef(df::job *job, df::general_ref_type type, int32_t id);
+
         // Duplicate the job structure. It is not linked into any DF lists.
         DFHACK_EXPORT df::job *cloneJobStruct(df::job *job, bool keepEverything=false);
 
@@ -66,6 +70,9 @@ namespace DFHack
         DFHACK_EXPORT df::unit *getWorker(df::job *job);
 
         DFHACK_EXPORT void setJobCooldown(df::building *workshop, df::unit *worker, int cooldown = 100);
+
+        // assign the job to a worker, clearing up the job posting (if it exists)
+        DFHACK_EXPORT bool addWorker(df::job *job, df::unit *unit);
         DFHACK_EXPORT bool removeWorker(df::job *job, int cooldown = 100);
 
         // This helpful method only removes the backref from the item to the job, but it doesn't

--- a/library/include/modules/References.h
+++ b/library/include/modules/References.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "df/general_ref.h"
+
+namespace DFHack
+{
+    namespace References {
+        df::general_ref *createGeneralRef(df::general_ref_type type);
+    }
+}

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -35,6 +35,7 @@ distribution.
 #include "modules/Job.h"
 #include "modules/Materials.h"
 #include "modules/Items.h"
+#include "modules/References.h"
 
 #include "df/building.h"
 #include "df/general_ref.h"
@@ -270,6 +271,17 @@ void DFHack::Job::printJobDetails(color_ostream &out, df::job *job)
         printItemDetails(out, job->job_items.elements[i], i);
 }
 
+bool Job::addGeneralRef(df::job *job, df::general_ref_type type, int32_t id)
+{
+    auto ref = References::createGeneralRef(type);
+    if (!ref)
+        return false;
+    ref->setID(id);
+    job->general_refs.push_back(ref);
+    return true;
+}
+
+
 df::general_ref *Job::getGeneralRef(df::job *job, df::general_ref_type type)
 {
     CHECK_NULL_POINTER(job);
@@ -407,6 +419,24 @@ bool DFHack::Job::removeJob(df::job* job) {
     volatile auto cancel_job_method = &df::job_handler::cancel_job;
     (world->jobs.*cancel_job_method)(job);
 
+    return true;
+}
+
+bool DFHack::Job::addWorker(df::job *job, df::unit *unit){
+    CHECK_NULL_POINTER(job);
+    CHECK_NULL_POINTER(unit);
+
+    if (unit->job.current_job)
+        return false;
+
+    if (job->posting_index != -1){
+        removePostings(job);
+    }
+
+    if (!addGeneralRef(job, general_ref_type::UNIT_WORKER, unit->id))
+        return false;
+    unit->job.current_job = job;
+    job->recheck_cntdn = 0;
     return true;
 }
 

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -273,6 +273,7 @@ void DFHack::Job::printJobDetails(color_ostream &out, df::job *job)
 
 bool Job::addGeneralRef(df::job *job, df::general_ref_type type, int32_t id)
 {
+    CHECK_NULL_POINTER(job)
     auto ref = References::createGeneralRef(type);
     if (!ref)
         return false;
@@ -523,18 +524,20 @@ bool DFHack::Job::removePostings(df::job *job, bool remove_all)
     {
         if (job->posting_index >= 0 && size_t(job->posting_index) < world->jobs.postings.size())
         {
-            world->jobs.postings[job->posting_index]->flags.bits.dead = true;
+            auto posting = world->jobs.postings[job->posting_index];
+            posting->flags.bits.dead = true;
+            posting->job = nullptr;
             removed = true;
         }
     }
     else
     {
-        for (auto it = world->jobs.postings.begin(); it != world->jobs.postings.end(); ++it)
+        for (auto posting : world->jobs.postings)
         {
-            if ((**it).job == job)
+            if (posting->job == job)
             {
-                (**it).job = NULL;
-                (**it).flags.bits.dead = true;
+                posting->flags.bits.dead = true;
+                posting->job = nullptr;
                 removed = true;
             }
         }

--- a/library/modules/References.cpp
+++ b/library/modules/References.cpp
@@ -1,0 +1,225 @@
+#include "modules/References.h"
+
+#include "df/general_ref.h"
+#include "df/general_ref_abstract_buildingst.h"
+#include "df/general_ref_activity_eventst.h"
+#include "df/general_ref_artifact.h"
+#include "df/general_ref_building_cagedst.h"
+#include "df/general_ref_building_chainst.h"
+#include "df/general_ref_building_civzone_assignedst.h"
+#include "df/general_ref_building_destinationst.h"
+#include "df/general_ref_building_display_furniturest.h"
+#include "df/general_ref_building.h"
+#include "df/general_ref_building_holderst.h"
+#include "df/general_ref_building_nest_boxst.h"
+#include "df/general_ref_building_triggerst.h"
+#include "df/general_ref_building_triggertargetst.h"
+#include "df/general_ref_building_use_target_1st.h"
+#include "df/general_ref_building_use_target_2st.h"
+#include "df/general_ref_building_well_tag.h"
+#include "df/general_ref_coinbatch.h"
+#include "df/general_ref_contained_in_itemst.h"
+#include "df/general_ref_contains_itemst.h"
+#include "df/general_ref_contains_unitst.h"
+#include "df/general_ref_creaturest.h"
+#include "df/general_ref_dance_formst.h"
+#include "df/general_ref_entity_art_image.h"
+#include "df/general_ref_entity.h"
+#include "df/general_ref_entity_itemownerst.h"
+#include "df/general_ref_entity_offeredst.h"
+#include "df/general_ref_entity_popst.h"
+#include "df/general_ref_entity_stolenst.h"
+#include "df/general_ref_feature_layerst.h"
+#include "df/general_ref_historical_eventst.h"
+#include "df/general_ref_historical_figurest.h"
+#include "df/general_ref_interactionst.h"
+#include "df/general_ref_is_artifactst.h"
+#include "df/general_ref_is_nemesisst.h"
+#include "df/general_ref_item.h"
+#include "df/general_ref_item_type.h"
+#include "df/general_ref_knowledge_scholar_flagst.h"
+#include "df/general_ref_languagest.h"
+#include "df/general_ref_locationst.h"
+#include "df/general_ref_mapsquare.h"
+#include "df/general_ref_musical_formst.h"
+#include "df/general_ref_nemesis.h"
+#include "df/general_ref_poetic_formst.h"
+#include "df/general_ref_projectile.h"
+#include "df/general_ref_sitest.h"
+#include "df/general_ref_spherest.h"
+#include "df/general_ref_subregionst.h"
+#include "df/general_ref_type.h"
+#include "df/general_ref_unit_beateest.h"
+#include "df/general_ref_unit_cageest.h"
+#include "df/general_ref_unit_climberst.h"
+#include "df/general_ref_unit_foodreceiverst.h"
+#include "df/general_ref_unit_geldeest.h"
+#include "df/general_ref_unit.h"
+#include "df/general_ref_unit_holderst.h"
+#include "df/general_ref_unit_infantst.h"
+#include "df/general_ref_unit_interrogateest.h"
+#include "df/general_ref_unit_itemownerst.h"
+#include "df/general_ref_unit_kidnapeest.h"
+#include "df/general_ref_unit_milkeest.h"
+#include "df/general_ref_unit_patientst.h"
+#include "df/general_ref_unit_reporteest.h"
+#include "df/general_ref_unit_riderst.h"
+#include "df/general_ref_unit_sheareest.h"
+#include "df/general_ref_unit_slaughtereest.h"
+#include "df/general_ref_unit_suckeest.h"
+#include "df/general_ref_unit_tradebringerst.h"
+#include "df/general_ref_unit_traineest.h"
+#include "df/general_ref_unit_workerst.h"
+#include "df/general_ref_value_levelst.h"
+#include "df/general_ref_written_contentst.h"
+
+using namespace df::enums;
+
+df::general_ref *DFHack::References::createGeneralRef(df::general_ref_type type)
+{
+    switch (type)
+    {
+    case general_ref_type::ARTIFACT:
+        return df::allocate<df::general_ref_artifact>();
+    case general_ref_type::IS_ARTIFACT:
+        return df::allocate<df::general_ref_is_artifactst>();
+    case general_ref_type::NEMESIS:
+        return df::allocate<df::general_ref_nemesis>();
+    case general_ref_type::IS_NEMESIS:
+        return df::allocate<df::general_ref_is_nemesisst>();
+    case general_ref_type::ITEM:
+        return df::allocate<df::general_ref_item>();
+    case general_ref_type::ITEM_TYPE:
+        return df::allocate<df::general_ref_item_type>();
+    case general_ref_type::COINBATCH:
+        return df::allocate<df::general_ref_coinbatch>();
+    case general_ref_type::MAPSQUARE:
+        return df::allocate<df::general_ref_mapsquare>();
+    case general_ref_type::ENTITY_ART_IMAGE:
+        return df::allocate<df::general_ref_entity_art_image>();
+    case general_ref_type::CONTAINS_UNIT:
+        return df::allocate<df::general_ref_contains_unitst>();
+    case general_ref_type::CONTAINS_ITEM:
+        return df::allocate<df::general_ref_contains_itemst>();
+    case general_ref_type::CONTAINED_IN_ITEM:
+        return df::allocate<df::general_ref_contained_in_itemst>();
+    case general_ref_type::PROJECTILE:
+        return df::allocate<df::general_ref_projectile>();
+    case general_ref_type::UNIT:
+        return df::allocate<df::general_ref_unit>();
+    case general_ref_type::UNIT_MILKEE:
+        return df::allocate<df::general_ref_unit_milkeest>();
+    case general_ref_type::UNIT_TRAINEE:
+        return df::allocate<df::general_ref_unit_traineest>();
+    case general_ref_type::UNIT_ITEMOWNER:
+        return df::allocate<df::general_ref_unit_itemownerst>();
+    case general_ref_type::UNIT_TRADEBRINGER:
+        return df::allocate<df::general_ref_unit_tradebringerst>();
+    case general_ref_type::UNIT_HOLDER:
+        return df::allocate<df::general_ref_unit_holderst>();
+    case general_ref_type::UNIT_WORKER:
+        return df::allocate<df::general_ref_unit_workerst>();
+    case general_ref_type::UNIT_CAGEE:
+        return df::allocate<df::general_ref_unit_cageest>();
+    case general_ref_type::UNIT_BEATEE:
+        return df::allocate<df::general_ref_unit_beateest>();
+    case general_ref_type::UNIT_FOODRECEIVER:
+        return df::allocate<df::general_ref_unit_foodreceiverst>();
+    case general_ref_type::UNIT_KIDNAPEE:
+        return df::allocate<df::general_ref_unit_kidnapeest>();
+    case general_ref_type::UNIT_PATIENT:
+        return df::allocate<df::general_ref_unit_patientst>();
+    case general_ref_type::UNIT_INFANT:
+        return df::allocate<df::general_ref_unit_infantst>();
+    case general_ref_type::UNIT_SLAUGHTEREE:
+        return df::allocate<df::general_ref_unit_slaughtereest>();
+    case general_ref_type::UNIT_SHEAREE:
+        return df::allocate<df::general_ref_unit_sheareest>();
+    case general_ref_type::UNIT_SUCKEE:
+        return df::allocate<df::general_ref_unit_suckeest>();
+    case general_ref_type::UNIT_REPORTEE:
+        return df::allocate<df::general_ref_unit_reporteest>();
+    case general_ref_type::BUILDING:
+        return df::allocate<df::general_ref_building>();
+    case general_ref_type::BUILDING_CIVZONE_ASSIGNED:
+        return df::allocate<df::general_ref_building_civzone_assignedst>();
+    case general_ref_type::BUILDING_TRIGGER:
+        return df::allocate<df::general_ref_building_triggerst>();
+    case general_ref_type::BUILDING_TRIGGERTARGET:
+        return df::allocate<df::general_ref_building_triggertargetst>();
+    case general_ref_type::BUILDING_CHAIN:
+        return df::allocate<df::general_ref_building_chainst>();
+    case general_ref_type::BUILDING_CAGED:
+        return df::allocate<df::general_ref_building_cagedst>();
+    case general_ref_type::BUILDING_HOLDER:
+        return df::allocate<df::general_ref_building_holderst>();
+    case general_ref_type::BUILDING_WELL_TAG:
+        return df::allocate<df::general_ref_building_well_tag>();
+    case general_ref_type::BUILDING_USE_TARGET_1:
+        return df::allocate<df::general_ref_building_use_target_1st>();
+    case general_ref_type::BUILDING_USE_TARGET_2:
+        return df::allocate<df::general_ref_building_use_target_2st>();
+    case general_ref_type::BUILDING_DESTINATION:
+        return df::allocate<df::general_ref_building_destinationst>();
+    case general_ref_type::BUILDING_NEST_BOX:
+        return df::allocate<df::general_ref_building_nest_boxst>();
+    case general_ref_type::ENTITY:
+        return df::allocate<df::general_ref_entity>();
+    case general_ref_type::ENTITY_STOLEN:
+        return df::allocate<df::general_ref_entity_stolenst>();
+    case general_ref_type::ENTITY_OFFERED:
+        return df::allocate<df::general_ref_entity_offeredst>();
+    case general_ref_type::ENTITY_ITEMOWNER:
+        return df::allocate<df::general_ref_entity_itemownerst>();
+    case general_ref_type::LOCATION:
+        return df::allocate<df::general_ref_locationst>();
+    case general_ref_type::INTERACTION:
+        return df::allocate<df::general_ref_interactionst>();
+    case general_ref_type::ABSTRACT_BUILDING:
+        return df::allocate<df::general_ref_abstract_buildingst>();
+    case general_ref_type::HISTORICAL_EVENT:
+        return df::allocate<df::general_ref_historical_eventst>();
+    case general_ref_type::SPHERE:
+        return df::allocate<df::general_ref_spherest>();
+    case general_ref_type::SITE:
+        return df::allocate<df::general_ref_sitest>();
+    case general_ref_type::SUBREGION:
+        return df::allocate<df::general_ref_subregionst>();
+    case general_ref_type::FEATURE_LAYER:
+        return df::allocate<df::general_ref_feature_layerst>();
+    case general_ref_type::HISTORICAL_FIGURE:
+        return df::allocate<df::general_ref_historical_figurest>();
+    case general_ref_type::ENTITY_POP:
+        return df::allocate<df::general_ref_entity_popst>();
+    case general_ref_type::CREATURE:
+        return df::allocate<df::general_ref_creaturest>();
+    case general_ref_type::UNIT_RIDER:
+        return df::allocate<df::general_ref_unit_riderst>();
+    case general_ref_type::UNIT_CLIMBER:
+        return df::allocate<df::general_ref_unit_climberst>();
+    case general_ref_type::UNIT_GELDEE:
+        return df::allocate<df::general_ref_unit_geldeest>();
+    case general_ref_type::KNOWLEDGE_SCHOLAR_FLAG:
+        return df::allocate<df::general_ref_knowledge_scholar_flagst>();
+    case general_ref_type::ACTIVITY_EVENT:
+        return df::allocate<df::general_ref_activity_eventst>();
+    case general_ref_type::VALUE_LEVEL:
+        return df::allocate<df::general_ref_value_levelst>();
+    case general_ref_type::LANGUAGE:
+        return df::allocate<df::general_ref_languagest>();
+    case general_ref_type::WRITTEN_CONTENT:
+        return df::allocate<df::general_ref_written_contentst>();
+    case general_ref_type::POETIC_FORM:
+        return df::allocate<df::general_ref_poetic_formst>();
+    case general_ref_type::MUSICAL_FORM:
+        return df::allocate<df::general_ref_musical_formst>();
+    case general_ref_type::DANCE_FORM:
+        return df::allocate<df::general_ref_dance_formst>();
+    case general_ref_type::BUILDING_DISPLAY_FURNITURE:
+        return df::allocate<df::general_ref_building_display_furniturest>();
+    case general_ref_type::UNIT_INTERROGATEE:
+        return df::allocate<df::general_ref_unit_interrogateest>();
+    default:
+        return nullptr;
+    }
+}


### PR DESCRIPTION
This adds a factory for general references and uses it in the `Job` module. Similar `addGeneralRef` wrappers can probably be added to the `Unit` and `Buildings` modules. 