### PR TITLE
ensure that `DFLinkedList` iterators satisfy std::bidirectional_iterator

### DIFF
--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -696,9 +696,8 @@ public:
         Reason reason;
 
 
-        for (auto job : df::global::world->jobs.list) {
-            if (!isConstructionJob(job)) continue;
-
+        for (auto job : df::global::world->jobs.list | std::views::filter(isConstructionJob))
+        {
             if (job->flags.bits.suspend && !suspensions.contains(job->id)) {
                 unsuspend(job); // suspended for no reason
                 ++num_unsuspend;


### PR DESCRIPTION
This makes `DFLinkedList` compatible with `std::ranges`.

I removed the `proxy` class. I could not find any use of this class outside of the files touched by this PR. 

I kept the editing functionality (e.g. `insert` and friends) , even though they are currently not used. This opens the possibility to implement existing list editing functionality from `MiscUtils.h` using iterators.

fixes: #4318 