### PR TITLE
isDanger(): don't mark visitors hostile

### DIFF
--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -642,7 +642,8 @@ bool Units::isDanger(df::unit *unit) {
     if (isTame(unit) || isOwnGroup(unit))
         return false;
 
-    return isCrazed(unit)
+    return unit->flags2.bits.visitor_uninvited
+        || isCrazed(unit)
         || isInvader(unit)
         || isAgitated(unit)
         || isSemiMegabeast(unit)

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -646,7 +646,7 @@ bool Units::isDanger(df::unit *unit) {
         || isInvader(unit)
         || isAgitated(unit)
         || isSemiMegabeast(unit)
-        || (!isVisiting(unit) && (isOpposedToLife(unit) || isNightCreature(unit)))
+        || ((isOpposedToLife(unit) || isNightCreature(unit)) && !unit->flags2.bits.visitor)
         || isGreatDanger(unit);
 }
 

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -644,10 +644,9 @@ bool Units::isDanger(df::unit *unit) {
 
     return isCrazed(unit)
         || isInvader(unit)
-        || isOpposedToLife(unit)
         || isAgitated(unit)
         || isSemiMegabeast(unit)
-        || isNightCreature(unit)
+        || (!isVisiting(unit) && (isOpposedToLife(unit) || isNightCreature(unit)))
         || isGreatDanger(unit);
 }
 

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -649,7 +649,7 @@ bool Units::isDanger(df::unit *unit) {
         || isOpposedToLife(unit)
         || isAgitated(unit)
         || unit->flags2.bits.visitor_uninvited
-        || ((isGreatDanger(unit) || isNightCreature()) && !unit->flags2.bits.visitor);
+        || ((isGreatDanger(unit) || isNightCreature(unit)) && !unit->flags2.bits.visitor);
 }
 
 bool Units::isGreatDanger(df::unit *unit) {

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -642,13 +642,14 @@ bool Units::isDanger(df::unit *unit) {
     if (isTame(unit) || isOwnGroup(unit))
         return false;
 
-    return unit->flags2.bits.visitor_uninvited
-        || isCrazed(unit)
+    // NOTE: demons from hell have visitor/visitor_unvited set to false
+    // other demons may visit as a diplomat
+    return isCrazed(unit)
         || isInvader(unit)
+        || isOpposedToLife(unit)
         || isAgitated(unit)
-        || isSemiMegabeast(unit)
-        || ((isOpposedToLife(unit) || isNightCreature(unit)) && !unit->flags2.bits.visitor)
-        || isGreatDanger(unit);
+        || unit->flags2.bits.visitor_uninvited;
+        || ((isGreatDanger(unit) || isNightCreature()) && !unit->flags2.bits.visitor)
 }
 
 bool Units::isGreatDanger(df::unit *unit) {

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -648,8 +648,8 @@ bool Units::isDanger(df::unit *unit) {
         || isInvader(unit)
         || isOpposedToLife(unit)
         || isAgitated(unit)
-        || unit->flags2.bits.visitor_uninvited;
-        || ((isGreatDanger(unit) || isNightCreature()) && !unit->flags2.bits.visitor)
+        || unit->flags2.bits.visitor_uninvited
+        || ((isGreatDanger(unit) || isNightCreature()) && !unit->flags2.bits.visitor);
 }
 
 bool Units::isGreatDanger(df::unit *unit) {


### PR DESCRIPTION
This only handles night creatures (the hostile one in the save this patch fixes) and opposed to lifers (necromancers? I don't recall.) 

May want this to apply to them all. It is possible for a demon to visit as a merchant.

I don't see anything obvious where this change will cause unwanted side effects in any of the callers of this function. 