### PR TITLE
add entry point for dfhooks_sdl_loop

### DIFF
--- a/library/Hooks.cpp
+++ b/library/Hooks.cpp
@@ -51,7 +51,7 @@ DFhackCExport void dfhooks_update() {
 DFhackCExport void dfhooks_prerender() {
     if (disabled)
         return;
-    // TODO: render overlay widgets that are not attached to a viewscreen
+    // TODO: potentially render overlay elements that are not attached to a viewscreen
 }
 
 // called from the main thread for each SDL event. if true is returned, then
@@ -60,6 +60,14 @@ DFhackCExport bool dfhooks_sdl_event(SDL_Event* event) {
     if (disabled)
         return false;
     return DFHack::Core::getInstance().DFH_SDL_Event(event);
+}
+
+// called from the main thread just after setting mouse state in gps and just
+// before rendering the screen buffer to the screen.
+DFhackCExport void dfhooks_sdl_loop() {
+    if (disabled)
+        return;
+    // TODO: wire this up to the new SDL-based console once it is merged
 }
 
 // called from the main thread for each utf-8 char read from the ncurses input

--- a/library/include/Hooks.h
+++ b/library/include/Hooks.h
@@ -31,4 +31,5 @@ DFhackCExport void dfhooks_shutdown();
 DFhackCExport void dfhooks_update();
 DFhackCExport void dfhooks_prerender();
 DFhackCExport bool dfhooks_sdl_event(SDL_Event* event);
+DFhackCExport void dfhooks_sdl_loop();
 DFhackCExport bool dfhooks_ncurses_key(int key);


### PR DESCRIPTION
FYI: @dhthwy 

Note that DF doesn't actually call this hook yet, and won't until at least 50.16/51.01-beta27

Until then, you can probably synthesize this call by tapping into `dfhooks_sdl_event` and rate limiting with a timer