### PR TITLE
correct implementation of `Gui::MTB_set_width`

### DIFF
--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -2562,7 +2562,7 @@ void Gui::MTB_set_width(df::markup_text_boxst *mtb, int32_t n_width)
             continue;
         }
 
-        size_t str_size = it[0]->str.size();
+        int32_t str_size = (int32_t)(it[0]->str.size());
         if (n_width < str_size)
         {
             n_width = mtb->current_width;


### PR DESCRIPTION
corrected reverse-engineering of this function

the previous version would wrap a single period, comma, question mark. or exclamation mark in the wrong place in certain cases

this version is more faithful to the actual code in DF

h/t to @vizv for bringing this up on discord