### PR TITLE
Reenable pdf documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,9 +15,7 @@ submodules:
 sphinx:
   configuration: conf.py
 
-formats:
-  - epub
-  - htmlzip
+formats: all
 
 python:
   install:

--- a/docs/plugins/stonesense.rst
+++ b/docs/plugins/stonesense.rst
@@ -82,7 +82,7 @@ Useful links
 ------------
 - Report issues on `Github <https://github.com/DFHack/stonesense/issues>`_
 - `support`
-- :forums:`Official Stonesense thread <106497>``
+- :forums:`Official Stonesense thread <106497>`
 - :forums:`Screenshots thread <48172>`
 - :wiki:`Main wiki page <Utility:Stonesense>`
 - :wiki:`How to add content <Utility:Stonesense/Adding_Content>`


### PR DESCRIPTION
This corrects a syntax issue in a rst file that was breaking the pdf build. The pdf build is also reenabled.