### PR TITLE
[Core] make version mismatch error message more informative

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -69,6 +69,7 @@ Template for new versions:
 
 ## Documentation
 - Dreamfort: add link to Dreamfort tutorial youtube series: https://www.youtube.com/playlist?list=PLzXx9JcB9oXxmrtkO1y8ZXzBCFEZrKxve
+- The error message that comes up if there is a version mismatch between DF and the installed DFHack now informs you which DF versions are supported by the installed version of DFHack
 
 ## API
 

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -93,6 +93,7 @@ using namespace DFHack;
 using namespace df::enums;
 using df::global::init;
 using df::global::world;
+using std::string;
 
 // FIXME: A lot of code in one file, all doing different things... there's something fishy about it.
 
@@ -1611,7 +1612,26 @@ bool Core::InitMainThread() {
         }
         else
         {
-            fatal("Not a known DF version.\n");
+            std::stringstream msg;
+            msg << "Not a known DF version.\n"
+                   "\n"
+                   "Please make sure that you have a version\n"
+                   "of DFHack installed that matches the version\n"
+                   "of Dwarf Fortress.\n"
+                   "\n";
+            auto supported_versions = vif->getVersionInfosForCurOs();
+            if (supported_versions.size()) {
+                msg << "DF releases supported by this version of DFHack:\n\n";
+                for (auto & sv : supported_versions) {
+                    string ver = sv->getVersion();
+                    if (ver.starts_with("v0.")) {  // translate "v0.50" to the standard format: "v50"
+                        ver = "v" + ver.substr(3);
+                    }
+                    msg << "    " << ver << "\n";
+                }
+                msg << "\n";
+            }
+            fatal(msg.str());
         }
         errorstate = true;
         return false;

--- a/library/VersionInfoFactory.cpp
+++ b/library/VersionInfoFactory.cpp
@@ -29,7 +29,6 @@ distribution.
 #include <algorithm>
 #include <map>
 #include <iostream>
-using namespace std;
 
 #include "VersionInfoFactory.h"
 #include "VersionInfo.h"
@@ -37,9 +36,14 @@ using namespace std;
 #include "Memory.h"
 #include "MemAccess.h"
 #include "PluginManager.h"
-using namespace DFHack;
 
 #include <tinyxml.h>
+
+using namespace DFHack;
+using std::cerr;
+using std::endl;
+using std::string;
+using std::vector;
 
 VersionInfoFactory::VersionInfoFactory()
 {
@@ -75,6 +79,19 @@ std::shared_ptr<const VersionInfo> VersionInfoFactory::getVersionInfoByPETimesta
             return version;
     }
     return nullptr;
+}
+
+std::vector<std::shared_ptr<const VersionInfo>> VersionInfoFactory::getVersionInfosForCurOs() const {
+    static const OSType expected = VersionInfo::getCurOS();
+
+    std::vector<std::shared_ptr<const VersionInfo>> ret;
+
+    for (const auto& version : versions) {
+        if (version->getOS() == expected && version->getVersion().find("LOCAL") == std::string::npos)
+            ret.emplace_back(version);
+    }
+
+    return ret;
 }
 
 static uintptr_t to_addr(const char * cstr) {

--- a/library/include/VersionInfo.h
+++ b/library/include/VersionInfo.h
@@ -75,6 +75,17 @@ namespace DFHack
             OS = rhs.OS;
         };
 
+        static OSType getCurOS() {
+#if defined(_WIN32)
+            const OSType expected = OS_WINDOWS;
+#elif defined(_DARWIN)
+            const OSType expected = OS_APPLE;
+#else
+            const OSType expected = OS_LINUX;
+#endif
+            return expected;
+        }
+
         uintptr_t getBase () const { return base; };
         intptr_t getRebaseDelta() const { return rebase_delta; }
         void setBase (const uintptr_t _base) { base = _base; };
@@ -171,13 +182,8 @@ namespace DFHack
         };
 
         void ValidateOS() {
-#if defined(_WIN32)
-            const OSType expected = OS_WINDOWS;
-#elif defined(_DARWIN)
-            const OSType expected = OS_APPLE;
-#else
-            const OSType expected = OS_LINUX;
-#endif
+            static const OSType expected = getCurOS();
+
             if (expected != getOS()) {
                 std::cerr << "OS mismatch; resetting to " << int(expected) << std::endl;
                 setOS(expected);

--- a/library/include/VersionInfoFactory.h
+++ b/library/include/VersionInfoFactory.h
@@ -42,6 +42,7 @@ namespace DFHack
             bool isInErrorState() const {return error;};
             std::shared_ptr<const VersionInfo> getVersionInfoByMD5(std::string md5string) const;
             std::shared_ptr<const VersionInfo> getVersionInfoByPETimestamp(uintptr_t timestamp) const;
+            std::vector<std::shared_ptr<const VersionInfo>> getVersionInfosForCurOs() const;
             // trash existing list
             void clear();
         private:


### PR DESCRIPTION
now reports which versions are supported:


![image](https://github.com/user-attachments/assets/94a52abc-728b-498b-9a31-093c58db6cba)
