### PR TITLE
[ZScreen, Panel] prevent mouse clicks from bleeding through

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ Template for new versions:
 - `tweak`: ``realistic-melting``: change melting return for inorganic armor parts, shields, weapons, trap components and tools to stop smelters from creating metal, bring melt return for adamantine in line with other metals to ~95% of forging cost. wear reduces melt return by 10% per level
 
 ## Fixes
+- Fix mouse clicks bleeding through DFHack windows when clicking in the space between the frame and the window content in resizable windows
 
 ## Misc Improvements
 - DFHack text edit fields now delete the character at the cursor when you hit the Delete key

--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -1127,7 +1127,7 @@ function ZScreen:onInput(keys)
         self:dismiss()
     else
         local passit = self.pass_pause and keys.D_PAUSE
-        if not passit and self.pass_mouse_clicks then
+        if not passit and self.pass_mouse_clicks and not has_mouse then
             if keys.CONTEXT_SCROLL_UP or keys.CONTEXT_SCROLL_DOWN or
                     keys.CONTEXT_SCROLL_PAGEUP or keys.CONTEXT_SCROLL_PAGEDOWN then
                 passit = true
@@ -1164,7 +1164,7 @@ end
 
 function ZScreen:isMouseOver()
     for _,sv in ipairs(self.subviews) do
-        if sv.visible and sv:getMouseFramePos() then return true end
+        if utils.getval(sv.visible) and sv:getMouseFramePos() then return true end
     end
 end
 

--- a/library/lua/gui/widgets/containers/panel.lua
+++ b/library/lua/gui/widgets/containers/panel.lua
@@ -71,7 +71,7 @@ Panel.ATTRS {
 ---@param args widgets.Panel.initTable
 function Panel:init(args)
     if not self.drag_anchors then
-        self.drag_anchors = {title=true, frame=not self.resizable, body=true}
+        self.drag_anchors = {title=true, frame=true, body=true}
     end
     if not self.resize_anchors then
         self.resize_anchors = {t=false, l=true, r=true, b=true}


### PR DESCRIPTION
when clicking in the inset area of resizable windows

this PR fixes the issue and also fixes the trigger. Mouse clicks over the window area are now guaranteed not to bleed thorugh. Also, the window was not handling those clicks in the first place because the inset area was not marked as draggable when the window was also resizable due to how the defaults were calculated. Now the inset area is draggable by default.