### PR TITLE
[cursecheck] fix build for gcc-13.3.1

### DIFF
--- a/plugins/cursecheck.cpp
+++ b/plugins/cursecheck.cpp
@@ -127,7 +127,7 @@ curses determineCurse(df::unit * unit)
 
 command_result cursecheck (color_ostream &out, vector <string> & parameters)
 {
-    df::unit* selected_unit = Gui::getSelectedUnit(out, true);
+    vector<df::unit*> selected_unit = {Gui::getSelectedUnit(out, true)};
 
     bool giveDetails = false;
     bool giveUnitID = false;
@@ -157,7 +157,7 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
     }
 
     // check whole map if no unit is selected
-    for(df::unit *unit : selected_unit ? vector{ selected_unit } : world->units.all)
+    for(df::unit *unit : selected_unit[0] ? selected_unit : world->units.all)
     {
         // filter out all "living" units that are currently removed from play
         // don't spam all completely dead creatures if not explicitly wanted
@@ -208,9 +208,9 @@ command_result cursecheck (color_ostream &out, vector <string> & parameters)
         }
     }
 
-    if (selected_unit && !giveDetails)
+    if (selected_unit[0] && !giveDetails)
         out.print("Selected unit is %scursed\n", cursecount == 0 ? "not " : "");
-    else if (!selected_unit)
+    else if (!selected_unit[0])
         out.print("%zd cursed creatures on map\n", cursecount);
 
     return CR_OK;


### PR DESCRIPTION
current code (with a vector being constructed inline in a for loop initializer) produces the following error (for me, at least; seems to pass fine in CI)

```sh
FAILED: plugins/CMakeFiles/cursecheck.dir/cursecheck.cpp.o 
/usr/bin/ccache /usr/lib/ccache/bin/g++ -DDFHACK64 -DHAVE_CUCHAR -DLINUX_BUILD -DLUA_BUILD_AS_DLL -DPROTOBUF_USE_DLLS -D_LINUX -Dcursecheck_EXPORTS -I/home/myk/src/dfhack/depends/SDL2/SDL2-2.26.2/include -I/home/myk/src/dfhack/depends/protobuf -I/home/myk/src/dfhack/depends/lua/include -I/home/myk/src/dfhack/depends/md5 -I/home/myk/src/dfhack/depends/tinyxml -I/home/myk/src/dfhack/depends/lodepng -I/home/myk/src/dfhack/depends/clsocket/src -I/home/myk/src/dfhack/depends/xlsxio/include -I/home/myk/src/dfhack/library/include -I/home/myk/src/dfhack/library/proto -I/home/myk/src/dfhack/plugins/proto -I/home/myk/src/dfhack/library/depends/xgetopt -fvisibility=hidden -mtune=generic -Wall -Werror -Wl,--disable-new-dtags -Wno-unknown-pragmas -m64 -mno-avx -Wl,-z,defs -O2 -g  -std=c++20 -fPIC -MD -MT plugins/CMakeFiles/cursecheck.dir/cursecheck.cpp.o -MF plugins/CMakeFiles/cursecheck.dir/cursecheck.cpp.o.d -o plugins/CMakeFiles/cursecheck.dir/cursecheck.cpp.o -c /home/myk/src/dfhack/plugins/cursecheck.cpp
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/x86_64-pc-linux-gnu/bits/c++allocator.h:33,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/allocator.h:46,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/list:63,
                 from /home/myk/src/dfhack/library/include/ColorText.h:28,
                 from /home/myk/src/dfhack/library/include/Console.h:27,
                 from /home/myk/src/dfhack/plugins/cursecheck.cpp:19:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = df::unit*]’,
    inlined from ‘constexpr void std::allocator< <template-parameter-1-1> >::deallocate(_Tp*, std::size_t) [with _Tp = df::unit*]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/allocator.h:210:35,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = df::unit*]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/alloc_traits.h:517:23,
    inlined from ‘constexpr void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:390:19,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:369:15,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::~vector() [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:738:7,
    inlined from ‘DFHack::command_result cursecheck(DFHack::color_ostream&, std::vector<std::__cxx11::basic_string<char> >&)’ at /home/myk/src/dfhack/plugins/cursecheck.cpp:209:5:
/usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/new_allocator.h:172:33: error: ‘void operator delete(void*, std::size_t)’ called on pointer ‘<unknown>’ with nonzero offset 8 [-Werror=free-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                 ^
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = df::unit*]’,
    inlined from ‘constexpr _Tp* std::allocator< <template-parameter-1-1> >::allocate(std::size_t) [with _Tp = df::unit*]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/allocator.h:198:40,
    inlined from ‘static constexpr _Tp* std::allocator_traits<std::allocator<_Up> >::allocate(allocator_type&, size_type) [with _Tp = df::unit*]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/alloc_traits.h:482:28,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:381:33,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:378:7,
    inlined from ‘constexpr void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:398:44,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:335:26,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = df::unit*; _Alloc = std::allocator<df::unit*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:603:61,
    inlined from ‘DFHack::command_result cursecheck(DFHack::color_ostream&, std::vector<std::__cxx11::basic_string<char> >&)’ at /home/myk/src/dfhack/plugins/cursecheck.cpp:160:81:
/usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/new_allocator.h:151:55: note: returned from ‘void* operator new(std::size_t)’
  151 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^
```