### PR TITLE
docs minor reST fixup and spelling fixes

### DIFF
--- a/docs/about/History.rst
+++ b/docs/about/History.rst
@@ -133,7 +133,7 @@ API
 
 Internals
 ---------
-- Constructions module: ``findAtTile`` now uses a binary search intead of a linear search
+- Constructions module: ``findAtTile`` now uses a binary search instead of a linear search
 - MSVC warning level upped to /W3, and /WX added to make warnings cause compilations to fail.
 
 Lua
@@ -231,7 +231,7 @@ Misc Improvements
 - `prospect`: add new ``--show`` option to give the player control over which report sections are shown. e.g. ``prospect all --show ores`` will just show information on ores.
 - `quickfort`:
     - `Dreamfort <quickfort-blueprint-guide>` blueprint set improvements: set traffic designations to encourage dwarves to eat cooked food instead of raw ingredients
-    - library blueprints are now included by default in ``quickfort list`` output. Use the new ``--useronly`` (or just ``-u``) option to filter out library bluerpints.
+    - library blueprints are now included by default in ``quickfort list`` output. Use the new ``--useronly`` (or just ``-u``) option to filter out library blueprints.
     - better error message when the blueprints directory cannot be found
 - `seedwatch`: ``seedwatch all`` now adds all plants with seeds to the watchlist, not just the "basic" crops.
 - ``materials.ItemTraitsDialog``: added a default ``on_select``-handler which toggles the traits.
@@ -338,7 +338,7 @@ Misc Improvements
     - allow players to pause the confirmation dialog until they exit the current screen
 - `deteriorate`: new ``now`` command immediately deteriorates items of the specified types
 - `dfhack-examples-guide`:
-    - refine food preparation orders so meal types are chosen intelligently according to the amount of meals that exist and the number of aviailable items to cook with
+    - refine food preparation orders so meal types are chosen intelligently according to the amount of meals that exist and the number of available items to cook with
     - reduce required stock of dye for "Dye cloth" orders
     - fix material conditions for making jugs and pots
     - make wooden jugs by default to differentiate them from other stone tools. this allows players to more easily select jugs out with a properly-configured stockpile (i.e. the new ``woodentools`` alias)
@@ -351,7 +351,7 @@ Misc Improvements
 - `quickfort`:
     - `Dreamfort <quickfort-blueprint-guide>` blueprint set improvements: automatically create tavern, library, and temple locations (restricted to residents only by default), automatically associate the rented rooms with the tavern
     - `Dreamfort <quickfort-blueprint-guide>` blueprint set improvements: new design for the services level, including were-bitten hospital recovery rooms and an appropriately-themed interrogation room next to the jail! Also fits better in a 1x1 embark for minimalist players.
-- `workorder`: a manager is no longer required for orders to be created (matching bevavior in the game itself)
+- `workorder`: a manager is no longer required for orders to be created (matching behavior in the game itself)
 
 Removed
 -------
@@ -407,7 +407,7 @@ Fixes
     - fixed a crash when trying to iterate over linked lists
 - `gui/advfort`: encrust and stud jobs no longer consume reagents without actually improving the target item
 - `luasocket`: return correct status code when closing socket connections so clients can know when to retry
-- `quickfort`: contructions and bridges are now properly placed over natural ramps
+- `quickfort`: constructions and bridges are now properly placed over natural ramps
 - `setfps`: keep internal ratio of processing FPS to graphics FPS in sync when updating FPS
 
 Misc Improvements
@@ -559,7 +559,7 @@ API
 Lua
 ---
 - ``argparse.processArgsGetopt()``: you can now have long form parameters that are not an alias for a short form parameter. For example, you can now have a parameter like ``--longparam`` without needing to have an equivalent one-letter ``-l`` param.
-- ``dwarfmode.enterSidebarMode()``: ``df.ui_sidebar_mode.DesignateMine`` is now a suported target sidebar mode
+- ``dwarfmode.enterSidebarMode()``: ``df.ui_sidebar_mode.DesignateMine`` is now a supported target sidebar mode
 
 Structures
 ----------
@@ -619,10 +619,10 @@ Misc Improvements
 - `gui/gm-editor`: made search case-insensitive
 - `orders`:
     - support importing and exporting reaction-specific item conditions, like "lye-containing" for soap production orders
-    - new ``sort`` command. sorts orders according to their repeat frequency. this prevents daily orders from blocking other orders for simlar items from ever getting completed.
+    - new ``sort`` command. sorts orders according to their repeat frequency. this prevents daily orders from blocking other orders for similar items from ever getting completed.
 - `quickfort`:
     - Dreamfort blueprint set improvements: extensive revision based on playtesting and feedback. includes updated ``onMapLoad_dreamfort.init`` settings file, enhanced automation orders, and premade profession definitions.  see full changelog at https://github.com/DFHack/dfhack/pull/1921 and https://github.com/DFHack/dfhack/pull/1925
-    - accept multiple commands, list numbers, and/or blueprint lables on a single commandline
+    - accept multiple commands, list numbers, and/or blueprint labels on a single commandline
 - `tailor`: allow user to specify which materials to be used, and in what order
 - `tiletypes-here`, `tiletypes-here-point`: add ``--cursor`` and ``--quiet`` options to support non-interactive use cases
 - `unretire-anyone`: replaced the 'undead' descriptor with 'reanimated' to make it more mod-friendly
@@ -743,7 +743,7 @@ Lua
     - ``string:wrap(width)`` wraps a string at space-separated word boundaries
     - ``string:trim()`` removes whitespace characters from the beginning and end of the string
     - ``string:split(delimiter, plain)`` splits a string with the given delimiter and returns a table of substrings. if ``plain`` is specified and set to ``true``, ``delimiter`` is interpreted as a literal string instead of as a pattern (the default)
-- new utility function: ``utils.normalizePath()``: normalizes directory slashes across platoforms to ``/`` and coaleses adjacent directory separators
+- new utility function: ``utils.normalizePath()``: normalizes directory slashes across platforms to ``/`` and coalesces adjacent directory separators
 - `reveal`: now exposes ``unhideFlood(pos)`` functionality to Lua
 - `xlsxreader`: added Lua class wrappers for the xlsxreader plugin API
 - ``argparse.processArgsGetopt()`` (previously ``utils.processArgsGetopt()``):
@@ -1502,7 +1502,7 @@ Misc Improvements
 - `modtools/reaction-trigger`:
     - added ``-ignoreWorker``: ignores the worker when selecting the targets
     - changed the default behavior to skip inactive/dead units; added ``-dontSkipInactive`` to include creatures that are inactive
-    - added ``-range``: controls how far elligible targets can be from the workshop
+    - added ``-range``: controls how far eligible targets can be from the workshop
     - syndromes now are applied before commands are run, not after
     - if both a command and a syndrome are given, the command only runs if the syndrome could be applied
 - `mousequery`: made it more clear when features are enabled
@@ -3574,7 +3574,7 @@ Internals
 
 New Plugins
 -----------
-- `hotkeys`: Shows ingame viewscreen with all dfhack keybindings active in current mode.
+- `hotkeys`: Shows in-game viewscreen with all dfhack keybindings active in current mode.
 - `automelt`: allows marking stockpiles so any items placed in them will be designated for melting
 
 Fixes
@@ -3585,7 +3585,7 @@ Fixes
 
 Misc Improvements
 -----------------
-- now you can use ``@`` to print things in interactive Lua with subtley different semantics
+- now you can use ``@`` to print things in interactive Lua with subtly different semantics
 - optimizations for stockpiles for `autotrade` and `stockflow`
 - updated `exportlegends` to work with new maps, dfhack 40.11 r1+
 
@@ -3706,7 +3706,7 @@ New scripts
 New plugins
 -----------
 - `rendermax`: replace the renderer with something else, eg ``rendermax light``- a lighting engine
-- `automelt`: allows marking stockpiles for automelt (i.e. any items placed in stocpile will be designated for melting)
+- `automelt`: allows marking stockpiles for automelt (i.e. any items placed in stockpile will be designated for melting)
 - `embark-tools`: implementations of Embark Anywhere, Nano Embark, and a few other embark-related utilities
 - `building-hacks`: Allows to add custom functionality and/or animations to buildings.
 - `petcapRemover`: triggers pregnancies in creatures so that you can effectively raise the default pet population cap
@@ -3829,7 +3829,7 @@ Misc improvements
 - `superdwarf`: work in adventure mode too
 - `tweak` stable-cursor: carries cursor location from/to Build menu.
 - `deathcause`: allow selection from the unitlist screen
-- slayrace: allow targetting undeads
+- slayrace: allow targeting undeads
 - `workflow` plugin:
 
     - properly considers minecarts assigned to routes busy.
@@ -3939,7 +3939,7 @@ New tweaks
 - tweak fast-heat: speeds up item heating & cooling, thus making stable-temp act faster.
 - tweak fix-dimensions: fixes subtracting small amounts from stacked liquids etc.
 - tweak advmode-contained: fixes UI bug in custom reactions with container inputs in advmode.
-- tweak fast-trade: Shift-Enter for selecting items quckly in Trade and Move to Depot screens.
+- tweak fast-trade: Shift-Enter for selecting items quickly in Trade and Move to Depot screens.
 - tweak military-stable-assign: Stop rightmost list of military->Positions from jumping to top.
 - tweak military-color-assigned: In same list, color already assigned units in brown & green.
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -141,7 +141,7 @@ Template for new versions:
 - `tweak`: ``named-codices``: display book titles instead of a material description in the stocks/trade screens
 - `logistics`: automatically forbid or claim items brought to a stockpile
 - `plant`: can now ``remove`` shrubs and saplings; ``list`` all valid shrub/sapling raw IDs; ``grow`` can make mature trees older; many new command options
-- Locale-senstive number formatting: select your preferred format in `gui/control-panel`. prices and other large numbers in DFHack UIs can be displayed with commas (English formatting), the number formatting used by your system locale, in SI units (e.g. ``12.3k``), or even in scientific notation
+- Locale-sensitive number formatting: select your preferred format in `gui/control-panel`. prices and other large numbers in DFHack UIs can be displayed with commas (English formatting), the number formatting used by your system locale, in SI units (e.g. ``12.3k``), or even in scientific notation
 
 ## Fixes
 - ``Gui::makeAnnouncement``, ``Gui::autoDFAnnouncement``: fix case where a new announcement is created instead of adding to the count of an existing announcement if the existing announcement was the first one in the reports vector
@@ -167,7 +167,7 @@ Template for new versions:
 - `tiletypes`: new ``autocorrect`` property for autocorrecting adjacent tiles when making changes (e.g. adding ramp tops when you add a ramp)
 - Dreamfort: add a full complement of beds and chests to both barracks
 - Dreamfort: redesign guildhall/temple/library level for better accessibility
-- Dreamfort: walkthough documentation refresh
+- Dreamfort: walkthrough documentation refresh
 - Dreamfort: add milking/shearing station in surface grazing pasture
 - Dreamfort: integrate building prioritization into the blueprints and remove `prioritize` checklist steps
 - Dreamfort: add plumbing template for filling cisterns with running water
@@ -217,7 +217,7 @@ Template for new versions:
 ## Removed
 - `plants`: renamed to `plant`
 - ``gui.FramedScreen``: this class is now deprecated; please use ``gui.ZScreen`` and ``widgets.Window`` instead
-- ``dfhack.HIDE_CONSOLE_ON_STARTUP`` and ``dfhack.HIDE_ARMOK_TOOLS`` are no longer directly accessible. Please use `control-panel` or `gui/control-panel` to interact wtih those settings.
+- ``dfhack.HIDE_CONSOLE_ON_STARTUP`` and ``dfhack.HIDE_ARMOK_TOOLS`` are no longer directly accessible. Please use `control-panel` or `gui/control-panel` to interact with those settings.
 
 # 50.13-r2.1
 
@@ -240,7 +240,7 @@ Template for new versions:
 - `dig`: don't affect already-revealed tiles when marking z-level for warm/damp dig
 - `zone`: refresh values in distance column when switching selected pastures when the assign animals dialog is open
 - `logistics`: include semi-wild pets when autoretrain is enabled
-- `suspendmanager`: fully suspend unbuildable dead ends (e.g. buildling second level of a wall when the wall top is only accessible via ramp, causing the planned wall to be pathable but not buildable)
+- `suspendmanager`: fully suspend unbuildable dead ends (e.g. building second level of a wall when the wall top is only accessible via ramp, causing the planned wall to be pathable but not buildable)
 - `prospect`: don't use scientific notation for representing large numbers
 
 ## Misc Improvements
@@ -360,7 +360,7 @@ Template for new versions:
 - `suspendmanager`: improve performance when there are many active jobs
 - `clean`: protect farm plots when cleaning mud
 - `tweak`: add ``quiet`` option for silent enablement and disablement of tweaks
-- `gui/teleport`: add global Ctrl-Shift-T keybinding (only avaiable when DFHack mortal mode is disabled)
+- `gui/teleport`: add global Ctrl-Shift-T keybinding (only available when DFHack mortal mode is disabled)
 - Dreamfort: the four Craftsdwarf's workshops on the industry level are now specialized for Stonecrafting, Woodcrafting, Bone Carving, and miscellaneous tasks, respectively
 - `dwarfvet`: automatically unassign animals from pastures when they need treatment so they can make their way to the hospital. reassign them to their original pasture when treatment is complete.
 - `dwarfvet`: ignore animals assigned to cages or restraints
@@ -398,7 +398,7 @@ Template for new versions:
 # 50.12-r1
 
 ## Misc Improvements
-- `sort`: squad assignment overlay rewritten for compatiblity with new vanilla data structures and screen layouts
+- `sort`: squad assignment overlay rewritten for compatibility with new vanilla data structures and screen layouts
 
 ## Fixes
 - `gui/design`: no longer comes up when Ctrl-D is pressed but other DFHack windows have focus
@@ -427,7 +427,7 @@ Template for new versions:
 - `tweak`: Add "flask-contents", makes flasks/vials/waterskins be named according to their contents
 
 ## Fixes
-- `dig`: overlay that shows damp designations in ASCII mode now propertly highlights tiles that are damp because of an aquifer in the layer above
+- `dig`: overlay that shows damp designations in ASCII mode now properly highlights tiles that are damp because of an aquifer in the layer above
 - `dig-now`: fix digging stairs in the surface sometimes creating underworld gates.
 - ``Units::getVisibleName``: don't reveal the true identities of units that are impersonating other historical figures
 - ``Gui::revealInDwarfmodeMap``: properly center the zoom even when the target tile is near the edge of the map
@@ -555,7 +555,7 @@ Template for new versions:
 - ``Persistence``: persistent keys are now namespaced by an entity_id (e.g. a player fort site ID)
 - ``Persistence``: data is now stored one file per entity ID (plus one for the global world) in the DF savegame directory
 - ``Units.isDanger``: now returns true for agitated wildlife
-- ``Constructions::designateRemove``: no longer designates the non-removable "pseudo" construtions that represent the top of walls
+- ``Constructions::designateRemove``: no longer designates the non-removable "pseudo" constructions that represent the top of walls
 
 ## Lua
 - ``dfhack.capitalizeStringWords``: new function, returns string with all words capitalized
@@ -607,7 +607,7 @@ Template for new versions:
 - `buildingplan`: make it easier to build single-tile staircases of any shape (up, down, or up/down)
 - `sort`: allow searching by profession on the squad assignment page
 - `sort`: add search for places screens
-- `sort`: add search for work animal assignment screen; allow filtering by miltary/squad/civilian/burrow
+- `sort`: add search for work animal assignment screen; allow filtering by military/squad/civilian/burrow
 - `sort`: on the squad assignment screen, make effectiveness and potential ratings use the same scale so effectiveness is always less than or equal to potential for a given unit. this way you can also tell when units are approaching their maximum potential
 - `sort`: new overlay on the animal assignment screen that shows how many work animals each visible unit already has assigned to them
 - `dreamfort`: Inside+ and Clearcutting burrows now automatically created and managed
@@ -662,7 +662,7 @@ Template for new versions:
 - `zone`: animals trained for war or hunting are now labeled as such in animal assignment screens
 - `buildingplan`: support filtering cages by whether they are occupied
 - `buildingplan`: show how many items you need to make when planning buildings
-- `tailor`: now adds to existing orders if possilbe instead of creating new ones
+- `tailor`: now adds to existing orders if possible instead of creating new ones
 
 ## Documentation
 - unavailable tools are no longer listed in the tag indices in the online docs
@@ -760,8 +760,8 @@ Template for new versions:
 ## API
 - ``Items::getValue()``: remove ``caravan_buying`` parameter since the identity of the selling party doesn't actually affect the item value
 - `RemoteFortressReader`: add a ``force_reload`` option to the GetBlockList RPC API to return blocks regardless of whether they have changed since the last request
-- ``Units``: new animal propery check functions ``isMarkedForTraining(unit)``, ``isMarkedForTaming(unit)``, ``isMarkedForWarTraining(unit)``, and ``isMarkedForHuntTraining(unit)``
-- ``Gui``: ``getAnyStockpile`` and ``getAnyCivzone`` (along with their ``getSelected`` variants) now work through layers of ZScreens. This means that they will still return valid results even if a DFHack tool window is in the foereground.
+- ``Units``: new animal property check functions ``isMarkedForTraining(unit)``, ``isMarkedForTaming(unit)``, ``isMarkedForWarTraining(unit)``, and ``isMarkedForHuntTraining(unit)``
+- ``Gui``: ``getAnyStockpile`` and ``getAnyCivzone`` (along with their ``getSelected`` variants) now work through layers of ZScreens. This means that they will still return valid results even if a DFHack tool window is in the foreground.
 
 ## Lua
 - ``new()``: improved error handling so that certain errors that were previously uncatchable (creating objects with members with unknown vtables) are now catchable with ``pcall()``
@@ -769,7 +769,7 @@ Template for new versions:
 - ``widgets.BannerPanel``: panel with distinctive border for marking DFHack UI elements on otherwise vanilla screens
 - ``widgets.Panel``: new functions to override instead of setting corresponding properties (useful when subclassing instead of just setting attributes): ``onDragBegin``, ``onDragEnd``, ``onResizeBegin``, ``onResizeEnd``
 - ``dfhack.screen.readTile()``: now populates extended tile property fields (like ``top_of_text``) in the returned ``Pen`` object
-- ``dfhack.units``: new animal propery check functions ``isMarkedForTraining(unit)``, ``isMarkedForTaming(unit)``, ``isMarkedForWarTraining(unit)``, and ``isMarkedForHuntTraining(unit)``
+- ``dfhack.units``: new animal property check functions ``isMarkedForTraining(unit)``, ``isMarkedForTaming(unit)``, ``isMarkedForWarTraining(unit)``, and ``isMarkedForHuntTraining(unit)``
 - ``dfhack.gui``: new ``getAnyCivZone`` and ``getAnyStockpile`` functions; also behavior of ``getSelectedCivZone`` and ``getSelectedStockpile`` functions has changes as per the related API notes
 
 # 50.09-r2
@@ -969,7 +969,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `buildingplan`: filters and global settings are now ignored when manually choosing items for a building, allowing you to make custom choices independently of the filters that would otherwise be used
-- `buildingplan`: if `suspendmanager` is running, then planned buildings will be left suspended when their items are all attached. `suspendmanager` will unsuspsend them for construction when it is safe to do so.
+- `buildingplan`: if `suspendmanager` is running, then planned buildings will be left suspended when their items are all attached. `suspendmanager` will unsuspend them for construction when it is safe to do so.
 - `buildingplan`: add option for autoselecting the last manually chosen item (like `automaterial` used to do)
 - `confirm`: adds confirmation for removing burrows via the repaint menu
 - `stockpiles`: support applying stockpile configurations with fully enabled categories to stockpiles in worlds other than the one where the configuration was exported from
@@ -985,7 +985,7 @@ Template for new versions:
 
 ## Documentation
 - `modding-guide`: guide updated to include information for 3rd party script developers
-- the ``untested`` tag has been renamed to ``unavailable`` to better reflect the status of the remaining unavaialable tools. most of the simply "untested" tools have now been tested and marked as working. the remaining tools are known to need development work before they are available again.
+- the ``untested`` tag has been renamed to ``unavailable`` to better reflect the status of the remaining unavailable tools. most of the simply "untested" tools have now been tested and marked as working. the remaining tools are known to need development work before they are available again.
 
 ## Lua
 - ``widgets.Label``: tokens can now specify a ``htile`` property to indicate the tile that should be shown when the Label is hovered over with the mouse
@@ -1115,7 +1115,7 @@ Template for new versions:
 - ``widgets.CycleHotkeyLabel``: Added ``key_back`` optional parameter to cycle backwards.
 - ``widgets.HotkeyLabel``: Added ``setLabel`` method to allow easily updating the label text without mangling the keyboard shortcut.
 - ``widgets.HotkeyLabel``: Added ``setOnActivate`` method to allow easily updating the ``on_activate`` callback.
-- ``widgets.FilteredList``: Added ``case_sensitive`` optional paramter to determine if filtering is case sensitive.
+- ``widgets.FilteredList``: Added ``case_sensitive`` optional parameter to determine if filtering is case sensitive.
 
 # 50.05-alpha3.1
 

--- a/docs/dev/Contributing.rst
+++ b/docs/dev/Contributing.rst
@@ -44,7 +44,7 @@ General contribution guidelines
 * Update ``docs/changelog.txt`` and ``docs/about/Authors.rst`` when applicable. See
   `build-changelog` for more information on the changelog format.
 * Submit ideas and bug reports as :issue:`issues on GitHub <>`.
-  Posts in the forum thread or on Disord can easily get missed or forgotten.
+  Posts in the forum thread or on Discord can easily get missed or forgotten.
 * Work on :issue:`reported problems <?q=is:open+-label:idea>`
   will take priority over ideas or suggestions.
 

--- a/docs/dev/Documentation.rst
+++ b/docs/dev/Documentation.rst
@@ -268,7 +268,7 @@ examples::
         Show help text.
     ``-l``, ``--quality <level>``
         Set the quality of the architecture for built architected
-        builtings.
+        buildings.
     ``-q``, ``--quiet``
         Suppress informational output (error messages are still
         printed).

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -736,14 +736,14 @@ arbitrary Lua tables.
 
     local state = dfhack.persistent.getSiteData('my-script-name', {somedata={}})
 
-* ``dfhack.peristent.getSiteDataString(key)``
+* ``dfhack.persistent.getSiteDataString(key)``
 
   Retrieves the underlying serialized string associated with the current site
   and the given string ``key``. Returns *nil* if the key isn't found in the
   current site's persistent data. Most scripts will want to use ``getSiteData``
   instead.
 
-* ``dfhack.peristent.saveSiteData(key, data)``
+* ``dfhack.persistent.saveSiteData(key, data)``
 
   Persists the given ``data`` (usually a table; can be of arbitrary complexity and depth)
   in the world save, associated with the current site and the given ``key``.
@@ -759,8 +759,8 @@ arbitrary Lua tables.
   ``key``. Returns *true* if succeeded.
 
 * ``dfhack.persistent.getWorldData(key[, default])``
-* ``dfhack.peristent.getWorldDataString(key)``
-* ``dfhack.peristent.saveWorldData(key, data)``
+* ``dfhack.persistent.getWorldDataString(key)``
+* ``dfhack.persistent.saveWorldData(key, data)``
 * ``dfhack.persistent.saveWorldDataString(key, data_str)``
 * ``dfhack.persistent.deleteWorldData(key)``
 
@@ -1047,7 +1047,7 @@ Screens
   The strings have a "screen/foo/bar/baz..." format e.g.::
 
     [1] = "dwarfmode/Info/CREATURES/CITIZEN"
-    [2] = "dwardmode/Squads"
+    [2] = "dwarfmode/Squads"
 
 * ``dfhack.gui.matchFocusString(focus_string[, viewscreen])``
 
@@ -1099,7 +1099,7 @@ General-purpose selections
   associated with the selected in-game object. For example, Calling
   ``getSelectedJob`` when a building is selected will return the job associated
   with the building (e.g., the ``ConstructBuilding`` job). If ``silent`` is
-  ommitted or set to ``false`` and a selected object cannot be found, then an
+  omitted or set to ``false`` and a selected object cannot be found, then an
   error is printed to the console.
 
 * ``dfhack.gui.getAnyWorkshopJob(screen)``
@@ -1244,7 +1244,7 @@ Announcements
   ``subid`` is only used for ``AB`` and ``ART_IMAGE``. ``[/LPAGE]`` ends the link text.
 
   ``[C:`` screenf ``:`` screenb ``:`` screenbright ``]``: Color text. Sets the
-  repective values in ``df.global.gps`` and then sets text color.
+  respective values in ``df.global.gps`` and then sets text color.
   ``color`` = ``screenf``, ``bright`` = ``screenbright``, ``screenb`` does nothing
   since popup backgrounds are always black.
   Example: ``"Light gray, [C:4:0:0]red, [C:4:0:1]orange, [C:7:0:0]light gray."``
@@ -1691,7 +1691,7 @@ Units module
 * ``dfhack.units.assignTrainer(unit[,trainer_id])``
 * ``dfhack.units.unassignTrainer(unit)``
 
-  Assignes (or unassigns) a trainer for the specified trainable unit. The
+  Assigns (or unassigns) a trainer for the specified trainable unit. The
   trainer ID can be omitted if "any trainer" is desired. Returns a boolean
   indicating whether the operation was successful.
 
@@ -4025,7 +4025,7 @@ parameters.
       optionActions: list of option specifications
 
   and returns a list of positional parameters -- that is, all strings that are
-  neither options nor argruments to options. Options and positional parameters
+  neither options nor arguments to options. Options and positional parameters
   can appear in any order on the commandline, as long as arguments to options
   immediately follow the option itself.
 
@@ -5213,7 +5213,7 @@ Has attributes:
   ``true`` if the drag was "successful" (i.e., not canceled) and ``false``
   otherwise. Dragging can be canceled by right clicking while dragging with the
   mouse, hitting :kbd:`Esc` (while dragging with the mouse or keyboard), or by
-  calling ``Panel:setKeyboaredDragEnabled(false)`` (while dragging with the
+  calling ``Panel:setKeyboardDragEnabled(false)`` (while dragging with the
   keyboard). If it is more convenient to do so, you can choose to override the
   ``panel:onDragBegin`` and/or the ``panel:onDragEnd`` methods instead of
   setting the ``on_drag_begin`` and/or ``on_drag_end`` attributes.
@@ -5303,7 +5303,7 @@ Has functions:
 
   If called with ``true`` and the panel is not already in keyboard drag mode,
   then any current drag or resize operations are halted where they are (not
-  canceled), the panel siezes input focus (see `View class`_ above for
+  canceled), the panel seizes input focus (see `View class`_ above for
   information on the DFHack focus subsystem), and further keyboard cursor keys
   move the window as if it were being dragged. Shift-cursor keys move by larger
   amounts. Hit :kbd:`Enter` to commit the new window position or :kbd:`Esc` to
@@ -5314,7 +5314,7 @@ Has functions:
 
   If called with ``true`` and the panel is not already in keyboard resize mode,
   then any current drag or resize operations are halted where they are (not
-  canceled), the panel siezes input focus (see `View class`_ above for
+  canceled), the panel seizes input focus (see `View class`_ above for
   information on the DFHack focus subsystem), and further keyboard cursor keys
   resize the window as if it were being dragged from the lower right corner. If
   neither the bottom or right edge is a valid anchor, an appropriate corner will
@@ -5526,7 +5526,7 @@ The Scrollbar widget implements the following methods:
   The ``top_elem`` param is the (one-based) index of the first visible element.
   The ``elems_per_page`` param is the maximum number of elements that can be
   shown at one time. The ``num_elems`` param is the total number of elements
-  that the paried widget can scroll through. If ``elems_per_page`` or
+  that the paired widget can scroll through. If ``elems_per_page`` or
   ``num_elems`` is not specified, the most recently specified value for these
   parameters is used. The scrollbar will adjust its scrollbar size and position
   according to the values passed to this function.
@@ -6484,7 +6484,7 @@ Native functions (exported to Lua)
 
 - ``rollNormal(rngID, avg, stddev)``
 
-  generates random normal[gaus.]
+  generates random double drawn from a normal (Gaussian) distribution
 
 - ``rollBool(rngID, chance)``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3672,7 +3672,7 @@ functions. These are invoked just like standard string functions, e.g.::
   Lines are split at space-separated word boundaries. Any existing newlines are
   kept in place. If a single word is longer than width, it is split over
   multiple lines. If ``width`` is not specified, 72 is used. The ``opts``
-  parameter can be a table with the following boolean fields specified::
+  parameter can be a table with the following boolean fields specified:
 
     :return_as_table: if ``true``, then the function will return a table of
         strings, with each string representing one wrapped line. Otherwise, a

--- a/docs/dev/overlay-dev-guide.rst
+++ b/docs/dev/overlay-dev-guide.rst
@@ -379,7 +379,7 @@ screen (by default, but the player can move it wherever).
     function MenuScreen:init()
         self.mouseover = false
 
-        -- derrive the menu frame from the hotspot frame so it
+        -- derive the menu frame from the hotspot frame so it
         -- can appear in a nearby location
         local frame = copyall(self.hotspot_frame)
         -- ...

--- a/docs/guides/quickfort-user-guide.rst
+++ b/docs/guides/quickfort-user-guide.rst
@@ -1728,7 +1728,7 @@ The industry_ level: advanced linking
   :target: https://drive.google.com/file/d/1c8YTHxTgJY5tUII-BOWdLhmDFAHwIOEs
   :align: center
 
-The industry level is densely packed and has more intracate stockpile and
+The industry level is densely packed and has more intricate stockpile and
 hauling route configuration.
 
 .. topic:: Tip
@@ -1854,7 +1854,7 @@ With option 2, if you need a "better" bedroom, you'd just expand the zone to
 cover the neighboring "unit". Satisfying the monarch is also simple: plop down
 a new suites level and assign each block of 4 rooms to one zone. four units for
 the bedroom, four for the office, four for the dining hall, and four for the
-tomb. Smooth and engrave and you're done. Of course, more asthetic-minded
+tomb. Smooth and engrave and you're done. Of course, more aesthetic-minded
 players are always free to design custom areas too. These blueprints are
 designed to be functional more than beautiful.
 
@@ -2054,7 +2054,7 @@ Property           Description
                    ``residents``, ``citizens``, or ``members``. defaults to
                    ``visitors``.
 ``profession``     (only if ``location=guildhall``) sets the profession of the
-                   guildhall. See possilbe values with ``:lua @df.profession``.
+                   guildhall. See possible values with ``:lua @df.profession``.
                    For example: ``profession=metalsmith``.
 ``desired_*``      (only if the location is set to the relevant type) sets the
                    desired number of stocked items for the attached location.

--- a/docs/plugins/autoclothing.rst
+++ b/docs/plugins/autoclothing.rst
@@ -12,7 +12,7 @@ generate manager orders to manufacture more when your stock drops below a
 configured per-citizen threshold.
 
 If you are wondering whether you should enable `tailor` instead, see the
-comparsion in the last section below.
+comparison in the last section below.
 
 Usage
 -----
@@ -62,6 +62,6 @@ Enable `tailor` when:
 - you want a tool that can run effectively with a default configuration
 
 You can even enable both tools if you only want to set configuration for a few
-specific clothing types (e.g. if you'd prefer that most pople wear dresses).
+specific clothing types (e.g. if you'd prefer that most people wear dresses).
 You can set the configuration for those types in ``autoclothing`` and let
 `tailor` automatically manage the rest.

--- a/docs/plugins/buildingplan.rst
+++ b/docs/plugins/buildingplan.rst
@@ -35,7 +35,7 @@ building to be fire- or magma-proof in the placement UI screen. This makes it
 very easy to ensure that your pump stacks and floodgates, for example, are
 magma-safe.
 
-Buildingplan works well in conjuction with other design tools like
+Buildingplan works well in conjunction with other design tools like
 `gui/quickfort`, which allow you to apply a building layout from a blueprint.
 You can apply very large, complicated layouts, and the buildings will simply be
 built when your dwarves get around to producing the needed materials. If you

--- a/docs/plugins/burrow.rst
+++ b/docs/plugins/burrow.rst
@@ -97,7 +97,7 @@ If you are auto-expanding a burrow (whose name ends in a ``+``) and the miner
 who is digging to expand the burrow is assigned to that burrow, then 1-wide
 corridors that expand the burrow will have very slow progress. This is because
 the burrow is expanded to include the next dig job only after the miner has
-chosen a next tile to dig, which may be far away. 2-wide cooridors are much
+chosen a next tile to dig, which may be far away. 2-wide corridors are much
 more efficient when expanding a burrow since the "next" tile to dig will still
 be nearby.
 

--- a/docs/plugins/fastdwarf.rst
+++ b/docs/plugins/fastdwarf.rst
@@ -51,5 +51,5 @@ Note that a dwarf will only teleport when:
 So you may still see dwarves walking normally or just standing still if they do
 not have a job to teleport to. Since jobs get done so much faster, you will
 likely see groups of dwarves just standing around, with individual dwarves
-periodically disappaearing and reappearing moments later when they have a job
+periodically disappearing and reappearing moments later when they have a job
 to do.

--- a/docs/plugins/orders.rst
+++ b/docs/plugins/orders.rst
@@ -94,7 +94,7 @@ armor, or just metalsmithing. Then, you can assign appropriate legendary
 masters to each forge, and they will only receive orders for appropriate
 products.
 
-Simiarly, you can set up Craftsdwarf's workshops to specialize in stone, wood,
+Similarly, you can set up Craftsdwarf's workshops to specialize in stone, wood,
 or bone.
 
 Regardless of the labor restriction settings, you can manually assign any task

--- a/docs/plugins/regrass.rst
+++ b/docs/plugins/regrass.rst
@@ -76,7 +76,7 @@ Options
     begin with. Will still fail in incompatible biomes.
 ``-f``, ``--force``
     Force a grass type on tiles with no compatible grass types. The ``--new``
-    option takes precidence for compatible biomes, otherwise such tiles will be
+    option takes precedence for compatible biomes, otherwise such tiles will be
     forced instead. By default, a single random grass type is selected from
     the world's raws. The ``--plant`` option allows a specific grass type to be
     specified.

--- a/docs/plugins/reveal.rst
+++ b/docs/plugins/reveal.rst
@@ -53,7 +53,7 @@ Usage
 ``revflood``
     Hide everything, then reveal tiles with a path to the keyboard cursor (if
     enabled) or the selected unit (if a unit is selected) or else a random
-    citizen. This allows reparing maps that you accidentally saved while they
+    citizen. This allows repairing maps that you accidentally saved while they
     were revealed. Note that tiles behind constructed walls are also revealed
     as a workaround for :bug:`1871`.
 

--- a/docs/plugins/sort.rst
+++ b/docs/plugins/sort.rst
@@ -45,7 +45,7 @@ weapon they have the most skill in. The effectiveness rating also takes into
 account physical and mental attributes as well as general fighting (non-weapon)
 skills.
 
-Simiarly, the "ranged effectiveness" annotation indicates expected
+Similarly, the "ranged effectiveness" annotation indicates expected
 effectiveness with a crossbow. This rating also takes into account relevant
 physical and mental attributes.
 
@@ -150,7 +150,7 @@ be involved in plots, such as criminals, necromancers, necromancer experiments,
 and intelligent undead.
 
 On the interrogations screen, you can also filter units by whether they have
-already been interviewed in realation to the current crime.
+already been interviewed in relation to the current crime.
 
 Candidates overlay
 ------------------

--- a/docs/plugins/tailor.rst
+++ b/docs/plugins/tailor.rst
@@ -16,7 +16,7 @@ materials that you have on hand in the fort. For example, if you have lots of
 silk, but no cloth, then ``tailor`` will order only silk clothing to be made.
 
 If you are wondering whether you should enable `autoclothing` instead, see the
-head-to-head comparsion in the `autoclothing` docs.
+head-to-head comparison in the `autoclothing` docs.
 
 Usage
 -----

--- a/docs/plugins/zone.rst
+++ b/docs/plugins/zone.rst
@@ -178,7 +178,7 @@ In the window that pops up when you click the hotkey hint or hit the hotkey on y
 - filter by whether the unit lays eggs
 - filter by whether the unit needs a grazing area
 
-The window is fully navigatable via keyboard or mouse. Hit Enter or click on a
+The window is fully navigable via keyboard or mouse. Hit Enter or click on a
 unit to assign/unassign it to the currently selected zone or building. Shift
 click to assign/unassign a range of units.
 


### PR DESCRIPTION
The "literal block" change (first commit) fixes a warning (and related HTML formatting issue) that I was getting in my local docs builds.

The other commit is the last chunk of my spelling fixes. All these spelling changes aren't super important, but they didn't seem completely valueless, so I have submitted them all.

This was a bit of a "side quest" that kicked off when I wanted to build and spell check a doc update for a not-yet-submitted code change.