### PR TITLE
fix focus string when choosing stockpile links for a workshop

### DIFF
--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -545,7 +545,9 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
             break;
         case df::view_sheet_type::BUILDING:
             if (game->main_interface.view_sheets.linking_lever)
-                newFocusString = baseFocus + "/LinkingLever";
+                newFocusString += "/LinkingLever";
+            else if (game->main_interface.stockpile_link.open && game->main_interface.stockpile_link.adding_new_link)
+                newFocusString += "/LinkingStockpile";
             else if (auto bld = df::building::find(game->main_interface.view_sheets.viewing_bldid)) {
                 newFocusString += '/' + enum_item_key(bld->getType());
                 auto bld_type = bld->getType();

--- a/plugins/lua/buildingplan/mechanisms.lua
+++ b/plugins/lua/buildingplan/mechanisms.lua
@@ -16,7 +16,7 @@ MechanismOverlay.ATTRS{
     desc='Adds mechanism selection capabilities to the link lever/pressure plate screens.',
     default_pos={x=5,y=5},
     default_enabled=true,
-    viewscreens='dwarfmode/LinkingLever',
+    viewscreens='dwarfmode/ViewSheets/BUILDING/LinkingLever',
     frame={w=57, h=13},
 }
 


### PR DESCRIPTION
fixes workshop skill restrictions widget being shown when stockpile links are being chosen