### PR TITLE
Proper symbol demangling for `doReadClassName`

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -330,7 +330,7 @@ elseif(UNIX)
     set(PROJECT_LIBS rt dl dfhack-md5 ${DFHACK_TINYXML})
 else(WIN32)
     # FIXME: do we really need psapi?
-    set(PROJECT_LIBS psapi dfhack-md5 ${DFHACK_TINYXML})
+    set(PROJECT_LIBS psapi dbghelp dfhack-md5 ${DFHACK_TINYXML})
 endif()
 
 set(VERSION_SRCS DFHackVersion.cpp)

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -24,6 +24,7 @@ distribution.
 
 #include <cstdio>
 #include <cstring>
+#include <cxxabi.h>
 #include <dirent.h>
 #include <errno.h>
 #include <map>
@@ -113,13 +114,18 @@ Process::~Process()
 
 string Process::doReadClassName (void * vptr)
 {
-    //FIXME: BAD!!!!!
-    char * typeinfo = Process::readPtr(((char *)vptr - sizeof(void*)));
-    char * typestring = Process::readPtr(typeinfo + sizeof(void*));
-    string raw = readCString(typestring);
-    size_t start = raw.find_first_of("abcdefghijklmnopqrstuvwxyz");// trim numbers
-    size_t end = raw.length();
-    return raw.substr(start,end-start);
+    char* typeinfo = Process::readPtr(((char *)vptr - sizeof(void*)));
+    char* typestring = Process::readPtr(typeinfo + sizeof(void*));
+
+    int status = -1;
+    char* demangledRaw = abi::__cxa_demangle(typestring, nullptr, nullptr, &status);
+    if (status != 0)
+        return "dummy"; // Failed to demangle, return dummy name
+
+    string demangled(demangledRaw);
+    free(demangledRaw);
+
+    return demangled;
 }
 
 //FIXME: cross-reference with ELF segment entries?


### PR DESCRIPTION
This replaces the flawed manual demangling with proper demanglers capable of supporting additional language features such as namespaces.

For example, the mangled symbol `N6DFHack21dfhack_lua_viewscreenE` was previously demangled as `DFHack21dhack_lua_viewscreenE`. This patch ensures demangling returns the proper `DFHack::dfhack_lua_viewscreen`. This also ensures that class names returned remain consistent between platforms.

Basic functionality has been tested on Linux, Windows, and Wine, with no unexpected results seen so far.