### PR TITLE
strangemood - fix macabre mood items

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 - `gui/settings-manager`: work details overlay no longer disappears when you click on a unit in the unit list
 - `buildingplan`: fixed processing errors when using quick material filter slot '0'
 - DFHack screens that allow keyboard cursor and camera movement while active now also allow diagonal and Z-change keyboard cursor keys
+- `strangemood`: manually-triggered Macabre moods will now correctly request up to 3 bones/remains for the primary component instead of only 1.
 
 ## Misc Improvements
 - `sort`: can now search for stockpiles on the Places>Stockpile tab by name, number, or enabled item categories

--- a/plugins/strangemood.cpp
+++ b/plugins/strangemood.cpp
@@ -734,14 +734,14 @@ command_result df_strangemood (color_ostream &out, vector <string> & parameters)
             job->job_items.elements.push_back(item = new df::job_item());
             item->item_type = item_type::REMAINS;
             item->flags1.bits.allow_buryable = true;
-            item->quantity = 1;
+            item->quantity = base_item_count;
             break;
         case 1:
             job->job_items.elements.push_back(item = new df::job_item());
             item->flags1.bits.allow_buryable = true;
             item->flags2.bits.bone = true;
             item->flags2.bits.body_part = true;
-            item->quantity = 1;
+            item->quantity = base_item_count;
             break;
         case 2:
             job->job_items.elements.push_back(item = new df::job_item());


### PR DESCRIPTION
Remains and bones were being given a quantity of 1, but in-game those use the same 1-3 quantity as other item types.

Turns out they were always this way, and I've been misreading that spot in the disassembly for the past 10 years.