### PR TITLE
`buildingplan`: performance improvement

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `buildingplan`: improved performance in forts with large numbers of items
 
 ## Misc Improvements
 

--- a/plugins/buildingplan/buildingplan.cpp
+++ b/plugins/buildingplan/buildingplan.cpp
@@ -666,22 +666,23 @@ static int scanAvailableItems(color_ostream &out, df::building_type type, int16_
     auto &jitem = job_items[index];
     auto vector_ids = getVectorIds(out, jitem, ignore_filters);
 
+    ItemFilter filter = filters[index];
+    set<string> special = specials;
+    if (ignore_filters || counts) {
+        // don't filter by material; we want counts for all materials
+        filter.setMaterialMask(0);
+        filter.setMaterials(set<MaterialInfo>());
+        special.clear();
+    }
+    if (ignore_quality) {
+        filter.setMinQuality(df::item_quality::Ordinary);
+        filter.setMaxQuality(df::item_quality::Artifact);
+    }
+
     int count = 0;
     for (auto vector_id : vector_ids) {
         auto other_id = ENUM_ATTR(job_item_vector_id, other, vector_id);
         for (auto &item : df::global::world->items.other[other_id]) {
-            ItemFilter filter = filters[index];
-            set<string> special = specials;
-            if (ignore_filters || counts) {
-                // don't filter by material; we want counts for all materials
-                filter.setMaterialMask(0);
-                filter.setMaterials(set<MaterialInfo>());
-                special.clear();
-            }
-            if (ignore_quality) {
-                filter.setMinQuality(df::item_quality::Ordinary);
-                filter.setMaxQuality(df::item_quality::Artifact);
-            }
             if (itemPassesScreen(out, item) && matchesFilters(item, jitem, heat, filter, special)) {
                 if (item_ids)
                     item_ids->emplace_back(item->id);


### PR DESCRIPTION
move filter creation out of the item scan

(no open issue, see [discussion on discord](https://discord.com/channels/793331351645323264/807444467140788254/1271131794539937928))