### PR TITLE
[lua] preserve spaces when wrapping text

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -125,6 +125,7 @@ Template for new versions:
 - ``dfhack.formatInt``, ``dfhack.formatFloat``: formats numbers according to the player preferences for number formatting set in `gui/control-panel`
 - ``gui.get_interface_rect``, ``gui.get_interface_frame``: convenience functions for working with scaled interfaces
 - ``overlay``: new attributes: ``fullscreen`` and ``full_interface`` for overlays that need access to the entire screen or the scaled interface area, respectively
+- ``string:wrap``: now preserves inter-word spacing and can return the wrapped lines as a table of strings instead of a single multi-line string
 
 ## Removed
 - `plants`: renamed to `plant`

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3493,12 +3493,20 @@ functions. These are invoked just like standard string functions, e.g.::
   Removes spaces (i.e. everything that matches ``'%s'``) from the start and end
   of a string. Spaces between non-space characters are left untouched.
 
-* ``string:wrap([width])``
+* ``string:wrap([width][, opts])``
 
   Inserts newlines into a string so no individual line exceeds the given width.
   Lines are split at space-separated word boundaries. Any existing newlines are
   kept in place. If a single word is longer than width, it is split over
-  multiple lines. If width is not specified, 72 is used.
+  multiple lines. If ``width`` is not specified, 72 is used. The ``opts``
+  parameter can be a table with the following boolean fields specified::
+
+    :return_as_table: if ``true``, then the function will return a table of
+        strings, with each string representing one wrapped line. Otherwise, a
+        single multi-line string is returned.
+    :keep_trailing_spaces: if ``true``, then spaces at the end of a wrapped
+        line will be kept. Normally, spaces at the end of a wrapped line are
+        elided.
 
 * ``string:escape_pattern()``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3493,7 +3493,7 @@ functions. These are invoked just like standard string functions, e.g.::
   Removes spaces (i.e. everything that matches ``'%s'``) from the start and end
   of a string. Spaces between non-space characters are left untouched.
 
-* ``string:wrap([width][, opts])``
+* ``string:wrap([width[, opts]])``
 
   Inserts newlines into a string so no individual line exceeds the given width.
   Lines are split at space-separated word boundaries. Any existing newlines are

--- a/library/lua/gui/widgets.lua
+++ b/library/lua/gui/widgets.lua
@@ -1870,7 +1870,7 @@ function WrappedLabel:getWrappedText(width)
     if type(text_to_wrap) == 'table' then
         text_to_wrap = table.concat(text_to_wrap, NEWLINE)
     end
-    return text_to_wrap:wrap(width - self.indent)
+    return text_to_wrap:wrap(width - self.indent, {return_as_table=true})
 end
 
 function WrappedLabel:preUpdateLayout()
@@ -1883,7 +1883,7 @@ function WrappedLabel:postComputeFrame()
     local wrapped_text = self:getWrappedText(self.frame_body.width-3)
     if not wrapped_text then return end
     local text = {}
-    for _,line in ipairs(wrapped_text:split(NEWLINE)) do
+    for _,line in ipairs(wrapped_text) do
         table.insert(text, {gap=self.indent, text=line})
         -- a trailing newline will get ignored so we don't have to manually trim
         table.insert(text, NEWLINE)

--- a/test/library/string.lua
+++ b/test/library/string.lua
@@ -62,22 +62,29 @@ end
 function test.wrap()
     expect.eq('', (''):wrap())
     expect.eq('  ', ('  '):wrap())
-    expect.eq('   \n ', ('    '):wrap(3))
-    expect.eq('   \n   \n ', ('       '):wrap(3))
+    expect.eq('\n', ('    '):wrap(3))
+    expect.eq('\n', ('       '):wrap(3))
+
+    expect.eq('', (''):wrap(3, {keep_trailing_spaces=true}))
+    expect.eq('  ', ('  '):wrap(3, {keep_trailing_spaces=true}))
+    expect.eq('   \n ', ('    '):wrap(3, {keep_trailing_spaces=true}))
+    expect.eq('   \n   \n ', ('       '):wrap(3, {keep_trailing_spaces=true}))
 
     expect.eq('hello world', ('hello world'):wrap(20))
     expect.eq('hello   world', ('hello   world'):wrap(20))
     expect.eq('  hello world  ', ('  hello world  '):wrap(20))
     expect.eq('  hello   world  ', ('  hello   world  '):wrap(20))
     expect.eq('hello world \nhow are you?',('hello world how are you?'):wrap(12))
-    expect.eq('hello\n \nworld', ('hello world'):wrap(5))
-    expect.eq('hello\n     \n   \nworld', ('hello        world'):wrap(5))
-    expect.eq('  \nhello\n  \nworld\n  ', ('  hello  world  '):wrap(5))
+    expect.eq('hello\nworld', ('hello world'):wrap(5))
+    expect.eq('hello\nworld', ('hello        world'):wrap(5))
+    expect.eq('  \nhello\nworld', ('  hello  world  '):wrap(5))
     expect.eq('hello \nworld', ('hello world'):wrap(8))
     expect.eq('hel\nlo \nwor\nld', ('hello world'):wrap(3))
-    expect.eq('hel\nloo\n  \nwor\nldo', ('helloo  worldo'):wrap(3))
+    expect.eq('hel\nloo\nwor\nldo', ('helloo  worldo'):wrap(3))
 
-    expect.table_eq({'hel', 'lo ', 'wor', 'ld'}, ('hello world'):wrap(3, true))
+    expect.eq('hel\nloo\n  \nwor\nldo', ('helloo  worldo'):wrap(3, {keep_trailing_spaces=true}))
+
+    expect.table_eq({'hel', 'lo ', 'wor', 'ld'}, ('hello world'):wrap(3, {return_as_table=true}))
 
     expect.error_match('expected width > 0', function() ('somestr'):wrap(0) end)
 end

--- a/test/library/string.lua
+++ b/test/library/string.lua
@@ -60,15 +60,24 @@ function test.trim()
 end
 
 function test.wrap()
+    expect.eq('', (''):wrap())
+    expect.eq('  ', ('  '):wrap())
+    expect.eq('   \n ', ('    '):wrap(3))
+    expect.eq('   \n   \n ', ('       '):wrap(3))
+
     expect.eq('hello world', ('hello world'):wrap(20))
     expect.eq('hello   world', ('hello   world'):wrap(20))
-    expect.eq('hello world\nhow are you?',('hello world how are you?'):wrap(12))
-    expect.eq('hello\nworld', ('hello world'):wrap(5))
-    expect.eq('hello\nworld', ('hello        world'):wrap(5))
-    expect.eq('hello\nworld', ('hello world'):wrap(8))
-    expect.eq('hel\nlo\nwor\nld', ('hello world'):wrap(3))
-    expect.eq('hel\nloo\nwor\nldo', ('helloo  worldo'):wrap(3))
-    expect.eq('', (''):wrap())
+    expect.eq('  hello world  ', ('  hello world  '):wrap(20))
+    expect.eq('  hello   world  ', ('  hello   world  '):wrap(20))
+    expect.eq('hello world \nhow are you?',('hello world how are you?'):wrap(12))
+    expect.eq('hello\n \nworld', ('hello world'):wrap(5))
+    expect.eq('hello\n     \n   \nworld', ('hello        world'):wrap(5))
+    expect.eq('  \nhello\n  \nworld\n  ', ('  hello  world  '):wrap(5))
+    expect.eq('hello \nworld', ('hello world'):wrap(8))
+    expect.eq('hel\nlo \nwor\nld', ('hello world'):wrap(3))
+    expect.eq('hel\nloo\n  \nwor\nldo', ('helloo  worldo'):wrap(3))
+
+    expect.table_eq({'hel', 'lo ', 'wor', 'ld'}, ('hello world'):wrap(3, true))
 
     expect.error_match('expected width > 0', function() ('somestr'):wrap(0) end)
 end


### PR DESCRIPTION
to better serve use cases like `gui/journal`: https://github.com/DFHack/scripts/pull/1208

defaults to a behavior that won't change wrapping for current WrappedText widgets