### PR TITLE
[preserve-rooms] don't keep reservations for units not in armies

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 - DFHack text edit fields now delete the character at the cursor when you hit the Delete key
 - DFHack text edit fields now move the cursor by one word left or right with Ctrl-Left and Ctrl-Right
 - DFHack text edit fields now move the cursor to the beginning or end of the line with Home and End
+- `preserve-rooms`: automatically release room reservations for captured squad members. we were kidding ourselves with our optimistic kept reservations. they're unlikely to come back : ((
 
 ## Documentation
 

--- a/docs/plugins/preserve-rooms.rst
+++ b/docs/plugins/preserve-rooms.rst
@@ -19,9 +19,8 @@ This tool mitigates both issues. It records when units leave the map and
 reserves their assigned bedrooms, offices, etc. for them. The zones will be
 disabled in their absence (so other units don't steal them), and will be
 re-enabled and reassigned to them when they appear back on the map. If they die
-away from the fort, the zone will become unreserved and available for reuse. If
-they are captured and held prisoner, their room will continue to be reserved in
-their name in the (optimistic) hope of their safe return.
+away from the fort (or are captured), the zone will become unreserved and
+available for reuse.
 
 When you click on an assignable zone, you will also now have the option to
 associate the room with a noble or administrative role. The room will be


### PR DESCRIPTION
this fixes old reservations kept from before we excluded expelled units as a side effect, reservations for prisoners are no longer kept