### PR TITLE
Fix possible crash in luasockets

### DIFF
--- a/plugins/luasocket.cpp
+++ b/plugins/luasocket.cpp
@@ -103,7 +103,7 @@ static int lua_server_accept(int id,bool fail_on_timeout)
     CActiveSocket* sock=cur_server.socket->Accept();
     if(!sock)
     {
-        handle_error(sock->GetSocketError(),!fail_on_timeout);
+        handle_error(cur_server.socket->GetSocketError(),!fail_on_timeout);
         return 0;
     }
     else


### PR DESCRIPTION
The Errno is set on the `CPassiveSocket` when `->Accept()` returns null. This corrects the behavior where it would try to call a function on the nullptr.