### PR TITLE
Remove MapCache dependency for Items module

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,7 @@ Template for new versions:
 - ``Units::isVisible``: account for units in cages
 - ``Units::isHidingCurse``: don't check ``hunt_target``, which is obsolete
 - ``Units::getReadableName``: correct display of ghost+curse names w/r/t each other and unit prof, use ``curse.name`` instead of iterating syndrome name effects
+- `autodump`: allow dumping on mid-air hatches and floor bars/grates.
 
 ## Misc Improvements
 - `tweak`: improve performance of ``adamantine-cloth-wear`` tweak
@@ -74,6 +75,7 @@ Template for new versions:
 - ``Units::getRaceChildName``, ``getRaceChildNameById``, ``getRaceBabyName``, ``getRaceBabyNameById``: bool ``plural`` to get plural form
 - ``Units::getProfessionName``: bool ``land_title`` to append "of Sitename" where applicable, use Prisoner/Slave and noble spouse titles (controlled by ``ignore_noble``)
 - `plant`: detect trees via branches/leaves for cuboid selection
+- ``Items``: module no longer dependent on MapCache. No longer need to pass MapCache parameter to ``moveToGround``, ``moveToContainer``, ``moveToBuilding``, ``moveToInventory``, ``makeProjectile``, or ``Items::remove``
 
 ## Documentation
 - ``Units.h``: more comments on what each fn does

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,7 +63,7 @@ Template for new versions:
 - ``Units::isVisible``: account for units in cages
 - ``Units::isHidingCurse``: don't check ``hunt_target``, which is obsolete
 - ``Units::getReadableName``: correct display of ghost+curse names w/r/t each other and unit prof, use ``curse.name`` instead of iterating syndrome name effects
-- `autodump`: allow dumping on mid-air hatches and floor bars/grates.
+- `autodump`: cancel active job on dumped items
 
 ## Misc Improvements
 - `tweak`: improve performance of ``adamantine-cloth-wear`` tweak
@@ -76,6 +76,7 @@ Template for new versions:
 - ``Units::getProfessionName``: bool ``land_title`` to append "of Sitename" where applicable, use Prisoner/Slave and noble spouse titles (controlled by ``ignore_noble``)
 - `plant`: detect trees via branches/leaves for cuboid selection
 - ``Items``: module no longer dependent on MapCache. No longer need to pass MapCache parameter to ``moveToGround``, ``moveToContainer``, ``moveToBuilding``, ``moveToInventory``, ``makeProjectile``, or ``Items::remove``
+- `autodump`: allow dumping items into air, converting into projectile like ``gui/autodump``
 
 ## Documentation
 - ``Units.h``: more comments on what each fn does

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -75,7 +75,6 @@ Template for new versions:
 - ``Units::getRaceChildName``, ``getRaceChildNameById``, ``getRaceBabyName``, ``getRaceBabyNameById``: bool ``plural`` to get plural form
 - ``Units::getProfessionName``: bool ``land_title`` to append "of Sitename" where applicable, use Prisoner/Slave and noble spouse titles (controlled by ``ignore_noble``)
 - `plant`: detect trees via branches/leaves for cuboid selection
-- ``Items``: module no longer dependent on MapCache. No longer need to pass MapCache parameter to ``moveToGround``, ``moveToContainer``, ``moveToBuilding``, ``moveToInventory``, ``makeProjectile``, or ``Items::remove``
 - `autodump`: allow dumping items into air, converting into projectile like ``gui/autodump``
 
 ## Documentation
@@ -90,6 +89,7 @@ Template for new versions:
 - ``Units::getCasteRaw``: get a caste_raw from a unit or race and caste
 - ``cuboid``: construct from ``df::map_block*``, ``forBlock`` iterator to access map blocks in cuboid
 - ``cuboid``: ``clamp(cuboid other)``, ``clampNew(cuboid other)`` for cuboid intersection. ``clampNew`` returns new cuboid instead of modifying.
+- ``Items``: module no longer dependent on MapCache. No longer need to pass MapCache parameter to ``moveToGround``, ``moveToContainer``, ``moveToBuilding``, ``moveToInventory``, ``makeProjectile``, or ``Items::remove``
 
 ## Lua
 - ``ZScreen``: new ``defocused`` property for starting screens without keyboard focus

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -94,6 +94,7 @@ Template for new versions:
 ## Lua
 - ``ZScreen``: new ``defocused`` property for starting screens without keyboard focus
 - ``dfhack.units``: allow historical figures to be passed instead of units for ``getReadableName``, ``getVisibleName``, and ``getProfessionName``
+- ``dfhack.items.moveToInventory``: make ``use_mode`` and ``body_part`` args optional
 
 ## Removed
 - The ``PRELOAD_LIB`` environment variable has been renamed to ``DF_PRELOAD`` to match the naming scheme of other environment variables used by the ``dfhack`` startup script. If you are preloading libraries (e.g. for performance testing) please define ``DF_PRELOAD`` instead of ``PRELOAD_LIB`` or ``LD_PRELOAD``

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2035,11 +2035,13 @@ Items module
   to be stored by the building (used for items temporarily used in traps in
   vanilla DF).
 
-* ``dfhack.items.moveToInventory(item,unit,use_mode,body_part)``
+* ``dfhack.items.moveToInventory(item,unit[,use_mode[,body_part]])``
 
   Move the item to the unit inventory. Returns *false* if impossible.
+  ``use_mode`` defaults to ``df.unit_inventory_item.T_mode.Hauled``.
+  ``body_part`` defaults to ``-1``.
 
-* ``dfhack.items.remove(item[, no_uncat])``
+* ``dfhack.items.remove(item[,no_uncat])``
 
   Cancels any jobs associated with the item, removes the item from containers
   and inventories, hides the item from the UI, and, unless ``no_uncat`` is

--- a/docs/plugins/autodump.rst
+++ b/docs/plugins/autodump.rst
@@ -10,12 +10,11 @@ autodump
 
 This tool can instantly move all unforbidden items marked for dumping to the
 tile under the keyboard cursor. After moving the items, the dump flag is unset
-and the forbid flag is set, just as if it had been dumped normally. Be aware
-that dwarves that are en route to pick up the item for dumping may still come
-and move the item to your dump zone.
+and the forbid flag is set, just as if it had been dumped normally.
 
-The keyboard cursor must be placed on a floor tile so the items can be dumped
-there.
+The keyboard cursor can be placed on a floor tile or in the air. If in air
+the items will be converted into projectiles and fall. Items cannot be dumped
+inside of walls or fortifications.
 
 Usage
 -----

--- a/docs/plugins/autodump.rst
+++ b/docs/plugins/autodump.rst
@@ -10,11 +10,12 @@ autodump
 
 This tool can instantly move all unforbidden items marked for dumping to the
 tile under the keyboard cursor. After moving the items, the dump flag is unset
-and the forbid flag is set, just as if it had been dumped normally.
+and the forbid flag is set, just as if it had been dumped normally. See
+``gui/autodump`` for an interactive version of this tool.
 
 The keyboard cursor can be placed on a floor tile or in the air. If in air,
 the items will be converted into projectiles and fall. Items cannot be dumped
-inside of walls nor fortifications.
+inside of walls.
 
 Usage
 -----

--- a/docs/plugins/autodump.rst
+++ b/docs/plugins/autodump.rst
@@ -12,9 +12,9 @@ This tool can instantly move all unforbidden items marked for dumping to the
 tile under the keyboard cursor. After moving the items, the dump flag is unset
 and the forbid flag is set, just as if it had been dumped normally.
 
-The keyboard cursor can be placed on a floor tile or in the air. If in air
+The keyboard cursor can be placed on a floor tile or in the air. If in air,
 the items will be converted into projectiles and fall. Items cannot be dumped
-inside of walls or fortifications.
+inside of walls nor fortifications.
 
 Usage
 -----

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2353,7 +2353,6 @@ static const LuaWrapper::FunctionReg dfhack_items_module[] = {
     WRAPM(Items, getCapacity),
     WRAPM(Items, moveToGround),
     WRAPM(Items, moveToContainer),
-    WRAPM(Items, moveToInventory),
     WRAPM(Items, makeProjectile),
     WRAPM(Items, remove),
     WRAPN(findType, items_findType),
@@ -2409,6 +2408,16 @@ static int items_moveToBuilding(lua_State *state)
     return 1;
 }
 
+static int items_moveToInventory(lua_State *state)
+{
+    auto item = Lua::CheckDFObject<df::item>(state, 1);
+    auto unit = Lua::CheckDFObject<df::unit>(state, 2);
+    df::unit_inventory_item::T_mode use_mode = (df::unit_inventory_item::T_mode)luaL_optint(state, 3, 0);
+    int body_part = luaL_optint(state, 4, -1);
+    lua_pushboolean(state, Items::moveToInventory(item, unit, use_mode, body_part));
+    return 1;
+}
+
 static int items_createItem(lua_State *state)
 {
     auto unit = Lua::CheckDFObject<df::unit>(state, 1);
@@ -2429,6 +2438,7 @@ static const luaL_Reg dfhack_items_funcs[] = {
     { "getOuterContainerRef", items_getOuterContainerRef },
     { "getContainedItems", items_getContainedItems },
     { "moveToBuilding", items_moveToBuilding },
+    { "moveToInventory", items_moveToBuilding },
     { "createItem", items_createItem },
     { NULL, NULL }
 };

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2353,7 +2353,6 @@ static const LuaWrapper::FunctionReg dfhack_items_module[] = {
     WRAPM(Items, getCapacity),
     WRAPM(Items, moveToGround),
     WRAPM(Items, moveToContainer),
-    WRAPM(Items, moveToBuilding),
     WRAPM(Items, moveToInventory),
     WRAPM(Items, makeProjectile),
     WRAPM(Items, remove),
@@ -2400,6 +2399,16 @@ static int items_getContainedItems(lua_State *state)
     return 1;
 }
 
+static int items_moveToBuilding(lua_State *state)
+{
+    auto item = Lua::CheckDFObject<df::item>(state, 1);
+    auto building = Lua::CheckDFObject<df::building_actual>(state, 2);
+    df::building_item_role_type use_mode = (df::building_item_role_type)luaL_optint(state, 3, 0);
+    bool force_in_building = lua_toboolean(state, 4);
+    lua_pushboolean(state, Items::moveToBuilding(item, building, use_mode, force_in_building));
+    return 1;
+}
+
 static int items_createItem(lua_State *state)
 {
     auto unit = Lua::CheckDFObject<df::unit>(state, 1);
@@ -2419,6 +2428,7 @@ static const luaL_Reg dfhack_items_funcs[] = {
     { "getPosition", items_getPosition },
     { "getOuterContainerRef", items_getOuterContainerRef },
     { "getContainedItems", items_getContainedItems },
+    { "moveToBuilding", items_moveToBuilding },
     { "createItem", items_createItem },
     { NULL, NULL }
 };

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2438,7 +2438,7 @@ static const luaL_Reg dfhack_items_funcs[] = {
     { "getOuterContainerRef", items_getOuterContainerRef },
     { "getContainedItems", items_getContainedItems },
     { "moveToBuilding", items_moveToBuilding },
-    { "moveToInventory", items_moveToBuilding },
+    { "moveToInventory", items_moveToInventory },
     { "createItem", items_createItem },
     { NULL, NULL }
 };

--- a/library/include/modules/Items.h
+++ b/library/include/modules/Items.h
@@ -26,11 +26,11 @@ distribution.
 /*
 * Items!
 */
+#include "DataDefs.h"
 #include "Export.h"
+#include "MemAccess.h"
 #include "Module.h"
 #include "Types.h"
-#include "MemAccess.h"
-#include "DataDefs.h"
 
 #include "modules/Materials.h"
 
@@ -53,10 +53,6 @@ namespace df {
     union item_flags;
 }
 
-namespace MapExtras {
-    class MapCache;
-}
-
 /**
  * \defgroup grp_items Items module and its types
  * @ingroup grp_modules
@@ -64,46 +60,41 @@ namespace MapExtras {
 
 namespace DFHack
 {
-    struct DFHACK_EXPORT ItemTypeInfo {
-        df::item_type type;
-        int16_t subtype;
+struct DFHACK_EXPORT ItemTypeInfo {
+    df::item_type type;
+    int16_t subtype;
 
-        df::itemdef *custom;
+    df::itemdef *custom;
 
     public:
-        ItemTypeInfo(df::item_type type_ = df::enums::item_type::NONE, int16_t subtype_ = -1) {
-            decode(type_, subtype_);
-        }
-        template<class T> ItemTypeInfo(T *ptr) { decode(ptr); }
+    ItemTypeInfo(df::item_type type_ = df::enums::item_type::NONE, int16_t subtype_ = -1) { decode(type_, subtype_); }
+    template<class T> ItemTypeInfo(T *ptr) { decode(ptr); }
 
-        bool isValid() const {
-            return (type != df::enums::item_type::NONE) && (subtype == -1 || custom);
-        }
+    bool isValid() const { return (type != df::enums::item_type::NONE) && (subtype == -1 || custom); }
 
-        bool decode(df::item_type type_, int16_t subtype_ = -1);
-        bool decode(df::item *ptr);
+    bool decode(df::item_type type_, int16_t subtype_ = -1);
+    bool decode(df::item *ptr);
 
-        template<class T> bool decode(T *ptr) {
-            return ptr ? decode(ptr->item_type, ptr->item_subtype) : decode(df::enums::item_type::NONE);
-        }
-
-        std::string getToken();
-        std::string toString();
-
-        bool find(const std::string &token);
-
-        bool matches(df::job_item_vector_id vec_id);
-        bool matches(const df::job_item &jitem, MaterialInfo *mat = NULL,
-                     bool skip_vector = false,
-                     df::item_type itype = df::item_type::NONE);
-    };
-
-    inline bool operator== (const ItemTypeInfo &a, const ItemTypeInfo &b) {
-        return a.type == b.type && a.subtype == b.subtype;
+    template<class T> bool decode(T *ptr) {
+        return ptr ? decode(ptr->item_type, ptr->item_subtype) : decode(df::enums::item_type::NONE);
     }
-    inline bool operator!= (const ItemTypeInfo &a, const ItemTypeInfo &b) {
-        return a.type != b.type || a.subtype != b.subtype;
-    }
+
+    std::string getToken();
+    std::string toString();
+
+    bool find(const std::string &token);
+
+    bool matches(df::job_item_vector_id vec_id);
+    bool matches(const df::job_item &jitem, MaterialInfo *mat = NULL,
+        bool skip_vector = false, df::item_type itype = df::item_type::NONE);
+};
+
+inline bool operator== (const ItemTypeInfo &a, const ItemTypeInfo &b) {
+    return a.type == b.type && a.subtype == b.subtype;
+}
+inline bool operator!= (const ItemTypeInfo &a, const ItemTypeInfo &b) {
+    return a.type != b.type || a.subtype != b.subtype;
+}
 
 /**
  * The Items module
@@ -112,7 +103,6 @@ namespace DFHack
  */
 namespace Items
 {
-
 DFHACK_EXPORT bool isCasteMaterial(df::item_type itype);
 DFHACK_EXPORT int getSubtypeCount(df::item_type itype);
 DFHACK_EXPORT df::itemdef *getSubtypeDef(df::item_type itype, int subtype);
@@ -155,18 +145,18 @@ DFHACK_EXPORT std::string getDescription(df::item *item, int type = 0, bool deco
 
 DFHACK_EXPORT std::string getReadableDescription(df::item *item);
 
-DFHACK_EXPORT bool moveToGround(MapExtras::MapCache &mc, df::item *item, df::coord pos);
-DFHACK_EXPORT bool moveToContainer(MapExtras::MapCache &mc, df::item *item, df::item *container);
-DFHACK_EXPORT bool moveToBuilding(MapExtras::MapCache &mc, df::item *item, df::building_actual *building,
+DFHACK_EXPORT bool moveToGround(df::item *item, df::coord pos);
+DFHACK_EXPORT bool moveToContainer(df::item *item, df::item *container);
+DFHACK_EXPORT bool moveToBuilding(df::item *item, df::building_actual *building,
     df::building_item_role_type use_mode = df::building_item_role_type::TEMP, bool force_in_building = false);
-DFHACK_EXPORT bool moveToInventory(MapExtras::MapCache &mc, df::item *item, df::unit *unit,
+DFHACK_EXPORT bool moveToInventory(df::item *item, df::unit *unit,
     df::unit_inventory_item::T_mode mode = df::unit_inventory_item::Hauled, int body_part = -1);
 
 /// Makes the item removed and marked for garbage collection
-DFHACK_EXPORT bool remove(MapExtras::MapCache &mc, df::item *item, bool no_uncat = false);
+DFHACK_EXPORT bool remove(df::item *item, bool no_uncat = false);
 
 /// Detaches the items from its current location and turns it into a projectile
-DFHACK_EXPORT df::proj_itemst *makeProjectile(MapExtras::MapCache &mc, df::item *item);
+DFHACK_EXPORT df::proj_itemst *makeProjectile(df::item *item);
 
 /// Gets value of base-quality item with specified type and material
 DFHACK_EXPORT int getItemBaseValue(int16_t item_type, int16_t item_subtype, int16_t mat_type, int32_t mat_subtype);
@@ -174,7 +164,8 @@ DFHACK_EXPORT int getItemBaseValue(int16_t item_type, int16_t item_subtype, int1
 /// Gets the value of a specific item, taking into account civ values and trade agreements if a caravan is given
 DFHACK_EXPORT int getValue(df::item *item, df::caravan_state *caravan = NULL);
 
-DFHACK_EXPORT bool createItem(std::vector<df::item *> &out_items, df::unit* creator, df::item_type type, int16_t item_subtype, int16_t mat_type, int32_t mat_index, int32_t growth_print = -1, bool no_floor = false);
+DFHACK_EXPORT bool createItem(std::vector<df::item *> &out_items, df::unit *creator, df::item_type type,
+    int16_t item_subtype, int16_t mat_type, int32_t mat_index, int32_t growth_print = -1, bool no_floor = false);
 
 /// Returns true if the item is free from mandates, or false if mandates prevent trading the item
 DFHACK_EXPORT bool checkMandates(df::item *item);
@@ -202,6 +193,5 @@ DFHACK_EXPORT bool isRouteVehicle(df::item *item);
 DFHACK_EXPORT bool isSquadEquipment(df::item *item);
 /// Returns the item's capacity as a storage container
 DFHACK_EXPORT int32_t getCapacity(df::item* item);
-
 }
 }

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -907,10 +907,7 @@ static bool removeItemOnGround(df::item *item)
     if (!block)
         return false;
 
-    int idx = binsearch_index(block->items, item->id);
-    if (idx < 0)
-        return false;
-    vector_erase_at(block->items, idx);
+    erase_from_vector(block->items, item->id);
 
     for (auto b_item : block->items) {
         auto other_item = df::item::find(b_item);
@@ -1005,33 +1002,13 @@ static bool detachItem(df::item *item)
             case general_ref_type::CONTAINED_IN_ITEM:
                 if (auto item2 = ref->getItem())
                 {
-                    /* TODO: understand how this changes for v50
-                    // Viewscreens hold general_ref_contains_itemst pointers
-                    for (auto screen = Core::getTopViewscreen(); screen; screen = screen->parent)
-                    {
-                        auto vsitem = strict_virtual_cast<df::viewscreen_itemst>(screen);
-                        if (vsitem && vsitem->item == item2)
-                            return false;
-                    }
-                    */
                     item2->flags.bits.weight_computed = false;
-
                     DFHack::removeRef(item2->general_refs, general_ref_type::CONTAINS_ITEM, item->id);
                 }
                 break;
             case general_ref_type::UNIT_HOLDER:
-                if (auto unit = ref->getUnit())
-                {
-                    /* TODO: understand how this changes for v50
-                    // Unit view sidebar holds inventory item pointers
-                    if (plotinfo->main.mode == ui_sidebar_mode::ViewUnits &&
-                        (!ui_selected_unit ||
-                        vector_get(world->units.active, *ui_selected_unit) == unit))
-                        return false;
-                    */
-
-                    for (int i = unit->inventory.size()-1; i >= 0; i--)
-                    {
+                if (auto unit = ref->getUnit()) {
+                    for (int i = unit->inventory.size()-1; i >= 0; i--) {
                         df::unit_inventory_item *inv_item = unit->inventory[i];
                         if (inv_item->item != item)
                             continue;

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -28,14 +28,14 @@ distribution.
 #include "Internal.h"
 #include "MemAccess.h"
 #include "MiscUtils.h"
+#include "ModuleFactory.h"
 #include "Types.h"
 #include "VersionInfo.h"
-#include "ModuleFactory.h"
 
-#include "modules/Job.h"
-#include "modules/MapCache.h"
-#include "modules/Materials.h"
+#include "modules/Buildings.h"
 #include "modules/Items.h"
+#include "modules/Job.h"
+#include "modules/Materials.h"
 #include "modules/Translation.h"
 #include "modules/Units.h"
 #include "modules/World.h"
@@ -901,32 +901,54 @@ string Items::getReadableDescription(df::item *item) {
     return desc;
 }
 
-static void resetUnitInvFlags(df::unit *unit, df::unit_inventory_item *inv_item)
-{
+static bool removeItemOnGround(df::item *item)
+{   // Replaces the MapCache fn
+    auto block = Maps::getTileBlock(item->pos);
+    if (!block)
+        return false;
+
+    int idx = binsearch_index(block->items, item->id);
+    if (idx < 0)
+        return false;
+    vector_erase_at(block->items, idx);
+
+    for (auto b_item : block->items) {
+        auto other_item = df::item::find(b_item);
+        if (other_item && other_item->pos == item->pos)
+            return true; // Don't touch occupancy
+    }
+
+    auto &occ = index_tile(block->occupancy, item->pos);
+    occ.bits.item = false;
+
+    if (occ.bits.building == tile_building_occ::Planned) {
+        if (auto bld = Buildings::findAtTile(item->pos))
+        {   // TODO: Maybe recheck other tiles like the game does.
+            bld->flags.bits.site_blocked = false;
+        }
+    }
+    return true;
+}
+
+static void resetUnitInvFlags(df::unit *unit, df::unit_inventory_item *inv_item) {
     if (inv_item->mode == df::unit_inventory_item::Worn ||
         inv_item->mode == df::unit_inventory_item::WrappedAround)
     {
         unit->flags2.bits.calculated_inventory = false;
         unit->flags2.bits.calculated_insulation = false;
     }
-    else if (inv_item->mode == df::unit_inventory_item::StuckIn)
-    {
+    else if (inv_item->mode == df::unit_inventory_item::StuckIn) {
         unit->flags3.bits.stuck_weapon_computed = false;
     }
 }
 
-static bool detachItem(MapExtras::MapCache &mc, df::item *item)
-{
-    if (!item->specific_refs.empty())
-        return false;
-    if (item->world_data_id != -1)
+static bool detachItem(df::item *item)
+{   // Remove item from any inventory or map block
+    if (!item->specific_refs.empty() || item->world_data_id != -1)
         return false;
 
     bool building_clutter = false;
-    for (size_t i = 0; i < item->general_refs.size(); i++)
-    {
-        df::general_ref *ref = item->general_refs[i];
-
+    for (auto ref : item->general_refs) {
         switch (ref->getType())
         {
             case general_ref_type::BUILDING_HOLDER:
@@ -939,22 +961,18 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
             case general_ref_type::BUILDING_TRIGGERTARGET:
             case general_ref_type::BUILDING_CIVZONE_ASSIGNED:
                 return false;
-
             default:
                 continue;
         }
     }
 
-    if (building_clutter)
-    {
+    if (building_clutter) {
         auto building = virtual_cast<df::building_actual>(Items::getHolderBuilding(item));
-        if (building)
-        {
+        if (building) {
             for (size_t i = 0; i < building->contained_items.size(); i++)
             {
                 auto ci = building->contained_items[i];
-                if (ci->item == item)
-                {
+                if (ci->item == item) {
                     DFHack::removeRef(item->general_refs, general_ref_type::BUILDING_HOLDER, building->id);
                     vector_erase_at(building->contained_items, i);
                     delete ci;
@@ -965,25 +983,19 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
     }
 
     if (auto *ref = virtual_cast<df::general_ref_projectile>(Items::getGeneralRef(item, general_ref_type::PROJECTILE)))
-    {
         return linked_list_remove(&world->proj_list, ref->projectile_id) &&
             DFHack::removeRef(item->general_refs, general_ref_type::PROJECTILE, ref->getID());
-    }
 
-    if (item->flags.bits.on_ground)
-    {
-        if (!mc.removeItemOnGround(item))
+    if (item->flags.bits.on_ground) {
+        if (!removeItemOnGround(item))
             Core::printerr("Item was marked on_ground, but not in block: %d (%d,%d,%d)\n",
-                           item->id, item->pos.x, item->pos.y, item->pos.z);
-
+                item->id, item->pos.x, item->pos.y, item->pos.z);
         item->flags.bits.on_ground = false;
         return true;
     }
 
-    if (item->flags.bits.in_inventory)
-    {
+    if (item->flags.bits.in_inventory) {
         bool found = false;
-
         for (int i = item->general_refs.size()-1; i >= 0; i--)
         {
             df::general_ref *ref = item->general_refs[i];
@@ -993,7 +1005,7 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
             case general_ref_type::CONTAINED_IN_ITEM:
                 if (auto item2 = ref->getItem())
                 {
-/* TODO: understand how this changes for v50
+                    /* TODO: understand how this changes for v50
                     // Viewscreens hold general_ref_contains_itemst pointers
                     for (auto screen = Core::getTopViewscreen(); screen; screen = screen->parent)
                     {
@@ -1001,30 +1013,28 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
                         if (vsitem && vsitem->item == item2)
                             return false;
                     }
-*/
+                    */
                     item2->flags.bits.weight_computed = false;
 
-                    removeRef(item2->general_refs, general_ref_type::CONTAINS_ITEM, item->id);
+                    DFHack::removeRef(item2->general_refs, general_ref_type::CONTAINS_ITEM, item->id);
                 }
                 break;
-
             case general_ref_type::UNIT_HOLDER:
                 if (auto unit = ref->getUnit())
                 {
-/* TODO: understand how this changes for v50
+                    /* TODO: understand how this changes for v50
                     // Unit view sidebar holds inventory item pointers
                     if (plotinfo->main.mode == ui_sidebar_mode::ViewUnits &&
                         (!ui_selected_unit ||
-                         vector_get(world->units.active, *ui_selected_unit) == unit))
+                        vector_get(world->units.active, *ui_selected_unit) == unit))
                         return false;
-*/
+                    */
 
                     for (int i = unit->inventory.size()-1; i >= 0; i--)
                     {
                         df::unit_inventory_item *inv_item = unit->inventory[i];
                         if (inv_item->item != item)
                             continue;
-
                         resetUnitInvFlags(unit, inv_item);
 
                         vector_erase_at(unit->inventory, i);
@@ -1032,7 +1042,6 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
                     }
                 }
                 break;
-
             default:
                 continue;
             }
@@ -1053,41 +1062,30 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
     {
         item->flags.bits.removed = false;
 
-        if (item->flags.bits.garbage_collect)
-        {
+        if (item->flags.bits.garbage_collect) {
             item->flags.bits.garbage_collect = false;
             item->categorize(true);
         }
-
         return true;
     }
-
     return false;
 }
 
-static void putOnGround(MapExtras::MapCache &mc, df::item *item, df::coord pos)
-{
+bool DFHack::Items::moveToGround(df::item *item, df::coord pos) {
+    CHECK_NULL_POINTER(item);
+    if (!detachItem(item))
+        return false;
+
     item->pos = pos;
     item->flags.bits.on_ground = true;
 
-    if (!mc.addItemOnGround(item))
+    if (!item->moveToGround(pos.x, pos.y, pos.z))
         Core::printerr("Could not add item %d to ground at (%d,%d,%d)\n",
-                       item->id, pos.x, pos.y, pos.z);
-}
-
-bool DFHack::Items::moveToGround(MapExtras::MapCache &mc, df::item *item, df::coord pos)
-{
-    CHECK_NULL_POINTER(item);
-
-    if (!detachItem(mc, item))
-        return false;
-
-    putOnGround(mc, item, pos);
+            item->id, pos.x, pos.y, pos.z);
     return true;
 }
 
-bool DFHack::Items::moveToContainer(MapExtras::MapCache &mc, df::item *item, df::item *container)
-{
+bool DFHack::Items::moveToContainer(df::item *item, df::item *container) {
     CHECK_NULL_POINTER(item);
     CHECK_NULL_POINTER(container);
 
@@ -1098,16 +1096,16 @@ bool DFHack::Items::moveToContainer(MapExtras::MapCache &mc, df::item *item, df:
     auto ref1 = df::allocate<df::general_ref_contains_itemst>();
     auto ref2 = df::allocate<df::general_ref_contained_in_itemst>();
 
-    if (!ref1 || !ref2)
-    {
-        delete ref1; delete ref2;
+    if (!ref1 || !ref2) {
+        delete ref1;
+        delete ref2;
         Core::printerr("Could not allocate container refs.\n");
         return false;
     }
 
-    if (!detachItem(mc, item))
-    {
-        delete ref1; delete ref2;
+    if (!detachItem(item)) {
+        delete ref1;
+        delete ref2;
         return false;
     }
 
@@ -1126,48 +1124,46 @@ bool DFHack::Items::moveToContainer(MapExtras::MapCache &mc, df::item *item, df:
     return true;
 }
 
-bool DFHack::Items::moveToBuilding(MapExtras::MapCache &mc, df::item *item, df::building_actual *building,
+bool DFHack::Items::moveToBuilding(df::item *item, df::building_actual *building,
     df::building_item_role_type use_mode, bool force_in_building)
 {
     CHECK_NULL_POINTER(item);
     CHECK_NULL_POINTER(building);
-    CHECK_INVALID_ARGUMENT(use_mode == 0 || use_mode == 2);
+    CHECK_INVALID_ARGUMENT(use_mode == building_item_role_type::TEMP ||
+        use_mode == building_item_role_type::PERM);
 
     auto ref = df::allocate<df::general_ref_building_holderst>();
-    if(!ref)
-    {
+    if(!ref) {
         delete ref;
         Core::printerr("Could not allocate building holder refs.\n");
         return false;
     }
 
-    if (!detachItem(mc, item))
-    {
+    if (!detachItem(item)) {
         delete ref;
         return false;
     }
 
-    item->pos.x=building->centerx;
-    item->pos.y=building->centery;
-    item->pos.z=building->z;
-    if (use_mode == 2 || force_in_building)
-        item->flags.bits.in_building=true;
+    item->pos.x = building->centerx;
+    item->pos.y = building->centery;
+    item->pos.z = building->z;
+    if (use_mode == building_item_role_type::PERM || force_in_building)
+        item->flags.bits.in_building = true;
 
-    ref->building_id=building->id;
+    ref->building_id = building->id;
     item->general_refs.push_back(ref);
 
-    auto con=new df::building_actual::T_contained_items;
-    con->item=item;
-    con->use_mode=use_mode;
+    auto con = new df::building_actual::T_contained_items;
+    con->item = item;
+    con->use_mode = use_mode;
     building->contained_items.push_back(con);
 
     return true;
 }
 
-bool DFHack::Items::moveToInventory(
-    MapExtras::MapCache &mc, df::item *item, df::unit *unit,
-    df::unit_inventory_item::T_mode mode, int body_part
-) {
+bool DFHack::Items::moveToInventory(df::item *item, df::unit *unit,
+    df::unit_inventory_item::T_mode mode, int body_part)
+{
     CHECK_NULL_POINTER(item);
     CHECK_NULL_POINTER(unit);
     CHECK_NULL_POINTER(unit->body.body_plan);
@@ -1176,14 +1172,12 @@ bool DFHack::Items::moveToInventory(
     CHECK_INVALID_ARGUMENT(body_part < 0 || body_part <= body_plan_size);
 
     auto holderReference = df::allocate<df::general_ref_unit_holderst>();
-    if (!holderReference)
-    {
+    if (!holderReference) {
         Core::printerr("Could not allocate UNIT_HOLDER reference.\n");
         return false;
     }
 
-    if (!detachItem(mc, item))
-    {
+    if (!detachItem(item)) {
         delete holderReference;
         return false;
     }
@@ -1200,18 +1194,16 @@ bool DFHack::Items::moveToInventory(
     item->general_refs.push_back(holderReference);
 
     resetUnitInvFlags(unit, newInventoryItem);
-
     return true;
 }
 
-bool Items::remove(MapExtras::MapCache &mc, df::item *item, bool no_uncat)
-{
+bool Items::remove(df::item *item, bool no_uncat) {
     CHECK_NULL_POINTER(item);
 
-    if (auto spec_ref = getSpecificRef(item, df::specific_ref_type::JOB))
+    if (auto spec_ref = getSpecificRef(item, specific_ref_type::JOB))
         Job::removeJob(spec_ref->data.job);
 
-    if (!detachItem(mc, item))
+    if (!detachItem(item))
         return false;
 
     if (auto pos = getPosition(item); pos.isValid())
@@ -1220,7 +1212,7 @@ bool Items::remove(MapExtras::MapCache &mc, df::item *item, bool no_uncat)
     if (!no_uncat)
         item->uncategorize();
 
-    // hide them from jobs and the UI until the item can be garbage collected
+    // Hide them from jobs and the UI until the item can be garbage collected
     item->flags.bits.forbid = true;
     item->flags.bits.hidden = true;
 
@@ -1229,10 +1221,8 @@ bool Items::remove(MapExtras::MapCache &mc, df::item *item, bool no_uncat)
     return true;
 }
 
-df::proj_itemst *Items::makeProjectile(MapExtras::MapCache &mc, df::item *item)
-{
+df::proj_itemst *Items::makeProjectile(df::item *item) {
     CHECK_NULL_POINTER(item);
-
     if (!world || !proj_next_id)
         return NULL;
 
@@ -1250,8 +1240,7 @@ df::proj_itemst *Items::makeProjectile(MapExtras::MapCache &mc, df::item *item)
         return NULL;
     }
 
-    if (!detachItem(mc, item))
-    {
+    if (!detachItem(item)) {
         delete ref;
         delete proj;
         return NULL;
@@ -1272,7 +1261,6 @@ df::proj_itemst *Items::makeProjectile(MapExtras::MapCache &mc, df::item *item)
     item->general_refs.push_back(ref);
 
     linked_list_append(&world->proj_list, proj->link);
-
     return proj;
 }
 
@@ -2487,7 +2475,7 @@ int32_t Items::getCapacity(df::item* item)
             return tool->subtype->container_capacity;
         // fall through
     default:
-        ; // fall through to default exit
+        break; // fall through to default exit
     }
     return 0;
 }

--- a/library/modules/MapCache.cpp
+++ b/library/modules/MapCache.cpp
@@ -1207,11 +1207,7 @@ bool MapExtras::Block::removeItemOnGround(df::item *item)
 
     init_item_counts();
 
-    int idx = binsearch_index(block->items, item->id);
-    if (idx < 0)
-        return false;
-
-    vector_erase_at(block->items, idx);
+    erase_from_vector(block->items,item->id);
 
     int &count = index_tile(item_counts,item->pos);
 

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -1,8 +1,9 @@
+// Automatically manage clothing work orders.
+
 #include "Debug.h"
 #include "PluginManager.h"
 
 #include "modules/Items.h"
-#include "modules/Maps.h"
 #include "modules/Materials.h"
 #include "modules/Persistence.h"
 #include "modules/Translation.h"
@@ -12,18 +13,18 @@
 #include "df/creature_raw.h"
 #include "df/item.h"
 #include "df/item_actual.h"
-#include "df/item_crafted.h"
-#include "df/item_constructed.h"
 #include "df/item_armorst.h"
+#include "df/item_constructed.h"
+#include "df/item_crafted.h"
 #include "df/item_glovesst.h"
-#include "df/item_shoesst.h"
 #include "df/item_helmst.h"
 #include "df/item_pantsst.h"
+#include "df/item_shoesst.h"
 #include "df/itemdef_armorst.h"
 #include "df/itemdef_glovesst.h"
-#include "df/itemdef_shoesst.h"
 #include "df/itemdef_helmst.h"
 #include "df/itemdef_pantsst.h"
+#include "df/itemdef_shoesst.h"
 #include "df/manager_order.h"
 #include "df/unit.h"
 #include "df/world.h"
@@ -34,8 +35,6 @@ using std::vector;
 using std::map;
 
 using namespace DFHack;
-using namespace DFHack::Items;
-using namespace DFHack::Units;
 using namespace df::enums;
 
 DFHACK_PLUGIN("autoclothing");
@@ -44,11 +43,11 @@ REQUIRE_GLOBAL(world);
 // Only run if this is enabled
 DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
-// logging levels can be dynamically controlled with the `debugfilter` command.
+// Logging levels can be dynamically controlled with the `debugfilter` command.
 namespace DFHack {
-    // for configuration-related logging
+    // For configuration-related logging
     DBG_DECLARE(autoclothing, control, DebugCategory::LINFO);
-    // for logging during the periodic scan
+    // For logging during the periodic scan
     DBG_DECLARE(autoclothing, cycle, DebugCategory::LINFO);
 }
 
@@ -63,15 +62,14 @@ enum ConfigValues {
 // Here go all the command declarations...
 // mostly to allow having the mandatory stuff on top of the file and commands on the bottom
 struct ClothingRequirement;
-command_result autoclothing(color_ostream &out, vector <string> & parameters);
+command_result autoclothing(color_ostream &out, vector<string> &parameters);
 static void do_autoclothing();
-static bool validateMaterialCategory(ClothingRequirement * requirement);
-static bool setItem(string name, ClothingRequirement* requirement);
-static void generate_control(color_ostream& out);
-static bool isAvailableItem(df::item* item);
+static bool validateMaterialCategory(ClothingRequirement *requirement);
+static bool setItem(string name, ClothingRequirement *requirement);
+static void generate_control(color_ostream &out);
+static bool isAvailableItem(df::item *item);
 
-enum match_strictness
-{
+enum match_strictness {
     STRICT_PERMISSIVE,
     STRICT_TYPE,
     STRICT_MATERIAL
@@ -79,32 +77,24 @@ enum match_strictness
 
 match_strictness strictnessSetting = STRICT_PERMISSIVE;
 
-vector<ClothingRequirement>clothingOrders;
+vector<ClothingRequirement> clothingOrders;
 
-struct ClothingRequirement
-{
-    df::job_type jobType;
-    df::item_type itemType;
-    int16_t item_subtype;
+struct ClothingRequirement {
+    df::job_type jobType = job_type::NONE;
+    df::item_type itemType = item_type::NONE;
+    int16_t item_subtype = -1;
     df::job_material_category material_category;
-    int16_t needed_per_citizen;
+    int16_t needed_per_citizen = 0;
     map<int16_t, int32_t> total_needed_per_race;
 
-    bool matches(ClothingRequirement * b)
-    {
-        if (b->jobType != this->jobType)
-            return false;
-        if (b->itemType != this->itemType)
-            return false;
-        if (b->item_subtype != this->item_subtype)
-            return false;
-        if (b->material_category.whole != this->material_category.whole)
-            return false;
-        return true;
+    bool matches(ClothingRequirement *b) {
+        return b->jobType == this->jobType
+            && b->itemType == this->itemType
+            && b->item_subtype == this->item_subtype
+            && b->material_category.whole == this->material_category.whole;
     }
 
-    string Serialize()
-    {
+    string Serialize() {
         std::stringstream stream;
         stream << ENUM_KEY_STR(job_type, jobType) << " ";
         stream << ENUM_KEY_STR(item_type,itemType) << " ";
@@ -114,25 +104,20 @@ struct ClothingRequirement
         return stream.str();
     }
 
-    void Deserialize(string s)
-    {
+    void Deserialize(string s) {
         std::stringstream stream(s);
         string loadedJob;
         stream >> loadedJob;
-        FOR_ENUM_ITEMS(job_type, job)
-        {
-            if (ENUM_KEY_STR(job_type, job) == loadedJob)
-            {
+        FOR_ENUM_ITEMS(job_type, job) {
+            if (ENUM_KEY_STR(job_type, job) == loadedJob) {
                 jobType = job;
                 break;
             }
         }
         string loadedItem;
         stream >> loadedItem;
-        FOR_ENUM_ITEMS(item_type, item)
-        {
-            if (ENUM_KEY_STR(item_type, item) == loadedItem)
-            {
+        FOR_ENUM_ITEMS(item_type, item) {
+            if (ENUM_KEY_STR(item_type, item) == loadedItem) {
                 itemType = item;
                 break;
             }
@@ -142,55 +127,51 @@ struct ClothingRequirement
         stream >> needed_per_citizen;
     }
 
-    bool SetFromParameters(color_ostream &out, vector <string> & parameters)
+    bool SetFromParameters(color_ostream &out, vector<string> &parameters)
     {
         if (!set_bitfield_field(&material_category, parameters[0], 1))
-        {
             out << "Unrecognized material type: " << parameters[0] << endl;
-        }
-        if (!setItem(parameters[1], this))
-        {
+        if (!setItem(parameters[1], this)) {
             out << "Unrecognized item name or token: " << parameters[1] << endl;
             return false;
         }
-        if (!validateMaterialCategory(this))
-        {
+        else if (!validateMaterialCategory(this)) {
             out << parameters[0] << " is not a valid material category for " << parameters[1] << endl;
             return false;
         }
         return true;
     }
 
-    string ToReadableLabel()
-    {
+    string ToReadableLabel() {
         std::stringstream stream;
         stream << bitfield_to_string(material_category) << " ";
         string adjective = "";
         string name = "";
+        auto &itemdefs = world->raws.itemdefs;
         switch (itemType)
         {
-        case df::enums::item_type::ARMOR:
-            adjective = world->raws.itemdefs.armor[item_subtype]->adjective;
-            name = world->raws.itemdefs.armor[item_subtype]->name;
-            break;
-        case df::enums::item_type::SHOES:
-            adjective = world->raws.itemdefs.shoes[item_subtype]->adjective;
-            name = world->raws.itemdefs.shoes[item_subtype]->name;
-            break;
-        case df::enums::item_type::HELM:
-            adjective = world->raws.itemdefs.helms[item_subtype]->adjective;
-            name = world->raws.itemdefs.helms[item_subtype]->name;
-            break;
-        case df::enums::item_type::GLOVES:
-            adjective = world->raws.itemdefs.gloves[item_subtype]->adjective;
-            name = world->raws.itemdefs.gloves[item_subtype]->name;
-            break;
-        case df::enums::item_type::PANTS:
-            adjective = world->raws.itemdefs.pants[item_subtype]->adjective;
-            name = world->raws.itemdefs.pants[item_subtype]->name;
-            break;
-        default:
-            break;
+            case item_type::ARMOR:
+                adjective = itemdefs.armor[item_subtype]->adjective;
+                name = itemdefs.armor[item_subtype]->name;
+                break;
+            case item_type::SHOES:
+                adjective = itemdefs.shoes[item_subtype]->adjective;
+                name = itemdefs.shoes[item_subtype]->name;
+                break;
+            case item_type::HELM:
+                adjective = itemdefs.helms[item_subtype]->adjective;
+                name = itemdefs.helms[item_subtype]->name;
+                break;
+            case item_type::GLOVES:
+                adjective = itemdefs.gloves[item_subtype]->adjective;
+                name = itemdefs.gloves[item_subtype]->name;
+                break;
+            case item_type::PANTS:
+                adjective = itemdefs.pants[item_subtype]->adjective;
+                name = itemdefs.pants[item_subtype]->name;
+                break;
+            default:
+                break;
         }
         if (!adjective.empty())
             stream << adjective << " ";
@@ -203,9 +184,8 @@ struct ClothingRequirement
 
 
 // Mandatory init function. If you have some global state, create it here.
-DFhackCExport command_result plugin_init(color_ostream &out, vector <PluginCommand> &commands)
-{
-    // Fill the command list with your commands.
+DFhackCExport command_result plugin_init(color_ostream &out, vector<PluginCommand> &commands)
+{   // Fill the command list with your commands.
     commands.push_back(PluginCommand(
         "autoclothing",
         "Automatically manage clothing work orders",
@@ -214,29 +194,27 @@ DFhackCExport command_result plugin_init(color_ostream &out, vector <PluginComma
 }
 
 // This is called right before the plugin library is removed from memory.
-DFhackCExport command_result plugin_shutdown(color_ostream &out)
-{
+DFhackCExport command_result plugin_shutdown(color_ostream &out) {
     return CR_OK;
 }
 
 // Called to notify the plugin about important state changes.
 // Invoked with DF suspended, and always before the matching plugin_onupdate.
 // More event codes may be added in the future.
-
-DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_change_event event)
-{
-    switch (event) {
-    case SC_WORLD_UNLOADED:
-        clothingOrders.clear();
-        is_enabled = false;
-        break;
-    default:
-        break;
+DFhackCExport command_result plugin_onstatechange(color_ostream &out, state_change_event event) {
+    switch (event)
+    {
+        case SC_WORLD_UNLOADED:
+            clothingOrders.clear();
+            is_enabled = false;
+            break;
+        default:
+            break;
     }
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_load_site_data (color_ostream &out) {
+DFhackCExport command_result plugin_load_site_data(color_ostream &out) {
     cycle_timestamp = 0;
     auto enabled = World::GetPersistentSiteData(CONFIG_KEY);
     if (!enabled.isValid()) {
@@ -253,8 +231,7 @@ DFhackCExport command_result plugin_load_site_data (color_ostream &out) {
     vector<PersistentDataItem> items;
     World::GetPersistentSiteData(&items, "autoclothing/clothingItems");
 
-    for (auto& item : items)
-    {
+    for (auto &item : items) {
         if (!item.isValid())
             continue;
         ClothingRequirement req;
@@ -262,13 +239,11 @@ DFhackCExport command_result plugin_load_site_data (color_ostream &out) {
         clothingOrders.push_back(req);
         out << "autoclothing added " << req.ToReadableLabel() << endl;
     }
-
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_save_site_data (color_ostream &out)
-{
-    for (auto& order : clothingOrders)
+DFhackCExport command_result plugin_save_site_data(color_ostream &out) {
+    for (auto &order : clothingOrders)
     {
         auto orderSave = World::AddPersistentSiteData("autoclothing/clothingItems");
         orderSave.set_str(order.Serialize());
@@ -278,16 +253,11 @@ DFhackCExport command_result plugin_save_site_data (color_ostream &out)
     vector<PersistentDataItem> items;
     World::GetPersistentSiteData(&items, "autoclothing/clothingItems");
 
-    for (size_t i = 0; i < items.size(); i++)
-    {
+    for (size_t i = 0; i < items.size(); i++) {
         if (i < clothingOrders.size())
-        {
             items[i].set_str(clothingOrders[i].Serialize());
-        }
         else
-        {
             World::DeletePersistentData(items[i]);
-        }
     }
     for (size_t i = items.size(); i < clothingOrders.size(); i++)
     {
@@ -297,7 +267,7 @@ DFhackCExport command_result plugin_save_site_data (color_ostream &out)
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_enable(color_ostream& out, bool enable) {
+DFhackCExport command_result plugin_enable(color_ostream &out, bool enable) {
     if (!Core::getInstance().isMapLoaded() || !World::isFortressMode()) {
         out.printerr("Cannot enable %s without a loaded fort.\n", plugin_name);
         return CR_FAILURE;
@@ -322,22 +292,18 @@ DFhackCExport command_result plugin_enable(color_ostream& out, bool enable) {
 
 // Whatever you put here will be done in each game step. Don't abuse it.
 // It's optional, so you can just comment it out like this if you don't need it.
-
-DFhackCExport command_result plugin_onupdate(color_ostream &out)
-{
+DFhackCExport command_result plugin_onupdate(color_ostream &out) {
     if (is_enabled && world->frame_counter - cycle_timestamp >= CYCLE_TICKS)
         do_autoclothing();
     return CR_OK;
 }
 
-static bool setItemFromName(string name, ClothingRequirement* requirement)
+static bool setItemFromName(string name, ClothingRequirement *requirement)
 {
 #define SEARCH_ITEM_RAWS(rawType, job, item) \
-for (auto& itemdef : world->raws.itemdefs.rawType) \
-{ \
+for (auto &itemdef : world->raws.itemdefs.rawType) { \
     string fullName = itemdef->adjective.empty() ? itemdef->name : itemdef->adjective + " " + itemdef->name; \
-    if (fullName == name) \
-    { \
+    if (fullName == name) { \
         requirement->jobType = job_type::job; \
         requirement->itemType = item_type::item; \
         requirement->item_subtype = itemdef->subtype; \
@@ -352,93 +318,84 @@ for (auto& itemdef : world->raws.itemdefs.rawType) \
     return false;
 }
 
-static bool setItemFromToken(string token, ClothingRequirement* requirement)
-{
+static bool setItemFromToken(string token, ClothingRequirement *requirement) {
     ItemTypeInfo itemInfo;
     if (!itemInfo.find(token))
         return false;
     switch (itemInfo.type)
     {
-    case item_type::ARMOR:
-        requirement->jobType = job_type::MakeArmor;
-        break;
-    case item_type::GLOVES:
-        requirement->jobType = job_type::MakeGloves;
-        break;
-    case item_type::SHOES:
-        requirement->jobType = job_type::MakeShoes;
-        break;
-    case item_type::HELM:
-        requirement->jobType = job_type::MakeHelm;
-        break;
-    case item_type::PANTS:
-        requirement->jobType = job_type::MakePants;
-        break;
-    default:
-        return false;
+        case item_type::ARMOR:
+            requirement->jobType = job_type::MakeArmor;
+            break;
+        case item_type::GLOVES:
+            requirement->jobType = job_type::MakeGloves;
+            break;
+        case item_type::SHOES:
+            requirement->jobType = job_type::MakeShoes;
+            break;
+        case item_type::HELM:
+            requirement->jobType = job_type::MakeHelm;
+            break;
+        case item_type::PANTS:
+            requirement->jobType = job_type::MakePants;
+            break;
+        default:
+            return false;
     }
     requirement->itemType = itemInfo.type;
     requirement->item_subtype = itemInfo.subtype;
     return true;
 }
 
-static bool setItem(string name, ClothingRequirement* requirement)
-{
-    if (setItemFromName(name, requirement))
-        return true;
-    if (setItemFromToken(name, requirement))
-        return true;
-    return false;
+static bool setItem(string name, ClothingRequirement *requirement) {
+    return setItemFromName(name, requirement) || setItemFromToken(name, requirement);
 }
 
-static bool armorFlagsMatch(BitArray<df::armor_general_flags> * flags, df::job_material_category * category)
-{
-    if (flags->is_set(df::armor_general_flags::SOFT) && category->bits.cloth)
+static bool armorFlagsMatch(BitArray<df::armor_general_flags> *flags, df::job_material_category *category) {
+    if (flags->is_set(df::armor_general_flags::SOFT) &&
+        (category->bits.cloth || category->bits.yarn || category->bits.silk)
+    )
         return true;
-    if (flags->is_set(df::armor_general_flags::SOFT) && category->bits.yarn)
+    else if (flags->is_set(df::armor_general_flags::BARRED) && category->bits.bone)
         return true;
-    if (flags->is_set(df::armor_general_flags::SOFT) && category->bits.silk)
+    else if (flags->is_set(df::armor_general_flags::SCALED) && category->bits.shell)
         return true;
-    if (flags->is_set(df::armor_general_flags::BARRED) && category->bits.bone)
-        return true;
-    if (flags->is_set(df::armor_general_flags::SCALED) && category->bits.shell)
-        return true;
-    if (flags->is_set(df::armor_general_flags::LEATHER) && category->bits.leather)
-        return true;
-    return false;
+    return flags->is_set(df::armor_general_flags::LEATHER) && category->bits.leather;
 }
 
-static bool validateMaterialCategory(ClothingRequirement * requirement)
-{
-    auto itemDef = getSubtypeDef(requirement->itemType, requirement->item_subtype);
+static bool validateMaterialCategory(ClothingRequirement *requirement) {
+    auto itemDef = Items::getSubtypeDef(requirement->itemType, requirement->item_subtype);
     switch (requirement->itemType)
     {
-    case item_type::ARMOR:
-        if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_armorst, itemDef))
-            return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
-    case item_type::GLOVES:
-        if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_glovesst, itemDef))
-            return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
-    case item_type::SHOES:
-        if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_shoesst, itemDef))
-            return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
-    case item_type::HELM:
-        if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_helmst, itemDef))
-            return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
-    case item_type::PANTS:
-        if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_pantsst, itemDef))
-            return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
-    default:
-        return false;
+        case item_type::ARMOR:
+            if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_armorst, itemDef))
+                return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
+            break;
+        case item_type::GLOVES:
+            if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_glovesst, itemDef))
+                return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
+            break;
+        case item_type::SHOES:
+            if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_shoesst, itemDef))
+                return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
+            break;
+        case item_type::HELM:
+            if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_helmst, itemDef))
+                return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
+            break;
+        case item_type::PANTS:
+            if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_pantsst, itemDef))
+                return armorFlagsMatch(&armor->props.flags, &requirement->material_category);
+            break;
+        default:
+            break;
     }
+    return false;
 }
 
-
-
 // A command! It sits around and looks pretty. And it's nice and friendly.
-command_result autoclothing(color_ostream &out, vector <string> & parameters)
-{
-    // be sure to suspend the core if any DF state is read or modified
+command_result autoclothing(color_ostream &out, vector<string> &parameters)
+{   // Be sure to suspend the core if any DF state is read or modified
     CoreSuspender suspend;
 
     if (!Core::getInstance().isMapLoaded() || !World::isFortressMode()) {
@@ -452,34 +409,29 @@ command_result autoclothing(color_ostream &out, vector <string> & parameters)
     // PluginCommand registration as show above, and then returning
     // CR_WRONG_USAGE from the function. The same string will also
     // be used by 'help your-command'.
-    if (parameters.size() == 0)
+    if (parameters.empty())
     {
         out << "Automatic clothing management is currently " << (is_enabled ? "enabled" : "disabled") << "." << endl;
         out << "Currently set " << clothingOrders.size() << " automatic clothing orders" << endl;
-        for (size_t i = 0; i < clothingOrders.size(); i++)
-        {
-            out << clothingOrders[i].ToReadableLabel() << endl;
-        }
+        for (auto &order : clothingOrders)
+            out << order.ToReadableLabel() << endl;
         generate_control(out);
         return CR_OK;
     }
-    ////Disabled until I have time to fully implement it.
-    //else if (parameters[0] == "strictness")
-    //{
-    //    if (parameters.size() != 2)
-    //    {
-    //        out << "Wrong number of arguments." << endl;
-    //        return CR_WRONG_USAGE;
-    //    }
-    //    if (parameters[1] == "permissive")
-    //        strictnessSetting = STRICT_PERMISSIVE;
-    //    else if (parameters[1] == "type")
-    //        strictnessSetting = STRICT_TYPE;
-    //    else if (parameters[1] == "material")
-    //        strictnessSetting = STRICT_MATERIAL;
-    //}
-    else if (parameters.size() < 2 || parameters.size() > 3)
-    {
+    /* TODO: Disabled until I have time to fully implement it.
+    else if (parameters[0] == "strictness") {
+        if (parameters.size() != 2) {
+            out << "Wrong number of arguments." << endl;
+            return CR_WRONG_USAGE;
+        }
+        else if (parameters[1] == "permissive")
+            strictnessSetting = STRICT_PERMISSIVE;
+        else if (parameters[1] == "type")
+            strictnessSetting = STRICT_TYPE;
+        else if (parameters[1] == "material")
+            strictnessSetting = STRICT_MATERIAL;
+    }*/
+    else if (parameters.size() < 2 || parameters.size() > 3) {
         out << "Wrong number of arguments." << endl;
         return CR_WRONG_USAGE;
     }
@@ -488,147 +440,112 @@ command_result autoclothing(color_ostream &out, vector <string> & parameters)
     ClothingRequirement newRequirement;
     if (!newRequirement.SetFromParameters(out, parameters))
         return CR_WRONG_USAGE;
-    //all checks are passed. Now we either show or set the amount.
+    // All checks are passed. Now we either show or set the amount.
     bool settingSize = false;
     bool matchedExisting = false;
-    if (parameters.size() > 2)
-    {
-        try
-        {
+    if (parameters.size() > 2) {
+        try {
             newRequirement.needed_per_citizen = std::stoi(parameters[2]);
         }
-        catch (const std::exception&)
-        {
+        catch (const std::exception&) {
             out << parameters[2] << " is not a valid number." << endl;
             return CR_WRONG_USAGE;
         }
         settingSize = true;
     }
 
-    for (size_t i = 0; i < clothingOrders.size(); i++)
-    {
+    for (size_t i = clothingOrders.size(); i-- > 0;) {
         if (!clothingOrders[i].matches(&newRequirement))
             continue;
         matchedExisting = true;
-        if (settingSize)
-        {
-            if (newRequirement.needed_per_citizen == 0)
-            {
+        if (settingSize) {
+            if (newRequirement.needed_per_citizen == 0) {
                 clothingOrders.erase(clothingOrders.begin() + i);
                 out << "Unset " << parameters[0] << " " << parameters[1] << endl;
             }
-            else
-            {
+            else {
                 clothingOrders[i] = newRequirement;
                 out << "Set " << parameters[0] << " " << parameters[1] << " to " << parameters[2] << endl;
             }
         }
         else
-        {
             out << parameters[0] << " " << parameters[1] << " is set to " << clothingOrders[i].needed_per_citizen << endl;
-        }
         break;
     }
-    if (!matchedExisting)
-    {
-        if (settingSize)
-        {
+    if (!matchedExisting) {
+        if (settingSize) {
             if (newRequirement.needed_per_citizen == 0)
-            {
                 out << parameters[0] << " " << parameters[1] << " already unset." << endl;
-            }
-            else
-            {
+            else {
                 clothingOrders.push_back(newRequirement);
                 out << "Added order for " << parameters[0] << " " << parameters[1] << " to " << parameters[2] << endl;
             }
         }
         else
-        {
             out << parameters[0] << " " << parameters[1] << " is not set." << endl;
-        }
     }
-    if (settingSize)
-    {
-        if (!is_enabled)
-        {
+    if (settingSize) {
+        if (!is_enabled) {
             out << "Enabling automatic clothing management" << endl;
             is_enabled = true;
         }
         do_autoclothing();
     }
-
     // Give control back to DF.
     return CR_OK;
 }
 
-static void find_needed_clothing_items()
-{
+static void find_needed_clothing_items() {
+    MaterialInfo matInfo;
     Units::forCitizens([&](auto unit) {
-        //now check each clothing order to see what the unit might be missing.
-        for (auto& clothingOrder : clothingOrders)
+        // Now check each clothing order to see what the unit might be missing.
+        for (auto &clothingOrder : clothingOrders)
         {
             int alreadyOwnedAmount = 0;
-
-            //looping through the items first, then clothing order might be a little faster, but this way is cleaner.
+            // Looping through the items first, then clothing order might be a little faster, but this way is cleaner.
             for (auto ownedItem : unit->owned_items)
             {
-                auto item = findItemByID(ownedItem);
-
-                if (!item)
-                {
+                auto item = Items::findItemByID(ownedItem);
+                if (!item) {
                     DEBUG(cycle).print("autoclothing: Invalid inventory item ID: %d\n", ownedItem);
                     continue;
                 }
 
-                if (item->getType() != clothingOrder.itemType)
-                    continue;
-                if (item->getSubtype() != clothingOrder.item_subtype)
-                    continue;
-                if (item->getWear() >= 1)
+                if (item->getType() != clothingOrder.itemType ||
+                    item->getSubtype() != clothingOrder.item_subtype ||
+                    item->getWear() >= 1
+                )
                     continue;
 
-                MaterialInfo matInfo;
                 matInfo.decode(item);
-
                 if (!matInfo.matches(clothingOrder.material_category))
                     continue;
 
                 alreadyOwnedAmount++;
             }
             int neededAmount = clothingOrder.needed_per_citizen - alreadyOwnedAmount;
-
             if (neededAmount <= 0)
                 continue;
-
-            //technically, there's some leeway in sizes, but only caring about exact sizes is simpler.
+            // Technically, there's some leeway in sizes, but only caring about exact sizes is simpler.
             clothingOrder.total_needed_per_race[unit->race] += neededAmount;
         }
     });
 }
 
-static void remove_available_clothing()
-{
-    for (auto& item : world->items.other.IN_PLAY)
-    {
-        //skip any owned items.
-        if (getOwner(item))
+static void remove_available_clothing() {
+    MaterialInfo matInfo;
+    for (auto &item : world->items.other.IN_PLAY)
+    {   // Skip any non-worn owned items
+        if (Items::getOwner(item) || item->getWear() >= 1)
             continue;
-        //skip any worn or more items
-        if (item->getWear() >= 1)
-            continue;
-
-        //again, for each item, find if any clothing order matches
-        for (auto& clothingOrder : clothingOrders)
-        {
-            if (item->getType() != clothingOrder.itemType)
-                continue;
-            if (item->getSubtype() != clothingOrder.item_subtype)
+        // Again, for each item, find if any clothing order matches
+        for (auto &clothingOrder : clothingOrders) {
+            if (item->getType() != clothingOrder.itemType ||
+                item->getSubtype() != clothingOrder.item_subtype
+            )
                 continue;
 
-            MaterialInfo matInfo;
             matInfo.decode(item);
-
             if (!matInfo.matches(clothingOrder.material_category))
                 continue;
 
@@ -637,43 +554,36 @@ static void remove_available_clothing()
     }
 }
 
-static void add_clothing_orders()
-{
-    for (auto& clothingOrder : clothingOrders)
-    {
-        for (auto& orderNeeded : clothingOrder.total_needed_per_race)
+static void add_clothing_orders() {
+    for (auto &clothingOrder : clothingOrders) {
+        for (auto &orderNeeded : clothingOrder.total_needed_per_race)
         {
             auto race = orderNeeded.first;
             auto amount = orderNeeded.second;
-            orderNeeded.second = 0; //once we get what we need, set it back to zero so we don't add it to further counts.
-            //Previous operations can easily make this negative. That jus means we have more than we need already.
+            orderNeeded.second = 0; // Once we get what we need, set it back to zero so we don't add it to further counts.
+            // Previous operations can easily make this negative. That just means we have more than we need already.
             if (amount <= 0)
                 continue;
 
             bool orderExistedAlready = false;
-            for (auto& managerOrder : world->manager_orders.all)
-            {
-                //Annoyingly, the manager orders store the job type for clothing orders, and actual item type is left at -1;
-                if (managerOrder->job_type != clothingOrder.jobType)
+            for (auto &managerOrder : world->manager_orders.all)
+            {   // Annoyingly, the manager orders store the job type for clothing orders, and actual item type is left at -1
+                if (managerOrder->job_type != clothingOrder.jobType ||
+                    managerOrder->item_subtype != clothingOrder.item_subtype ||
+                    managerOrder->specdata.hist_figure_id != race
+                )
                     continue;
-                if (managerOrder->item_subtype != clothingOrder.item_subtype)
-                    continue;
-                if (managerOrder->specdata.hist_figure_id != race)
-                    continue;
-
-                //We found a work order, that means we don't need to make a new one.
+                // We found a work order, that means we don't need to make a new one.
                 orderExistedAlready = true;
                 amount -= managerOrder->amount_left;
-                if (amount > 0)
-                {
+                if (amount > 0) {
                     managerOrder->amount_left += amount;
                     managerOrder->amount_total += amount;
                 }
             }
-            //if it wasn't there, we need to make a new one.
-            if (!orderExistedAlready)
-            {
-                df::manager_order * newOrder = new df::manager_order();
+            // If it wasn't there, we need to make a new one.
+            if (!orderExistedAlready) {
+                df::manager_order *newOrder = new df::manager_order();
 
                 newOrder->id = world->manager_orders.manager_order_next_id;
                 world->manager_orders.manager_order_next_id++;
@@ -690,27 +600,20 @@ static void add_clothing_orders()
 }
 
 static void do_autoclothing()
-{
-    // mark that we have recently run
+{   // Mark that we have recently run
     cycle_timestamp = world->frame_counter;
-
-    if (clothingOrders.size() == 0)
+    if (clothingOrders.empty())
         return;
-
-    //first we look through all the units on the map to see who needs new clothes.
+    // First we look through all the units on the map to see who needs new clothes.
     find_needed_clothing_items();
-
-    //Now we go through all the items in the map to see how many clothing items we have but aren't owned yet.
+    // Now we go through all the items in the map to see how many clothing items we have but aren't owned yet.
     remove_available_clothing();
-
-    //Finally loop through the clothing orders to find ones that need more made.
+    // Finally loop through the clothing orders to find ones that need more made.
     add_clothing_orders();
 }
 
-static void list_unit_counts(color_ostream& out, map<int, int>& unitList)
-{
-    for (const auto& race : unitList)
-    {
+static void list_unit_counts(color_ostream &out, map<int, int> &unitList) {
+    for (const auto &race : unitList) {
         if (race.second == 1)
             out << "    1 " << Units::getRaceReadableNameById(race.first) << endl;
         else
@@ -718,39 +621,34 @@ static void list_unit_counts(color_ostream& out, map<int, int>& unitList)
     }
 }
 
-static bool isAvailableItem(df::item* item)
-{
-    static struct BadFlags {
-        uint32_t whole;
+static constexpr uint32_t bad_flags = (
+    df::item_flags::mask_in_job |
+    df::item_flags::mask_hostile |
+    df::item_flags::mask_removed |
+    df::item_flags::mask_in_building |
+    df::item_flags::mask_rotten |
+    df::item_flags::mask_spider_web |
+    df::item_flags::mask_construction |
+    df::item_flags::mask_encased |
+    df::item_flags::mask_foreign |
+    df::item_flags::mask_trader |
+    df::item_flags::mask_owned |
+    df::item_flags::mask_garbage_collect |
+    // df::item_flags::mask_artifact | // TODO: use this?
+    df::item_flags::mask_forbid |
+    df::item_flags::mask_dump |
+    df::item_flags::mask_on_fire |
+    df::item_flags::mask_melt |
+    df::item_flags::mask_hidden
+);
 
-        BadFlags() {
-            df::item_flags flags;
-#define F(x) flags.bits.x = true;
-            F(in_job); F(hostile); F(in_building); F(encased);
-            F(foreign); F(trader); F(owned); F(forbid);
-            F(dump); F(on_fire); F(melt); F(hidden);
-
-            F(garbage_collect); F(rotten); F(construction);
-            F(removed); F(spider_web);
-
-            // F(artifact); -- TODO: should this be included?
-#undef F
-            whole = flags.whole;
-        }
-    } badFlags;
-
-    if ((item->flags.whole & badFlags.whole) != 0)
-        return false;
-
-    if (item->getWear() >= 1)
-        return false;
-    if (!item->isClothing())
-        return false;
-    return true;
+static bool isAvailableItem(df::item *item) {
+    return (item->flags.whole & bad_flags) == 0
+        && item->getWear() < 1
+        && item->isClothing();
 }
 
-static void generate_control(color_ostream& out)
-{
+static void generate_control(color_ostream &out) {
     map<int, int> fullUnitList;
     map<int, int> missingArmor;
     map<int, int> missingShoes;
@@ -764,32 +662,31 @@ static void generate_control(color_ostream& out)
         for (auto itemId : unit->owned_items)
         {
             auto item = Items::findItemByID(itemId);
-            if (!item)
-            {
+            if (!item) {
                 DEBUG(cycle, out).print("autoclothing: Invalid inventory item ID: %d\n", itemId);
                 continue;
             }
-            if (item->getWear() >= 1)
+            else if (item->getWear() >= 1)
                 continue;
             switch (item->getType())
             {
-            case df::item_type::ARMOR:
-                numArmor++;
-                break;
-            case df::item_type::SHOES:
-                numShoes++;
-                break;
-            case df::item_type::HELM:
-                numHelms++;
-                break;
-            case df::item_type::GLOVES:
-                numGloves++;
-                break;
-            case df::item_type::PANTS:
-                numPants++;
-                break;
-            default:
-                break;
+                case df::item_type::ARMOR:
+                    numArmor++;
+                    break;
+                case df::item_type::SHOES:
+                    numShoes++;
+                    break;
+                case df::item_type::HELM:
+                    numHelms++;
+                    break;
+                case df::item_type::GLOVES:
+                    numGloves++;
+                    break;
+                case df::item_type::PANTS:
+                    numPants++;
+                    break;
+                default:
+                    break;
             }
         }
         if (numArmor == 0)
@@ -802,103 +699,93 @@ static void generate_control(color_ostream& out)
             missingGloves[unit->race]++;
         if (numPants == 0)
             missingPants[unit->race]++;
-        DEBUG(control,out) << Translation::TranslateName(Units::getVisibleName(unit)) << " has " << numArmor << " armor, " << numShoes << " shoes, " << numHelms << " helms, " << numGloves << " gloves, " << numPants << " pants" << endl;
+        DEBUG(control, out) << Translation::TranslateName(Units::getVisibleName(unit)) <<
+            " has " << numArmor << " armor, " << numShoes << " shoes, " << numHelms <<
+            " helms, " << numGloves << " gloves, " << numPants << " pants" << endl;
     });
 
-    if (missingArmor.size() + missingShoes.size() + missingHelms.size() + missingGloves.size() + missingPants.size() == 0)
+    if (missingArmor.empty() && missingShoes.empty() && missingHelms.empty() &&
+        missingGloves.empty() && missingPants.empty())
     {
         out << "Everybody has a full set of clothes to wear, congrats!" << endl;
         return;
     }
-    else
-    {
-        if (missingArmor.size())
-        {
+    else {
+        if (!missingArmor.empty()) {
             out << "The following units need new bodywear:" << endl;
             list_unit_counts(out, missingArmor);
         }
-        if (missingShoes.size())
-        {
+        if (!missingShoes.empty()) {
             out << "The following units need new shoes:" << endl;
             list_unit_counts(out, missingShoes);
         }
-        if (missingHelms.size())
-        {
+        if (!missingHelms.empty()) {
             out << "The following units need new headwear:" << endl;
             list_unit_counts(out, missingHelms);
         }
-        if (missingGloves.size())
-        {
+        if (!missingGloves.empty()) {
             out << "The following units need new handwear:" << endl;
             list_unit_counts(out, missingGloves);
         }
-        if (missingPants.size())
-        {
+        if (!missingPants.empty()) {
             out << "The following units need new legwear:" << endl;
             list_unit_counts(out, missingPants);
         }
     }
     map<int, int> availableArmor;
-    for (auto armor : world->items.other.ARMOR)
-    {
+    for (auto armor : world->items.other.ARMOR) {
         if (!isAvailableItem(armor))
             continue;
         availableArmor[armor->maker_race]++;
     }
-    if (availableArmor.size())
-    {
+    if (!availableArmor.empty()) {
         out << "We have available bodywear for:" << endl;
         list_unit_counts(out, availableArmor);
     }
+
     map<int, int> availableShoes;
-    for (auto shoe : world->items.other.SHOES)
-    {
+    for (auto shoe : world->items.other.SHOES) {
         if (!isAvailableItem(shoe))
             continue;
         availableShoes[shoe->maker_race]++;
     }
-    if (availableShoes.size())
-    {
+    if (!availableShoes.empty()) {
         out << "We have available footwear for:" << endl;
         list_unit_counts(out, availableShoes);
     }
+
     map<int, int> availableHelms;
-    for (auto helm : world->items.other.HELM)
-    {
+    for (auto helm : world->items.other.HELM) {
         if (!isAvailableItem(helm))
             continue;
         availableHelms[helm->maker_race]++;
     }
-    if (availableHelms.size())
-    {
+    if (!availableHelms.empty()) {
         out << "We have available headwear for:" << endl;
         list_unit_counts(out, availableHelms);
     }
+
     map<int, int> availableGloves;
-    for (auto glove : world->items.other.HELM)
-    {
+    for (auto glove : world->items.other.HELM) {
         if (!isAvailableItem(glove))
             continue;
         availableGloves[glove->maker_race]++;
     }
-    if (availableGloves.size())
-    {
+    if (!availableGloves.empty()) {
         out << "We have available handwear for:" << endl;
         list_unit_counts(out, availableGloves);
     }
+
     map<int, int> availablePants;
-    for (auto pants : world->items.other.HELM)
-    {
+    for (auto pants : world->items.other.HELM) {
         if (!isAvailableItem(pants))
             continue;
         availablePants[pants->maker_race]++;
     }
-    if (availablePants.size())
-    {
+    if (!availablePants.empty()) {
         out << "We have available legwear for:" << endl;
         list_unit_counts(out, availablePants);
     }
-
 }
 
 /////////////////////////////////////////////////////
@@ -906,17 +793,16 @@ static void generate_control(color_ostream& out)
 // TODO: implement Lua hooks to manipulate the persistent order configuration
 //
 
-static void autoclothing_doCycle(color_ostream& out) {
+static void autoclothing_doCycle(color_ostream &out) {
     DEBUG(control, out).print("entering autoclothing_doCycle\n");
     do_autoclothing();
 }
 
-
-DFHACK_PLUGIN_LUA_FUNCTIONS{
+DFHACK_PLUGIN_LUA_FUNCTIONS {
     DFHACK_LUA_FUNCTION(autoclothing_doCycle),
     DFHACK_LUA_END
 };
 
-DFHACK_PLUGIN_LUA_COMMANDS{
+DFHACK_PLUGIN_LUA_COMMANDS {
     DFHACK_LUA_END
 };

--- a/plugins/autodump.cpp
+++ b/plugins/autodump.cpp
@@ -120,7 +120,7 @@ static command_result autodump_main(color_ostream &out, vector<string> &paramete
             out.printerr("Cursor is in an invalid/uninitialized area. Place it over a floor.\n");
             return CR_FAILURE;
         }
-        else if(!isWalkable(*ttype)) { // TODO: Improve this w/r/t impassible buildings
+        else if(!isWalkable(*ttype)) { // TODO: Bring this in line with gui/autodump?
             auto b_occ = Maps::getTileOccupancy(pos_cursor)->bits.building;
             if (b_occ != tile_building_occ::Floored)
             {   // Some Dynamic act as floors

--- a/plugins/autodump.cpp
+++ b/plugins/autodump.cpp
@@ -125,10 +125,10 @@ static command_result autodump_main(color_ostream &out, vector<string> &paramete
             out.printerr("Cursor is in an invalid/uninitialized area.\n");
             return CR_FAILURE;
         }
-        else if(!isWalkable(*ttype))
-        {   // Not floor, stair, nor ramp.
+        else if(!isWalkable(*ttype) && tileShape(*ttype) != tiletype_shape::FORTIFICATION)
+        {   // Not floor, stair, ramp, nor fortification.
             if (tileShapeBasic(tileShape(*ttype)) == tiletype_shape_basic::Wall) {
-                out.printerr("Can't dump inside walls or fortifications.\n");
+                out.printerr("Can't dump inside walls.\n");
                 return CR_FAILURE;
             }
             make_projectile = true;

--- a/plugins/createitem.cpp
+++ b/plugins/createitem.cpp
@@ -1,31 +1,30 @@
 // Create arbitrary items
 
-#include "Core.h"
 #include "Console.h"
-#include "Export.h"
-#include "PluginManager.h"
-#include "MiscUtils.h"
+#include "Core.h"
 #include "DataDefs.h"
+#include "Export.h"
+#include "MiscUtils.h"
+#include "PluginManager.h"
 
-#include "modules/Maps.h"
-#include "modules/MapCache.h"
 #include "modules/Gui.h"
 #include "modules/Items.h"
+#include "modules/Maps.h"
 #include "modules/Materials.h"
 #include "modules/Units.h"
 #include "modules/World.h"
 
 #include "df/building.h"
-#include "df/game_type.h"
-#include "df/world.h"
-#include "df/unit.h"
-#include "df/item.h"
-#include "df/creature_raw.h"
 #include "df/caste_raw.h"
-#include "df/tool_uses.h"
+#include "df/creature_raw.h"
+#include "df/game_type.h"
+#include "df/item.h"
 #include "df/plant_growth.h"
 #include "df/plant_growth_print.h"
 #include "df/plant_raw.h"
+#include "df/tool_uses.h"
+#include "df/unit.h"
+#include "df/world.h"
 
 using std::string;
 using std::vector;
@@ -40,10 +39,9 @@ REQUIRE_GLOBAL(cur_year_tick);
 
 int dest_container = -1, dest_building = -1;
 
-command_result df_createitem (color_ostream &out, vector <string> & parameters);
+command_result df_createitem(color_ostream &out, vector<string> &parameters);
 
-DFhackCExport command_result plugin_init (color_ostream &out, std::vector<PluginCommand> &commands)
-{
+DFhackCExport command_result plugin_init(color_ostream &out, std::vector<PluginCommand> &commands) {
     commands.push_back(
         PluginCommand("createitem",
                       "Create arbitrary items.",
@@ -51,14 +49,13 @@ DFhackCExport command_result plugin_init (color_ostream &out, std::vector<Plugin
     return CR_OK;
 }
 
-DFhackCExport command_result plugin_shutdown ( color_ostream &out )
-{
+DFhackCExport command_result plugin_shutdown(color_ostream &out) {
     return CR_OK;
 }
 
-bool makeItem (df::unit *unit, df::item_type type, int16_t subtype, int16_t mat_type, int32_t mat_index, int32_t growth_print = -1, bool move_to_cursor = false, bool second_item = false)
-{
-    // Special logic for making Gloves and Shoes in pairs
+bool makeItem(df::unit *unit, df::item_type type, int16_t subtype, int16_t mat_type, int32_t mat_index,
+    int32_t growth_print = -1, bool move_to_cursor = false, bool second_item = false)
+{   // Special logic for making Gloves and Shoes in pairs
     bool is_gloves = (type == item_type::GLOVES);
     bool is_shoes = (type == item_type::SHOES);
 
@@ -75,20 +72,17 @@ bool makeItem (df::unit *unit, df::item_type type, int16_t subtype, int16_t mat_
     if (!Items::createItem(out_items, unit, type, subtype, mat_type, mat_index, growth_print, !on_floor))
         return false;
 
-    MapExtras::MapCache mc;
-
-    for (size_t i = 0; i < out_items.size(); i++)
-    {
+    for (size_t i = 0; i < out_items.size(); i++) {
         if (container)
         {
             out_items[i]->flags.bits.removed = 1;
-            if (!Items::moveToContainer(mc, out_items[i], container))
+            if (!Items::moveToContainer(out_items[i], container))
                 out_items[i]->moveToGround(container->pos.x, container->pos.y, container->pos.z);
         }
         else if (building)
         {
             out_items[i]->flags.bits.removed = 1;
-            if (!Items::moveToBuilding(mc, out_items[i], (df::building_actual *)building, df::building_item_role_type::TEMP))
+            if (!Items::moveToBuilding(out_items[i], (df::building_actual *)building, df::building_item_role_type::TEMP))
                 out_items[i]->moveToGround(building->centerx, building->centery, building->z);
         }
         else if (move_to_cursor)
@@ -97,8 +91,7 @@ bool makeItem (df::unit *unit, df::item_type type, int16_t subtype, int16_t mat_
 
         // Special logic for creating proper gloves in pairs
         if (is_gloves)
-        {
-            // If the gloves have non-zero handedness, then disable special pair-making logic
+        {   // If the gloves have non-zero handedness, then disable special pair-making logic
             // ("reaction-gloves" tweak is active, or Toady fixed glove-making reactions)
             // Otherwise, set them to be either Left or Right-handed
             if (out_items[i]->getGloveHandedness() > 0)
@@ -107,22 +100,133 @@ bool makeItem (df::unit *unit, df::item_type type, int16_t subtype, int16_t mat_
                 out_items[i]->setGloveHandedness(second_item ? 2 : 1);
         }
     }
-
     // If we asked to make a Shoe and we got more than one, then disable special pair-making logic
     if (is_shoes && out_items.size() > 1)
         is_shoes = false;
-
     // If we asked for gloves/shoes and only got one (and we're making the first one), make another
     if ((is_gloves || is_shoes) && !second_item)
         return makeItem(unit, type, subtype, mat_type, mat_index, growth_print, move_to_cursor, true);
-
     return true;
 }
 
-command_result df_createitem (color_ostream &out, vector <string> & parameters)
+static inline bool select_caste_mat(color_ostream &out, vector<string> &tokens,
+    int16_t &mat_type, int32_t &mat_index, const string &material_str)
 {
+    split_string(&tokens, material_str, ":");
+    if (tokens.size() == 1)
+    {   // Default to empty caste to display a list of valid castes later
+        tokens.push_back("");
+    }
+    else if (tokens.size() != 2) {
+        out.printerr("You must specify a creature ID and caste for this item type!\n");
+        return CR_FAILURE;
+    }
+
+    for (size_t i = 0; i < world->raws.creatures.all.size(); i++)
+    {
+        string castes = "";
+        auto creature = world->raws.creatures.all[i];
+        if (creature->creature_id == tokens[0])
+        {
+            for (size_t j = 0; j < creature->caste.size(); j++)
+            {
+                auto caste = creature->caste[j];
+                castes += " " + caste->caste_id;
+                if (caste->caste_id == tokens[1])
+                {
+                    mat_type = i;
+                    mat_index = j;
+                    break;
+                }
+            }
+            if (mat_type == -1) {
+                if (tokens[1].empty())
+                    out.printerr("You must also specify a caste.\n");
+                else
+                    out.printerr("The creature you specified has no such caste!\n");
+                out.printerr("Valid castes:%s\n", castes.c_str());
+                return false;
+            }
+        }
+    }
+    if (mat_type == -1) {
+        out.printerr("Unrecognized creature ID!\n");
+        return false;
+    }
+    return true;
+}
+
+static inline bool select_plant_growth(color_ostream &out, vector<string> &tokens, df::item_type &item_type,
+    int16_t &item_subtype, int16_t &mat_type, int32_t &mat_index, int32_t &growth_print, const string &material_str)
+{
+    split_string(&tokens, material_str, ":");
+    if (tokens.size() == 1)
+    {   // Default to empty to display a list of valid growths later
+        tokens.push_back("");
+    }
+    else if (tokens.size() == 3 && tokens[0] == "PLANT")
+        tokens.erase(tokens.begin());
+    else if (tokens.size() != 2) {
+        out.printerr("You must specify a plant and growth ID for this item type!\n");
+        return false;
+    }
+
+    for (size_t i = 0; i < world->raws.plants.all.size(); i++)
+    {
+        string growths = "";
+        auto plant = world->raws.plants.all[i];
+        if (plant->id != tokens[0])
+            continue;
+
+        for (size_t j = 0; j < plant->growths.size(); j++)
+        {
+            auto growth = plant->growths[j];
+            growths += " " + growth->id;
+            if (growth->id != tokens[1])
+                continue;
+
+            // Plant growths specify the actual item type/subtype
+            // so that certain growths can drop as SEEDS items
+            item_type = growth->item_type;
+            item_subtype = growth->item_subtype;
+            mat_type = growth->mat_type;
+            mat_index = growth->mat_index;
+
+            // Try and find a growth print matching the current time
+            // (in practice, only tree leaves use this for autumn color changes)
+            for (size_t k = 0; k < growth->prints.size(); k++)
+            {
+                auto print = growth->prints[k];
+                if (print->timing_start <= *cur_year_tick && *cur_year_tick <= print->timing_end)
+                {
+                    growth_print = k;
+                    break;
+                }
+            }
+            // If we didn't find one, then pick the first one (if it exists)
+            if (growth_print == -1 && !growth->prints.empty())
+                growth_print = 0;
+            break;
+        }
+        if (mat_type == -1) {
+            if (tokens[1].empty())
+                out.printerr("You must also specify a growth ID.\n");
+            else
+                out.printerr("The plant you specified has no such growth!\n");
+            out.printerr("Valid growths:%s\n", growths.c_str());
+            return false;
+        }
+    }
+    if (mat_type == -1) {
+        out.printerr("Unrecognized plant ID!\n");
+        return false;
+    }
+    return true;
+}
+
+command_result df_createitem (color_ostream &out, vector<string> &parameters) {
     string item_str, material_str;
-    df::item_type item_type = item_type::NONE;
+    auto item_type = item_type::NONE;
     int16_t item_subtype = -1;
     int16_t mat_type = -1;
     int32_t mat_index = -1;
@@ -130,62 +234,53 @@ command_result df_createitem (color_ostream &out, vector <string> & parameters)
     int count = 1;
     bool move_to_cursor = false;
 
-    if (parameters.size() == 1)
-    {
-        if (parameters[0] == "inspect")
-        {
+    if (parameters.size() == 1) {
+        if (parameters[0] == "inspect") {
             CoreSuspender suspend;
-            df::item *item = Gui::getSelectedItem(out);
+            auto item = Gui::getSelectedItem(out);
             if (!item)
-            {
                 return CR_FAILURE;
-            }
 
             ItemTypeInfo iinfo(item->getType(), item->getSubtype());
             MaterialInfo minfo(item->getMaterial(), item->getMaterialIndex());
             out.print("%s %s\n", iinfo.getToken().c_str(), minfo.getToken().c_str());
             return CR_OK;
         }
-        else if (parameters[0] == "floor")
-        {
+        else if (parameters[0] == "floor") {
             dest_container = -1;
             dest_building = -1;
             out.print("Items created will be placed on the floor.\n");
             return CR_OK;
         }
-        else if (parameters[0] == "item")
-        {
+        else if (parameters[0] == "item") {
             dest_building = -1;
-            df::item *item = Gui::getSelectedItem(out);
-            if (!item)
-            {
+            auto item = Gui::getSelectedItem(out);
+            if (!item) {
                 out.printerr("You must select a container!\n");
                 return CR_FAILURE;
             }
             switch (item->getType())
-            {
-            case item_type::FLASK:
-            case item_type::BARREL:
-            case item_type::BUCKET:
-            case item_type::ANIMALTRAP:
-            case item_type::BOX:
-            case item_type::BAG:
-            case item_type::BIN:
-            case item_type::BACKPACK:
-            case item_type::QUIVER:
-                break;
-            case item_type::TOOL:
-                if (item->hasToolUse(tool_uses::LIQUID_CONTAINER))
+            {   using namespace df::enums::item_type;
+                case FLASK:
+                case BARREL:
+                case BUCKET:
+                case ANIMALTRAP:
+                case BOX:
+                case BAG:
+                case BIN:
+                case BACKPACK:
+                case QUIVER:
                     break;
-                if (item->hasToolUse(tool_uses::FOOD_STORAGE))
-                    break;
-                if (item->hasToolUse(tool_uses::SMALL_OBJECT_STORAGE))
-                    break;
-                if (item->hasToolUse(tool_uses::TRACK_CART))
-                    break;
-            default:
-                out.printerr("The selected item cannot be used for item storage!\n");
-                return CR_FAILURE;
+                case TOOL:
+                    if (item->hasToolUse(tool_uses::LIQUID_CONTAINER) ||
+                        item->hasToolUse(tool_uses::FOOD_STORAGE) ||
+                        item->hasToolUse(tool_uses::SMALL_OBJECT_STORAGE) ||
+                        item->hasToolUse(tool_uses::TRACK_CART)
+                    )
+                        break;
+                default:
+                    out.printerr("The selected item cannot be used for item storage!\n");
+                    return CR_FAILURE;
             }
             dest_container = item->id;
             string name;
@@ -193,40 +288,37 @@ command_result df_createitem (color_ostream &out, vector <string> & parameters)
             out.print("Items created will be placed inside %s.\n", name.c_str());
             return CR_OK;
         }
-        else if (parameters[0] == "building")
-        {
+        else if (parameters[0] == "building") {
             dest_container = -1;
-            df::building *building = Gui::getSelectedBuilding(out);
-            if (!building)
-            {
+            auto building = Gui::getSelectedBuilding(out);
+            if (!building) {
                 out.printerr("You must select a building!\n");
                 return CR_FAILURE;
             }
             switch (building->getType())
-            {
-            case building_type::Coffin:
-            case building_type::Furnace:
-            case building_type::TradeDepot:
-            case building_type::Shop:
-            case building_type::Box:
-            case building_type::Weaponrack:
-            case building_type::Armorstand:
-            case building_type::Workshop:
-            case building_type::Cabinet:
-            case building_type::SiegeEngine:
-            case building_type::Trap:
-            case building_type::AnimalTrap:
-            case building_type::Cage:
-            case building_type::Wagon:
-            case building_type::NestBox:
-            case building_type::Hive:
-                break;
-            default:
-                out.printerr("The selected building cannot be used for item storage!\n");
-                return CR_FAILURE;
+            {   using namespace df::enums::building_type;
+                case Coffin:
+                case Furnace:
+                case TradeDepot:
+                case Shop:
+                case Box:
+                case Weaponrack:
+                case Armorstand:
+                case Workshop:
+                case Cabinet:
+                case SiegeEngine:
+                case Trap:
+                case AnimalTrap:
+                case Cage:
+                case Wagon:
+                case NestBox:
+                case Hive:
+                    break;
+                default:
+                    out.printerr("The selected building cannot be used for item storage!\n");
+                    return CR_FAILURE;
             }
-            if (building->getBuildStage() != building->getMaxBuildStage())
-            {
+            if (building->getBuildStage() != building->getMaxBuildStage()) {
                 out.printerr("The selected building has not yet been fully constructed!\n");
                 return CR_FAILURE;
             }
@@ -246,12 +338,10 @@ command_result df_createitem (color_ostream &out, vector <string> & parameters)
     item_str = parameters[0];
     material_str = parameters[1];
 
-    if (parameters.size() == 3)
-    {
+    if (parameters.size() == 3) {
         std::stringstream ss(parameters[2]);
         ss >> count;
-        if (count < 1)
-        {
+        if (count < 1) {
             out.printerr("You cannot produce less than one item!\n");
             return CR_FAILURE;
         }
@@ -261,233 +351,107 @@ command_result df_createitem (color_ostream &out, vector <string> & parameters)
     MaterialInfo material;
     vector<string> tokens;
 
-    if (item.find(item_str))
-    {
+    if (item.find(item_str)) {
         item_type = item.type;
         item_subtype = item.subtype;
     }
-    if (item_type == item_type::NONE)
-    {
+    if (item_type == item_type::NONE) {
         out.printerr("You must specify a valid item type to create!\n");
         return CR_FAILURE;
     }
     switch (item.type)
-    {
-    case item_type::INSTRUMENT:
-    case item_type::TOY:
-    case item_type::WEAPON:
-    case item_type::ARMOR:
-    case item_type::SHOES:
-    case item_type::SHIELD:
-    case item_type::HELM:
-    case item_type::GLOVES:
-    case item_type::AMMO:
-    case item_type::PANTS:
-    case item_type::SIEGEAMMO:
-    case item_type::TRAPCOMP:
-    case item_type::TOOL:
-        if (item_subtype == -1)
-        {
-            out.printerr("You must specify a subtype!\n");
+    {   using namespace df::enums::item_type;
+        case REMAINS:
+        case FISH:
+        case FISH_RAW:
+        case VERMIN:
+        case PET:
+        case EGG:
+            if (!select_caste_mat(out, tokens, mat_type, mat_index, material_str))
+                return CR_FAILURE;
+            break;
+        case PLANT_GROWTH:
+            if (!select_plant_growth(out, tokens, item_type, item_subtype,
+                mat_type, mat_index, growth_print, material_str)
+                )
+                return CR_FAILURE;
+            break;
+        case CORPSE:
+        case CORPSEPIECE:
+        case FOOD:
+            out.printerr("Cannot create that type of item!\n");
             return CR_FAILURE;
-        }
-    default:
-        if (!material.find(material_str))
-        {
-            out.printerr("Unrecognized material!\n");
-            return CR_FAILURE;
-        }
-        mat_type = material.type;
-        mat_index = material.index;
-        break;
-
-    case item_type::REMAINS:
-    case item_type::FISH:
-    case item_type::FISH_RAW:
-    case item_type::VERMIN:
-    case item_type::PET:
-    case item_type::EGG:
-        split_string(&tokens, material_str, ":");
-        if (tokens.size() == 1)
-        {
-            // default to empty caste to display a list of valid castes later
-            tokens.push_back("");
-        }
-        else if (tokens.size() != 2)
-        {
-            out.printerr("You must specify a creature ID and caste for this item type!\n");
-            return CR_FAILURE;
-        }
-
-        for (size_t i = 0; i < world->raws.creatures.all.size(); i++)
-        {
-            string castes = "";
-            df::creature_raw *creature = world->raws.creatures.all[i];
-            if (creature->creature_id == tokens[0])
-            {
-                for (size_t j = 0; j < creature->caste.size(); j++)
-                {
-                    df::caste_raw *caste = creature->caste[j];
-                    castes += " " + caste->caste_id;
-                    if (caste->caste_id == tokens[1])
-                    {
-                        mat_type = i;
-                        mat_index = j;
-                        break;
-                    }
-                }
-                if (mat_type == -1)
-                {
-                    if (tokens[1].empty())
-                    {
-                        out.printerr("You must also specify a caste.\n");
-                    }
-                    else
-                    {
-                        out.printerr("The creature you specified has no such caste!\n");
-                    }
-                    out.printerr("Valid castes:%s\n", castes.c_str());
-                    return CR_FAILURE;
-                }
-            }
-        }
-        if (mat_type == -1)
-        {
-            out.printerr("Unrecognized creature ID!\n");
-            return CR_FAILURE;
-        }
-        break;
-
-    case item_type::PLANT_GROWTH:
-        split_string(&tokens, material_str, ":");
-        if (tokens.size() == 1)
-        {
-            // default to empty to display a list of valid growths later
-            tokens.push_back("");
-        }
-        else if (tokens.size() == 3 && tokens[0] == "PLANT")
-        {
-            tokens.erase(tokens.begin());
-        }
-        else if (tokens.size() != 2)
-        {
-            out.printerr("You must specify a plant and growth ID for this item type!\n");
-            return CR_FAILURE;
-        }
-
-        for (size_t i = 0; i < world->raws.plants.all.size(); i++)
-        {
-            string growths = "";
-            df::plant_raw *plant = world->raws.plants.all[i];
-            if (plant->id != tokens[0])
-                continue;
-
-            for (size_t j = 0; j < plant->growths.size(); j++)
-            {
-                df::plant_growth *growth = plant->growths[j];
-                growths += " " + growth->id;
-                if (growth->id != tokens[1])
-                    continue;
-
-                // Plant growths specify the actual item type/subtype
-                // so that certain growths can drop as SEEDS items
-                item_type = growth->item_type;
-                item_subtype = growth->item_subtype;
-                mat_type = growth->mat_type;
-                mat_index = growth->mat_index;
-
-                // Try and find a growth print matching the current time
-                // (in practice, only tree leaves use this for autumn color changes)
-                for (size_t k = 0; k < growth->prints.size(); k++)
-                {
-                    df::plant_growth_print *print = growth->prints[k];
-                    if (print->timing_start <= *cur_year_tick && *cur_year_tick <= print->timing_end)
-                    {
-                        growth_print = k;
-                        break;
-                    }
-                }
-                // If we didn't find one, then pick the first one (if it exists)
-                if (growth_print == -1 && growth->prints.size() > 0)
-                    growth_print = 0;
-                break;
-            }
-            if (mat_type == -1)
-            {
-                if (tokens[1].empty())
-                    out.printerr("You must also specify a growth ID.\n");
-                else
-                    out.printerr("The plant you specified has no such growth!\n");
-                out.printerr("Valid growths:%s\n", growths.c_str());
+        case INSTRUMENT:
+        case TOY:
+        case WEAPON:
+        case ARMOR:
+        case SHOES:
+        case SHIELD:
+        case HELM:
+        case GLOVES:
+        case AMMO:
+        case PANTS:
+        case SIEGEAMMO:
+        case TRAPCOMP:
+        case TOOL:
+            if (item_subtype == -1) {
+                out.printerr("You must specify a subtype!\n");
                 return CR_FAILURE;
             }
-        }
-        if (mat_type == -1)
-        {
-            out.printerr("Unrecognized plant ID!\n");
-            return CR_FAILURE;
-        }
-        break;
-
-    case item_type::CORPSE:
-    case item_type::CORPSEPIECE:
-    case item_type::FOOD:
-        out.printerr("Cannot create that type of item!\n");
-        return CR_FAILURE;
-        break;
+        default:
+            if (!material.find(material_str)) {
+                out.printerr("Unrecognized material!\n");
+                return CR_FAILURE;
+            }
+            mat_type = material.type;
+            mat_index = material.index;
     }
 
+    if (!Maps::IsValid()) {
+        out.printerr("Map is not available.\n");
+        return CR_FAILURE;
+    }
     CoreSuspender suspend;
 
-    df::unit *unit = Gui::getSelectedUnit(out, true);
-    if (!unit)
-    {
+    auto unit = Gui::getSelectedUnit(out, true);
+    if (!unit) {
         if (*gametype == game_type::ADVENTURE_ARENA || World::isAdventureMode())
-        {
-            // Use the adventurer unit
+        {   // Use the adventurer unit
             unit = World::getAdventurer();
         }
         else if (cursor->x >= 0)
-        {
-            // Use the first possible citizen if possible, otherwise the first unit
+        {   // Use the first possible citizen if possible, otherwise the first unit
             for (auto u : Units::citizensRange(world->units.active)) {
                 unit = u;
                 break;
             }
-            if (!unit && world->units.active.size())
-                unit = world->units.active[0];
+            if (!unit)
+                unit = vector_get(world->units.active, 0);
             move_to_cursor = true;
         }
-        if (!unit)
-        {
+        if (!unit) {
             out.printerr("No unit selected!\n");
             return CR_FAILURE;
         }
     }
-    if (!Maps::IsValid())
-    {
-        out.printerr("Map is not available.\n");
-        return CR_FAILURE;
-    }
-    df::map_block *block = Maps::getTileBlock(unit->pos.x, unit->pos.y, unit->pos.z);
-    if (block == NULL)
-    {
+
+    auto block = Maps::getTileBlock(unit->pos);
+    if (!block) {
         out.printerr("Unit does not reside in a valid map block, somehow?\n");
         return CR_FAILURE;
     }
-    if ((dest_container != -1) && !df::item::find(dest_container))
+    if (dest_container != -1 && !df::item::find(dest_container))
     {
         dest_container = -1;
         out.printerr("Previously selected container no longer exists - item will be placed on the floor.\n");
     }
-    if ((dest_building != -1) && !df::building::find(dest_building))
+    if (dest_building != -1 && !df::building::find(dest_building))
     {
         dest_building = -1;
         out.printerr("Previously selected building no longer exists - item will be placed on the floor.\n");
     }
 
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
         if (!makeItem(unit, item_type, item_subtype, mat_type, mat_index, growth_print, move_to_cursor, false))
         {
             out.printerr("Failed to create item!\n");

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -3,37 +3,37 @@
  */
 
 #include "DataFuncs.h"
+#include "Debug.h"
+#include "LuaTools.h"
 #include "PluginManager.h"
 #include "TileTypes.h"
-#include "LuaTools.h"
-#include "Debug.h"
 
 #include "modules/Buildings.h"
+#include "modules/EventManager.h"
 #include "modules/Gui.h"
+#include "modules/Job.h"
 #include "modules/Maps.h"
 #include "modules/MapCache.h"
 #include "modules/Random.h"
 #include "modules/Units.h"
 #include "modules/World.h"
-#include "modules/EventManager.h"
-#include "modules/Job.h"
 
 #include "df/building.h"
 #include "df/historical_entity.h"
 #include "df/item.h"
 #include "df/map_block.h"
+#include "df/plotinfost.h"
 #include "df/reaction_product_itemst.h"
 #include "df/tile_designation.h"
 #include "df/tile_occupancy.h"
-#include "df/plotinfost.h"
 #include "df/unit.h"
 #include "df/vermin.h"
 #include "df/world.h"
 #include "df/world_site.h"
 
 #include <cinttypes>
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
 
 DFHACK_PLUGIN("dig-now");
 REQUIRE_GLOBAL(plotinfo);
@@ -981,11 +981,8 @@ static void post_process_dug_tiles(color_ostream &out,
                     }
                 }
                 if (!items.empty()) {
-                    // fresh MapCache since tile properties are being actively changed
-                    MapExtras::MapCache mc;
                     for (auto item : items)
-                        Items::moveToGround(mc, item, resting_pos);
-                    mc.WriteAll();
+                        Items::moveToGround(item, resting_pos);
                 }
             }
         }


### PR DESCRIPTION
Remove `MapCache` dependency for `Items` module.

Moved a bunch of code out of a switch statement in `createitem.cpp` into separate utility fns for readability.

Made improvements to `autodump.cpp` so it's in line with `gui/autodump`. (Convert to projectile, cancel any active job.)

Tidied up `autoclothing.cpp` a bit, made sure to initialize variables in a struct.

Made `dfhack.items.moveToInventory` args `use_mode` and `body_part` optional.