### PR TITLE
[Units] return original unit name instead of hf name

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -69,6 +69,7 @@ Template for new versions:
 
 ## API
 - ``Units::isUnitInBox``, ``Units::getUnitsInBox``: add versions accepting pos arguments
+- ``Units::getVisibleName``: when acting on a unit without an impersonated identity, returns the unit's name structure instead of the associated histfig's name structure
 
 ## Lua
 - ``dfhack.units.isUnitInBox``, ``dfhack.units.getUnitsInBox``: add versions accepting pos arguments

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -897,8 +897,12 @@ df::language_name *Units::getVisibleName(df::historical_figure *hf) {
 
 df::language_name *Units::getVisibleName(df::unit *unit) {
     CHECK_NULL_POINTER(unit);
-    auto hf = df::historical_figure::find(unit->hist_figure_id);
-    return hf ? getVisibleName(hf) : &unit->name;
+    if (auto identity = getIdentity(unit))
+    {
+        auto imp_hf = df::historical_figure::find(identity->impersonated_hf);
+        return (imp_hf && imp_hf->name.has_name) ? &imp_hf->name : &identity->name;
+    }
+    return &unit->name;
 }
 
 bool Units::assignTrainer(df::unit *unit, int32_t trainer_id) {


### PR DESCRIPTION
when acting on a df::unit and there is no impersonated identity