### PR TITLE
Fix build on older versions of WinSDK

### DIFF
--- a/library/MiscUtils.cpp
+++ b/library/MiscUtils.cpp
@@ -33,7 +33,12 @@ distribution.
 // We don't want min and max macros
 #define NOMINMAX
     #include <Windows.h>
+    // Suppress warning which occurs in header on some WinSDK versions
+    // See dfhack/dfhack#5147 for more information
+    #pragma warning(push)
+    #pragma warning(disable:4091)
     #include <DbgHelp.h>
+    #pragma warning(pop)
 #else
     #include <sys/time.h>
     #include <ctime>


### PR DESCRIPTION
Some versions of the Windows SDK (pre-8.1 are known) include a version of DbgHelp.h that trigger a warning upon compilation. To maintain compatability with these versions of the SDK, the warning is suppressed.

Fixes #5147