### PR TITLE
Don't include raiding units in Units::isActive; make getPosition return invalid coords

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 - `preserve-rooms`: don't reserve a room for citizens that you expel from the fort
 - `autobutcher`: fix regression in ordering of butcherable animals
 - ``Units::getPosition``, ``Items::getPosition``: return invalid coord for inactive units, items held by units off map
+- ``Units::isUnitInBox``, ``Units::getUnitsInBox``: don't include inactive units
 - ``Units::isActive``: return false for units off map
 
 ## Misc Improvements

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,8 @@ Template for new versions:
 ## Fixes
 - `preserve-rooms`: don't reserve a room for citizens that you expel from the fort
 - `autobutcher`: fix regression in ordering of butcherable animals
+- ``Units::getPosition``, ``Items::getPosition``: return invalid coord for inactive units, items held by units off map
+- ``Units::isActive``: return false for units off map
 
 ## Misc Improvements
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1643,7 +1643,7 @@ Units module
 
   Returns the true *x,y,z* of the unit, or *nil* if invalid. You should
   generally use this method instead of reading *unit.pos* directly since
-  that field can be inaccurate when the unit is caged.
+  that field can be inaccurate when the unit is caged, off map, or dead.
 
 * ``dfhack.units.teleport(unit, pos)``
 

--- a/library/RemoteTools.cpp
+++ b/library/RemoteTools.cpp
@@ -584,7 +584,7 @@ static command_result ListUnits(color_ostream &stream,
 
     if (in->scan_all())
     {
-        auto &vec = df::unit::get_vector();
+        auto &vec = df::global::world->units.active;
 
         for (size_t i = 0; i < vec.size(); i++)
         {

--- a/library/include/modules/Items.h
+++ b/library/include/modules/Items.h
@@ -137,7 +137,7 @@ DFHACK_EXPORT df::building *getHolderBuilding(df::item *item);
 // Get unit that holds the item or NULL.
 DFHACK_EXPORT df::unit *getHolderUnit(df::item *item);
 
-// Returns the true position of the item (non-trivial if in inventory).
+// Get the true position of the item (non-trivial if in inventory). Return invalid coord if holder off map.
 DFHACK_EXPORT df::coord getPosition(df::item *item);
 
 /// Returns the title of a codex or "tool", either as the codex title or as the title of the

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -202,7 +202,7 @@ inline auto citizensRange(std::vector<df::unit *> &vec, bool exclude_residents =
 DFHACK_EXPORT void forCitizens(std::function<void(df::unit *)> fn, bool exclude_residents = false, bool include_insane = false);
 DFHACK_EXPORT bool getCitizens(std::vector<df::unit *> &citizens, bool exclude_residents = false, bool include_insane = false);
 
-// Returns the true position of the unit (non-trivial in case of caged).
+// Get the true position of the unit (non-trivial in case of caged or inactive). Returns invalid coord if dead or off map.
 DFHACK_EXPORT df::coord getPosition(df::unit *unit);
 
 // Moves unit and any riders to the target coordinates. Sets tile occupancy flags.


### PR DESCRIPTION
Raiding units are unflagged as `inactive` shortly after they leave the map, as they are removed from `units.active`. Scan this vector to rule out raiding units. The `move_state` and `can_swap` flags are also unset, which can be used to optimize the check.

`Units::getPosition` now returns invalid coords for inactive units. This impacts `Units::isUnitInBox`, and Units::getUnitsInBox`.

It also impacts `Items::getPosition`, though an item in `items.other.IN_PLAY` has its holder is guaranteed to be active (artifact theft bugs notwithstanding).