### PR TITLE
Improve docs by linking to GUI versions of tools

### DIFF
--- a/docs/plugins/autobutcher.rst
+++ b/docs/plugins/autobutcher.rst
@@ -6,7 +6,8 @@ autobutcher
     :tags: fort auto fps animals
 
 This plugin monitors how many pets you have of each gender and age and assigns
-excess livestock for slaughter. Units will be ignored if they are:
+excess livestock for slaughter. See `gui/autobutcher` for an in-game interface.
+Units will be ignored if they are:
 
 * Untamed
 * Named or nicknamed

--- a/docs/plugins/autodump.rst
+++ b/docs/plugins/autodump.rst
@@ -11,7 +11,7 @@ autodump
 This tool can instantly move all unforbidden items marked for dumping to the
 tile under the keyboard cursor. After moving the items, the dump flag is unset
 and the forbid flag is set, just as if it had been dumped normally. See
-``gui/autodump`` for an interactive version of this tool.
+`gui/autodump` for an interactive version of this tool.
 
 The keyboard cursor can be placed on a floor tile or in the air. If in air,
 the items will be converted into projectiles and fall. Items cannot be dumped

--- a/docs/plugins/blueprint.rst
+++ b/docs/plugins/blueprint.rst
@@ -11,7 +11,7 @@ in a blueprint file that you (or anyone else) can later play back with
 
 Blueprints are ``.csv`` or ``.xlsx`` files created in the ``dfhack-config/blueprints``
 subdirectory of your DF folder. The map area to turn into a blueprint is either
-selected interactively with the ``gui/blueprint`` command or, if the GUI is not
+selected interactively with the `gui/blueprint` command or, if the GUI is not
 used, starts at the active cursor location and extends right and down for the
 requested width and height.
 

--- a/docs/plugins/createitem.rst
+++ b/docs/plugins/createitem.rst
@@ -21,6 +21,7 @@ reaction raws, with the following differences:
   instead of a material token.
 
 Corpses, body parts, and prepared meals cannot be created using this tool.
+See `gui/create-item` for an interactive version of the tool.
 
 Usage
 -----

--- a/docs/plugins/stockpiles.rst
+++ b/docs/plugins/stockpiles.rst
@@ -6,7 +6,8 @@ stockpiles
     :tags: fort design productivity stockpiles
 
 Commands act upon the stockpile selected in the UI unless another stockpile
-identifier is specified on the commandline.
+identifier is specified on the commandline. See `gui/stockpiles` for an
+in-game version of this tool.
 
 You can also specify hauling route stops to import and export "desired items"
 configuration.

--- a/docs/plugins/stockpiles.rst
+++ b/docs/plugins/stockpiles.rst
@@ -6,8 +6,7 @@ stockpiles
     :tags: fort design productivity stockpiles
 
 Commands act upon the stockpile selected in the UI unless another stockpile
-identifier is specified on the commandline. See `gui/stockpiles` for an
-in-game version of this tool.
+identifier is specified on the commandline.
 
 You can also specify hauling route stops to import and export "desired items"
 configuration.

--- a/docs/plugins/suspendmanager.rst
+++ b/docs/plugins/suspendmanager.rst
@@ -20,6 +20,8 @@ When enabled, ``suspendmanager`` will watch your active jobs and:
 - suspend construction jobs that would cave in immediately on completion,
   such as when building walls or floors next to grates/bars.
 
+See `gui/suspendmanager` for a graphical configuration interface.
+
 Usage
 -----
 


### PR DESCRIPTION
Make sure there are links to `gui/` Lua scripts in plugin docs.