### PR TITLE
Refactor core Lua state and add thread safety assertions

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -55,6 +55,7 @@ set(MAIN_HEADERS
     include/ColorText.h
     include/Console.h
     include/Core.h
+    include/CoreDefs.h
     include/DataDefs.h
     include/DataFuncs.h
     include/DataIdentity.h

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -346,7 +346,7 @@ static command_result runLuaScript(color_ostream &out, std::string name, std::ve
     data.pcmd = &name;
     data.pargs = &args;
 
-    bool ok = Lua::RunCoreQueryLoop(out, DFHack::Core::getInstance().getLuaState(), init_run_script, &data);
+    bool ok = Lua::RunCoreQueryLoop(out, DFHack::Core::getInstance().getLuaState(true), init_run_script, &data);
 
     return ok ? CR_OK : CR_FAILURE;
 }

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -346,7 +346,7 @@ static command_result runLuaScript(color_ostream &out, std::string name, std::ve
     data.pcmd = &name;
     data.pargs = &args;
 
-    bool ok = Lua::RunCoreQueryLoop(out, Lua::Core::State, init_run_script, &data);
+    bool ok = Lua::RunCoreQueryLoop(out, DFHack::Core::getInstance().getLuaState(), init_run_script, &data);
 
     return ok ? CR_OK : CR_FAILURE;
 }
@@ -370,7 +370,7 @@ static command_result enableLuaScript(color_ostream &out, std::string name, bool
     data.pcmd = &name;
     data.pstate = state;
 
-    bool ok = Lua::RunCoreQueryLoop(out, Lua::Core::State, init_enable_script, &data);
+    bool ok = Lua::RunCoreQueryLoop(out, DFHack::Core::getInstance().getLuaState(), init_enable_script, &data);
 
     return ok ? CR_OK : CR_FAILURE;
 }
@@ -399,7 +399,7 @@ command_result Core::runCommand(color_ostream &out, const std::string &command)
 
 bool is_builtin(color_ostream &con, const std::string &command) {
     CoreSuspender suspend;
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
     if (!lua_checkstack(L, 1) ||
@@ -427,7 +427,7 @@ void get_commands(color_ostream &con, std::vector<std::string> &commands) {
         return;
     }
 
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
     if (!lua_checkstack(L, 1) ||
@@ -632,7 +632,7 @@ void help_helper(color_ostream &con, const std::string &entry_name) {
         con.printerr("Failed Lua call to helpdb.help (could not acquire core lock).\n");
         return;
     }
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
     if (!lua_checkstack(L, 2) ||
@@ -650,7 +650,7 @@ void help_helper(color_ostream &con, const std::string &entry_name) {
 
 void tags_helper(color_ostream &con, const std::string &tag) {
     CoreSuspender suspend;
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
     if (!lua_checkstack(L, 1) ||
@@ -687,7 +687,7 @@ void ls_helper(color_ostream &con, const std::vector<std::string> &params) {
     }
 
     CoreSuspender suspend;
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
     if (!lua_checkstack(L, 5) ||
@@ -1366,7 +1366,7 @@ static void run_dfhack_init(color_ostream &out, Core *core)
     loadScriptFiles(core, out, prefixes, CONFIG_PATH + "init");
 
     // show the terminal if requested
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     Lua::CallLuaModuleFunction(out, L, "dfhack", "getHideConsoleOnStartup", 0, 1,
         Lua::DEFAULT_LUA_LAMBDA, [&](lua_State* L) {
             if (!lua_toboolean(L, -1))
@@ -1805,7 +1805,10 @@ bool Core::InitSimulationThread()
     loadScriptPaths(con);
 
     // initialize common lua context
-    if (!Lua::Core::Init(con))
+    // Calls InitCoreContext after checking IsCoreContext
+    State = luaL_newstate();
+    State = Lua::Open(con, State);
+    if (!State)
     {
         fatal("Lua failed to initialize");
         return false;
@@ -2319,7 +2322,7 @@ void Core::onStateChange(color_ostream &out, state_change_event event)
         Persistence::Internal::load(out);
         plug_mgr->doLoadWorldData(out);
         loadModScriptPaths(out);
-        auto L = Lua::Core::State;
+        auto L = DFHack::Core::getInstance().getLuaState();
         Lua::StackUnwinder top(L);
         Lua::CallLuaModuleFunction(con, "script-manager", "reload", std::make_tuple(true));
         if (world && world->cur_savegame.save_dir.size())

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -71,8 +71,6 @@ distribution.
 using namespace DFHack;
 using namespace DFHack::LuaWrapper;
 
-//lua_State *DFHack::DFHack::Core::getInstance().getLuaState() = NULL;
-
 void dfhack_printerr(lua_State *S, const std::string &str);
 
 inline bool is_null_userdata(lua_State *L, int idx)

--- a/library/PluginManager.cpp
+++ b/library/PluginManager.cpp
@@ -704,7 +704,7 @@ void Plugin::index_lua(DFLibrary *lib)
             cmd->event = evlist->event;
             if (cmd->active)
             {
-                cmd->event->bind(Lua::Core::State, cmd);
+                cmd->event->bind(DFHack::Core::getInstance().getLuaState(), cmd);
                 if (cmd->count > 0)
                     cmd->event->on_count_changed(cmd->count, 0);
             }
@@ -830,7 +830,7 @@ void Plugin::open_lua(lua_State *state, int table)
 
             it->second->active = true;
             if (it->second->event)
-                it->second->event->bind(Lua::Core::State, it->second);
+                it->second->event->bind(DFHack::Core::getInstance().getLuaState(), it->second);
 
             lua_setfield(state, table, it->first.c_str());
         }

--- a/library/RemoteTools.cpp
+++ b/library/RemoteTools.cpp
@@ -757,7 +757,7 @@ command_result CoreService::RunLua(color_ostream &stream,
                                    const dfproto::CoreRunLuaRequest *in,
                                    StringListMessage *out)
 {
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     LuaFunctionData data = { CR_FAILURE, in, out };
 
     lua_pushcfunction(L, doRunLuaFunction);

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -382,8 +382,6 @@ namespace DFHack
             if (tid == std::thread::id{})
                 Lua::Core::Reset(core.getConsole(), "suspend");
             core.ownerThread.store(tid, std::memory_order_release);
-            //if (tid == std::thread::id{})
-            //    Lua::Core::Reset(core.getConsole(), "suspend");
             parent_t::unlock();
         }
 

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -48,6 +48,7 @@ distribution.
 #define DFH_MOD_ALT 4
 
 struct WINDOW;
+struct lua_State;
 
 namespace df
 {
@@ -243,6 +244,8 @@ namespace DFHack
 
         PerfCounters perf_counters;
 
+        lua_State* getLuaState() { return State; }
+
     private:
         DFHack::Console con;
 
@@ -349,6 +352,8 @@ namespace DFHack
 
         std::thread::id df_render_thread;
         std::thread::id df_simulation_thread;
+
+        lua_State* State;
 
         friend class CoreService;
         friend class ServerConnection;

--- a/library/include/CoreDefs.h
+++ b/library/include/CoreDefs.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/**
+  * Split off from Core.h to keep unnecessary class definitions out of compilation units that do not need them
+  *
+  */
+
+namespace DFHack
+{
+
+    enum command_result
+    {
+        CR_LINK_FAILURE = -3,    // RPC call failed due to I/O or protocol error
+        CR_NEEDS_CONSOLE = -2,   // Attempt to call interactive command without console
+        CR_NOT_IMPLEMENTED = -1, // Command not implemented, or plugin not loaded
+        CR_OK = 0,               // Success
+        CR_FAILURE = 1,          // Failure
+        CR_WRONG_USAGE = 2,      // Wrong arguments or ui state
+        CR_NOT_FOUND = 3         // Target object not found (for RPC mainly)
+    };
+
+    enum state_change_event
+    {
+        SC_UNKNOWN = -1,
+        SC_WORLD_LOADED = 0,
+        SC_WORLD_UNLOADED = 1,
+        SC_MAP_LOADED = 2,
+        SC_MAP_UNLOADED = 3,
+        SC_VIEWSCREEN_CHANGED = 4,
+        SC_CORE_INITIALIZED = 5,
+        SC_BEGIN_UNLOAD = 6,
+        SC_PAUSED = 7,
+        SC_UNPAUSED = 8
+    };
+
+}

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -472,10 +472,10 @@ namespace DFHack {namespace Lua {
      * All accesses must be done under CoreSuspender.
      */
     namespace Core {
-        DFHACK_EXPORT extern lua_State *State;
+//        DFHACK_EXPORT extern lua_State *State;
 
         // Not exported; for use by the Core class
-        bool Init(color_ostream &out);
+        lua_State* Init(color_ostream &out);
         DFHACK_EXPORT void Reset(color_ostream &out, const char *where);
 
         // Events signalled by the core
@@ -483,17 +483,32 @@ namespace DFHack {namespace Lua {
         // Signals timers
         void onUpdate(color_ostream &out);
 
-        template<class T> inline void Push(T &arg) { Lua::Push(State, arg); }
-        template<class T> inline void Push(const T &arg) { Lua::Push(State, arg); }
-        template<class T> inline void PushVector(const T &arg) { Lua::PushVector(State, arg); }
+        template<class T> inline void Push(T &arg)
+        {
+            auto State = DFHack::Core::getInstance().getLuaState();
+            Lua::Push(State, arg);
+        }
+        template<class T> inline void Push(const T &arg)
+        {
+            auto State = DFHack::Core::getInstance().getLuaState();
+            Lua::Push(State, arg);
+        }
+        template<class T> inline void PushVector(const T &arg)
+        {
+            auto State = DFHack::Core::getInstance().getLuaState();
+            Lua::PushVector(State, arg);
+        }
 
         inline bool SafeCall(color_ostream &out, int nargs, int nres, bool perr = true) {
+            auto State = DFHack::Core::getInstance().getLuaState();
             return Lua::SafeCall(out, State, nargs, nres, perr);
         }
         inline bool PushModule(color_ostream &out, const char *module) {
+            auto State = DFHack::Core::getInstance().getLuaState();
             return Lua::PushModule(out, State, module);
         }
         inline bool PushModulePublic(color_ostream &out, const char *module, const char *name) {
+            auto State = DFHack::Core::getInstance().getLuaState();
             return Lua::PushModulePublic(out, State, module, name);
         }
     }
@@ -507,7 +522,7 @@ namespace DFHack {namespace Lua {
         color_ostream &out, const char* module_name, const char* fn_name, std::tuple<aT...>&& args = {},
         size_t nres = 0, Lua::LuaLambda && res_lambda = Lua::DEFAULT_LUA_LAMBDA)
     {
-        auto L = Lua::Core::State;
+        auto L = DFHack::Core::getInstance().getLuaState();
         bool ok;
 
         ok = Lua::CallLuaModuleFunction(out, L, module_name, fn_name, sizeof...(aT), nres,
@@ -523,7 +538,7 @@ namespace DFHack {namespace Lua {
         color_ostream &out, const char* module_name, const char* fn_name, const std::vector<aT> &args,
         size_t nres = 0, Lua::LuaLambda && res_lambda = Lua::DEFAULT_LUA_LAMBDA)
     {
-        auto L = Lua::Core::State;
+        auto L = DFHack::Core::getInstance().getLuaState();
         bool ok;
 
         ok = Lua::CallLuaModuleFunction(out, L, module_name, fn_name, args.size(), nres,

--- a/library/include/RemoteClient.h
+++ b/library/include/RemoteClient.h
@@ -25,7 +25,7 @@ distribution.
 #pragma once
 #include "Export.h"
 #include "ColorText.h"
-#include "Core.h"
+#include "CoreDefs.h"
 
 class CPassiveSocket;
 class CActiveSocket;

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -863,7 +863,7 @@ bool dfhack_lua_viewscreen::safe_call_lua(int (*pf)(lua_State *), int args, int 
     CoreSuspender suspend;
     color_ostream_proxy out(Core::getInstance().getConsole());
 
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     lua_pushcfunction(L, pf);
     if (args > 0) lua_insert(L, -args-1);
     lua_pushlightuserdata(L, this);
@@ -1065,7 +1065,7 @@ void dfhack_lua_viewscreen::logic()
 
     dfhack_viewscreen::logic();
 
-    lua_pushstring(Lua::Core::State, "onIdle");
+    lua_pushstring(DFHack::Core::getInstance().getLuaState(), "onIdle");
     safe_call_lua(do_notify, 1, 0);
 }
 
@@ -1080,7 +1080,7 @@ void dfhack_lua_viewscreen::help()
 {
     if (Screen::isDismissed(this)) return;
 
-    lua_pushstring(Lua::Core::State, "onHelp");
+    lua_pushstring(DFHack::Core::getInstance().getLuaState(), "onHelp");
     safe_call_lua(do_notify, 1, 0);
 }
 
@@ -1088,7 +1088,7 @@ void dfhack_lua_viewscreen::resize(int w, int h)
 {
     if (Screen::isDismissed(this)) return;
 
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     lua_pushstring(L, "onResize");
     lua_pushinteger(L, w);
     lua_pushinteger(L, h);
@@ -1099,30 +1099,31 @@ void dfhack_lua_viewscreen::feed(std::set<df::interface_key> *keys)
 {
     if (Screen::isDismissed(this)) return;
 
-    lua_pushlightuserdata(Lua::Core::State, keys);
+    lua_pushlightuserdata(DFHack::Core::getInstance().getLuaState(), keys);
     safe_call_lua(do_input, 1, 0);
     df::global::enabler->last_text_input[0] = '\0';
 }
 
 void dfhack_lua_viewscreen::onShow()
 {
-    lua_pushstring(Lua::Core::State, "onShow");
+    lua_pushstring(DFHack::Core::getInstance().getLuaState(), "onShow");
     safe_call_lua(do_notify, 1, 0);
 }
 
 void dfhack_lua_viewscreen::onDismiss()
 {
-    lua_pushstring(Lua::Core::State, "onDismiss");
+    lua_pushstring(DFHack::Core::getInstance().getLuaState(), "onDismiss");
     safe_call_lua(do_notify, 1, 0);
 }
 
 template<typename T>
 T* dfhack_lua_viewscreen::getSelected(const char* method_name)
 {
-    Lua::StackUnwinder frame(Lua::Core::State);
-    lua_pushstring(Lua::Core::State, method_name);
+    auto L = DFHack::Core::getInstance().getLuaState();
+    Lua::StackUnwinder frame(L);
+    lua_pushstring(L, method_name);
     safe_call_lua(do_notify, 1, 1);
-    return Lua::GetDFObject<T>(Lua::Core::State, -1);
+    return Lua::GetDFObject<T>(L, -1);
 }
 
 df::unit* dfhack_lua_viewscreen::getSelectedUnit()

--- a/plugins/devel/check-structures-sanity/main.cpp
+++ b/plugins/devel/check-structures-sanity/main.cpp
@@ -114,6 +114,7 @@ static command_result command(color_ostream & out, std::vector<std::string> & pa
         using namespace DFHack::Lua::Core;
         using namespace DFHack::LuaWrapper;
 
+        auto State = DFHack::Core::getInstance().getLuaState();
         StackUnwinder unwinder(State);
         PushModulePublic(out, "utils", "df_expr_to_ref");
         Push(parameters.at(0));

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -995,7 +995,7 @@ static void post_process_dug_tiles(color_ostream &out,
 static bool get_options(color_ostream &out,
                         dig_now_options &opts,
                         const std::vector<std::string> &parameters) {
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
     if (!lua_checkstack(L, parameters.size() + 2) ||

--- a/plugins/overlay.cpp
+++ b/plugins/overlay.cpp
@@ -54,7 +54,7 @@ static void overlay_interpose_lua(const char *fn_name, int nargs = 0, int nres =
     CoreSuspender guard;
 
     color_ostream & out = Core::getInstance().getConsole();
-    auto L = Lua::Core::State;
+    auto L = DFHack::Core::getInstance().getLuaState();
 
     auto & core = Core::getInstance();
     auto & counters = core.perf_counters;

--- a/plugins/remotefortressreader/item_reader.cpp
+++ b/plugins/remotefortressreader/item_reader.cpp
@@ -53,6 +53,7 @@
 #include "modules/MapCache.h"
 #include "modules/Materials.h"
 #include "MiscUtils.h"
+#include "Core.h"
 
 
 using namespace DFHack;


### PR DESCRIPTION
This moves the global Lua state from a static global in LuaTools.h to a member variable of the singleton `Core`. A public accessor, `getLuaState`, is added to `Core` to provide access. This accessor includes an assertion which guarantees that only threads that hold the core mutex attempt to acquire the core lua state. Passing `true` to `getLuaState` will bypass the assertion; this should only be used in code that is guaranteed to acquire a `CoreSuspender` before trying to use the acquired Lua state.