### PR TITLE
Likely Minor: cleanup the mutex attributes object after mutex pthread_mutex_init().…

### DIFF
--- a/depends/lua/include/dfhack_llimits.h
+++ b/depends/lua/include/dfhack_llimits.h
@@ -60,6 +60,7 @@ struct lua_extra_state {
       pthread_mutexattr_init(&attr); \
       pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE); \
       pthread_mutex_init(luai_mutex(L), &attr); \
+      pthread_mutexattr_destroy(&attr); \
    } while (0)
 #define luai_userstateclose(L) do { \
       lua_unlock(L); \


### PR DESCRIPTION
… pthread_mutex_init() temporarily uses the attributes object for configuration but does not take any ownership.

There is a memory allocation performed by pthread_mutexattr_init().

Assuming luai_userstateopen() is only called once or rarely, this resolves a small resource leak.