### PR TITLE
thread safety checks

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -1528,6 +1528,7 @@ df::viewscreen * Core::getTopViewscreen() {
 }
 
 bool Core::InitMainThread() {
+    // this hook is always called from DF's main (render) thread, so capture this thread id
     df_render_thread = std::this_thread::get_id();
 
     Filesystem::init();
@@ -1689,6 +1690,7 @@ bool Core::InitMainThread() {
 
 bool Core::InitSimulationThread()
 {
+    // the update hook is only called from the simulation thread, so capture this thread id
     df_simulation_thread = std::this_thread::get_id();
     if(started)
         return true;
@@ -2508,11 +2510,7 @@ bool Core::DFH_SDL_Event(SDL_Event* ev) {
 
 bool Core::doSdlInputEvent(SDL_Event* ev)
 {
-    // DF only calls the sdl input event hook from the render thread
-    // we use this to identify the render thread
-    //
-    // first time this is called, set df_render_thread to calling thread
-    // afterwards, assert that it's never changed
+    // this should only ever be called from the render thread
     assert(std::this_thread::get_id() == df_render_thread);
 
     static std::map<int, bool> hotkey_states;

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -388,7 +388,7 @@ bool Plugin::unload(color_ostream &con)
     // get the mutex
     access->lock();
     // if we are actually loaded
-    if(state == PS_LOADED)
+    if (state == PS_LOADED)
     {
         if (Screen::hasActiveScreens(this))
         {
@@ -408,14 +408,18 @@ bool Plugin::unload(color_ostream &con)
         // wait for all calls to finish
         access->wait();
         state = PS_UNLOADING;
-        access->unlock();
-        // enter suspend
-        CoreSuspender suspend;
-        access->lock();
-        if (Core::getInstance().isMapLoaded() && plugin_save_site_data && World::IsSiteLoaded() && plugin_save_site_data(con) != CR_OK)
-            con.printerr("Plugin %s has failed to save site data.\n", name.c_str());
-        if (Core::getInstance().isWorldLoaded() && plugin_save_world_data && plugin_save_world_data(con) != CR_OK)
-            con.printerr("Plugin %s has failed to save world data.\n", name.c_str());
+        // only attempt to unload site or world data if the core is in a valid state
+        if (Core::getInstance().isValid())
+        {
+            // enter suspend
+            access->unlock();
+            CoreSuspender suspend;
+            access->lock();
+            if (Core::getInstance().isMapLoaded() && plugin_save_site_data && World::IsSiteLoaded() && plugin_save_site_data(con) != CR_OK)
+                con.printerr("Plugin %s has failed to save site data.\n", name.c_str());
+            if (Core::getInstance().isWorldLoaded() && plugin_save_world_data && plugin_save_world_data(con) != CR_OK)
+                con.printerr("Plugin %s has failed to save world data.\n", name.c_str());
+        }
         // notify plugin about shutdown, if it has a shutdown function
         command_result cr = CR_OK;
         if(plugin_shutdown)


### PR DESCRIPTION
The main thing this PR does is add some code to monitor for attempts to acquire a `CoreSuspender` from the DF render thread, which is impermissible and will lead to deadlock. It currently only uses an `assert` for this (which means it's only operational in a debug build).

It also removes some dead code related to threading and fixes a couple of semantic errors:

* `Core::Shutdown` attempts to unlock the main core lock, but cannot do so because it always runs on the render thread while the main core lock is held by the simulation thread. This is replaced by an atomic flag `shutdown` which `Core::Shutdown` sets and which `Core::Update` checks.
* Plugin unloading would attempt to acquire a `CoreSuspender` to save plugin site and world data. Plugin unload during shutdown cannot acquire a `CoreSuspender` (because shutdown runs on the render thread), so unload now skips saving plugin site and world data during shutdown. This is harmless because site and world data cannot be saved during shutdown anyway.