### PR TITLE
simulateInput mishandles _STRING

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -79,6 +79,7 @@ Template for new versions:
 - ``dfhack.units``: ``isWildlife`` and ``isAgitated`` property checks
 - ``dfhack.units.isDanger``: no longer returns true for intelligent undead
 - Overlay widgets can now assume their ``active`` and ``visible`` functions will only execute in a context that matches their ``viewscreens`` associations
+- ``gui.simulateInput``: do not generate spurious keycode from ``_STRING``
 
 ## Removed
 - ``quickfortress.csv``: remove old sample blueprints for "The Quick Fortress", which were unmaintained and non-functional in DF v50+. Online blueprints are available at https://docs.google.com/spreadsheets/d/1WuLYZBM6S2nt-XsPS30kpDnngpOQCuIdlw4zjrcITdY if anyone is interested in giving these blueprints some love

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -4512,7 +4512,10 @@ Misc
   Every argument after the initial screen may be *nil*, a numeric keycode,
   a string keycode, a sequence of numeric or string keycodes, or a mapping
   of keycodes to *true* or *false*. For instance, it is possible to use the
-  table passed as argument to ``onInput``.
+  table passed as argument to ``onInput``. The ``_STRING`` convenience field of
+  an ``onInput`` keys table will be ignored; the presence (or absence) of a
+  ``STRING_A???`` keycode will determine the text content of the simulated
+  input.
 
   You can send mouse clicks as well by setting the ``_MOUSE_L`` key or other
   mouse-related pseudo-keys documented with the ``screen:onInput(keys)``

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -81,7 +81,7 @@ function simulateInput(screen,...)
                 for k,v in pairs(arg) do
                     if v == true then
                         push_key(k)
-                    else
+                    elseif k ~= '_STRING' then
                         push_key(v)
                     end
                 end


### PR DESCRIPTION
Note: This is a draft PR due to the second commit probably being unnecessary (and lacking docs).

# Problem

simulateInput is documented as accepting (among other kinds of values) the same
table that is provided to onInput. However, simulateInput seems to mishandle the
`_STRING` field of such tables.

The Git history looks like it shows that simulateInput has had this behavior
since 2012 August (its origin?):
* 38a07a4ca584e2cccc2c2814c35266ba33d692c8 for `_STRING` given to doInput, and
* 601a3a7927d50500b3dbdd2d20c5d7740a5484a1 for simulateInput.

This sure seems like a bug, but its age gives me doubts.

I didn't find any (open or closed) issues on GitHub that looked like they were
related to this, either.

# Proposed Solution

The first commit in this PR changes simulateInput to ignore `_STRING` of any table
arguments it receives. `_STRING` seems to be (informationally) redundant (being
derived from the presence/absence of a `STRING_A…` keycode), so it seemed
reasonable to ignore it.

The second commit offers a possible Lua-side "normalization" helper if such a thing
seems like a good idea.

# Alternate Solutions

Instead of ignoring `_STRING` (the commit with this PR), it could be converted
to a `STRING_A…` keycode (although this risks producing multiple (distinct)
"text" keycodes if the caller made "unaligned" changes to either `_STRING` or
`STRING_A…`). Or simulateInput could integrate something like what
DFHack::Screen::normalize_text_keys does on the C++ side (this gets a bit
complicated due to needing to aggregate effects over multiple arguments).

# Impact

The biggest impact I found is through ZScreen, but I also found:
- scripts/confirm.lua ConfirmOverlay does onInput->simulateInput, but only for a
  very restricted range of inputs that won't *usually* have `_STRING`
- scripts/gui/sandbox.lua Screen (a widgets.Window) using its ScreenView (a
  gui.ZScreen) to forward unhandled input
- several unavailable-tagged scripts that I didn't examine closely

The ZScreen onInput->simulateInput code path happens for defocused ZScreens and
focused ZScreens that have pass_movement_keys=true (and pass_mouse_clicks, but I
haven't investigated that one fully; I have seen single input events with
`_STRING` and mouse fields though).

## demonstration setup

My demonstration setup looks like this:
- a normal fortress game is loaded and running (i.e. ready for designations)
  - (probably paused to avoid the visual noise of other stuff changing on the
    screen)
- the camera is not following anyone/anything
- the DF mining designation tool is active
- the current map view makes it easy to visually identify camera movement (e.g.
  a mostly unrevealed area with a stair-mineshaft in view, or maybe some type of
  "test pattern" of previously committed designations)
- the keyboard cursor is
  - enabled,
  - currently visible (start a fresh designation if is disappears on you),
  - near the center of the screen (so most cursor movements won't also cause
    camera movement)
  - positioned so that any movement can be easily visually identified (e.g. at
    the center of the mineshaft)
- the window from gui/autochop is
  - open
  - moved and/or minimized to make it unobtrusive
  - defocused by (e.g.) either
    - left-clicking on the DF status bar, or
    - left-clicking on the main map (though this will start a mouse-based mining
      designation that then needs to be committed (or canceled and mining
      restarted))

Nothing is special about using gui/autochop; it just provides a convenient
ZScreen.

## examples

- <kbd>8</kbd>
  - default bindings: KEYBOARD_CURSOR_UP, STANDARDSCROLL_UP, STRING_A**056**
  - spurious keycode: KEYBOARD_CURSOR_RIGHT_FAST (df::interface_key **56**)
  - expect: keyboard cursor moves *up one* tile
  - got: keyboard cursor moves *right ten* tiles
      - for whatever internal implementation reasons, DF skips the original up
        keycode and acts only acts on the right-fast keycode
  - See the last section for more numeric keyboard cursor movement keystroke
    examples; several end up with "simulated" key-sets where DF acts on more
    than one keycode.
- <kbd>/</kbd>
  - default binding: STRING_A**047**
  - spurious keycode: KEYBOARD_CURSOR_LEFT (df::interface_key **47**)
  - expect: no effect, this is a text-only keystroke
  - got: keyboard cursor moves left one tile
- <kbd>0</kbd> (digit zero) 
  - default binding: STRING_A**048**
  - spurious keycode: KEYBOARD_CURSOR_RIGHT (df::interface_key **48**)
  - expect: no effect, this is a text-only keystroke
  - got: keyboard cursor moves right one tile
- <kbd>"</kbd>
  - default binding: STRING_A**034**
  - spurious keycode: CURSOR_RIGHT_FAST (df::interface_key **34**)
  - expect: no effect, this is a text-only keystroke
  - got: camera moves right twenty tiles (seen as the map moving left twenty)

To confirm the "default" bindings, I temporarily use devel/input-monitor. To
confirm the generated keycodes, I temporarily placed a print in simulateInput's
`type(kv) == 'number'` block.

# Behavior of 8/2/4/6 when (re)injected by simulateInput

<details>
<summary>Camera and keyboard cursor movements when simulateInput forwards un/shifted-8246:</summary>

I use an US-English QWERTY keyboard layout in Windows; some of the behavior will likely
be different for other keyboard layouts.

The Numpad keys used below are with NumLock off. They act as an experimental
control since they do not generate "text" keycodes and thus don't trigger the
bug.

- <kbd>8</kbd>: KEYBOARD_CURSOR_UP
  ```
              expect: cursor+=(  0, -1,  0); camera+=(  0,  0,  0)
        Numpad 8 did: cursor+=(  0, -1,  0); camera+=(  0,  0,  0)
               8 did: cursor+=( 10,  0,  0); camera+=(  0,  0,  0)
               8 uses _STRING=56; interface_key[56] == KEYBOARD_CURSOR_RIGHT_FAST
  ```
  - DF only did the spurious KEYBOARD_CURSOR_RIGHT_FAST

- <kbd>Shift</kbd>-<kbd>8</kbd>: KEYBOARD_CURSOR_UP_FAST
  ```
              expect: cursor+=(  0,-10,  0); camera+=(  0,  0,  0)
  Shift Numpad 8 did: cursor+=(  0,-10,  0); camera+=(  0,  0,  0)
         Shift 8 did: cursor+=(  0,-10, -1); camera+=(  0,  0, -1)
         Shift 8 (*) uses _STRING=42; interface_key[42] == CURSOR_DOWN_Z_AUX
  ```
  - DF did both KEYBOARD_CURSOR_UP_FAST and CURSOR_DOWN_Z_AUX

- <kbd>2</kbd>: KEYBOARD_CURSOR_DOWN
  ```
              expect: cursor+=(  0,  1,  0); camera+=(  0,  0,  0)
        Numpad 2 did: cursor+=(  0,  1,  0); camera+=(  0,  0,  0)
               2 did: cursor+=(  1, -1,  0); camera+=(  0,  0,  0)
               2 uses _STRING=50; interface_key[50] == KEYBOARD_CURSOR_UPRIGHT
  ```
  - DF only did the spurious KEYBOARD_CURSOR_UPRIGHT

- <kbd>Shift</kbd>-<kbd>2</kbd>: KEYBOARD_CURSOR_DOWN_FAST
  ```
              expect: cursor+=(  0, 10,  0); camera+=(  0,  0,  0)
  Shift Numpad 2 did: cursor+=(  0, 10,  0); camera+=(  0,  0,  0)
         Shift 2 did: cursor+=(  0, 10, -1); camera+=(  0,  0, -1)
      Shift 2 (@) uses _STRING=64; interface_key[64] == KEYBOARD_CURSOR_DOWN_Z_AUX
  ```
  - DF did both KEYBOARD_CURSOR_DOWN_FAST and KEYBOARD_CURSOR_DOWN_Z_AUX

- <kbd>4</kbd>: KEYBOARD_CURSOR_LEFT
  ```
              expect: cursor+=( -1,  0,  0); camera+=(  0,  0,  0)
        Numpad 4 did: cursor+=( -1,  0,  0); camera+=(  0,  0,  0)
               4 did: cursor+=(  1,  1,  0); camera+=(  0,  0,  0)
               4 uses _STRING=52; interface_key[52] == KEYBOARD_CURSOR_DOWNRIGHT
  ```
  - DF only did the spurious KEYBOARD_CURSOR_DOWNRIGHT

- <kbd>Shift</kbd>-<kbd>4</kbd>: KEYBOARD_CURSOR_LEFT_FAST
  ```
              expect: cursor+=(-10,  0,  0); camera+=(  0,  0,  0)
  Shift Numpad 4 did: cursor+=(-10,  0,  0); camera+=(  0,  0,  0)
         Shift 4 did: cursor+=( 10,-20,  0); camera+=( 20,-20,  0)
         Shift 4 ($) uses _STRING=36; interface_key[36] == CURSOR_UPRIGHT_FAST
  ```
  - DF did both KEYBOARD_CURSOR_LEFT_FAST and CURSOR_UPRIGHT_FAST

- <kbd>6</kbd>: KEYBOARD_CURSOR_RIGHT
  ```
              expect: cursor+=(  1,  0,  0); camera+=(  0,  0,  0)
        Numpad 6 did: cursor+=(  1,  0,  0); camera+=(  0,  0,  0)
               6 did: cursor+=(  0, 10,  0); camera+=(  0,  0,  0)
               6 uses _STRING=54; interface_key[54] == KEYBOARD_CURSOR_DOWN_FAST
  ```
  - DF only did the spurious KEYBOARD_CURSOR_DOWN_FAST

- <kbd>Shift</kbd>-<kbd>6</kbd>: KEYBOARD_CURSOR_RIGHT_FAST
  ```
              expect: cursor+=( 10,  0,  0); camera+=(  0,  0,  0)
  Shift Numpad 6 did: cursor+=( 10,  0,  0); camera+=(  0,  0,  0)
         Shift 6 did: cursor+=( 10,  0,  0); camera+=(  0,  0,  0)
         Shift 6 (^) uses _STRING=94; interface_key[94] == CUSTOM_X
  ```
  - DF did KEYBOARD_CURSOR_RIGHT_FAST, and got CUSTOM_X (but did nothing with it)
</details>
