### PR TITLE
Prevent deadlocks when unlocking a CoreSuspender

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -419,9 +419,6 @@ bool is_builtin(color_ostream &con, const std::string &command) {
 }
 
 void get_commands(color_ostream &con, std::vector<std::string> &commands) {
-#ifdef LINUX_BUILD
-    CoreSuspender suspend;
-#else
     ConditionalCoreSuspender suspend{};
 
     if (!suspend) {
@@ -429,7 +426,6 @@ void get_commands(color_ostream &con, std::vector<std::string> &commands) {
         commands.clear();
         return;
     }
-#endif
 
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
@@ -630,16 +626,12 @@ static std::string sc_event_name (state_change_event id) {
 }
 
 void help_helper(color_ostream &con, const std::string &entry_name) {
-#ifdef LINUX_BUILD
-    CoreSuspender suspend;
-#else
     ConditionalCoreSuspender suspend{};
 
     if (!suspend) {
         con.printerr("Failed Lua call to helpdb.help (could not acquire core lock).\n");
         return;
     }
-#endif
 
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
@@ -658,16 +650,12 @@ void help_helper(color_ostream &con, const std::string &entry_name) {
 }
 
 void tags_helper(color_ostream &con, const std::string &tag) {
-#ifdef LINUX_BUILD
-    CoreSuspender suspend;
-#else
     ConditionalCoreSuspender suspend{};
 
     if (!suspend) {
         con.printerr("Failed Lua call to helpdb.help (could not acquire core lock).\n");
         return;
     }
-#endif
 
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);
@@ -705,16 +693,12 @@ void ls_helper(color_ostream &con, const std::vector<std::string> &params) {
             filter.push_back(str);
     }
 
-#ifdef LINUX_BUILD
-    CoreSuspender suspend;
-#else
     ConditionalCoreSuspender suspend{};
 
     if (!suspend) {
         con.printerr("Failed Lua call to helpdb.help (could not acquire core lock).\n");
         return;
     }
-#endif
 
     auto L = DFHack::Core::getInstance().getLuaState();
     Lua::StackUnwinder top(L);

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -376,8 +376,6 @@ namespace DFHack
 
         void unlock()
         {
-            if (!owns_lock())
-                return;
             /* Restore core owner to previous value */
             if (tid == std::thread::id{})
                 Lua::Core::Reset(core.getConsole(), "suspend");
@@ -386,7 +384,8 @@ namespace DFHack
         }
 
         ~CoreSuspenderBase() {
-            unlock();
+            if (owns_lock())
+                unlock();
         }
 
     protected:
@@ -438,7 +437,8 @@ namespace DFHack
 
         // note that this is needed so the destructor will call CoreSuspender::unlock instead of CoreSuspenderBase::unlock
         ~CoreSuspender() {
-            unlock();
+            if (owns_lock())
+                unlock();
         }
 
     protected:
@@ -465,8 +465,6 @@ namespace DFHack
 
         void unlock()
         {
-            if (!owns_lock())
-                return;
             parent_t::unlock();
             dec_tool_count();
         }

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -465,6 +465,8 @@ namespace DFHack
 
         void unlock()
         {
+            if (!owns_lock())
+                return;
             parent_t::unlock();
             dec_tool_count();
         }


### PR DESCRIPTION
`dec_tool_count` was being called on already unlocked CoreSuspenders, causing the tool count to go negative. As the core only resumes when the tool count is 0, a deadlock occured. By returning early if the underlying lock isn't held, this issue is avoided.