### PR TITLE
remove `DFSDL.h` dependency from `Graphic.h`

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -43,6 +43,7 @@ distribution.
 #include "modules/Burrows.h"
 #include "modules/Constructions.h"
 #include "modules/Designations.h"
+#include "modules/DFSDL.h"
 #include "modules/EventManager.h"
 #include "modules/Filesystem.h"
 #include "modules/Gui.h"

--- a/library/include/modules/Graphic.h
+++ b/library/include/modules/Graphic.h
@@ -33,11 +33,13 @@ distribution.
 #include <stdint.h>
 #include "Export.h"
 #include "Module.h"
-#include "DFSDL.h"
 #include <vector>
 
 namespace DFHack
 {
+    // forward declaration used here instead of including DFSDL.h to reduce inclusion loading
+    struct DFTileSurface;
+
     class DFHACK_EXPORT Graphic : public Module
     {
         public:


### PR DESCRIPTION
this significantly reduces the number of compilation units that depend on `DFSDL.h`

this allows us to include more content into `DFSDL.h` without as much compile-time loading; `Graphic.h` is included by `Core.h` which is included by many many things, but only a handful of compilation units include `DFSDL.h` directly

the only module that needed to be adjusted was `LuaApi.cpp`