### PR TITLE
[nestboxes, timestream] fix handling of eggs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,8 @@ Template for new versions:
 ## Fixes
 - Fix mouse clicks bleeding through DFHack windows when clicking in the space between the frame and the window content in resizable windows
 - `autobutcher`: don't run a scanning and marking cycle on the first tick of a fortress to allow for all custom configuration to be set first
+- `nestboxes`: don't consider eggs to be infertile just because the mother has left the nest; eggs can still hatch in this situation
+- `timestream`: adjust the incubation counter on fertile eggs so they hatch at the expected time
 - `logistics`: don't ignore rotten items when applying stockpile logistics operations (e.g. autodump, autoclaim, etc.)
 
 ## Misc Improvements


### PR DESCRIPTION
testing shows that it is the properties of the egg that matter, not the properties of the mother

this also brings the behavior of `nestboxes` in line with the fertile egg indicator tweak. before this PR, eggs marked "fertile" could be unforbidden by `nestboxes`, collected, and eaten. This was confusing to players.

@Birkow FYI -- logic might need updating in https://github.com/DFHack/dfhack/pull/4947