### PR TITLE
[infinite-sky, timestream] don't explicitly disable on load

### DIFF
--- a/plugins/infinite-sky.cpp
+++ b/plugins/infinite-sky.cpp
@@ -31,9 +31,9 @@ REQUIRE_GLOBAL(world);
 
 namespace DFHack {
     // for configuration-related logging
-    DBG_DECLARE(infiniteSky, control, DebugCategory::LINFO);
+    DBG_DECLARE(infinitesky, control, DebugCategory::LINFO);
     // for logging during creation of z-levels
-    DBG_DECLARE(infiniteSky, cycle, DebugCategory::LINFO);
+    DBG_DECLARE(infinitesky, cycle, DebugCategory::LINFO);
 }
 
 static const string CONFIG_KEY = string(plugin_name) + "/config";
@@ -98,7 +98,9 @@ DFhackCExport command_result plugin_load_site_data(color_ostream &out) {
     }
 
     // Call plugin_enable to set value to ensure the event handler is properly registered
-    plugin_enable(out, config.get_bool(CONFIG_IS_ENABLED));
+    if (config.get_bool(CONFIG_IS_ENABLED)) {
+        plugin_enable(out, true);
+    }
     DEBUG(control, out)
         .print("loading persisted enabled state: %s\n",
                is_enabled ? "true" : "false");

--- a/plugins/timestream.cpp
+++ b/plugins/timestream.cpp
@@ -216,7 +216,9 @@ DFhackCExport command_result plugin_load_site_data(color_ostream &out) {
         migrate_old_config(out);
     }
 
-    plugin_enable(out, config.get_bool(CONFIG_IS_ENABLED));
+    if (config.get_bool(CONFIG_IS_ENABLED)) {
+        plugin_enable(out, true);
+    }
     DEBUG(control,out).print("loading persisted enabled state: %s\n",
                             is_enabled ? "true" : "false");
 


### PR DESCRIPTION
it will already be disabled and it results in spurious error messages in non-fort modes