### PR TITLE
[dig-now] consider pool and river tiles as diggable

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -67,6 +67,7 @@ Template for new versions:
 ## Misc Improvements
 - `strangemood`: add ability to choose Stone Cutting and Stone Carving as the mood skill
 - `suspendmanager`: add more specific messages for submerged jobsites and those managed by `buildingplan`
+- `dig-now`: handle digging in pool and river tiles
 
 ## Documentation
 - Added example code for creating plugin RPC endpoints that can be used to extend the DFHack API

--- a/plugins/dig-now.cpp
+++ b/plugins/dig-now.cpp
@@ -438,8 +438,6 @@ static bool is_diggable(MapExtras::MapCache &map, const DFCoord &pos,
     df::tiletype_material mat = tileMaterial(tt);
     switch (mat) {
     case df::tiletype_material::CONSTRUCTION:
-    case df::tiletype_material::POOL:
-    case df::tiletype_material::RIVER:
     case df::tiletype_material::TREE:
     case df::tiletype_material::ROOT:
     case df::tiletype_material::MAGMA:


### PR DESCRIPTION
I don't think there is any reason these tiles should be ignored. Looking at the history, I think I just didn't fully understand the tile types when I first wrote the plugin.