### PR TITLE
Update regrass plugin; DFHack::cuboid fixes

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -65,6 +65,8 @@ Template for new versions:
 - `buildingplan`: fixed processing errors when using quick material filter slot '0'
 - DFHack screens that allow keyboard cursor and camera movement while active now also allow diagonal and Z-change keyboard cursor keys
 - `strangemood`: manually-triggered Macabre moods will now correctly request up to 3 bones/remains for the primary component instead of only 1.
+- `regrass`: no longer add all compatible grass types when using ``--force`` without ``--new``
+- `regrass`: ``--mud`` now converts muddy slade to grass, consistent with normal DF behavior
 
 ## Misc Improvements
 - `sort`: can now search for stockpiles on the Places>Stockpile tab by name, number, or enabled item categories
@@ -76,6 +78,7 @@ Template for new versions:
 ## API
 - ``Units``: new ``isWildlife`` and ``isAgitated`` property checks
 - ``Items::createItem``: removed growth_print parameter; now determined automatically
+- ``DFHack::cuboid``: ``cuboid::clampMap`` now returns the cuboid itself (instead of boolean) to allow method chaining; call ``cuboid::isValid`` to determine success instead
 
 ## Lua
 - ``dfhack.units``: ``isWildlife`` and ``isAgitated`` property checks

--- a/docs/plugins/regrass.rst
+++ b/docs/plugins/regrass.rst
@@ -18,11 +18,11 @@ Usage
 
 Regrasses the entire map by default, restricted to compatible tiles in map
 blocks that had grass at some point. Supplying a ``pos`` argument can limit
-operation to a single tile. Supplying both can operate on a cuboid. ``pos``
-should normally be in the form ``0,0,0``, without spaces. The string ``here``
-can be used in place of numeric coordinates to use the position of the keyboard
-cursor, if active. The ``--block`` and ``--zlevel`` options use the ``pos``
-values differently.
+operation to a single tile. Supplying both can operate on a cuboid region.
+``pos`` should normally be in the form ``0,0,0``, without spaces. The string
+``here`` can be used in place of numeric coordinates to use the position of the
+keyboard cursor, if active. The ``--block`` and ``--zlevel`` options use the
+``pos`` values differently.
 
 Examples
 --------
@@ -36,26 +36,26 @@ Examples
     90, refilling existing and depleted grass.
 ``regrass 0,0,100 19,19,119 --ashes --mud``
     Regrass tiles in the 20 x 20 x 20 cube defined by the coords, refilling
-    existing and depleted grass, and converting ashes and muddy stone (if
-    respective blocks ever had grass).
+    existing and depleted grass, and converting ashes and muddy stone. Fails
+    in any block that never had grass.
 ``regrass 10,10,100 -baudnm``
-    Regrass the block that contains the given coord; converting ashes, muddy
-    stone, and tiles under buildings; adding all compatible grass types, and
-    filling each grass type to max.
+    Regrass the block that contains the given coord. Converts ashes, muddy
+    stone, and tiles under buildings. Adds all compatible grass types and
+    fills each grass type to max.
 ``regrass -f``
     Regrass the entire map, refilling existing and depleted grass, else filling
-    with a randomly selected grass type if non-existent.
+    with a single randomly selected grass type if non-existent.
 ``regrass -l``
     Print all valid grass raw IDs for use with ``--plant``. Both numerical and
     string IDs are provided. This ignores all other options and skips regrass.
 ``regrass -zf -p 128``
     Regrass the current z-level, refilling existing and depleted grass, else
-    filling with ``underlichen`` if non-existent.
+    filling with ``underlichen`` (subject to world's raws) if non-existent.
 ``regrass here -bnf -p "dog's tooth grass"``
     Regrass the selected block, adding all compatible grass types to block data,
-    ``dog's tooth grass`` if no compatible types exist. Refill existing grass
-    on each tile, else select one of the block's types if depleted or
-    previously non-existent.
+    and ``dog's tooth grass`` if no compatible types exist for a tile. Refill
+    existing grass on each tile, else select a compatible (or forced) type if
+    depleted or previously non-existent.
 
 Options
 -------
@@ -65,38 +65,39 @@ Options
     option. The map will not be affected when running with this option.
 ``-m``, ``--max``
     Maxes out every grass type in the tile, giving extra grazing time.
-    Not normal DF behavior. Tile will appear to be the first type of grass
-    present in the map block until that is depleted, moving on to the next
-    type. When this option isn't used, non-depleted grass tiles will have their
-    existing type refilled, while grass-depleted soils will have a type
-    selected randomly.
+    Not normal DF behavior. The tile will appear to be the first type of grass
+    present in the map block until that is depleted for the tile, moving on to
+    the next type. Ignores biome compatibility per tile, using every type
+    present in the block data. When this option *isn't* used, non-depleted
+    grass tiles will have their existing type refilled, while grass-depleted
+    soils will have a type selected randomly.
 ``-n``, ``--new``
-    Adds biome-compatible grass types that were not originally present in the
-    map block. Allows regrass to work in blocks that never had any grass to
+    Adds all biome-compatible grass types that were not originally present in
+    the map block. Allows regrass to work in blocks that never had any grass to
     begin with. Will still fail in incompatible biomes.
 ``-f``, ``--force``
-    Force a grass type on tiles with no compatible grass types. The ``--new``
-    option takes precedence for compatible biomes, otherwise such tiles will be
-    forced instead. By default, a single random grass type is selected from
-    the world's raws. The ``--plant`` option allows a specific grass type to be
-    specified.
+    Force a grass type on tiles with no compatible grass types. Unsets the
+    ``no_grow`` flag on all tiles. The ``--new`` option takes precedence for
+    compatible biomes, otherwise such tiles will be forced instead. By default,
+    a single random grass type is selected from the world's raws to be the
+    forced type for the duration of the command. The ``--plant`` option allows
+    a specific grass type to be specified.
 ``-p``, ``--plant <grass_id>``
     Specify a grass type for the ``--force`` option. ``grass_id`` is not
     case-sensitive, but must be enclosed in quotes if spaces exist. A numerical
     ID can also be used.
 ``-a``, ``--ashes``
     Regrass tiles that've been burnt to ash. Usually ash must revert to soil
-    first before grass can grow.
+    first before grass can regrow.
 ``-d``, ``--buildings``
     Regrass tiles under certain passable building tiles including stockpiles,
     planned buildings, workshops, and farms. (Farms will convert grass tiles to
-    furrowed soil after a short while, but is useful with ``--mud`` option.)
+    furrowed soil after a short while, but is useful with the ``--mud`` option.)
     Doesn't work on "dynamic" buildings such as doors and floor grates.
     (Dynamic buildings also include levers and cage traps, for some reason.)
     Existing grass tiles will always be refilled, regardless of building tile.
 ``-u``, ``--mud``
-    Converts non-smoothed, mud-spattered stone into grass. Valid for layer
-    stone, obsidian, and ore.
+    Converts non-smoothed, mud-spattered stone into grass.
 ``-b``, ``--block``
     Only regrass the map block that contains the first ``pos`` argument.
     `devel/block-borders` can be used to visualize map blocks.
@@ -108,9 +109,10 @@ Options
 Troubleshooting
 ---------------
 
-``debugfilter set Debug regrass log`` can be used to figure out why regrass
-is failing on a tile. (Avoid regrassing large parts of the map with this
-enabled, as it will make the game unresponsive and flood the console for
+Use ``debugfilter set Debug regrass log`` (or
+``debugfilter set Trace regrass log`` for more detail) to figure out why
+regrass is failing on a tile. (Avoid regrassing large parts of the map with
+this enabled, as it will make the game unresponsive and flood the console for
 several minutes!)
 
 Disable with ``debugfilter set Info regrass log``.

--- a/library/include/modules/Maps.h
+++ b/library/include/modules/Maps.h
@@ -190,36 +190,36 @@ class cuboid {
     int16_t z_min = -1;
     int16_t z_max = -1;
 
-    // Default constructor
+    // Default constructor.
     DFHACK_EXPORT cuboid() {}
 
-    // Construct from two corners
+    // Construct from two corners.
     DFHACK_EXPORT cuboid(int16_t x1, int16_t y1, int16_t z1, int16_t x2, int16_t y2, int16_t z2);
     DFHACK_EXPORT cuboid(const df::coord &p1, const df::coord &p2) : cuboid(p1.x, p1.y, p1.z, p2.x, p2.y, p2.z) {}
 
-    // Construct as single tile
+    // Construct as single tile.
     DFHACK_EXPORT cuboid(int16_t x, int16_t y, int16_t z);
     DFHACK_EXPORT cuboid(const df::coord &p) : cuboid(p.x, p.y, p.z) {}
 
-    // Construct from map block
+    // Construct from map block.
     DFHACK_EXPORT cuboid(const df::map_block *block);
 
-    // Valid cuboid? True if all max >= min >= 0
+    // Valid cuboid? True if all max >= min >= 0.
     DFHACK_EXPORT bool isValid() const;
 
     // Clear cuboid dimensions, making it invalid.
     DFHACK_EXPORT void clear() { x_min = x_max = y_min = y_max = z_min = z_max = -1; }
 
-    // Clamp this cuboid within another cuboid. If valid input, invalid result implies no intersection.
+    // Clamp this cuboid within another cuboid. Invalid result implies no intersection or invalid input.
     DFHACK_EXPORT cuboid clamp(const cuboid &other);
 
-    // Return a new cuboid representing overlapping volume. If valid input, invalid result implies no intersection.
+    // Return a new cuboid representing overlapping volume. Invalid result implies no intersection or invalid input.
     DFHACK_EXPORT cuboid clampNew(const cuboid &other) const { return cuboid(*this).clamp(other); }
 
-    /// Clamp cuboid within map area and ensure max >= min. Fails if map not loaded or any bound < 0.
+    /// Clamp this cuboid within map area. Invalid result implies no intersection or invalid input (e.g., no map).
     /// Can optionally treat cuboid as map blocks instead of tiles.
     /// Note: A point being in map area isn't sufficient to know that a tile block is allocated there!
-    DFHACK_EXPORT bool clampMap(bool block = false);
+    DFHACK_EXPORT cuboid clampMap(bool block = false);
 
     // Expand cuboid to include point. Returns true if bounds changed. Fails if x/y/z < 0.
     DFHACK_EXPORT bool addPos(int16_t x, int16_t y, int16_t z);
@@ -236,7 +236,7 @@ class cuboid {
     /// Iterate over every non-NULL map block intersecting the tile cuboid from top-down, N-S, then W-E.
     /// Will also supply the intersection of this cuboid and block to your "fn" for use with cuboid::forCoord.
     /// Can optionally attempt to create map blocks if they aren't allocated.
-    /// "fn" should return true to keep iterating. Won't iterate if map not loaded or any bound < 0.
+    /// "fn" should return true to keep iterating. Won't iterate if cuboid::clampMap() would fail.
     DFHACK_EXPORT void forBlock(std::function<bool(df::map_block *, cuboid)> fn, bool ensure_block = false) const;
 };
 

--- a/plugins/regrass.cpp
+++ b/plugins/regrass.cpp
@@ -365,21 +365,6 @@ int regrass_tile(color_ostream &out, const regrass_options &options, df::map_blo
         TRACE(log, out).print("Tiletype no change.\n");
         return 1;
     }
-    /*else if (mat == tiletype_material::STONE || // Note: DF doesn't seem to remove mud.
-        mat == tiletype_material::FEATURE ||
-        mat == tiletype_material::LAVA_STONE ||
-        mat == tiletype_material::MINERAL)
-    {   // Muddy stone.
-        for (auto blev : block->block_events)
-        {   // Remove mud spatter.
-            auto ms_ev = virtual_cast<df::block_square_event_material_spatterst>(blev);
-            if (ms_ev && ms_ev->mat_type == builtin_mats::MUD) {
-                ms_ev->amount[tx][ty] = 0;
-                DEBUG(log, out).print("Removed tile mud.\n");
-                break;
-            }
-        }
-    }*/
 
     if (shape == tiletype_shape::FLOOR)
     {   // Floor (including ashes).

--- a/plugins/regrass.cpp
+++ b/plugins/regrass.cpp
@@ -32,18 +32,17 @@ namespace DFHack
     DBG_DECLARE(regrass, log, DebugCategory::LINFO);
 }
 
-struct regrass_options
-{
-    bool max_grass = false; // Fill all tile grass events
-    bool new_grass = false; // Add new valid grass events
-    bool force = false; // Force a grass regardless of no_grow and biome
-    bool ashes = false; // Regrass ashes
-    bool buildings = false; // Regrass under stockpiles and passable buildings
-    bool mud = false; // Regrass muddy stone
-    bool block = false; // Operate on single map block
-    bool zlevel = false; // Operate on entire z-levels
+struct regrass_options {
+    bool max_grass = false; // Fill all tile grass events.
+    bool new_grass = false; // Add new valid grass events.
+    bool force = false; // Force a grass regardless of no_grow and biome.
+    bool ashes = false; // Regrass ashes.
+    bool buildings = false; // Regrass under stockpiles and passable buildings.
+    bool mud = false; // Regrass muddy stone.
+    bool block = false; // Operate on single map block.
+    bool zlevel = false; // Operate on entire z-levels.
 
-    int32_t forced_plant = -1; // Plant raw index of grass to force; -2 means print all ids
+    int32_t forced_plant = -1; // Plant raw index of grass to force; -2 means print all IDs.
 
     static struct_identity _identity;
 };
@@ -65,7 +64,7 @@ struct_identity regrass_options::_identity(sizeof(regrass_options), &df::allocat
 command_result df_regrass(color_ostream &out, vector<string> &parameters);
 
 static bool valid_tile(color_ostream &out, regrass_options options, df::map_block *block, int tx, int ty)
-{   // Is valid tile for regrass
+{   // Is valid tile for regrass.
     auto des = block->designation[tx][ty];
     auto tt = block->tiletype[tx][ty];
     auto shape = tileShape(tt);
@@ -74,28 +73,28 @@ static bool valid_tile(color_ostream &out, regrass_options options, df::map_bloc
 
     if (mat == tiletype_material::GRASS_LIGHT ||
         mat == tiletype_material::GRASS_DARK ||
-        mat == tiletype_material::PLANT) // Shrubs and saplings can have grass underneath
-    {   // Refill existing grass
-        DEBUG(log, out).print("Valid tile: Grass/Shrub/Sapling\n");
+        mat == tiletype_material::PLANT) // Shrubs and saplings can have grass underneath.
+    {   // Refill existing grass.
+        TRACE(log, out).print("Valid tile: Grass/Shrub/Sapling\n");
         return true;
     }
     else if (tt == tiletype::TreeTrunkPillar || tt == tiletype::TreeTrunkInterior ||
         (tt >= tiletype::TreeTrunkThickN && tt <= tiletype::TreeTrunkThickSE))
-    {   // Trees can have grass for ground level tiles
+    {   // Trees can have grass for ground level tiles.
         auto p = df::coord(block->map_pos.x + tx, block->map_pos.y + ty, block->map_pos.z);
         auto plant = Maps::getPlantAtTile(p);
         if (plant && plant->pos.z == p.z)
         {
-            DEBUG(log, out).print("Valid tile: Tree\n");
-            return true; // Ground tile
+            TRACE(log, out).print("Valid tile: Tree\n");
+            return true; // Ground tile.
         }
 
-        DEBUG(log, out).print("Invalid tile: Tree\n");
-        return false; // Not ground tile
+        TRACE(log, out).print("Invalid tile: Tree\n");
+        return false; // Not ground tile.
     }
     else if (des.bits.flow_size > (des.bits.liquid_type == tile_liquid::Magma ? 0 : 3))
-    {   // Under water/magma (df::plant_raw::shrub_drown_level is usually 4)
-        DEBUG(log, out).print("Invalid tile: Liquid\n");
+    {   // Under water/magma (df::plant_raw::shrub_drown_level is usually 4).
+        TRACE(log, out).print("Invalid tile: Liquid\n");
         return false;
     }
     else if (shape != tiletype_shape::FLOOR &&
@@ -104,111 +103,96 @@ static bool valid_tile(color_ostream &out, regrass_options options, df::map_bloc
         shape != tiletype_shape::STAIR_DOWN &&
         shape != tiletype_shape::STAIR_UPDOWN)
     {
-        DEBUG(log, out).print("Invalid tile: Shape\n");
+        TRACE(log, out).print("Invalid tile: Shape\n");
         return false;
     }
     else if (block->occupancy[tx][ty].bits.building >
         (options.buildings ? tile_building_occ::Passable : tile_building_occ::None))
-    {   // Avoid stockpiles and planned/passable buildings unless enabled
-        DEBUG(log, out).print("Invalid tile: Building (%s)\n",
+    {   // Avoid stockpiles and planned/passable buildings unless enabled.
+        TRACE(log, out).print("Invalid tile: Building (%s)\n",
             ENUM_KEY_STR(tile_building_occ, block->occupancy[tx][ty].bits.building).c_str());
         return false;
     }
-    else if (!options.force && block->occupancy[tx][ty].bits.no_grow)
-    {
-        DEBUG(log, out).print("Invalid tile: no_grow\n");
+    else if (!options.force && block->occupancy[tx][ty].bits.no_grow) {
+        TRACE(log, out).print("Invalid tile: no_grow\n");
         return false;
     }
-    else if (mat == tiletype_material::SOIL)
-    {
+    else if (mat == tiletype_material::SOIL) {
         if (spec == tiletype_special::FURROWED || spec == tiletype_special::WET)
-        {   // Dirt road or beach
-            DEBUG(log, out).print("Invalid tile: Furrowed/Wet\n");
+        {   // Dirt road or beach.
+            TRACE(log, out).print("Invalid tile: Furrowed/Wet\n");
             return false;
         }
-
-        DEBUG(log, out).print("Valid tile: Soil\n");
+        TRACE(log, out).print("Valid tile: Soil\n");
         return true;
     }
-    else if (options.ashes && mat == tiletype_material::ASHES)
-    {
-        DEBUG(log, out).print("Valid tile: Ashes\n");
+    else if (options.ashes && mat == tiletype_material::ASHES) {
+        TRACE(log, out).print("Valid tile: Ashes\n");
         return true;
     }
     else if (options.mud)
     {
         if (spec == tiletype_special::SMOOTH || spec == tiletype_special::TRACK)
-        {   // Don't replace smoothed stone
-            DEBUG(log, out).print("Invalid tile: Smooth (mud check)\n");
+        {   // Don't replace smoothed stone.
+            TRACE(log, out).print("Invalid tile: Smooth (mud check)\n");
             return false;
         }
         else if (mat != tiletype_material::STONE &&
+            mat != tiletype_material::FEATURE &&
             mat != tiletype_material::LAVA_STONE &&
             mat != tiletype_material::MINERAL)
-        {   // Not non-feature stone
-            DEBUG(log, out).print("Invalid tile: Wrong tile mat (mud check)\n");
+        {   // Not any stone.
+            TRACE(log, out).print("Invalid tile: Wrong tile mat (mud check)\n");
             return false;
         }
 
         for (auto blev : block->block_events)
-        {
-            if (blev->getType() != block_square_event_type::material_spatter)
-                continue;
-
-            auto &ms_ev = *(df::block_square_event_material_spatterst *)blev;
-            if (ms_ev.mat_type == builtin_mats::MUD)
-            {
-                if (ms_ev.amount[tx][ty] > 0)
-                {
-                    DEBUG(log, out).print("Valid tile: Muddy stone\n");
+        {   // Look for mud on tile. Note: DF doesn't allow for surface grass, but we do.
+            auto ms_ev = virtual_cast<df::block_square_event_material_spatterst>(blev);
+            if (ms_ev && ms_ev->mat_type == builtin_mats::MUD) {
+                if (ms_ev->amount[tx][ty] > 0) {
+                    TRACE(log, out).print("Valid tile: Muddy stone\n");
                     return true;
                 }
-                else
-                {
-                    DEBUG(log, out).print("Invalid tile: Non-muddy stone\n");
+                else {
+                    TRACE(log, out).print("Invalid tile: Non-muddy stone\n");
                     return false;
                 }
             }
         }
     }
-
-    DEBUG(log, out).print("Invalid tile: No success\n");
+    TRACE(log, out).print("Invalid tile: No success\n");
     return false;
 }
 
-static vector<int32_t> grasses_for_tile(color_ostream &out, df::map_block *block, int tx, int ty)
-{   // Return sorted vector of valid grass ids
-    vector<int32_t> grasses;
-
-    if (block->occupancy[tx][ty].bits.no_grow)
-    {
-        DEBUG(log, out).print("Skipping grass collection: no_grow\n");
-        return grasses;
+static void grasses_for_tile(color_ostream &out, vector<int32_t> &vec, df::map_block *block, int tx, int ty)
+{   // Fill vector with sorted valid grass IDs.
+    vec.clear();
+    if (block->occupancy[tx][ty].bits.no_grow) {
+        TRACE(log, out).print("Skipping grass collection: no_grow\n");
+        return;
     }
-
-    DEBUG(log, out).print("Collecting grasses...\n");
-    if (block->designation[tx][ty].bits.subterranean)
-    {
+    // TODO: Use world.area_grasses.layer_grasses[] if not options.new_grass?
+    TRACE(log, out).print("Collecting grasses...\n");
+    if (block->designation[tx][ty].bits.subterranean) {
         for (auto p_raw : world->raws.plants.grasses)
         {   // Sorted by df::plant_raw::index
-            if (p_raw->flags.is_set(plant_raw_flags::BIOME_SUBTERRANEAN_WATER))
-            {
-                DEBUG(log, out).print("Cave grass: %s\n", p_raw->id.c_str());
-                grasses.push_back(p_raw->index);
+            if (p_raw->flags.is_set(plant_raw_flags::BIOME_SUBTERRANEAN_WATER)) {
+                TRACE(log, out).print("Cave grass: %s\n", p_raw->id.c_str());
+                vec.push_back(p_raw->index);
             }
         }
     }
-    else // Above ground
-    {
+    else
+    {   // Surface
         auto rgn_pos = Maps::getBlockTileBiomeRgn(block, df::coord2d(tx, ty));
-
         if (!rgn_pos.isValid())
-        {   // No biome (happens in sky)
-            DEBUG(log, out).print("No grass: No biome region!\n");
-            return grasses;
+        {   // No biome (happens in sky).
+            TRACE(log, out).print("No grass: No biome region!\n");
+            return;
         }
 
-        auto &biome_info = *Maps::getRegionBiome(rgn_pos);
+        auto &biome_info = *Maps::getRegionBiome(rgn_pos); // TODO: Cache grasses based on region?
         auto plant_biome_flag = ENUM_ATTR(biome_type, plant_raw_flag, Maps::getBiomeType(rgn_pos.x, rgn_pos.y));
 
         bool good = (biome_info.evilness < 33);
@@ -223,115 +207,147 @@ static vector<int32_t> grasses_for_tile(color_ostream &out, df::map_block *block
                 (evil || !flags.is_set(plant_raw_flags::EVIL)) &&
                 (savage || !flags.is_set(plant_raw_flags::SAVAGE)))
             {
-                DEBUG(log, out).print("Surface grass: %s\n", p_raw->id.c_str());
-                grasses.push_back(p_raw->index);
+                TRACE(log, out).print("Surface grass: %s\n", p_raw->id.c_str());
+                vec.push_back(p_raw->index);
             }
         }
     }
-
-    DEBUG(log, out).print("Done collecting grasses.\n");
-    return grasses;
+    TRACE(log, out).print("Done collecting grasses.\n");
 }
 
 static bool regrass_events(color_ostream &out, const regrass_options &options, df::map_block *block, int tx, int ty)
-{   // Modify grass block events
-    if (!valid_tile(out, options, block, tx, ty))
+{   // Utility fn to modify grass block events.
+    if (!valid_tile(out, options, block, tx, ty)) {
+        DEBUG(log, out).print("Skipping invalid tile.\n");
         return false;
-
-    bool success = false;
+    }
+    // Gather grass events for consideration.
+    vector<df::block_square_event_grassst *> consider_grev;
     for (auto blev : block->block_events)
-    {   // Try to refill existing events
-        if (blev->getType() != block_square_event_type::grass)
-            continue;
+        if (auto gr_ev = virtual_cast<df::block_square_event_grassst>(blev))
+            consider_grev.push_back(gr_ev);
 
-        auto &gr_ev = *(df::block_square_event_grassst *)blev;
+    df::block_square_event_grassst *forced_grev = NULL;
+    bool success = false; // Determine if max regrass worked.
 
+    for (auto gr_ev : consider_grev)
+    {   // Try to refill existing events.
         if (options.max_grass)
-        {   // Refill all
-            gr_ev.amount[tx][ty] = 100;
+        {   // Refill all.
+            gr_ev->amount[tx][ty] = 100;
             success = true;
         }
-        else if (gr_ev.amount[tx][ty] > 0)
-        {   // Refill first non-zero grass
-            gr_ev.amount[tx][ty] = 100;
-            DEBUG(log, out).print("Refilled existing grass.\n");
+        else if (gr_ev->amount[tx][ty] > 0)
+        {   // Refill first non-zero grass.
+            DEBUG(log, out).print("Refilling existing grass (ID %d).\n", gr_ev->plant_index);
+            gr_ev->amount[tx][ty] = 100;
             return true;
         }
-    }
 
-    auto valid_grasses = grasses_for_tile(out, block, tx, ty);
-    if (options.force && valid_grasses.empty())
-    {
-        DEBUG(log, out).print("Forcing grass.\n");
-        valid_grasses.push_back(options.forced_plant);
+        if (options.force && gr_ev->plant_index == options.forced_plant)
+            forced_grev = gr_ev; // Avoid allocating a new event.
+    }
+    if (options.force)
         block->occupancy[tx][ty].bits.no_grow = false;
-    }
 
-    if (options.force || (options.new_grass && !valid_grasses.empty()))
-    {
-        DEBUG(log, out).print("Adding missing grasses...\n");
-        auto new_grasses(valid_grasses); // Copy vector
-        for (auto blev : block->block_events)
-        {   // Find which grasses we're missing
-            if (blev->getType() == block_square_event_type::grass)
-                erase_from_vector(new_grasses, ((df::block_square_event_grassst *)blev)->plant_index);
+    vector<int32_t> valid_grasses;
+    if (options.new_grass || !options.max_grass) // Find out what belongs.
+        grasses_for_tile(out, valid_grasses, block, tx, ty);
+
+    if (options.new_grass && !valid_grasses.empty()) {
+        TRACE(log, out).print("Handling new grasses...\n");
+        auto new_grasses(valid_grasses); // Copy vector.
+
+        for (auto gr_ev : consider_grev)
+        {   // These grass events are already present.
+            if (erase_from_vector(new_grasses, gr_ev->plant_index))
+                TRACE(log, out).print("Grass (ID %d) already present.\n", gr_ev->plant_index);
         }
 
-        for (auto id : new_grasses)
-        {   // Add new grass events
-            DEBUG(log, out).print("Adding grass with plant index %d\n", id);
+        for (auto id : new_grasses) {
+            DEBUG(log, out).print("Allocating new grass event (ID %d).\n", id);
             auto gr_ev = df::allocate<df::block_square_event_grassst>();
-            block->block_events.push_back(gr_ev);
+            if (!gr_ev) {
+                out.printerr("Failed to allocate new grass event! Aborting loop.\n");
+                break;
+            }
             gr_ev->plant_index = id;
+            block->block_events.push_back(gr_ev);
 
             if (options.max_grass)
-            {   // Initialize tile as full
+            {   // Initialize at max.
                 gr_ev->amount[tx][ty] = 100;
                 success = true;
             }
+            else // Add as random choice.
+                consider_grev.push_back(gr_ev);
         }
-        DEBUG(log, out).print("Done adding grasses.\n");
+    }
+
+    if (!options.max_grass) {
+        TRACE(log, out).print("Ruling out invalid grasses for random select...\n");
+        if (valid_grasses.empty()) {
+            TRACE(log, out).print("No valid grasses. Remove all.\n");
+            consider_grev.clear();
+        }
+
+        for (size_t i = consider_grev.size(); i-- > 0;)
+        {   // Iterate backwards and remove invalid events from consideration.
+            if (!vector_contains(valid_grasses, consider_grev[i]->plant_index)) {
+                TRACE(log, out).print("Removing grass (ID %d) from consideration.\n",
+                    consider_grev[i]->plant_index);
+                consider_grev.erase(consider_grev.begin() + i);
+            }
+        }
+    }
+
+    if (options.force && !success && (options.max_grass || consider_grev.empty())) {
+        TRACE(log, out).print("Handling forced grass...\n");
+        if (forced_grev) {
+            DEBUG(log, out).print("Forced regrass with existing event.\n");
+            forced_grev->amount[tx][ty] = 100;
+            return true;
+        }
+
+        DEBUG(log, out).print("Allocating new forced grass event.\n");
+        if (forced_grev = df::allocate<df::block_square_event_grassst>())
+        {   // Initialize it.
+            forced_grev->plant_index = options.forced_plant;
+            forced_grev->amount[tx][ty] = 100;
+            block->block_events.push_back(forced_grev);
+            return true;
+        }
+        out.printerr("Failed to allocate forced grass event!\n");
+        return false;
     }
 
     if (options.max_grass)
-    {
-        DEBUG(log, out).print("Tile grasses maxed.\n");
+    {   // Don't need random choice.
+        DEBUG(log, out).print("Done with max regrass, %s.\n",
+            success ? "success" : "failure");
         return success;
     }
+    TRACE(log, out).print("Selecting random valid grass event...\n");
 
-    vector<df::block_square_event_grassst *> temp;
-    for (auto blev : block->block_events)
-    {   // Gather all valid grass events
-        if (blev->getType() != block_square_event_type::grass)
-            continue;
-
-        auto gr_ev = (df::block_square_event_grassst *)blev;
-        if (vector_contains(valid_grasses, gr_ev->plant_index))
-            temp.push_back(gr_ev);
-    }
-
-    auto gr_ev = vector_get_random(temp);
-    if (gr_ev)
-    {
-        gr_ev->amount[tx][ty] = 100;
-        DEBUG(log, out).print("Random regrass plant index %d\n", gr_ev->plant_index);
+    if (auto rand_grev = vector_get_random(consider_grev)) {
+        DEBUG(log, out).print("Refilling random grass (ID %d).\n", rand_grev->plant_index);
+        rand_grev->amount[tx][ty] = 100;
         return true;
     }
-
-    DEBUG(log, out).print("Tile doesn't support grass! new_grass = %s\n", options.new_grass ? "true" : "false");
+    DEBUG(log, out).print("No existing valid grass event to select.\n");
     return false;
 }
 
 int regrass_tile(color_ostream &out, const regrass_options &options, df::map_block *block, int tx, int ty)
-{   // Regrass single tile. Return 1 if tile success, else 0
+{   // Regrass single tile. Return 1 if tile success, else 0.
     CHECK_NULL_POINTER(block);
-    if (!is_valid_tile_coord(df::coord2d(tx, ty)))
-    {
+    if (!is_valid_tile_coord(df::coord2d(tx, ty))) {
         out.printerr("(%d, %d) not in range 0-15!\n", tx, ty);
         return 0;
     }
 
-    DEBUG(log, out).print("Regrass tile (%d, %d, %d)\n", block->map_pos.x + tx, block->map_pos.y + ty, block->map_pos.z);
+    DEBUG(log, out).print("Regrass tile (%d, %d, %d)\n",
+        block->map_pos.x + tx, block->map_pos.y + ty, block->map_pos.z);
     if (!regrass_events(out, options, block, tx, ty))
         return 0;
 
@@ -343,23 +359,20 @@ int regrass_tile(color_ostream &out, const regrass_options &options, df::map_blo
         mat == tiletype_material::GRASS_DARK ||
         mat == tiletype_material::PLANT ||
         mat == tiletype_material::TREE)
-    {   // Already appropriate tile
-        DEBUG(log, out).print("Tiletype no change.\n");
+    {   // Already appropriate tile.
+        TRACE(log, out).print("Tiletype no change.\n");
         return 1;
     }
-    /*else if (mat == tiletype_material::STONE || // DF doesn't seem to remove mud
+    /*else if (mat == tiletype_material::STONE || // Note: DF doesn't seem to remove mud.
+        mat == tiletype_material::FEATURE ||
         mat == tiletype_material::LAVA_STONE ||
         mat == tiletype_material::MINERAL)
-    {   // Muddy non-feature stone
+    {   // Muddy stone.
         for (auto blev : block->block_events)
-        {   // Remove mud spatter
-            if (blev->getType() != block_square_event_type::material_spatter)
-                continue;
-
-            auto &ms_ev = *(df::block_square_event_material_spatterst *)blev;
-            if (ms_ev.mat_type == builtin_mats::MUD)
-            {
-                ms_ev.amount[tx][ty] = 0;
+        {   // Remove mud spatter.
+            auto ms_ev = virtual_cast<df::block_square_event_material_spatterst>(blev);
+            if (ms_ev && ms_ev->mat_type == builtin_mats::MUD) {
+                ms_ev->amount[tx][ty] = 0;
                 DEBUG(log, out).print("Removed tile mud.\n");
                 break;
             }
@@ -367,110 +380,60 @@ int regrass_tile(color_ostream &out, const regrass_options &options, df::map_blo
     }*/
 
     if (shape == tiletype_shape::FLOOR)
-    {   // Handle random variant, ashes
+    {   // Floor (including ashes).
         DEBUG(log, out).print("Tiletype to random grass floor.\n");
         block->tiletype[tx][ty] = findRandomVariant((rand() & 1) ? tiletype::GrassLightFloor1 : tiletype::GrassDarkFloor1);
     }
     else
-    {
+    {   // Ramp or stairs.
         auto new_mat = (rand() & 1) ? tiletype_material::GRASS_LIGHT : tiletype_material::GRASS_DARK;
         auto new_tt = findTileType(shape, new_mat, tiletype_variant::NONE, tiletype_special::NONE, nullptr);
         DEBUG(log, out).print("Tiletype to %s.\n", ENUM_KEY_STR(tiletype, new_tt).c_str());
         block->tiletype[tx][ty] = new_tt;
     }
-
     return 1;
 }
 
+int regrass_cuboid(color_ostream &out, const regrass_options &options, const cuboid &bounds)
+{   // Regrass all tiles in the defined cuboid.
+    DEBUG(log, out).print("Regrassing cuboid (%d:%d, %d:%d, %d:%d), clipped to map.\n",
+        bounds.x_min, bounds.x_max, bounds.y_min, bounds.y_max, bounds.z_min, bounds.z_max);
+
+    int count = 0;
+    bounds.forBlock([&](df::map_block *block, cuboid intersect) {
+        DEBUG(log, out).print("Cuboid regrass block at (%d, %d, %d)\n",
+            block->map_pos.x, block->map_pos.y, block->map_pos.z);
+        intersect.forCoord([&](df::coord pos) {
+            count += regrass_tile(out, options, block, pos.x&15, pos.y&15);
+            return true;
+        });
+        return true;
+    });
+    return count;
+}
+
 int regrass_block(color_ostream &out, const regrass_options &options, df::map_block *block)
-{   // Regrass single block
+{   // Regrass all tiles in a single block.
     CHECK_NULL_POINTER(block);
+    DEBUG(log, out).print("Regrass block at (%d, %d, %d)\n",
+        block->map_pos.x, block->map_pos.y, block->map_pos.z);
 
     int count = 0;
     for (int tx = 0; tx < 16; tx++)
-    {
         for (int ty = 0; ty < 16; ty++)
             count += regrass_tile(out, options, block, tx, ty);
-    }
-
-    return count;
-}
-
-int regrass_zlevels(color_ostream &out, const regrass_options &options, int32_t z1, int32_t z2 = -30000)
-{   // Regrass a range of z-levels
-    if (z1 < 0 || z1 >= world->map.z_count_block)
-    {
-        out.printerr("z1 out of map bounds!\n");
-        return 0;
-    }
-    else if (z2 != -30000 && (z2 < 0 || z2 >= world->map.z_count_block))
-    {
-        out.printerr("z2 out of map bounds!\n");
-        return 0;
-    }
-
-    auto z = z2 < 0 ? z1 : std::min(z1, z2);
-    auto z_end = std::max(z1, z2);
-    int count = 0;
-    for (; z <= z_end; z++)
-    {   // Iterate all blocks in z-level range
-        for (int32_t x = 0; x < world->map.x_count_block; x++)
-        {
-            for (int32_t y = 0; y < world->map.y_count_block; y++)
-            {
-                auto block = Maps::getBlock(x, y, z);
-                if (block)
-                    count += regrass_block(out, options, block);
-                else // Probably below HFS
-                    out.print("No getBlock(%d, %d, %d)! Skipping.\n", x, y, z);
-            }
-        }
-    }
-
-    return count;
-}
-
-int regrass_cuboid(color_ostream &out, const regrass_options &options, df::coord pos_1, df::coord pos_2)
-{   // Regrass cuboid defined by pos_1, pos_2
-    if (!Maps::isValidTilePos(pos_1) || !Maps::isValidTilePos(pos_2))
-    {
-        out.printerr("Cuboid extends out of map bounds!\n");
-        return 0;
-    }
-
-    int32_t x_max = std::max(pos_1.x, pos_2.x);
-    int32_t y_max = std::max(pos_1.y, pos_2.y);
-    int32_t z_max = std::max(pos_1.z, pos_2.z);
-    int count = 0;
-    for (int32_t z = std::min(pos_1.z, pos_2.z); z <= z_max; z++)
-    {   // Iterate all tiles in cuboid
-        for (int32_t x = std::min(pos_1.x, pos_2.x); x <= x_max; x++)
-        {
-            for (int32_t y = std::min(pos_1.y, pos_2.y); y <= y_max; y++)
-            {
-                auto block = Maps::getTileBlock(x, y, z);
-                if (block)
-                    count += regrass_tile(out, options, block, x&15, y&15);
-                else // Probably below HFS
-                    DEBUG(log, out).print("No getTileBlock(%d, %d, %d)! Skipping.\n", x, y, z);
-            }
-        }
-    }
-
     return count;
 }
 
 int regrass_map(color_ostream &out, const regrass_options &options)
-{   // Regrass entire map
+{   // Regrass entire map.
     int count = 0;
     for (auto block : world->map.map_blocks)
         count += regrass_block(out, options, block);
-
     return count;
 }
 
-DFhackCExport command_result plugin_init(color_ostream &out, vector<PluginCommand> &commands)
-{
+DFhackCExport command_result plugin_init(color_ostream &out, vector<PluginCommand> &commands) {
     commands.push_back(PluginCommand(
         "regrass",
         "Regrow surface grass and cavern moss.",
@@ -487,51 +450,43 @@ command_result df_regrass(color_ostream &out, vector<string> &parameters)
 
     if (!Lua::CallLuaModuleFunction(out, "plugins.regrass", "parse_commandline",
         std::make_tuple(&options, &pos_1, &pos_2, parameters)))
-    {
+    {   // Failure in Lua script.
         return CR_WRONG_USAGE;
     }
     else if (options.forced_plant == -2)
-    {   // Print all grass raw ids
+    {   // Print all grass raw IDs.
         for (auto p_raw : world->raws.plants.grasses)
             out.print("%d: %s\n", p_raw->index, p_raw->id.c_str());
-
         return CR_OK;
     }
 
     DEBUG(log, out).print("pos_1 = (%d, %d, %d)\npos_2 = (%d, %d, %d)\n",
         pos_1.x, pos_1.y, pos_1.z, pos_2.x, pos_2.y, pos_2.z);
 
-    if (options.block && options.zlevel)
-    {
+    if (options.block && options.zlevel) {
         out.printerr("Choose only --block or --zlevel!\n");
         return CR_WRONG_USAGE;
     }
-    else if (options.block && (!pos_1.isValid() || pos_2.isValid()))
-    {
+    else if (options.block && (!pos_1.isValid() || pos_2.isValid())) {
         out.printerr("Invalid pos for --block (or used more than one!)\n");
         return CR_WRONG_USAGE;
     }
-    else if (!Core::getInstance().isMapLoaded())
-    {
+    else if (!Core::getInstance().isMapLoaded()) {
         out.printerr("Map not loaded!\n");
         return CR_FAILURE;
     }
 
-    if (options.force)
-    {
+    if (options.force) {
         DEBUG(log, out).print("forced_plant = %d\n", options.forced_plant);
         auto p_raw = vector_get(world->raws.plants.all, options.forced_plant);
-        if (p_raw)
-        {
-            DEBUG(log, out).print("Forced plant raw: %s\n", p_raw->id.c_str());
-            if (!p_raw->flags.is_set(plant_raw_flags::GRASS))
-            {
+        if (p_raw) {
+            if (!p_raw->flags.is_set(plant_raw_flags::GRASS)) {
                 out.printerr("Plant raw wasn't grass: %d (%s)\n", options.forced_plant, p_raw->id.c_str());
                 return CR_FAILURE;
             }
+            out.print("Forced grass: %s\n", p_raw->id.c_str());
         }
-        else
-        {
+        else {
             out.printerr("Plant raw not found for --force: %d\n", options.forced_plant);
             return CR_FAILURE;
         }
@@ -539,47 +494,44 @@ command_result df_regrass(color_ostream &out, vector<string> &parameters)
 
     int count = 0;
     if (options.zlevel)
-    {
+    {   // Specified z-levels or viewport z.
         auto z1 = pos_1.isValid() ? pos_1.z : Gui::getViewportPos().z;
         auto z2 = pos_2.isValid() ? pos_2.z : z1;
         DEBUG(log, out).print("Regrassing z-levels %d to %d...\n", z1, z2);
-        count = regrass_zlevels(out, options, z1, z2);
+        count = regrass_cuboid(out, options, cuboid(0, 0, z1,
+            world->map.x_count-1, world->map.y_count-1, z2));
     }
     else if (pos_1.isValid())
-    {   // Block, cuboid, or point
+    {   // Block, cuboid, or point.
         if (!options.block && pos_2.isValid())
         {   // Cuboid
             DEBUG(log, out).print("Regrassing cuboid...\n");
-            count = regrass_cuboid(out, options, pos_1, pos_2);
+            count = regrass_cuboid(out, options, cuboid(pos_1, pos_2));
         }
-        else // Block or point
-        {
+        else
+        {   // Block or point.
             auto b = Maps::getTileBlock(pos_1);
-            if (!b)
-            {
+            if (!b) {
                 out.printerr("No map block at pos!\n");
                 return CR_FAILURE;
             }
 
-            if (options.block)
-            {
+            if (options.block) {
                 DEBUG(log, out).print("Regrassing block...\n");
                 count = regrass_block(out, options, b);
             }
-            else // Point
-            {
+            else
+            {   // Point
                 DEBUG(log, out).print("Regrassing single tile...\n");
                 count = regrass_tile(out, options, b, pos_1.x&15, pos_1.y&15);
             }
         }
     }
-    else // Entire map
-    {
+    else
+    {   // Do entire map.
         DEBUG(log, out).print("Regrassing map...\n");
         count = regrass_map(out, options);
     }
-
     out.print("Regrew %d tiles of grass.\n", count);
-
     return CR_OK;
 }

--- a/plugins/regrass.cpp
+++ b/plugins/regrass.cpp
@@ -260,8 +260,9 @@ static bool regrass_events(color_ostream &out, const regrass_options &options, d
 
         for (auto gr_ev : consider_grev)
         {   // These grass events are already present.
-            if (erase_from_vector(new_grasses, gr_ev->plant_index))
+            if (erase_from_vector(new_grasses, gr_ev->plant_index)) {
                 TRACE(log, out).print("Grass (ID %d) already present.\n", gr_ev->plant_index);
+            }
         }
 
         for (auto id : new_grasses) {
@@ -310,7 +311,8 @@ static bool regrass_events(color_ostream &out, const regrass_options &options, d
         }
 
         DEBUG(log, out).print("Allocating new forced grass event.\n");
-        if (forced_grev = df::allocate<df::block_square_event_grassst>())
+        forced_grev = df::allocate<df::block_square_event_grassst>();
+        if (forced_grev)
         {   // Initialize it.
             forced_grev->plant_index = options.forced_plant;
             forced_grev->amount[tx][ty] = 100;


### PR DESCRIPTION
Fixed an issue where `cuboid::clampMap` would include map edge tiles for cuboids completely outside of map. Function now returns `cuboid` instead of `bool` to allow for method chaining. Call `cuboid::isValid()` on the result to determine success (e.g., `bool success = some_cuboid.clampMap().isValid();`).

`cuboid::clamp` and `cuboid::clampNew` will now always return invalid cuboids for invalid input, instead of putting the responsibility on the caller.

Updated `regrass` plugin to use `cuboid` class. Improved debug logging. Allowed muddy feature stone (i.e., slade) to be converted to grass, since this can occur in vanilla. Made `--force` no longer imply `--new`, since someone didn't want random grass in their muddy cavern level.