### PR TITLE
some header cleanups

### DIFF
--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -34,11 +34,6 @@ distribution.
 
 #include "BitArray.h"
 
-// Stop some MS stupidity
-#ifdef interface
-    #undef interface
-#endif
-
 typedef struct lua_State lua_State;
 
 /*

--- a/library/include/DataFuncs.h
+++ b/library/include/DataFuncs.h
@@ -30,6 +30,7 @@ distribution.
 #include <map>
 #include <type_traits>
 
+#include "ColorText.h"
 #include "DataIdentity.h"
 #include "LuaWrapper.h"
 

--- a/library/include/modules/DFSDL.h
+++ b/library/include/modules/DFSDL.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Error.h"
 #include "Export.h"
 #include "ColorText.h"
 

--- a/library/modules/Constructions.cpp
+++ b/library/modules/Constructions.cpp
@@ -33,6 +33,7 @@ using namespace std;
 
 #include "Core.h"
 #include "MemAccess.h"
+#include "MiscUtils.h"
 #include "TileTypes.h"
 #include "Types.h"
 #include "VersionInfo.h"


### PR DESCRIPTION
Add some shadowed dependencies as future-proofing

Also, remove some crud left over to mitigate long-dead bugs in MSVC

This came up during exploratory investigations of using C++20 modules. We probably won't be doing _that_ until CMake support for modules is much better than it is now, but it was worth looking at.