### PR TITLE
allow ZScreens to start unfocused

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 ## API
 
 ## Lua
+- ``ZScreen``: new ``defocused`` property for starting screens without keyboard focus
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4861,6 +4861,10 @@ ZScreen subclasses can set the following attributes:
   of the screen other than the tool window. If the player clicks on a different
   ZScreen window, focus still transfers to that other ZScreen.
 
+* ``defocused`` (default: ``false``)
+
+  Whether the ZScreen starts in a defocused state.
+
 * ``initial_pause`` (default: ``DEFAULT_INITIAL_PAUSE or not pass_mouse_clicks``)
 
   Whether to pause the game when the ZScreen is shown. If not explicitly set,

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -1007,6 +1007,7 @@ ZScreen = defclass(ZScreen, Screen)
 ZScreen.ATTRS{
     defocusable=true,
     initial_pause=DEFAULT_NIL,
+    defocused=false,
     force_pause=false,
     pass_pause=true,
     pass_movement_keys=false,
@@ -1028,7 +1029,6 @@ function ZScreen:init()
     if self.initial_pause and dfhack.isMapLoaded() then
         df.global.pause_state = true
     end
-    self.defocused = false
 end
 
 function ZScreen:dismiss()


### PR DESCRIPTION
useful for `open-legends` where we *don't* want the ZScreen to immediately capture keyboard focus