### PR TITLE
Widgets/edit field to text area

### DIFF
--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -24,7 +24,7 @@ TextFieldArea.ATTRS{
 
 function TextFieldArea:onInput(keys)
     if self.on_char and keys._STRING and keys._STRING ~= 0 then
-        if not self.on_char(string.char(keys._STRING), self.text) then
+        if not self.on_char(string.char(keys._STRING), self:getText()) then
             return self.modal
         end
     end
@@ -50,6 +50,11 @@ function TextFieldArea:onInput(keys)
     end
 
     return TextFieldArea.super.onInput(self, keys)
+end
+
+function TextFieldArea:getPreferredFocusState()
+    -- allow EditField to manage focus
+    return false
 end
 
 ----------------
@@ -124,6 +129,8 @@ function EditField:init()
         key = self.key,
         on_submit = self.on_submit,
         on_submit2 = self.on_submit2,
+        on_focus = self.on_focus,
+        on_unfocus = self.on_unfocus,
         ignore_keys={
             'KEYBOARD_CURSOR_UP',
             'KEYBOARD_CURSOR_DOWN',
@@ -134,11 +141,8 @@ function EditField:init()
     }
 
     self:addviews{self.label, self.text_area}
-    self.text_area.frame.l = self.label:getTextWidth()
 
-    if self.key then
-        self.text_area:setFocus(false)
-    end
+    self.text_area.frame.l = self.label:getTextWidth()
 end
 
 function EditField:getPreferredFocusState()
@@ -170,6 +174,7 @@ end
 
 function EditField:onTextAreaTextChange(text)
     if self.text ~= text then
+        local old = self.text
         self.text = text
         if self.on_change then
             self.on_change(self.text, old)
@@ -190,11 +195,8 @@ function EditField:insert(text)
 end
 
 function EditField:onInput(keys)
-    if not self.text_area.focus then
-        return self.label:onInput(keys)
-    end
-
-    if self.key and (keys.LEAVESCREEN or keys._MOUSE_R) then
+    if self.text_area.focus and self.key and
+     (keys.LEAVESCREEN or keys._MOUSE_R) then
         self:setText(self.saved_text)
         self:setFocus(false)
         return true

--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -17,7 +17,7 @@ TextFieldArea.ATTRS{
 
 function TextFieldArea:onInput(keys)
     if self.on_char and keys._STRING and keys._STRING ~= 0 then
-        if  not self.on_char(string.char(keys._STRING), self.text) then
+        if not self.on_char(string.char(keys._STRING), self.text) then
             return self.modal
         end
     end
@@ -26,6 +26,7 @@ function TextFieldArea:onInput(keys)
         if self.key then
             self:setFocus(false)
         end
+
         if keys.SELECT_ALL then
             if self.on_submit2 then
                 self.on_submit2(self:getText())
@@ -37,6 +38,7 @@ function TextFieldArea:onInput(keys)
                 return true
             end
         end
+
         return not not self.key
     end
 

--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -104,7 +104,6 @@ end
 
 function EditField:init()
     local function on_activate()
-        self.saved_text = self.text
         self:setFocus(true)
     end
 
@@ -129,7 +128,7 @@ function EditField:init()
         key = self.key,
         on_submit = self.on_submit,
         on_submit2 = self.on_submit2,
-        on_focus = self.on_focus,
+        on_focus = self:callback('onFocus'),
         on_unfocus = self.on_unfocus,
         ignore_keys={
             table.unpack(self.ignore_keys)
@@ -141,6 +140,14 @@ function EditField:init()
     self:addviews{self.label, self.text_area}
 
     self.text_area.frame.l = self.label:getTextWidth()
+end
+
+function EditField:onFocus()
+    self.saved_text = self.text
+
+    if self.on_focus then
+        self:on_focus()
+    end
 end
 
 function EditField:getPreferredFocusState()

--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -132,8 +132,6 @@ function EditField:init()
         on_focus = self.on_focus,
         on_unfocus = self.on_unfocus,
         ignore_keys={
-            'KEYBOARD_CURSOR_UP',
-            'KEYBOARD_CURSOR_DOWN',
             table.unpack(self.ignore_keys)
         },
         on_text_change=self:callback('onTextAreaTextChange'),

--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -114,12 +114,13 @@ function EditField:getPreferredFocusState()
 end
 
 function EditField:setCursor(cursor)
-    if not cursor or cursor > #self.text then
-        self.cursor = #self.text + 1
-        return
+    if not cursor then
+        cursor = #self.text + 1
     end
-    self.cursor = math.max(1, cursor)
+    self.cursor = cursor
+
     self.text_area:setCursor(cursor)
+    self.cursor = self.text_area:getCursor()
 end
 
 function EditField:setText(text, cursor)

--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -72,10 +72,9 @@ function EditField:init()
         self:setFocus(true)
     end
 
-    self.key = 'CUSTOM_N'
-
     self.start_pos = 1
     self.cursor = #self.text + 1
+    self.ignore_keys = self.ignore_keys or {}
 
     self.label = HotkeyLabel{
         frame={t=0,l=0},
@@ -91,13 +90,23 @@ function EditField:init()
         text_pen=self.text_pen or COLOR_LIGHTCYAN,
         modal=self.modal,
         on_char=self.on_char,
-        ignore_keys={'SELECT', 'SELECT_ALL'},
+        ignore_keys={
+            'SELECT',
+            'SELECT_ALL',
+            'KEYBOARD_CURSOR_UP',
+            'KEYBOARD_CURSOR_DOWN',
+            table.unpack(self.ignore_keys)
+        },
         on_text_change=self:callback('onTextAreaTextChange'),
         on_cursor_change=function(cursor) self.cursor = cursor end
     }
 
     self:addviews{self.label, self.text_area}
     self.text_area.frame.l = self.label:getTextWidth()
+
+    if self.key then
+        self.text_area:setFocus(false)
+    end
 end
 
 function EditField:getPreferredFocusState()
@@ -146,12 +155,6 @@ end
 function EditField:onInput(keys)
     if not self.focus then
         return self.label:onInput(keys)
-    end
-
-    if self.ignore_keys then
-        for _,ignore_key in ipairs(self.ignore_keys) do
-            if keys[ignore_key] then return false end
-        end
     end
 
     if self.key and (keys.LEAVESCREEN or keys._MOUSE_R) then

--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -200,14 +200,17 @@ function EditField:insert(text)
 end
 
 function EditField:onInput(keys)
-    if self.text_area.focus and self.key and
-     (keys.LEAVESCREEN or keys._MOUSE_R) then
+    if not self.text_area.focus then
+        return self:inputToSubviews(keys)
+    end
+
+    if self.key and (keys.LEAVESCREEN or keys._MOUSE_R) then
         self:setText(self.saved_text)
         self:setFocus(false)
         return true
     end
 
-    if EditField.super.onInput(self, keys) then
+    if self.text_area:onInput(keys) then
         return true
     end
 

--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -3,8 +3,15 @@ local utils = require('utils')
 local Widget = require('gui.widgets.widget')
 local HotkeyLabel = require('gui.widgets.labels.hotkey_label')
 local TextArea = require('gui.widgets.text_area')
+local WrappedText = require('gui.widgets.text_area.wrapped_text')
 
 local getval = utils.getval
+
+OneLineWrappedText = defclass(OneLineWrappedText, WrappedText)
+
+function OneLineWrappedText:update(text)
+    self.lines = {text}
+end
 
 TextFieldArea = defclass(TextFieldArea, TextArea)
 TextFieldArea.ATTRS{

--- a/library/lua/gui/widgets/text_area.lua
+++ b/library/lua/gui/widgets/text_area.lua
@@ -25,7 +25,7 @@ function TextArea:init()
     self.render_start_line_y = 1
 
     self.text_area = TextAreaContent{
-        frame={l=0,r=3,t=0},
+        frame={l=0,r=self.one_line_mode and 0 or 3,t=0},
         text=self.init_text,
 
         text_pen=self.text_pen,

--- a/library/lua/gui/widgets/text_area.lua
+++ b/library/lua/gui/widgets/text_area.lua
@@ -35,7 +35,10 @@ function TextArea:init()
         one_line_mode=self.one_line_mode,
 
         on_text_change=function (text, old_text)
-            self:updateLayout()
+            if self.frame_body then
+                self:updateLayout()
+            end
+
             if self.on_text_change then
                 self.on_text_change(text, old_text)
             end
@@ -85,12 +88,14 @@ function TextArea:onCursorChange(cursor, old_cursor)
         self.text_area.cursor
     )
 
-    if y >= self.render_start_line_y + self.text_area.frame_body.height then
-        self:updateScrollbar(
-            y - self.text_area.frame_body.height + 1
-        )
-    elseif  (y < self.render_start_line_y) then
-        self:updateScrollbar(y)
+    if self.text_area.frame_body then
+        if y >= self.render_start_line_y + self.text_area.frame_body.height then
+            self:updateScrollbar(
+                y - self.text_area.frame_body.height + 1
+            )
+        elseif  (y < self.render_start_line_y) then
+            self:updateScrollbar(y)
+        end
     end
 
     if self.on_cursor_change then

--- a/library/lua/gui/widgets/text_area.lua
+++ b/library/lua/gui/widgets/text_area.lua
@@ -23,6 +23,7 @@ TextArea.ATTRS{
 
 function TextArea:init()
     self.render_start_line_y = 1
+    self.render_start_x = 1
 
     self.text_area = TextAreaContent{
         frame={l=0,r=self.one_line_mode and 0 or 3,t=0},
@@ -95,6 +96,17 @@ function TextArea:onCursorChange(cursor, old_cursor)
             )
         elseif  (y < self.render_start_line_y) then
             self:updateScrollbar(y)
+        end
+
+        if self.one_line_mode then
+            local x_screen_offset_right = math.max(0, x - self.render_start_x - self.text_area.frame_body.width + 1)
+            local x_screen_offset_left = math.max(0, self.render_start_x - x)
+
+            if x_screen_offset_right > 0 then
+                self.render_start_x = self.render_start_x + x_screen_offset_right
+            elseif x_screen_offset_left > 0 then
+                self.render_start_x = self.render_start_x - x_screen_offset_left
+            end
         end
     end
 
@@ -169,6 +181,9 @@ end
 
 function TextArea:renderSubviews(dc)
     self.text_area.frame_body.y1 = self.frame_body.y1-(self.render_start_line_y - 1)
+    if self.one_line_mode then
+        self.text_area.frame_body.x1 = self.frame_body.x1-(self.render_start_x - 1)
+    end
     -- only visible lines of text_area will be rendered
     TextArea.super.renderSubviews(self, dc)
 end

--- a/library/lua/gui/widgets/text_area.lua
+++ b/library/lua/gui/widgets/text_area.lua
@@ -197,6 +197,10 @@ function TextArea:onInput(keys)
         self:setFocus(true)
     end
 
+    if not self.focus then
+        return false
+    end
+
     return TextArea.super.onInput(self, keys)
 end
 

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -28,7 +28,7 @@ function TextAreaContent:init()
     self.clipboard_mode = CLIPBOARD_MODE.LOCAL
     self.render_start_line_y = 1
 
-    self.cursor = nil
+    self.cursor = 1
 
     self.main_pen = dfhack.pen.parse({
         fg=self.text_pen,
@@ -483,6 +483,7 @@ function TextAreaContent:onMouseInput(keys)
     elseif keys._MOUSE_L_DOWN then
 
         local mouse_x, mouse_y = self:getMousePos()
+
         if mouse_x and mouse_y then
             if (self:getMultiLeftClick(mouse_x + 1, mouse_y + 1) > 1) then
                 return true

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -68,6 +68,11 @@ function TextAreaContent:postComputeFrame()
 end
 
 function TextAreaContent:recomputeLines()
+    if not self.frame_body then
+        -- called before first layout compute
+        return
+    end
+
     self.wrapped_text:update(
         self.text,
         -- something cursor '_' need to be add at the end of a line

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -570,12 +570,13 @@ end
 function TextAreaContent:onTextManipulationInput(keys)
     if keys.SELECT then
         -- handle enter
+        self.history:store(
+            HISTORY_ENTRY.WHITESPACE_BLOCK,
+            self.text,
+            self.cursor
+        )
+
         if not self.one_line_mode then
-            self.history:store(
-                HISTORY_ENTRY.WHITESPACE_BLOCK,
-                self.text,
-                self.cursor
-            )
             self:insert(NEWLINE)
         end
 

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -98,7 +98,7 @@ function TextAreaContent:setCursor(cursor_offset)
 end
 
 function TextAreaContent:setSelection(from_offset, to_offset)
-    -- text selection is always start on self.cursor and on self.sel_end
+    -- text selection is always start on self.cursor and end on self.sel_end
     self:setCursor(from_offset)
     self.sel_end = to_offset
 
@@ -512,10 +512,20 @@ end
 
 function TextAreaContent:onCursorInput(keys)
     if keys.KEYBOARD_CURSOR_LEFT then
-        self:setCursor(self.cursor - 1)
+        if self:hasSelection() then
+            self:setCursor(math.min(self.cursor, self.sel_end))
+        else
+            self:setCursor(self.cursor - 1)
+        end
+
         return true
     elseif keys.KEYBOARD_CURSOR_RIGHT then
-        self:setCursor(self.cursor + 1)
+        if self:hasSelection() then
+            self:setCursor(math.max(self.cursor, self.sel_end))
+        else
+            self:setCursor(self.cursor + 1)
+        end
+
         return true
     elseif keys.KEYBOARD_CURSOR_UP and not self.one_line_mode then
         local x, y = self.wrapped_text:indexToCoords(self.cursor)

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -28,7 +28,7 @@ function TextAreaContent:init()
     self.clipboard_mode = CLIPBOARD_MODE.LOCAL
     self.render_start_line_y = 1
 
-    self.cursor = 1
+    self.cursor = nil
 
     self.main_pen = dfhack.pen.parse({
         fg=self.text_pen,

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -7,20 +7,10 @@ local HistoryStore = require('gui.widgets.text_area.history_store')
 local CLIPBOARD_MODE = {LOCAL = 1, LINE = 2}
 local HISTORY_ENTRY = HistoryStore.HISTORY_ENTRY
 
+OneLineWrappedText = defclass(OneLineWrappedText, WrappedText)
 
-PassthroughText = defclass(PassthroughText)
-
-function PassthroughText:init()
-end
-
-function PassthroughText:update(text)
+function OneLineWrappedText:update(text)
     self.lines = {text}
-end
-function PassthroughText:coordsToIndex(x, y)
-    return x or 1
-end
-function PassthroughText:indexToCoords(index)
-    return index or 1, 1
 end
 
 TextAreaContent = defclass(TextAreaContent, Widget)
@@ -57,7 +47,7 @@ function TextAreaContent:init()
         bold=true
     })
 
-    local TextWrapper = self.one_line_mode and PassthroughText or WrappedText
+    local TextWrapper = self.one_line_mode and OneLineWrappedText or WrappedText
     self.wrapped_text = TextWrapper{
         text=self.text,
         wrap_width=256

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -517,7 +517,7 @@ function TextAreaContent:onCursorInput(keys)
     elseif keys.KEYBOARD_CURSOR_RIGHT then
         self:setCursor(self.cursor + 1)
         return true
-    elseif keys.KEYBOARD_CURSOR_UP then
+    elseif keys.KEYBOARD_CURSOR_UP and not self.one_line_mode then
         local x, y = self.wrapped_text:indexToCoords(self.cursor)
         local last_cursor_x = self.last_cursor_x or x
         local offset = y > 1 and
@@ -526,7 +526,7 @@ function TextAreaContent:onCursorInput(keys)
         self:setCursor(offset)
         self.last_cursor_x = last_cursor_x
         return true
-    elseif keys.KEYBOARD_CURSOR_DOWN then
+    elseif keys.KEYBOARD_CURSOR_DOWN and not self.one_line_mode then
         local x, y = self.wrapped_text:indexToCoords(self.cursor)
         local last_cursor_x = self.last_cursor_x or x
         local offset = y < #self.wrapped_text.lines and

--- a/test/library/gui/widgets.EditField.lua
+++ b/test/library/gui/widgets.EditField.lua
@@ -4,6 +4,9 @@ local widgets = require('gui.widgets')
 
 function test.editfield_cursor()
     local e = widgets.EditField{}
+
+    -- cursor is normally set in `postUpdateLayout`, hard to test in unit tests
+    e:setCursor(1)
     e:setFocus(true)
     expect.eq(1, e.cursor, 'cursor should be after the empty string')
 
@@ -64,6 +67,8 @@ end
 
 function test.editfield_ignore_keys()
     local e = widgets.EditField{ignore_keys={'CUSTOM_B', 'CUSTOM_C'}}
+    -- cursor is normally set in `postUpdateLayout`, hard to test in unit tests
+    e:setCursor(1)
     e:setFocus(true)
 
     e:onInput{_STRING=string.byte('a'), CUSTOM_A=true}

--- a/test/library/gui/widgets.EditField.lua
+++ b/test/library/gui/widgets.EditField.lua
@@ -29,11 +29,11 @@ function test.editfield_cursor()
     e:onInput{CUSTOM_HOME=true}
     expect.eq(1, e.cursor, 'cursor should be at beginning of string')
     e:onInput{CUSTOM_CTRL_RIGHT=true}
-    expect.eq(6, e.cursor, 'goto beginning of next word')
+    expect.eq(5, e.cursor, 'goto end of current word')
     e:onInput{CUSTOM_END=true}
     expect.eq(16, e.cursor, 'cursor should be at end of string')
     e:onInput{CUSTOM_CTRL_LEFT=true}
-    expect.eq(9, e.cursor, 'goto end of previous word')
+    expect.eq(10, e.cursor, 'goto beginning of current word')
 end
 
 function test.editfield_click()
@@ -41,20 +41,25 @@ function test.editfield_click()
     e:setFocus(true)
     expect.eq(5, e.cursor)
 
-    mock.patch(e, 'getMousePos', mock.func(0), function()
-            e:onInput{_MOUSE_L_DOWN=true}
-            expect.eq(1, e.cursor)
-        end)
+    local text_area_content = e.text_area.text_area
 
-    mock.patch(e, 'getMousePos', mock.func(20), function()
-            e:onInput{_MOUSE_L_DOWN=true}
-            expect.eq(5, e.cursor, 'should only seek to end of text')
-        end)
+    mock.patch(text_area_content, 'getMousePos', mock.func(0, 0), function()
+        e:onInput{_MOUSE_L_DOWN=true, _MOUSE_L=true}
+        e:onInput{_MOUSE_L_DOWN=true}
+        expect.eq(1, e.cursor)
+    end)
 
-    mock.patch(e, 'getMousePos', mock.func(2), function()
-            e:onInput{_MOUSE_L_DOWN=true}
-            expect.eq(3, e.cursor)
-        end)
+    mock.patch(text_area_content, 'getMousePos', mock.func(20, 0), function()
+        e:onInput{_MOUSE_L_DOWN=true, _MOUSE_L=true}
+        e:onInput{_MOUSE_L_DOWN=true}
+        expect.eq(5, e.cursor, 'should only seek to end of text')
+    end)
+
+    mock.patch(text_area_content, 'getMousePos', mock.func(2, 0), function()
+        e:onInput{_MOUSE_L_DOWN=true, _MOUSE_L=true}
+        e:onInput{_MOUSE_L_DOWN=true}
+        expect.eq(3, e.cursor)
+    end)
 end
 
 function test.editfield_ignore_keys()

--- a/test/library/gui/widgets.TextArea.lua
+++ b/test/library/gui/widgets.TextArea.lua
@@ -66,8 +66,8 @@ local function arrange_textarea(options)
 
     if options.w then
         local border_width = 2
-        local scrollbar_width = 3
-        local cursor_buffor = 1
+        local scrollbar_width = options.one_line_mode and 0 or 3
+        local cursor_buffor = options.one_line_mode and 0 or 1
         window_width = options.w + border_width + scrollbar_width + cursor_buffor
     end
 
@@ -90,6 +90,7 @@ local function arrange_textarea(options)
                     init_text=options.text or '',
                     init_cursor=options.cursor or 1,
                     frame={l=0,r=0,t=0,b=0},
+                    one_line_mode=options.one_line_mode,
                     on_cursor_change=options.on_cursor_change,
                     on_text_change=options.on_text_change,
                 }
@@ -3312,6 +3313,26 @@ function test.clear_undo_redo_history()
     simulate_input_keys('CUSTOM_CTRL_Z')
 
     expect.eq(read_rendered_text(text_area), text .. 'A longer text_')
+
+    screen:dismiss()
+end
+
+function test.render_new_lines_in_one_line_mode()
+    local text_area, screen, window, widget = arrange_textarea({
+        w=80,
+        one_line_mode=true
+    })
+
+    local text = table.concat({
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        'Pellentesque dignissim volutpat orci, sed molestie metus elementum vel.',
+        'Donec sit amet mattis ligula, ac vestibulum lorem.',
+    }, '\n')
+
+    widget:setText(text)
+    widget:setCursor(1)
+
+    expect.eq(read_rendered_text(text_area), '_' .. text:sub(2, 80))
 
     screen:dismiss()
 end

--- a/test/library/gui/widgets.TextArea.lua
+++ b/test/library/gui/widgets.TextArea.lua
@@ -1718,32 +1718,27 @@ function test.arrows_reset_selection()
 
     local text = table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh porttitor mi, vitae rutrum eros metus nec libero.',
+        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
+        'porttitor mi, vitae rutrum eros metus nec libero._',
     }, '\n')
 
     simulate_input_text(text)
 
     simulate_input_keys('CUSTOM_CTRL_A')
 
-    expect.eq(read_rendered_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero._',
-    }, '\n'));
+    expect.eq(read_rendered_text(text_area), text .. '_');
 
-    expect.eq(read_selected_text(text_area), table.concat({
-        '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero.',
-    }, '\n'));
+    expect.eq(read_selected_text(text_area), text);
 
     simulate_input_keys('KEYBOARD_CURSOR_LEFT')
     expect.eq(read_selected_text(text_area), '')
+    expect.eq(read_rendered_text(text_area), '_' .. text:sub(2))
 
     simulate_input_keys('CUSTOM_CTRL_A')
 
     simulate_input_keys('KEYBOARD_CURSOR_RIGHT')
     expect.eq(read_selected_text(text_area), '')
+    expect.eq(read_rendered_text(text_area), text:sub(1, #text) .. '_')
 
     simulate_input_keys('CUSTOM_CTRL_A')
 


### PR DESCRIPTION
This PR migrate commonly used `EditField` widget to be based on `TextArea` component.
Its inherits all `TextArea` features in one line mode, keeping original interface of `EditField` widget.

Also, I polished one line mode of `TextArea` to display cp437 character (`◙`) instead of remove them.

![screen](https://github.com/user-attachments/assets/19fc25d2-97b9-455f-857d-78ad8e491c5d)
