### PR TITLE
Mitigations for deadlock behavior on Linux

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -419,6 +419,9 @@ bool is_builtin(color_ostream &con, const std::string &command) {
 }
 
 void get_commands(color_ostream &con, std::vector<std::string> &commands) {
+#ifdef LINUX_BUILD
+    CoreSuspender suspend;
+#else
     ConditionalCoreSuspender suspend{};
 
     if (!suspend) {
@@ -426,6 +429,7 @@ void get_commands(color_ostream &con, std::vector<std::string> &commands) {
         commands.clear();
         return;
     }
+#endif
 
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
@@ -626,12 +630,17 @@ static std::string sc_event_name (state_change_event id) {
 }
 
 void help_helper(color_ostream &con, const std::string &entry_name) {
+#ifdef LINUX_BUILD
+    CoreSuspender suspend;
+#else
     ConditionalCoreSuspender suspend{};
 
     if (!suspend) {
         con.printerr("Failed Lua call to helpdb.help (could not acquire core lock).\n");
         return;
     }
+#endif
+
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
@@ -649,7 +658,17 @@ void help_helper(color_ostream &con, const std::string &entry_name) {
 }
 
 void tags_helper(color_ostream &con, const std::string &tag) {
+#ifdef LINUX_BUILD
     CoreSuspender suspend;
+#else
+    ConditionalCoreSuspender suspend{};
+
+    if (!suspend) {
+        con.printerr("Failed Lua call to helpdb.help (could not acquire core lock).\n");
+        return;
+    }
+#endif
+
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 
@@ -686,7 +705,17 @@ void ls_helper(color_ostream &con, const std::vector<std::string> &params) {
             filter.push_back(str);
     }
 
+#ifdef LINUX_BUILD
     CoreSuspender suspend;
+#else
+    ConditionalCoreSuspender suspend{};
+
+    if (!suspend) {
+        con.printerr("Failed Lua call to helpdb.help (could not acquire core lock).\n");
+        return;
+    }
+#endif
+
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
 

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -706,7 +706,7 @@ void ls_helper(color_ostream &con, const std::vector<std::string> &params) {
     }
 }
 
-command_result Core::runCommand(color_ostream &con, const std::string &first_, std::vector<std::string> &parts)
+command_result Core::runCommand(color_ostream &con, const std::string &first_, std::vector<std::string> &parts, bool no_autocomplete)
 {
     std::string first = first_;
     CommandDepthCounter counter;
@@ -1273,7 +1273,7 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, s
             }
             if ( lua )
                 res = runLuaScript(con, first, parts);
-            else if ( try_autocomplete(con, first, completed) )
+            else if (!no_autocomplete && try_autocomplete(con, first, completed))
                 res = CR_NOT_IMPLEMENTED;
             else
                 con.printerr("%s is not a recognized command.\n", first.c_str());

--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -521,7 +521,7 @@ static void interrupt_hook (lua_State *L, lua_Debug *ar)
 
 bool DFHack::Lua::Interrupt (bool force)
 {
-    lua_State *L = DFHack::Core::getInstance().getLuaState();
+    lua_State *L = DFHack::Core::getInstance().getLuaState(true);
     if (L->hook != interrupt_hook && !force)
         return false;
     if (force)

--- a/library/RemoteTools.cpp
+++ b/library/RemoteTools.cpp
@@ -721,7 +721,9 @@ command_result CoreService::RunCommand(color_ostream &stream,
     for (int i = 0; i < in->arguments_size(); i++)
         args.push_back(in->arguments(i));
 
-    return Core::getInstance().runCommand(stream, cmd, args);
+    // disable try_autocomplete in runCommand so misspellings of kill-lua won't cause deadlocks
+    // this remote server connection could be the last chance for recovering from stuck Lua scripts
+    return Core::getInstance().runCommand(stream, cmd, args, true);
 }
 
 command_result CoreService::CoreSuspend(color_ostream &stream, const EmptyMessage*, IntMessage *cnt)

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -171,7 +171,7 @@ namespace DFHack
         /// returns a named pointer.
         void *GetData(std::string key);
 
-        command_result runCommand(color_ostream &out, const std::string &command, std::vector <std::string> &parameters);
+        command_result runCommand(color_ostream &out, const std::string &command, std::vector <std::string> &parameters, bool no_autocomplete = false);
         command_result runCommand(color_ostream &out, const std::string &command);
         bool loadScriptFile(color_ostream &out, std::string fname, bool silent = false);
 


### PR DESCRIPTION
- Fix unintended assert when interrupting Lua
- Protect the remote server from try_autocomplete deadlock when attempting to run `kill-lua` but misspelling it
- disable ConditionalCoreSuspender on Linux (until we can figure out why it's misbehaving)

Discord discussion: https://discord.com/channels/793331351645323264/807444515194798090/1327095546804047995