### PR TITLE
[stockpiles] don't use uninitialized value for use_links_only

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 - `preserve-rooms`: handle case where unit records are culled by DF immediately after a unit leaves the map
 - `preserve-tombs`: properly re-enable after loading a game that had the tool enabled
 - `zone`: assign animal to cage/restraint dialog now allows you to unassign a pet from the cage or restraint if the pet is already somehow assigned (e.g.  war dog was in cage and was subsequently assigned to a dwarf)
+- `stockpiles`: don't set ``use_links_only`` flag to a random value when the flag is not set to anything in the settings that are being imported
 
 ## Misc Improvements
 - `strangemood`: add ability to choose Stone Cutting and Stone Carving as the mood skill

--- a/plugins/stockpiles/StockpileSerializer.cpp
+++ b/plugins/stockpiles/StockpileSerializer.cpp
@@ -904,11 +904,10 @@ void StockpileSettingsSerializer::read_general(color_ostream& out, DeserializeMo
 
 void StockpileSerializer::read_general(color_ostream& out, DeserializeMode mode) {
     StockpileSettingsSerializer::read_general(out, mode);
-    bool use_links_only;
-    read_elem<bool, bool>(out, "use_links_only", mode,
-            std::bind(&StockpileSettings::has_use_links_only, mBuffer),
-            std::bind(&StockpileSettings::use_links_only, mBuffer),
-            use_links_only);
+    if (!mBuffer.has_use_links_only())
+        return;
+    bool use_links_only = mBuffer.use_links_only();
+    DEBUG(log, out).print("setting use_links_only to %d\n", use_links_only);
     mPile->stockpile_flag.bits.use_links_only = use_links_only;
 }
 


### PR DESCRIPTION
when the setting is not contained in the import file

Thanks, @NicksWorld 