### PR TITLE
track unpaused FPS for more accurate FPS measurements

### DIFF
--- a/library/DataDefs.cpp
+++ b/library/DataDefs.cpp
@@ -304,7 +304,7 @@ virtual_identity *virtual_identity::get(virtual_ptr instance_ptr)
 
 virtual_identity *virtual_identity::find(void *vtable)
 {
-    if (!vtable)
+    if (!vtable || !known_mutex)
         return NULL;
 
     // Actually, a reader/writer lock would be sufficient,

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3399,6 +3399,11 @@ static void recordZScreenRuntime(string name, uint32_t start_ms) {
     counters.incCounter(counters.zscreen_per_focus[name.c_str()], start_ms);
 }
 
+static uint32_t getUnpausedFps() {
+    auto & counters = Core::getInstance().perf_counters;
+    return counters.getUnpausedFps();
+}
+
 static void setPreferredNumberFormat(color_ostream & out, int32_t type_int) {
     NumberFormatType type = (NumberFormatType)type_int;
     switch (type) {
@@ -3439,6 +3444,7 @@ static const LuaWrapper::FunctionReg dfhack_internal_module[] = {
     WRAP(resetPerfCounters),
     WRAP(recordRepeatRuntime),
     WRAP(recordZScreenRuntime),
+    WRAP(getUnpausedFps),
     WRAP(setPreferredNumberFormat),
     { NULL, NULL }
 };

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -126,8 +126,18 @@ namespace DFHack
         // noop if game is paused and getIgnorePauseState() returns false
         void incCounter(uint32_t &perf_counter, uint32_t baseline_ms);
 
+        void registerTick(uint32_t baseline_ms);
+        uint32_t getUnpausedFps();
+
     private:
         bool ignore_pause_state = false;
+
+        static const size_t RECENT_TICKS_HISTORY_SIZE = 1000;
+        uint32_t last_tick_baseline_ms;
+        uint32_t recent_ticks_ms[RECENT_TICKS_HISTORY_SIZE];
+        size_t recent_ticks_head_idx;
+        bool recent_ticks_full;
+        uint32_t recent_ticks_sum_ms;
     };
 
     class DFHACK_EXPORT StateChangeScript

--- a/library/modules/World.cpp
+++ b/library/modules/World.cpp
@@ -25,6 +25,8 @@ distribution.
 
 #include "Internal.h"
 
+#include "modules/Gui.h"
+#include "modules/Translation.h"
 #include "modules/Units.h"
 #include "modules/World.h"
 
@@ -34,6 +36,7 @@ distribution.
 #include "df/map_block.h"
 #include "df/nemesis_record.h"
 #include "df/plotinfost.h"
+#include "df/viewscreen_dwarfmodest.h"
 #include "df/world.h"
 #include "df/world_data.h"
 #include "df/world_site.h"
@@ -53,6 +56,12 @@ bool World::ReadPauseState()
 
     if (!pause_state || !plotinfo || !game || !world)
         return false;
+
+    // count single stepping as paused
+    if (World::isFortressMode()) {
+        if (auto scr = Gui::getViewscreenByType<df::viewscreen_dwarfmodest>(0); scr && scr->keyRepeat)
+            return true;
+    }
 
     return *pause_state ||
         (plotinfo->main.mode != df::ui_sidebar_mode::Default &&


### PR DESCRIPTION
in service of `timestream`