### PR TITLE
Additional Suspendmanager Reason Descriptions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -64,6 +64,7 @@ Template for new versions:
 
 ## Misc Improvements
 - `strangemood`: add ability to choose Stone Cutting and Stone Carving as the mood skill
+- `suspendmanager`: add more specific messages for submerged jobsites and those managed by `buildingplan`
 
 ## Documentation
 - Added example code for creating plugin RPC endpoints that can be used to extend the DFHack API

--- a/plugins/suspendmanager.cpp
+++ b/plugins/suspendmanager.cpp
@@ -87,14 +87,18 @@ inline bool isExternalReason(Reason reason) {
 
 static string reasonToString(Reason reason) {
   switch (reason) {
-    case Reason::DEADEND:
-        return "Blocks another build job";
+    case Reason::UNDER_WATER:
+        return "Jobsite is submerged";
+    case Reason::BUILDINGPLAN:
+        return "Managed by buildingplan";
     case Reason::RISK_BLOCKING:
         return "May block another build job";
-    case Reason::UNSUPPORTED:
-        return "Would collapse immediately";
     case Reason::ERASE_DESIGNATION:
         return "Waiting for carve/smooth/engrave";
+    case Reason::DEADEND:
+        return "Blocks another build job";
+    case Reason::UNSUPPORTED:
+        return "Would collapse immediately";
     case Reason::ITEM_IN_JOB:
         return "Blocked by an unmovable item";
     default:


### PR DESCRIPTION
This eliminates the `"External reason"` descriptions in suspendmanager, adding cases for when a jobsite is submerged and when a job is being planned/managed by buildingplan.