### PR TITLE
Add a basic size safety check to DFHack startup 

### DIFF
--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -334,6 +334,17 @@ used regardless of whether you run Dwarf Fortress from its own app or DFHack's.
   counted towards your hours, see the DFHack stub launcher ``--nowait`` option
   below.
 
+- ``--skip-size-check``: DFHack normally compares its idea of the sizes of a
+  handful of key game structures against the sizes reported by DF itself in
+  DF's global "cheat sheet", and shuts down if a discrepancy is detected.
+  This is intended to reduce the risk of misalignments in these structures leading
+  to crashes or other misbehavior. This option bypasses this check.
+  This option should normally only be used to faciliate DFHack development.
+  This option will **not** enable DFHack to be used usefully with a version of DF
+  to which DFHack has not been aligned. Without properly aligned structures,
+  DFHack is mostly useless and most operations will either fail
+  or cause DF to crash or otherwise misoperate.
+
 Options passed to the DFHack Steam stub launcher
 ------------------------------------------------
 

--- a/docs/Core.rst
+++ b/docs/Core.rst
@@ -339,7 +339,7 @@ used regardless of whether you run Dwarf Fortress from its own app or DFHack's.
   DF's global "cheat sheet", and shuts down if a discrepancy is detected.
   This is intended to reduce the risk of misalignments in these structures leading
   to crashes or other misbehavior. This option bypasses this check.
-  This option should normally only be used to faciliate DFHack development.
+  This option should normally only be used to facilitate DFHack development.
   This option will **not** enable DFHack to be used usefully with a version of DF
   to which DFHack has not been aligned. Without properly aligned structures,
   DFHack is mostly useless and most operations will either fail

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 - `logistics`: don't ignore rotten items when applying stockpile logistics operations (e.g. autodump, autoclaim, etc.)
 
 ## Misc Improvements
+- DFHack startup now verifies that its idea of the size of certain DF global objects are the same as what DF says they are, and refuses to start if there is a mismatch
 - DFHack text edit fields now delete the character at the cursor when you hit the Delete key
 - DFHack text edit fields now move the cursor by one word left or right with Ctrl-Left and Ctrl-Right
 - DFHack text edit fields now move the cursor to the beginning or end of the line with Home and End

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1680,7 +1680,6 @@ bool Core::InitMainThread() {
         }
     }
 
-
     perf_counters.reset();
 
     return true;

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -68,7 +68,6 @@ distribution.
 #include <stdio.h>
 #include <iomanip>
 #include <stdlib.h>
-#include <format>
 #include <fstream>
 #include <thread>
 #include <mutex>
@@ -1666,7 +1665,7 @@ bool Core::InitMainThread() {
                 std::string name{ gte.name };
                 if (sizechecks.contains(name) && gte.size != sizechecks.at(name))
                 {
-                    msg << std::format("Global '{}' size mismatch: is {}, expected {}\n", name, gte.size, sizechecks.at(name));
+                    msg << "Global '" << name << "' size mismatch: is " << gte.size << ", expected " << sizechecks.at(name) << "\n";
                     gt_error = true;
                 }
             }


### PR DESCRIPTION
at startup, check selected DF global objects to ensure that the size reported in the DF global table matches what df-structures says, and refuse to start if they don't

the check is bypassed if the `--skip-size-check` command line option is added to the DF command line