### PR TITLE
Add simulate support for mouse middle btn and "*DOWN" mouse btn events

### DIFF
--- a/docs/about/Authors.rst
+++ b/docs/about/Authors.rst
@@ -171,6 +171,7 @@ PopnROFL                PopnROFL
 potato
 ppaawwll                ppaawwll                🐇🐇🐇🐇
 Priit Laes              plaes
+psychowico              wiktor-obrebski
 Putnam                  Putnam3145
 quarque2                quarque2
 Quietust                quietust                _Q

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -46,10 +46,10 @@ end
 local MOUSE_KEYS = {
     _MOUSE_L = curry(set_and_get_undo, 'mouse_lbut'),
     _MOUSE_R = curry(set_and_get_undo, 'mouse_rbut'),
-    _MOUSE_M = true,
-    _MOUSE_L_DOWN = true,
-    _MOUSE_R_DOWN = true,
-    _MOUSE_M_DOWN = true,
+    _MOUSE_M = curry(set_and_get_undo, 'mouse_mbut'),
+    _MOUSE_L_DOWN = curry(set_and_get_undo, 'mouse_lbut_down'),
+    _MOUSE_R_DOWN = curry(set_and_get_undo, 'mouse_rbut_down'),
+    _MOUSE_M_DOWN = curry(set_and_get_undo, 'mouse_mbut_down'),
 }
 
 local FAKE_INPUT_KEYS = copyall(MOUSE_KEYS)


### PR DESCRIPTION
Add support for `_MOUSE_L_DOWN`, `_MOUSE_R_DOWN`, `_MOUSE_M_DOWN` and `_MOUSE_M` to `simulateInput` function.

Withot it, it is impossible to test some of gui scripts (e.g. journal) in integration way, as only `_MOUSE_L` and `_MOUSE_R` inputs are working with `gui.simulateInput` right now.

The same table (`MOUSE_KEYS`) is also used on `ZScreen:onInput`. I am not sure if this can affect it negatively somehow.