### PR TITLE
Improved Symbol Demangling

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -329,7 +329,7 @@ elseif(UNIX)
     set(PROJECT_LIBS rt dl dfhack-md5 ${DFHACK_TINYXML})
 else(WIN32)
     # FIXME: do we really need psapi?
-    set(PROJECT_LIBS psapi dfhack-md5 ${DFHACK_TINYXML})
+    set(PROJECT_LIBS psapi dbghelp dfhack-md5 ${DFHACK_TINYXML})
 endif()
 
 set(VERSION_SRCS DFHackVersion.cpp)
@@ -418,6 +418,9 @@ target_link_libraries(dfhack protobuf-lite clsocket lua jsoncpp_static dfhack-ve
 set_target_properties(dfhack PROPERTIES INTERFACE_LINK_LIBRARIES "")
 
 target_link_libraries(dfhack-client protobuf-lite clsocket jsoncpp_static)
+if(WIN32)
+    target_link_libraries(dfhack-client dbghelp)
+endif()
 target_link_libraries(dfhack-run dfhack-client)
 
 if(APPLE)

--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -33,6 +33,7 @@ distribution.
 // We don't want min and max macros
 #define NOMINMAX
     #include <Windows.h>
+    #include <DbgHelp.h>
 #else
     #include <sys/time.h>
     #include <ctime>
@@ -687,10 +688,35 @@ DFHACK_EXPORT std::string cxx_demangle(const std::string &mangled_name, std::str
         else *status_out = "unknown error";
     }
     return out;
-#else
-    if (status_out) {
-        *status_out = "not implemented on this platform";
+#elif defined(_WIN32)
+    const char* mangled_cstr = mangled_name.c_str();
+
+    char demangledBuf[MAX_SYM_NAME];
+    DWORD flags = UNDNAME_NAME_ONLY;
+
+    if (mangled_cstr[0] == '.') {
+        // Symbol is a type, demangle as such
+        // Flag is actually "UNDNAME_TYPE_ONLY", but hasn't been renamed for this method yet.
+        flags |= UNDNAME_NO_ARGUMENTS;
+        mangled_cstr++;
     }
-    return "";
+
+    DWORD res = UnDecorateSymbolName(mangled_cstr, (char*)&demangledBuf, MAX_SYM_NAME, flags);
+
+    std::string out;
+    if (res == 0) {
+        // Demangling failed
+        *status_out = "demangling failed";
+        return out;
+    }
+    if (demangledBuf[0] == '?') {
+        // Wine failed to demangle symbol
+        *status_out = "wine demangling failed";
+        return out;
+    }
+    out = (char*)&demangledBuf;
+    return out;
+#else
+    #error Platform does not support symbol demangling
 #endif
 }

--- a/library/Process-darwin.cpp
+++ b/library/Process-darwin.cpp
@@ -47,6 +47,7 @@ distribution.
 #include "Internal.h"
 #include "MemAccess.h"
 #include "Memory.h"
+#include "MiscUtils.h"
 #include "VersionInfo.h"
 #include "VersionInfoFactory.h"
 #include "md5wrapper.h"
@@ -122,13 +123,18 @@ Process::~Process()
 
 string Process::doReadClassName (void * vptr)
 {
-    //FIXME: BAD!!!!!
     char * typeinfo = Process::readPtr(((char *)vptr - sizeof(void*)));
     char * typestring = Process::readPtr(typeinfo + sizeof(void*));
     string raw = readCString(typestring);
-    size_t start = raw.find_first_of("abcdefghijklmnopqrstuvwxyz");// trim numbers
-    size_t end = raw.length();
-    return raw.substr(start,end-start);
+
+    string status;
+    string demangled = cxx_demangle(raw, &status);
+
+    if (demangled.length() == 0) {
+        return "dummy";
+    }
+
+    return demangled;
 }
 
 const char *

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -40,6 +40,7 @@ distribution.
 #include "Internal.h"
 #include "MemAccess.h"
 #include "Memory.h"
+#include "MiscUtils.h"
 #include "VersionInfo.h"
 #include "VersionInfoFactory.h"
 #include "modules/Filesystem.h"
@@ -120,13 +121,18 @@ Process::~Process()
 
 string Process::doReadClassName (void * vptr)
 {
-    //FIXME: BAD!!!!!
-    char * typeinfo = Process::readPtr(((char *)vptr - sizeof(void*)));
-    char * typestring = Process::readPtr(typeinfo + sizeof(void*));
+    char* typeinfo = Process::readPtr(((char *)vptr - sizeof(void*)));
+    char* typestring = Process::readPtr(typeinfo + sizeof(void*));
     string raw = readCString(typestring);
-    size_t start = raw.find_first_of("abcdefghijklmnopqrstuvwxyz");// trim numbers
-    size_t end = raw.length();
-    return raw.substr(start,end-start);
+
+    string status;
+    string demangled = cxx_demangle(raw, &status);
+
+    if (demangled.length() == 0) {
+        return "dummy";
+    }
+
+    return demangled;
 }
 
 //FIXME: cross-reference with ELF segment entries?


### PR DESCRIPTION
This set of changes adds support for symbol demangling via `cxx_demangle` on Windows and uses the improved symbol demangling in reading classnames from RTTI entries on all current targets.

Known problems:
- Wine environments fail on some advanced STL features.

When running a modified `devel/scan-vtables` for Windows under wine, a number of symbols fail demangling, all of which can be filtered out by excluding those belonging to std/Concurency. This can be automatically performed by checking if the end of the mangled name is `std@@` or `Concurrency@@`.

I have not discovered any further issues, but practical testing is likely a requirement.

Thank you to @ab9rf and @lethosor for their help with understanding particular issues that arose.