### PR TITLE
[preserve-rooms] evict owner and suspend zone when assigned to a role

### DIFF
--- a/docs/plugins/preserve-rooms.rst
+++ b/docs/plugins/preserve-rooms.rst
@@ -23,10 +23,12 @@ away from the fort, the zone will become unreserved and available for reuse.
 
 When you click on an assignable zone, you will also now have the option to
 associate the room with a noble or administrative role. The room will be
-automatically reassigned to whoever currently holds that position. If multiple
-rooms of the same type are assigned to a position, then only one room of that
-type will be assigned to each holder of that position (e.g. one room per baron
-or militia captain).
+automatically reassigned to whoever currently holds that position. If there
+isn't anyone who is currently assigned to the designated role, then the zone
+becomes reserved: any current owner is evicted and the zone is suspended. If
+multiple rooms of the same type are assigned to a position, then only one room
+of that type will be assigned to each holder of that position (e.g. one room
+per baron or militia captain).
 
 Usage
 -----

--- a/plugins/lua/preserve-rooms.lua
+++ b/plugins/lua/preserve-rooms.lua
@@ -181,7 +181,9 @@ function ReservedWidget:onInput(keys)
     if ReservedWidget.super.onInput(self, keys) then
         return true
     end
-    if keys._MOUSE_L and preserve_rooms_isReserved() then
+    if keys._MOUSE_L and
+        (preserve_rooms_isReserved() or preserve_rooms_getRoleAssignment() ~= '')
+    then
         if self.subviews.pause_mask:getMousePos() then return true end
         if self.subviews.add_mask:getMousePos() then return true end
     end


### PR DESCRIPTION
and there is no current office holder to assign to the zone

ref: https://github.com/DFHack/dfhack/issues/4881