### PR TITLE
[docs] don't expand clean to cleaners

### DIFF
--- a/docs/plugins/add-spatter.rst
+++ b/docs/plugins/add-spatter.rst
@@ -11,7 +11,7 @@ automatically enables itself when you load a world with reactions that include
 names starting with ``SPATTER_ADD_``, so there are no commands to run to use it.
 These reactions will then produce contaminants on items instead of improvements.
 The contaminants are immune to being washed away by water or destroyed by
-`clean`.
+`clean <cleaners>`.
 
 You must have a mod installed that adds the appropriate tokens in order for this
 plugin to do anything.

--- a/docs/plugins/cleaners.rst
+++ b/docs/plugins/cleaners.rst
@@ -33,8 +33,8 @@ includes hostiles, and that cleaning items removes poisons from weapons.
 
 ``spotclean`` works like ``clean map snow mud``, removing all contaminants from
 the tile under the keyboard cursor. This is ideal if you just want to clean a
-specific tile but don't want the `clean` command to remove all the glorious
-blood from your entranceway.
+specific tile but don't want the `clean <cleaners>` command to remove all the
+glorious blood from your entranceway.
 
 Mud will not be cleaned out from under farm plots, since that would render the
 plot inoperable.


### PR DESCRIPTION
why is the plugin named cleaners?