### PR TITLE
remove obsolete `t_building`

### DIFF
--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -59,44 +59,11 @@ class color_ostream;
 namespace Buildings
 {
 /**
- * Structure for holding a read DF building object
- * \ingroup grp_buildings
- */
-struct t_building
-{
-    uint32_t x1;
-    uint32_t y1;
-    uint32_t x2;
-    uint32_t y2;
-    uint32_t z;
-    t_matglossPair material;
-    df::building_type type;
-    union
-    {
-        int16_t subtype;
-        df::civzone_type civzone_type;
-        df::furnace_type furnace_type;
-        df::workshop_type workshop_type;
-        df::construction_type construction_type;
-        df::shop_type shop_type;
-        df::siegeengine_type siegeengine_type;
-        df::trap_type trap_type;
-    };
-    int32_t custom_type;
-    df::building * origin;
-};
-
-/**
  * The Buildings module - allows reading DF buildings
  * \ingroup grp_modules
  * \ingroup grp_buildings
  */
 DFHACK_EXPORT uint32_t getNumBuildings ();
-
-/**
- * read building by index
- */
-DFHACK_EXPORT bool Read (const uint32_t index, t_building & building);
 
 /**
  * read mapping from custom_type value to building RAW name

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -278,24 +278,6 @@ uint32_t Buildings::getNumBuildings()
     return world->buildings.all.size();
 }
 
-bool Buildings::Read (const uint32_t index, t_building & building)
-{
-    df::building *bld = world->buildings.all[index];
-
-    building.x1 = bld->x1;
-    building.x2 = bld->x2;
-    building.y1 = bld->y1;
-    building.y2 = bld->y2;
-    building.z = bld->z;
-    building.material.index = bld->mat_index;
-    building.material.type = bld->mat_type;
-    building.type = bld->getType();
-    building.subtype = bld->getSubtype();
-    building.custom_type = bld->getCustomType();
-    building.origin = bld;
-    return true;
-}
-
 bool Buildings::ReadCustomWorkshopTypes(map <uint32_t, string> & btypes)
 {
     vector <building_def *> & bld_def = world->raws.buildings.all;


### PR DESCRIPTION
this obsolete type is a leftover from DFHack's out of process days, vastly out of date and useless today... except in stonesense, which now has it locally (as `Stonesense_Building`)