### PR TITLE
clear unit bit when teleporting a unit that is not prone

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -70,6 +70,7 @@ Template for new versions:
 - `gui/pathable`: fix hang when showing trade depot wagon access and a trade depot is submerged under water
 - `gui/pathable`: fix representation of wagon paths over stairs and through doors
 - DFHack state for a site is now properly saved when retiring a fort
+- `gui/teleport`: fix issue when teleporting units that are not prone, resulting in later issues with phantom "cannot build here: unit blocking tile" messages
 
 ## Misc Improvements
 - `sort`: can now search for stockpiles on the Places>Stockpile tab by name, number, or enabled item categories

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -762,7 +762,7 @@ bool Units::teleport(df::unit *unit, df::coord target_pos)
         // This is potentially wrong, but the game will recompute this as needed
         old_occ->bits.unit_grounded = false;
     else
-        old_occ->bits.unit = true;
+        old_occ->bits.unit = false;
 
     // If there's already somebody standing at the destination, then force the unit to lay down
     if (new_occ->bits.unit)


### PR DESCRIPTION
fixes transcription error introduced in #4810