### PR TITLE
adapt to new location of stonesense keybinds file

### DIFF
--- a/docs/plugins/stonesense.rst
+++ b/docs/plugins/stonesense.rst
@@ -52,7 +52,7 @@ See ``dfhack-config/stonesense/keybinds.txt`` to learn or set keybindings, inclu
 zooming, changing the dimensions of the rendered area, toggling various
 views, fog, and rotation. Here's the important section:
 
-.. include:: ../../plugins/stonesense/resources/keybinds.txt
+.. include:: ../../plugins/stonesense/configs/keybinds.txt
    :literal:
    :end-before: VALID ACTIONS:
 


### PR DESCRIPTION
I'm decoupling the path change from other changes in #5187 so that PR can just address docs for new features