### PR TITLE
Scrolling `TabBar`

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -85,6 +85,7 @@ Template for new versions:
 ## Lua
 
 - ``dfhack.units``: new function ``setPathGoal``
+- ``widgets.TabBar``: updated to allow for horizontal scrolling of tabs when there are too many to fit in the available space
 
 ## Removed
 - UI focus strings for squad panel flows combined into a single tree: ``dwarfmode/SquadEquipment`` -> ``dwarfmode/Squads/Equipment``, ``dwarfmode/SquadSchedule`` -> ``dwarfmode/Squads/Schedule``

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -6194,9 +6194,16 @@ TabBar class
 ------------
 
 This widget implements a set of one or more tabs to allow navigation between groups
-of content. Tabs automatically wrap on the width of the window and will continue
-rendering on the next line(s) if all tabs cannot fit on a single line.
+of content.
 
+:wrap: If true, tabs automatically wrap on the width of the window and will
+       continue rendering on the next line(s) if all tabs cannot fit on a single line.
+       If false, tabs will be truncated and can be scrolled using ``scroll_key``
+       and ``scroll_key_back``, mouse wheel or by clicking on the scroll labels
+       that will automatically appear on the left and right sides of the tab bar
+       as needed. When clicking on a tab or using ``key`` or ``key_back`` to switch tabs,
+       the selected tab will be scrolled into view if it is not already visible.
+       Defaults to true.
 :key: Specifies a keybinding that can be used to switch to the next tab.
       Defaults to ``CUSTOM_CTRL_T``.
 :key_back: Specifies a keybinding that can be used to switch to the previous
@@ -6222,6 +6229,28 @@ rendering on the next line(s) if all tabs cannot fit on a single line.
            itself as the second. The default implementation, which will handle most
            situations, returns ``self.active_tab_pens``, if ``self.get_cur_page() == idx``,
            otherwise returns ``self.inactive_tab_pens``.
+:scroll_key: Specifies a keybinding that can be used to scroll the tabs to the right.
+             Defaults to ``CUSTOM_ALT_T``.
+:scroll_key_back: Specifies a keybinding that can be used to scroll the tabs to the left.
+                  Defaults to ``CUSTOM_ALT_Y``.
+:scroll_left_text: The text to display on the left scroll label.
+                   Defaults to "<<<".
+:scroll_right_text: The text to display on the right scroll label.
+                    Defaults to ">>>".
+:scroll_label_text_pen: The pen to use for the scroll label text.
+                        Defaults to ``Label`` default.
+:scroll_label_text_hpen: The pen to use for the scroll label text when hovered.
+                         Defaults to ``scroll_label_text_pen`` with the background
+                         and foreground colors swapped.
+:scroll_step: The number of units to scroll tabs by.
+              Defaults to 10.
+:fast_scroll_multiplier: The multiplier for fast scrolling (holding shift).
+                         Defaults to 3.
+:scroll_into_view_offset: After a selected tab is scrolled into view, this offset
+                          is added to the scroll position to ensure the tab is
+                          not flush against the edge of the tab bar, allowing
+                          some space for the user to see the next tab.
+                          Defaults to 5.
 
 Tab class
 ---------

--- a/library/lua/gui/widgets/tab_bar.lua
+++ b/library/lua/gui/widgets/tab_bar.lua
@@ -334,7 +334,7 @@ function TabBar:isMouseOver()
 end
 
 function TabBar:postComputeFrame(body)
-    self.all_tabs_width = 0
+    local all_tabs_width = 0
 
     local t, l, width = 0, 0, body.width
     self.scrollable = false
@@ -357,14 +357,13 @@ function TabBar:postComputeFrame(body)
         tab.frame.t = t
         tab.frame.l = l
         l = l + tab.frame.w
-        self.all_tabs_width = self.all_tabs_width + tab.frame.w
+        all_tabs_width = all_tabs_width + tab.frame.w
     end
 
-    self.offset_to_show_last_tab = -(self.all_tabs_width - self.post_compute_width)
+    self.offset_to_show_last_tab = -(all_tabs_width - self.post_compute_width)
 
     if self.scrollable and not self.wrap then
         self:scrollRightElement().frame.l = width - 1
-
         if self.last_post_compute_width ~= self.post_compute_width then
             self.scroll_offset = 0
         end

--- a/library/lua/gui/widgets/tab_bar.lua
+++ b/library/lua/gui/widgets/tab_bar.lua
@@ -136,8 +136,6 @@ end
 ---@field key_back string
 ---@field wrap boolean
 ---@field scroll_step integer
----@field scroll_left_text string
----@field scroll_right_text string
 ---@field scroll_key string
 ---@field scroll_key_back string
 ---@field fast_scroll_modifier integer
@@ -166,8 +164,6 @@ TabBar.ATTRS{
     key_back='CUSTOM_CTRL_Y',
     wrap = true,
     scroll_step = 10,
-    scroll_left_text = '<<<',
-    scroll_right_text = '>>>',
     scroll_key = 'CUSTOM_ALT_T',
     scroll_key_back = 'CUSTOM_ALT_Y',
     fast_scroll_modifier = 3,
@@ -175,6 +171,9 @@ TabBar.ATTRS{
     scroll_label_text_pen = DEFAULT_NIL,
     scroll_label_text_hpen = DEFAULT_NIL,
 }
+
+local TO_THE_RIGHT = string.char(16)
+local TO_THE_LEFT = string.char(17)
 
 ---@param self widgets.TabBar
 function TabBar:init()
@@ -217,10 +216,10 @@ function TabBar:init()
       self:addviews{
         Label{
           view_id='TabBar__scroll_left',
-          frame={t=0, l=0, w=#self.scroll_left_text},
+          frame={t=0, l=0, w=1},
           text_pen=self.scroll_label_text_pen,
           text_hpen=self.scroll_label_text_hpen,
-          text=self.scroll_left_text,
+          text=TO_THE_LEFT,
           visible = false,
           on_click=function()
               self:scrollLeft()
@@ -228,10 +227,10 @@ function TabBar:init()
         },
         Label{
           view_id='TabBar__scroll_right',
-          frame={t=0, l=0, w=#self.scroll_right_text},
+          frame={t=0, l=0, w=1},
           text_pen=self.scroll_label_text_pen,
           text_hpen=self.scroll_label_text_hpen,
-          text=self.scroll_right_text,
+          text=TO_THE_RIGHT,
           visible = false,
           on_click=function()
               self:scrollRight()
@@ -256,13 +255,13 @@ function TabBar:showScrollLeft()
     self:scrollLeftElement().visible = self:leftScrollVisible()
 end
 
-function TabBar:scrollRightVisible()
+function TabBar:rightScrollVisible()
     return self.scroll_offset > self.offset_to_show_last_tab
 end
 
 function TabBar:showScrollRight()
     if self.wrap then return end
-    self:scrollRightElement().visible = self:scrollRightVisible()
+    self:scrollRightElement().visible = self:rightScrollVisible()
 end
 
 function TabBar:updateTabPanelPosition()
@@ -347,11 +346,12 @@ function TabBar:postComputeFrame(body)
     for _,tab in ipairs(self:tabsElement().subviews) do
         tab.visible = true
         if l > 0 and l + tab.frame.w > width then
-            self.scrollable = true
             if self.wrap then
                 t = t + 2
                 l = 0
                 tab_rows = tab_rows + 1
+            else
+                self.scrollable = true
             end
         end
         tab.frame.t = t
@@ -363,7 +363,7 @@ function TabBar:postComputeFrame(body)
     self.offset_to_show_last_tab = -(self.all_tabs_width - self.post_compute_width)
 
     if self.scrollable and not self.wrap then
-        self:scrollRightElement().frame.l = width - #self.scroll_right_text
+        self:scrollRightElement().frame.l = width - 1
 
         if self.last_post_compute_width ~= self.post_compute_width then
             self.scroll_offset = 0

--- a/library/lua/gui/widgets/tab_bar.lua
+++ b/library/lua/gui/widgets/tab_bar.lua
@@ -1,5 +1,8 @@
 local Widget = require('gui.widgets.widget')
 local ResizingPanel = require('gui.widgets.containers.resizing_panel')
+local Label = require('gui.widgets.labels.label')
+local Panel = require('gui.widgets.containers.panel')
+local utils = require('utils')
 
 local to_pen = dfhack.pen.parse
 
@@ -131,6 +134,16 @@ end
 ---@field get_pens? fun(index: integer, tabbar: self): widgets.TabPens
 ---@field key string
 ---@field key_back string
+---@field wrap boolean
+---@field scroll_step integer
+---@field scroll_left_text string
+---@field scroll_right_text string
+---@field scroll_key string
+---@field scroll_key_back string
+---@field fast_scroll_modifier integer
+---@field scroll_into_view_offset integer
+---@field scroll_label_text_pen dfhack.pen
+---@field scroll_label_text_hpen dfhack.pen
 
 ---@class widgets.TabBar.attrs.partial: widgets.TabBar.attrs
 
@@ -151,17 +164,40 @@ TabBar.ATTRS{
     get_pens=DEFAULT_NIL,
     key='CUSTOM_CTRL_T',
     key_back='CUSTOM_CTRL_Y',
+    wrap = true,
+    scroll_step = 10,
+    scroll_left_text = '<<<',
+    scroll_right_text = '>>>',
+    scroll_key = 'CUSTOM_ALT_T',
+    scroll_key_back = 'CUSTOM_ALT_Y',
+    fast_scroll_modifier = 3,
+    scroll_into_view_offset = 5,
+    scroll_label_text_pen = DEFAULT_NIL,
+    scroll_label_text_hpen = DEFAULT_NIL,
 }
 
 ---@param self widgets.TabBar
 function TabBar:init()
+    self.scrollable = false
+    self.scroll_offset = 0
+    self.first_render = true
+
+    local panel = Panel{
+      view_id='TabBar__tabs',
+      frame={t=0, l=0, h=2},
+      frame_inset={l=0},
+    }
+
     for idx,label in ipairs(self.labels) do
-        self:addviews{
+        panel:addviews{
             Tab{
                 frame={t=0, l=0},
                 id=idx,
                 label=label,
-                on_select=self.on_select,
+                on_select=function()
+                    self.scrollTabIntoView(self, idx)
+                    self.on_select(idx)
+                end,
                 get_pens=self.get_pens and function()
                     return self.get_pens(idx, self)
                 end or function()
@@ -174,32 +210,225 @@ function TabBar:init()
             }
         }
     end
+
+    self:addviews{panel}
+
+    if not self.wrap then
+      self:addviews{
+        Label{
+          view_id='TabBar__scroll_left',
+          frame={t=0, l=0, w=#self.scroll_left_text},
+          text_pen=self.scroll_label_text_pen,
+          text_hpen=self.scroll_label_text_hpen,
+          text=self.scroll_left_text,
+          visible = false,
+          on_click=function()
+              self:scrollLeft()
+          end,
+        },
+        Label{
+          view_id='TabBar__scroll_right',
+          frame={t=0, l=0, w=#self.scroll_right_text},
+          text_pen=self.scroll_label_text_pen,
+          text_hpen=self.scroll_label_text_hpen,
+          text=self.scroll_right_text,
+          visible = false,
+          on_click=function()
+              self:scrollRight()
+          end,
+        },
+      }
+    end
+end
+
+function TabBar:updateScrollElements()
+    self:showScrollLeft()
+    self:showScrollRight()
+    self:updateTabPanelPosition()
+end
+
+function TabBar:leftScrollVisible()
+    return self.scroll_offset < 0
+end
+
+function TabBar:showScrollLeft()
+    if self.wrap then return end
+    self:scrollLeftElement().visible = self:leftScrollVisible()
+end
+
+function TabBar:scrollRightVisible()
+    return self.scroll_offset > self.offset_to_show_last_tab
+end
+
+function TabBar:showScrollRight()
+    if self.wrap then return end
+    self:scrollRightElement().visible = self:scrollRightVisible()
+end
+
+function TabBar:updateTabPanelPosition()
+    self:tabsElement().frame_inset.l = self.scroll_offset
+    self:tabsElement():updateLayout(self.frame_body)
+end
+
+function TabBar:tabsElement()
+    return self.subviews.TabBar__tabs
+end
+
+function TabBar:scrollLeftElement()
+    return self.subviews.TabBar__scroll_left
+end
+
+function TabBar:scrollRightElement()
+    return self.subviews.TabBar__scroll_right
+end
+
+function TabBar:scrollTabIntoView(idx)
+    if self.wrap or not self.scrollable then return end
+
+    local tab = self:tabsElement().subviews[idx]
+    local tab_l = tab.frame.l
+    local tab_r = tab.frame.l + tab.frame.w
+    local tabs_l = self:tabsElement().frame.l
+    local tabs_r = tabs_l + self.frame_body.width
+    local scroll_offset = self.scroll_offset
+
+    if tab_l < tabs_l - scroll_offset then
+        self.scroll_offset = tabs_l - tab_l + self.scroll_into_view_offset
+    elseif tab_r > tabs_r - scroll_offset then
+        self.scroll_offset = self.scroll_offset - (tab_r - tabs_r) - self.scroll_into_view_offset
+    end
+
+    self:capScrollOffset()
+    self:updateScrollElements()
+end
+
+function TabBar:capScrollOffset()
+    if self.scroll_offset > 0 then
+        self.scroll_offset = 0
+    elseif self.scroll_offset < self.offset_to_show_last_tab then
+        self.scroll_offset = self.offset_to_show_last_tab
+    end
+end
+
+function TabBar:scrollRight(alternate_step)
+    if not self:scrollRightElement().visible then return end
+
+    self.scroll_offset = self.scroll_offset - (alternate_step and alternate_step or self.scroll_step)
+
+    self:capScrollOffset()
+    self:updateScrollElements()
+end
+
+function TabBar:scrollLeft(alternate_step)
+    if not self:scrollLeftElement().visible then return end
+
+    self.scroll_offset = self.scroll_offset + (alternate_step and alternate_step or self.scroll_step)
+
+    self:capScrollOffset()
+    self:updateScrollElements()
+end
+
+function TabBar:isMouseOver()
+    for _, sv in ipairs(self:tabsElement().subviews) do
+        if utils.getval(sv.visible) and sv:getMouseFramePos() then return true end
+    end
 end
 
 function TabBar:postComputeFrame(body)
+    self.all_tabs_width = 0
+
     local t, l, width = 0, 0, body.width
-    for _,tab in ipairs(self.subviews) do
+    self.scrollable = false
+
+    self.last_post_compute_width = self.post_compute_width or 0
+    self.post_compute_width = width
+
+    local tab_rows = 1
+    for _,tab in ipairs(self:tabsElement().subviews) do
+        tab.visible = true
         if l > 0 and l + tab.frame.w > width then
-            t = t + 2
-            l = 0
+            self.scrollable = true
+            if self.wrap then
+                t = t + 2
+                l = 0
+                tab_rows = tab_rows + 1
+            end
         end
         tab.frame.t = t
         tab.frame.l = l
         l = l + tab.frame.w
+        self.all_tabs_width = self.all_tabs_width + tab.frame.w
     end
+
+    self.offset_to_show_last_tab = -(self.all_tabs_width - self.post_compute_width)
+
+    if self.scrollable and not self.wrap then
+        self:scrollRightElement().frame.l = width - #self.scroll_right_text
+
+        if self.last_post_compute_width ~= self.post_compute_width then
+            self.scroll_offset = 0
+        end
+    end
+
+    if self.first_render then
+        self.first_render = false
+        if not self.wrap then
+          self:scrollTabIntoView(self.get_cur_page())
+        end
+    end
+
+    -- we have to calculate the height of this based on the number of tab rows we will have
+    -- so that autoarrange_subviews will work correctly
+    self:tabsElement().frame.h = tab_rows * 2
+
+    self:updateScrollElements()
+end
+
+function TabBar:fastStep()
+    return self.scroll_step * self.fast_scroll_modifier
 end
 
 function TabBar:onInput(keys)
     if TabBar.super.onInput(self, keys) then return true end
+    if not self.wrap then
+        if self:isMouseOver() then
+          if keys.CONTEXT_SCROLL_UP then
+              self:scrollLeft()
+              return true
+          end
+          if keys.CONTEXT_SCROLL_DOWN then
+              self:scrollRight()
+              return true
+          end
+          if keys.CONTEXT_SCROLL_PAGEUP then
+              self:scrollLeft(self:fastStep())
+              return true
+          end
+          if keys.CONTEXT_SCROLL_PAGEDOWN then
+              self:scrollRight(self:fastStep())
+              return true
+          end
+        end
+        if self.scroll_key and keys[self.scroll_key] then
+            self:scrollRight()
+            return true
+        end
+        if self.scroll_key_back and keys[self.scroll_key_back] then
+            self:scrollLeft()
+            return true
+        end
+    end
     if self.key and keys[self.key] then
         local zero_idx = self.get_cur_page() - 1
         local next_zero_idx = (zero_idx + 1) % #self.labels
+        self.scrollTabIntoView(self, next_zero_idx + 1)
         self.on_select(next_zero_idx + 1)
         return true
     end
     if self.key_back and keys[self.key_back] then
         local zero_idx = self.get_cur_page() - 1
         local prev_zero_idx = (zero_idx - 1) % #self.labels
+        self.scrollTabIntoView(self, prev_zero_idx + 1)
         self.on_select(prev_zero_idx + 1)
         return true
     end

--- a/test/library/gui/widgets.TabBar.lua
+++ b/test/library/gui/widgets.TabBar.lua
@@ -533,3 +533,23 @@ function test.key_back_should_scroll_previous_tab_into_view_if_necessary_when_wr
     expect.eq(tb:get_cur_page(), 3, 'key back should select the previous tab')
     expect.gt(tb.scroll_offset, scroll_offset_before_input, 'key back should scroll the previous tab into view')
 end
+
+function test.scroll_offset_is_reset_if_width_changes()
+    local tb = setup({frame_width=10})
+
+    tb:postComputeFrame({t=0,l=0,width=100})
+
+    expect.eq(tb.scroll_offset, 0, 'scroll offset should be reset when parent frame width changes')
+
+    tb.scroll_offset = -50
+
+    tb:postComputeFrame({t=0,l=0,width=100})
+
+    expect.eq(tb.scroll_offset, -50, 'scroll offset should not be reset when parent frame width does not change')
+end
+
+function test.offset_to_show_last_tab_is_calculated_on_first_render()
+    local tb = setup({frame_width=10})
+
+    expect.lt(tb.offset_to_show_last_tab, 0, 'offset_to_show_last_tab should be calculated on first render')
+end

--- a/test/library/gui/widgets.TabBar.lua
+++ b/test/library/gui/widgets.TabBar.lua
@@ -1,0 +1,537 @@
+config.target = 'core'
+
+local gui = require('gui')
+local widgets = require('gui.widgets')
+local mock = require('test_util.mock')
+
+local fs = defclass(nil, gui.FramedScreen)
+fs.ATTRS = {
+    frame_style = gui.GREY_LINE_FRAME,
+    frame_title = 'TestFramedScreen',
+    frame_inset = 0,
+    focus_path = 'test-framed-screen',
+}
+
+---@class SetupArgs
+---@field frame_width number | nil
+---@field frame_height number | nil
+---@field wrap boolean | nil
+---@field selected number | nil
+---@field labels string[] | nil
+
+local DEFAULT_FRAME_WIDTH = 20
+local DEFAULT_FRAME_HEIGHT = 20
+local DEFAULT_WRAP = false
+local DEFAULT_LABELS = {'Foo', 'Bar', 'Baz', 'Qux'}
+local DEFAULT_SELECTED = 1
+
+---@param args SetupArgs | nil
+local function setup(args)
+    args = args or {
+        frame_width = DEFAULT_FRAME_WIDTH,
+        frame_height = DEFAULT_FRAME_HEIGHT,
+        wrap = DEFAULT_WRAP,
+        labels = DEFAULT_LABELS,
+        selected = DEFAULT_SELECTED,
+    }
+
+    local wrap = args.wrap or DEFAULT_WRAP
+    local frame_width = args.frame_width or DEFAULT_FRAME_WIDTH
+    local frame_height = args.frame_height or DEFAULT_FRAME_HEIGHT
+    local labels = args.labels or DEFAULT_LABELS
+    local selected = args.selected or DEFAULT_SELECTED
+
+    local panel = Panel{
+        frame = {t=0},
+        subviews={
+            widgets.TabBar {
+                frame = {t=0},
+                labels = labels,
+                wrap = wrap,
+                key = 'CUSTOM_ALT_S',
+                key_back = 'CUSTOM_ALT_A',
+                on_select=function(idx) selected = idx end,
+                get_cur_page=function() return selected end,
+            },
+        }
+    }
+
+    function fs:init()
+        self:addviews{
+            panel
+        }
+    end
+
+    local framed_screen = fs{
+        frame_width = frame_width,
+        frame_height = frame_height,
+    }
+    local tab_bar = framed_screen.subviews[1].subviews[1]
+    return tab_bar, framed_screen
+end
+
+function test.tabsElement()
+    local tb = setup()
+    local tabsElement = tb:tabsElement()
+
+    local tabsElementSubviewCount = #tabsElement.subviews
+
+    expect.eq(tabsElementSubviewCount, 4, 'tabsElement should have 4 subviews (one for each Tab)')
+
+    for i = 1, tabsElementSubviewCount do
+        expect.eq(tabsElement.subviews[i].label, tb.labels[i], 'tabsElement subview text should match label')
+    end
+end
+
+function test.scroll_elements_do_not_exist_when_wrap_is_true()
+    local tb = setup({wrap = true})
+
+    expect.eq(tb:scrollLeftElement(), nil, 'scroll elements should exist when wrap is true')
+    expect.eq(tb:scrollRightElement(), nil, 'scroll elements should exist when wrap is true')
+end
+
+function test.tabs_element_frame_height_increases_with_number_of_tab_rows()
+    local tb = setup({wrap = true})
+
+    expect.eq(tb:tabsElement().frame.h, 4, 'tabsElement height should be equal to the number of rows to fit all tabs * 2')
+
+    tb = setup({
+        wrap = true,
+        labels = {'Foo', 'Bar', 'Baz', 'Qux', 'Foo2', 'Bar2', 'Baz2', 'Qux2', 'Foo3', 'Bar3', 'Baz3', 'Qux3'},
+    })
+
+    expect.eq(tb:tabsElement().frame.h, 12, 'tabsElement height should be equal to the number of rows to fit all tabs * 2')
+end
+
+function test.tab_on_select_called_when_tab_is_clicked()
+    local tb = setup()
+    local secondTab = tb:tabsElement().subviews[2]
+
+    secondTab.on_select = mock.observe_func(secondTab.on_select)
+    secondTab.getMousePos = function() return {x=0, y=0} end
+
+    secondTab:onInput({_MOUSE_L = true, _MOUSE_L_DOWN = true})
+
+    expect.eq(secondTab.on_select.call_count, 1, 'on_select should be called when tab is clicked')
+end
+
+function test.tab_on_select_not_called_without_mouse_pos()
+    local tb = setup()
+    local secondTab = tb:tabsElement().subviews[2]
+
+    secondTab.on_select = mock.observe_func(secondTab.on_select)
+    secondTab.getMousePos = function() return nil end
+
+    secondTab:onInput({_MOUSE_L = true, _MOUSE_L_DOWN = true})
+
+    expect.eq(secondTab.on_select.call_count, 0, 'on_select should not be called when getMousePos returns nil')
+end
+
+local TO_THE_RIGHT = string.char(16)
+local TO_THE_LEFT = string.char(17)
+
+function test.scrollLeftElement()
+    local tb = setup()
+    local scrollLeftElement = tb:scrollLeftElement()
+
+    expect.eq(scrollLeftElement.text, TO_THE_LEFT, 'scrollLeftElement should have text "' .. TO_THE_LEFT .. '"')
+end
+
+function test.scrollRightElement()
+    local tb = setup()
+    local scrollRightElement = tb:scrollRightElement()
+
+    expect.eq(scrollRightElement.text, TO_THE_RIGHT, 'scrollRightElement should have text "' .. TO_THE_RIGHT .. '"')
+end
+
+function test.leftScrollVisible()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+
+    expect.eq(tb:leftScrollVisible(), false, 'leftScrollVisible should return false when scroll_offset is 0')
+
+    tb.scroll_offset = -1
+    expect.eq(tb:leftScrollVisible(), true, 'leftScrollVisible should return true when scroll_offset is less than 0')
+end
+
+function test.rightScrollVisible()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+    tb.offset_to_show_last_tab = 50
+
+    expect.eq(tb:rightScrollVisible(), false, 'rightScrollVisible should return false when scroll_offset is 0')
+
+    tb.scroll_offset = 51
+    expect.eq(tb:rightScrollVisible(), true, 'rightScrollVisible should return true when scroll_offset is greater than offset_to_show_last_tab')
+end
+
+function test.showScrollRight()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+    tb.offset_to_show_last_tab = 50
+    tb:showScrollRight()
+
+    expect.eq(tb:scrollRightElement().visible, false, 'scroll right element should not be visible')
+
+    tb.scroll_offset = 51
+    tb:showScrollRight()
+
+    expect.eq(tb:scrollRightElement().visible, true, 'scroll right element should be visible')
+end
+
+function test.showScrollLeft()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+    tb:showScrollLeft()
+
+    expect.eq(tb:scrollLeftElement().visible, false, 'scroll left element should not be visible')
+
+    tb.scroll_offset = -1
+    tb:showScrollLeft()
+
+    expect.eq(tb:scrollLeftElement().visible, true, 'scroll left element should be visible')
+end
+
+function test.updateTabPanelPosition()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+    tb:tabsElement().updateLayout = mock.observe_func(tb:tabsElement().updateLayout)
+    tb:updateTabPanelPosition()
+
+    expect.eq(tb:tabsElement().frame_inset.l, tb.scroll_offset, 'frame_inset.l should be equal to scroll_offset after updateTabPanelPosition')
+    expect.eq(tb:tabsElement().updateLayout.call_count, 1, 'updateTabPanelPosition should call updateLayout')
+
+    tb.scroll_offset = -50
+    tb:tabsElement().updateLayout = mock.observe_func(tb:tabsElement().updateLayout)
+    tb:updateTabPanelPosition()
+
+    expect.eq(tb:tabsElement().frame_inset.l, tb.scroll_offset, 'frame_inset.l should be equal to scroll_offset after updateTabPanelPosition')
+    expect.eq(tb:tabsElement().updateLayout.call_count, 1, 'updateTabPanelPosition should call updateLayout')
+end
+
+function test.updateScrollElements()
+    local tb = setup()
+
+    tb.showScrollLeft = mock.observe_func(tb.showScrollLeft)
+    tb.showScrollRight = mock.observe_func(tb.showScrollRight)
+    tb.updateTabPanelPosition = mock.observe_func(tb.updateTabPanelPosition)
+
+    tb:updateScrollElements()
+
+    expect.eq(tb.showScrollLeft.call_count, 1, 'updateScrollElements should call showScrollLeft')
+    expect.eq(tb.showScrollRight.call_count, 1, 'updateScrollElements should call showScrollRight')
+    expect.eq(tb.updateTabPanelPosition.call_count, 1, 'updateScrollElements should call updateTabPanelPosition')
+end
+
+function test.scrollLeft()
+    local tb = setup()
+    tb.offset_to_show_last_tab = -100
+    tb.scroll_step = 25
+
+    tb.scroll_offset = -50
+    tb:showScrollLeft()
+
+    tb.updateScrollElements = mock.observe_func(tb.updateScrollElements)
+    tb:scrollLeft()
+
+    expect.eq(tb.scroll_offset, -25, 'scroll left should increase scroll offset by scroll step')
+    expect.eq(tb.updateScrollElements.call_count, 1, 'scroll left should call updateScrollElements')
+end
+
+function test.scrollRight()
+    local tb = setup()
+    tb.offset_to_show_last_tab = -100
+    tb.scroll_step = 25
+
+    tb.scroll_offset = -50
+    tb:updateScrollElements()
+
+    tb.updateScrollElements = mock.observe_func(tb.updateScrollElements)
+    tb.updateTabPanelPosition = mock.observe_func(tb.updateTabPanelPosition)
+    tb:scrollRight()
+
+    expect.eq(tb.scroll_offset, -75, 'scroll right should decrease scroll offset by scroll step')
+    expect.eq(tb.updateScrollElements.call_count, 1, 'scroll right should call updateScrollElements')
+end
+
+function test.capScrollOffset()
+    local tb = setup()
+    tb.offset_to_show_last_tab = -100
+
+    tb.scroll_offset = -50
+    tb:capScrollOffset()
+
+    expect.eq(tb.scroll_offset, -50, 'capScrollOffset should not change scroll offset when it is within bounds')
+
+    tb.scroll_offset = -101
+    tb:capScrollOffset()
+
+    expect.eq(tb.scroll_offset, -100, 'capScrollOffset should set scroll offset to -100 when it is less than -100')
+
+    tb.scroll_offset = 0
+    tb:capScrollOffset()
+
+    expect.eq(tb.scroll_offset, 0, 'capScrollOffset should not change scroll offset when it is 0')
+
+    tb.scroll_offset = 1
+    tb:capScrollOffset()
+
+    expect.eq(tb.scroll_offset, 0, 'capScrollOffset should set scroll offset to 0 when it is greater than 0')
+end
+
+function test.scrollTabIntoView()
+    local tb = setup()
+
+    tb.scroll_step = 10
+
+    tb:scrollTabIntoView(1)
+    expect.eq(tb.scroll_offset, 0, 'scrollTabIntoView should not change scroll offset when tab is already in view')
+
+    tb:scrollTabIntoView(2)
+    expect.eq(tb.scroll_offset, 0, 'scrollTabIntoView should not change scroll offset when tab is already in view')
+
+    tb:scrollTabIntoView(4)
+    expect.eq(tb.scroll_offset, tb.offset_to_show_last_tab, 'scrollTabIntoView should scroll to the right when tab is to the right of the view')
+
+    tb:scrollTabIntoView(3)
+    expect.eq(tb.scroll_offset, tb.offset_to_show_last_tab, 'scrollTabIntoView should not change scroll offset when tab is already in view')
+
+    tb:scrollTabIntoView(1)
+    expect.eq(tb.scroll_offset, 0, 'scrollTabIntoView should scroll to the left when tab is to the left of the view')
+end
+
+function test.selected_tab_scrolled_into_view_on_first_render()
+    local tb = setup({selected=4})
+
+    expect.eq(tb.scroll_offset, tb.offset_to_show_last_tab,
+        'scroll offset should be set to offset_to_show_last_tab on first render to ensure current tab is visible'
+    )
+
+    tb = setup({selected=1})
+
+    expect.eq(tb.scroll_offset, 0,
+        'scroll offset should be set to 0 on first render to ensure current tab is visible'
+    )
+
+    tb = setup({selected=3})
+
+    expect.gt(tb.scroll_offset, tb.offset_to_show_last_tab,
+        'scroll offset should be greather than offset_to_show_last_tab'
+    )
+    expect.lt(tb.scroll_offset, 0,
+        'scroll offset should be less than 0'
+    )
+end
+
+function test.fastStep()
+    local tb = setup()
+
+    tb.scroll_step = 10
+    tb.fast_scroll_modifier = 2
+    expect.eq(tb:fastStep(), 20, 'fastStep should return scroll_step * fast_scroll_modifier')
+
+    tb.scroll_step = 5
+    tb.fast_scroll_modifier = 3
+    expect.eq(tb:fastStep(), 15, 'fastStep should return scroll_step * fast_scroll_modifier')
+end
+
+function test.scroll_controls_do_nothing_when_wrap_true()
+    local tb = setup({wrap = true})
+
+    tb.scroll_offset = tb.offset_to_show_last_tab
+    local current_scroll_offset = tb.scroll_offset
+
+    tb:onInput({
+        CONTEXT_SCROLL_UP = true,
+        CONTEXT_SCROLL_DOWN = true,
+        CONTEXT_SCROLL_PAGEUP= true,
+        CONTEXT_SCROLL_PAGEDOWN = true,
+        [tb.scroll_key] = true,
+        [tb.scroll_key_back] = true,
+    })
+
+    expect.eq(tb.scroll_offset, current_scroll_offset, 'scroll offset should not change when wrap is true')
+end
+
+function test.mouse_scroll_up_requires_mouse_focus()
+    local tb = setup()
+
+    tb.scroll_offset = tb.offset_to_show_last_tab
+    tb:updateScrollElements()
+    local current_scroll_offset = tb.scroll_offset
+
+    tb.isMouseOver = mock.func(false)
+    tb:onInput({CONTEXT_SCROLL_UP = true})
+
+    expect.eq(tb.scroll_offset, current_scroll_offset, 'scroll offset should not change if the mouse is not over the tab bar')
+
+    tb.isMouseOver = mock.func(true)
+    tb:onInput({CONTEXT_SCROLL_UP = true})
+
+    expect.gt(tb.scroll_offset, current_scroll_offset, 'scroll offset should increase if the mouse is over the tab bar')
+end
+
+function test.shift_mouse_scroll_up_requires_mouse_focus()
+    local tb = setup()
+
+    tb.scroll_offset = tb.offset_to_show_last_tab
+    tb:updateScrollElements()
+    local current_scroll_offset = tb.scroll_offset
+
+    tb.isMouseOver = mock.func(false)
+    tb:onInput({CONTEXT_SCROLL_PAGEUP = true})
+
+    expect.eq(tb.scroll_offset, current_scroll_offset, 'scroll offset should not change if the mouse is not over the tab bar')
+
+    tb.isMouseOver = mock.func(true)
+    tb:onInput({CONTEXT_SCROLL_PAGEUP = true})
+
+    expect.gt(tb.scroll_offset, current_scroll_offset, 'scroll offset should increase if the mouse is over the tab bar')
+end
+
+function test.mouse_scroll_down_requires_mouse_focus()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+    tb:updateScrollElements()
+    local current_scroll_offset = tb.scroll_offset
+
+    tb.isMouseOver = mock.func(false)
+    tb:onInput({CONTEXT_SCROLL_DOWN = true})
+
+    expect.eq(tb.scroll_offset, current_scroll_offset, 'scroll offset should not change if the mouse is not over the tab bar')
+
+    tb.isMouseOver = mock.func(true)
+    tb:onInput({CONTEXT_SCROLL_DOWN = true})
+
+    expect.lt(tb.scroll_offset, current_scroll_offset, 'scroll offset should decrease if the mouse is over the tab bar')
+end
+
+function test.shift_mouse_scroll_down_requires_mouse_focus()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+    tb:updateScrollElements()
+    local current_scroll_offset = tb.scroll_offset
+
+    tb.isMouseOver = mock.func(false)
+    tb:onInput({CONTEXT_SCROLL_PAGEDOWN = true})
+
+    expect.eq(tb.scroll_offset, current_scroll_offset, 'scroll offset should not change if the mouse is not over the tab bar')
+
+    tb.isMouseOver = mock.func(true)
+    tb:onInput({CONTEXT_SCROLL_PAGEDOWN = true})
+
+    expect.lt(tb.scroll_offset, current_scroll_offset, 'scroll offset should decrease if the mouse is over the tab bar')
+end
+
+function test.scroll_key_should_scroll_right()
+    local tb = setup()
+
+    tb.scroll_offset = 0
+    tb:updateScrollElements()
+    local current_scroll_offset = tb.scroll_offset
+
+    tb:onInput({[tb.scroll_key] = true})
+
+    expect.lt(tb.scroll_offset, current_scroll_offset, 'scroll offset should decrease when scroll key is pressed')
+end
+
+function test.scroll_key_back_should_scroll_left()
+    local tb = setup()
+
+    tb.scroll_offset = tb.offset_to_show_last_tab
+    tb:updateScrollElements()
+    local current_scroll_offset = tb.scroll_offset
+
+    tb:onInput({[tb.scroll_key_back] = true})
+
+    expect.gt(tb.scroll_offset, current_scroll_offset, 'scroll offset should increase when scroll key back is pressed')
+end
+
+function test.scrollable_is_false_when_wrap_is_true()
+    local tb = setup({wrap = true})
+
+    expect.eq(tb.scrollable, false, 'scrollable should return false when wrap is true')
+end
+
+function test.scrollable_is_false_when_all_tabs_fit_and_wrap_is_false()
+    local tb = setup({
+        frame_width = 100,
+        frame_height = 100,
+    })
+
+    expect.eq(tb.scrollable, false, 'scrollable should return false when all tabs fit in the frame')
+end
+
+function test.scrollable_is_true_when_tabs_do_not_fit_and_wrap_is_false()
+    local tb = setup()
+
+    expect.eq(tb.scrollable, true, 'scrollable should return true when tabs do not fit in the frame')
+end
+
+function test.key_should_select_next_tab()
+    local tb = setup({wrap=false})
+
+    tb:onInput({[tb.key] = true})
+
+    expect.eq(tb:get_cur_page(), 2, 'key should select the next tab')
+end
+
+function test.key_back_should_select_previous_tab()
+    local tb = setup({wrap=false})
+
+    tb:onInput({[tb.key_back] = true})
+
+    expect.eq(tb:get_cur_page(), 4, 'key back should select the previous tab')
+end
+
+function test.key_should_wrap_to_first_tab_when_on_last_tab()
+    local tb = setup({wrap=false, selected=4})
+
+    tb:onInput({[tb.key] = true})
+
+    expect.eq(tb:get_cur_page(), 1, 'key should wrap to the first tab when on the last tab')
+end
+
+function test.key_back_should_wrap_to_last_tab_when_on_first_tab()
+    local tb = setup({wrap=false, selected=1})
+
+    tb:onInput({[tb.key_back] = true})
+
+    expect.eq(tb:get_cur_page(), 4, 'key back should wrap to the last tab when on the first tab')
+end
+
+function test.key_should_scroll_next_tab_into_view_if_necessary_when_wrap_is_false()
+    local tb = setup({
+        wrap=false,
+        frame_width=10,
+        labels={'Foo', 'Bar', 'Baz', 'Qux'},
+    })
+
+    local scroll_offset_before_input = tb.scroll_offset
+    tb:onInput({[tb.key] = true})
+
+    expect.eq(tb:get_cur_page(), 2, 'key should select the next tab')
+    expect.lt(tb.scroll_offset, scroll_offset_before_input, 'key should scroll the next tab into view')
+end
+
+function test.key_back_should_scroll_previous_tab_into_view_if_necessary_when_wrap_is_false()
+    local tb = setup({
+        selected=4,
+        wrap=false,
+        frame_width=10,
+        labels={'Foo', 'Bar', 'Baz', 'Qux'},
+    })
+
+    local scroll_offset_before_input = tb.scroll_offset
+    tb:onInput({[tb.key_back] = true})
+
+    expect.eq(tb:get_cur_page(), 3, 'key back should select the previous tab')
+    expect.gt(tb.scroll_offset, scroll_offset_before_input, 'key back should scroll the previous tab into view')
+end

--- a/test/library/gui/widgets.TabBar.lua
+++ b/test/library/gui/widgets.TabBar.lua
@@ -511,7 +511,6 @@ function test.key_should_scroll_next_tab_into_view_if_necessary_when_wrap_is_fal
     local tb = setup({
         wrap=false,
         frame_width=10,
-        labels={'Foo', 'Bar', 'Baz', 'Qux'},
     })
 
     local scroll_offset_before_input = tb.scroll_offset
@@ -526,7 +525,6 @@ function test.key_back_should_scroll_previous_tab_into_view_if_necessary_when_wr
         selected=4,
         wrap=false,
         frame_width=10,
-        labels={'Foo', 'Bar', 'Baz', 'Qux'},
     })
 
     local scroll_offset_before_input = tb.scroll_offset


### PR DESCRIPTION
- Modify `TabBar` to allow tabs to be scrolled instead of wrapping by setting `wrap=false` in the `TabBar` attributes. `wrap` defaults to true so any existing instances of `TabBar` should be unaffected (tested with launcher and control-panel and they're looking good).
- Add tests for Tab/TabBar

I made a little [demo script](https://gist.github.com/robob27/1edf22efff8bedd0956987390612d4a3) with a scrolling TabBar alongside a wrapping one with a resizable window so the behavior can be easily tested (requires this branch). Testers should try changing `autoarrange_subviews` in the script and ensure it doesn't break things, play around with the options, and double check that existing consumers of this widget like launcher and control-panel doesn't get messed up in some way that I missed.

Some notes on the expected behavior:

- If the window is resized while the tabs are scrolled to the right, it will just reset the scroll offset back to 0
- The scroll left/scroll right buttons should only be shown when needed. If resizing the window, the scroll right button should disappear as soon as the last tab is fully in view
- When switching tabs with hotkeys or by clicking, the selected tab should be scrolled into view + a slight (customizable) offset to show part of the next tab. The default offset seems generally appropriate but didn't work well with a `TabBar` with a small width, so I made it possible to customize it.