### PR TITLE
remove pdf from offline formats list

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,9 @@ submodules:
 sphinx:
   configuration: conf.py
 
-formats: all
+formats:
+  - epub
+  - htmlzip
 
 python:
   install:


### PR DESCRIPTION
our readthedocs pdf build is failing with `pdflatex: Command for 'pdflatex' gave return code 1`

example: https://app.readthedocs.org/projects/dfhack/builds/26702685/

it may be that our docs have grown too large. the failures started with the recent updates to stonesense, but that may be coincidental

this PR will remove the pdf format from the build until we can figure out how to fix it

FWIW, the PDF build produces a PDF when I run it locally. However the process *does* exit with a non-zero error code.