### PR TITLE
Items::createItem - auto-select growth prints

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -74,12 +74,14 @@ Template for new versions:
 
 ## API
 - ``Units``: new ``isWildlife`` and ``isAgitated`` property checks
+- ``Items::createItem``: removed growth_print parameter, now determined automatically
 
 ## Lua
 - ``dfhack.units``: ``isWildlife`` and ``isAgitated`` property checks
 - ``dfhack.units.isDanger``: no longer returns true for intelligent undead
 - Overlay widgets can now assume their ``active`` and ``visible`` functions will only execute in a context that matches their ``viewscreens`` associations
 - ``gui.simulateInput``: do not generate spurious keycode from ``_STRING``
+- ``dfhack.items.createItem``: removed growth_print parameter to match C++ API
 
 ## Removed
 - ``quickfortress.csv``: remove old sample blueprints for "The Quick Fortress", which were unmaintained and non-functional in DF v50+. Online blueprints are available at https://docs.google.com/spreadsheets/d/1WuLYZBM6S2nt-XsPS30kpDnngpOQCuIdlw4zjrcITdY if anyone is interested in giving these blueprints some love

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2414,10 +2414,9 @@ static int items_createItem(lua_State *state)
     auto item_subtype = lua_tointeger(state, 3);
     auto mat_type = lua_tointeger(state, 4);
     auto mat_index = lua_tointeger(state, 5);
-    int growth_print = luaL_optint(state, 6, -1);
-    bool no_floor = lua_toboolean(state, 7);
+    bool no_floor = lua_toboolean(state, 6);
     vector<df::item *> out_items;
-    Items::createItem(out_items, unit, item_type, item_subtype, mat_type, mat_index, growth_print, no_floor);
+    Items::createItem(out_items, unit, item_type, item_subtype, mat_type, mat_index, no_floor);
     Lua::PushVector(state, out_items);
     return 1;
 }

--- a/library/include/modules/Items.h
+++ b/library/include/modules/Items.h
@@ -173,7 +173,7 @@ DFHACK_EXPORT int getItemBaseValue(int16_t item_type, int16_t item_subtype, int1
 DFHACK_EXPORT int getValue(df::item *item, df::caravan_state *caravan = NULL);
 
 DFHACK_EXPORT bool createItem(std::vector<df::item *> &out_items, df::unit *creator, df::item_type type,
-    int16_t item_subtype, int16_t mat_type, int32_t mat_index, int32_t growth_print = -1, bool no_floor = false);
+    int16_t item_subtype, int16_t mat_type, int32_t mat_index, bool no_floor = false);
 
 // Returns true if the item is free from mandates, or false if mandates prevent trading the item.
 DFHACK_EXPORT bool checkMandates(df::item *item);


### PR DESCRIPTION
instead of requiring the caller to figure it out on their own.

I did some basic tests with oak leaves (to make sure they got the correct colors based on the time of year), but further tests would be welcome.

Conveniently, none of the Lua scripts had to be touched (because they weren't specifying growth print information in the first place).