### PR TITLE
[overlay] check focus strings before evaluating widget properties

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -71,6 +71,7 @@ Template for new versions:
 ## Lua
 - ``dfhack.units``: ``isWildlife`` and ``isAgitated`` property checks
 - ``dfhack.units.isDanger``: no longer returns true for intelligent undead
+- Overlay widgets can now assume their ``active`` and ``visible`` functions will only execute in a context that matches their ``viewscreens`` associations
 
 ## Removed
 

--- a/docs/dev/overlay-dev-guide.rst
+++ b/docs/dev/overlay-dev-guide.rst
@@ -152,6 +152,11 @@ The ``overlay.OverlayWidget`` superclass defines the following class attributes:
     updates, set it to ``0`` and it will be noticed immediately.
 
 Common widget attributes such as ``active`` and ``visible`` are also respected.
+Note that those properties are checked *after* matching ``viewscreens`` focus
+string(s), so you can assume they are evaluated in an consistent context. For
+example, if your widget has ``viewscreens='dwarfmode/Trade/Default'``, then you
+can assume your ``visible=function() ... end`` function will be executing while
+the trade screen is active.
 
 Registering a widget with the overlay framework
 ***********************************************

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -502,15 +502,14 @@ local function _feed_viewscreen_widgets(vs_name, vs, keys)
     if not vs_widgets then return false end
     for _,db_entry in pairs(vs_widgets) do
         local w = db_entry.widget
-        if not utils.getval(w.active) or not utils.getval(w.visible) then
-            goto skip
-        end
         if (not vs or matches_focus_strings(db_entry, vs_name, vs)) and
-                detect_frame_change(w, function() return w:onInput(keys) end) then
+            utils.getval(w.active) and
+            utils.getval(w.visible) and
+            detect_frame_change(w, function() return w:onInput(keys) end)
+        then
             --print('widget handled input:', w.name)
             return true
         end
-        ::skip::
     end
     return false
 end
@@ -531,11 +530,9 @@ local function _render_viewscreen_widgets(vs_name, vs, full_dc, scaled_dc)
     scaled_dc = scaled_dc or gui.Painter.new(scaled)
     for _,db_entry in pairs(vs_widgets) do
         local w = db_entry.widget
-        if not utils.getval(w.visible) then goto skip end
-        if not vs or matches_focus_strings(db_entry, vs_name, vs) then
+        if (not vs or matches_focus_strings(db_entry, vs_name, vs)) and utils.getval(w.visible) then
             detect_frame_change(w, function() w:render(w.fullscreen and full_dc or scaled_dc) end)
         end
-        ::skip::
     end
     return full_dc, scaled_dc
 end


### PR DESCRIPTION
so widgets can have stronger guarantees about the context for their `visible` and `active` attribute functions