### PR TITLE
[logistics] don't ignore rotten items

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ Template for new versions:
 
 ## Fixes
 - Fix mouse clicks bleeding through DFHack windows when clicking in the space between the frame and the window content in resizable windows
+- `logistics`: don't ignore rotten items when applying stockpile logistics operations (e.g. autodump, autoclaim, etc.)
 
 ## Misc Improvements
 - DFHack text edit fields now delete the character at the cursor when you hit the Delete key

--- a/plugins/logistics.cpp
+++ b/plugins/logistics.cpp
@@ -431,7 +431,7 @@ private:
         df::item_flags flags;
         #define F(x) flags.bits.x = true;
         F(garbage_collect); F(hostile); F(on_fire);
-        F(rotten); F(trader); F(in_building); F(construction);
+        F(trader); F(in_building); F(construction);
         F(artifact); F(spider_web); F(owned); F(in_job);
         #undef F
         return flags.whole;


### PR DESCRIPTION
bad_flags was probably copied from another plugin that *did* need to ignore rotten items. `logistics` should not filter those out, though.

Reported on [Steam](https://steamcommunity.com/app/2346660/discussions/0/4844275132580268851/)