### PR TITLE
reorganize/tidy `Process-*.cpp` source units

### DIFF
--- a/library/Process-darwin.cpp
+++ b/library/Process-darwin.cpp
@@ -21,32 +21,40 @@ must not be misrepresented as being the original software.
 3. This notice may not be removed or altered from any source
 distribution.
 */
-
-#include "Internal.h"
-#include <dirent.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/mman.h>
-#include <sys/time.h>
-
-#include <mach-o/dyld.h>
-
-#include <string>
-#include <vector>
+#include <cstring>
+#include <cstdio>
 #include <map>
 #include <set>
-#include <cstdio>
-#include <cstring>
-using namespace std;
+#include <string>
+#include <vector>
 
-#include <md5wrapper.h>
+#include <dirent.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <string.h>
+
+#include <mach-o/dyld.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <mach/vm_region.h>
+#include <mach/vm_statistics.h>
+#include <dlfcn.h>
+
+
+#include "Error.h"
+#include "Internal.h"
 #include "MemAccess.h"
 #include "Memory.h"
-#include "VersionInfoFactory.h"
 #include "VersionInfo.h"
-#include "Error.h"
-#include <string.h>
+#include "VersionInfoFactory.h"
+#include "md5wrapper.h"
 using namespace DFHack;
+
+using std::string;
+using std::map;
+using std::vector;
 
 Process::Process(const VersionInfoFactory& known_versions) : identified(false), my_pe(0)
 {
@@ -67,8 +75,8 @@ Process::Process(const VersionInfoFactory& known_versions) : identified(false), 
     auto vinfo = known_versions.getVersionInfoByMD5(my_md5);
     if(vinfo)
     {
-        my_descriptor = std::make_shared<VersionInfo>(*vinfo);
         identified = true;
+        my_descriptor = std::make_shared<VersionInfo>(*vinfo);
     }
     else
     {
@@ -115,16 +123,10 @@ string Process::doReadClassName (void * vptr)
     char * typeinfo = Process::readPtr(((char *)vptr - sizeof(void*)));
     char * typestring = Process::readPtr(typeinfo + sizeof(void*));
     string raw = readCString(typestring);
-    size_t  start = raw.find_first_of("abcdefghijklmnopqrstuvwxyz");// trim numbers
+    size_t start = raw.find_first_of("abcdefghijklmnopqrstuvwxyz");// trim numbers
     size_t end = raw.length();
     return raw.substr(start,end-start);
 }
-
-#include <mach/mach.h>
-#include <mach/mach_vm.h>
-#include <mach/vm_region.h>
-#include <mach/vm_statistics.h>
-#include <dlfcn.h>
 
 const char *
 inheritance_strings[] = {

--- a/library/Process-darwin.cpp
+++ b/library/Process-darwin.cpp
@@ -55,6 +55,9 @@ using namespace DFHack;
 using std::string;
 using std::map;
 using std::vector;
+using std::endl;
+using std::cerr;
+
 
 Process::Process(const VersionInfoFactory& known_versions) : identified(false), my_pe(0)
 {

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -50,6 +50,8 @@ using namespace DFHack;
 using std::string;
 using std::map;
 using std::vector;
+using std::endl;
+using std::cerr;
 
 Process::Process(const VersionInfoFactory& known_versions) : identified(false), my_pe(0)
 {

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -22,29 +22,34 @@ must not be misrepresented as being the original software.
 distribution.
 */
 
-#include <cstdio>
 #include <cstring>
-#include <dirent.h>
-#include <errno.h>
+#include <cstdio>
+#include <cstdlib>
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
+
+#include <dirent.h>
+#include <errno.h>
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
-#include <vector>
 
 #include "Error.h"
 #include "Internal.h"
-#include "md5wrapper.h"
 #include "MemAccess.h"
 #include "Memory.h"
-#include "modules/Filesystem.h"
 #include "VersionInfo.h"
 #include "VersionInfoFactory.h"
+#include "modules/Filesystem.h"
+#include "md5wrapper.h"
 
-using namespace std;
 using namespace DFHack;
+
+using std::string;
+using std::map;
+using std::vector;
 
 Process::Process(const VersionInfoFactory& known_versions) : identified(false), my_pe(0)
 {
@@ -69,8 +74,8 @@ Process::Process(const VersionInfoFactory& known_versions) : identified(false), 
     auto vinfo = known_versions.getVersionInfoByMD5(my_md5);
     if(vinfo)
     {
-        my_descriptor = std::make_shared<VersionInfo>(*vinfo);
         identified = true;
+        my_descriptor = std::make_shared<VersionInfo>(*vinfo);
     }
     else
     {

--- a/library/Process-windows.cpp
+++ b/library/Process-windows.cpp
@@ -49,6 +49,9 @@ using namespace DFHack;
 using std::string;
 using std::map;
 using std::vector;
+using std::endl;
+using std::cerr;
+
 
 namespace DFHack
 {


### PR DESCRIPTION
Rearrange all three `Process-*.cpp` files so that the contents are in parallel as much as possible

remove `using namespace std` code smell
reorganize header includes
change minimum supported windows version to 6.0 (Vista)