### PR TITLE
Make EditField grab focus instead of proxying it to children

### DIFF
--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -57,6 +57,13 @@ function TextFieldArea:getPreferredFocusState()
     return false
 end
 
+function TextFieldArea:hasFocus()
+    return self.parent_view.focus
+end
+
+function TextFieldArea:setFocus(focus)
+    return self.parent_view:setFocus(focus)
+end
 ----------------
 -- Edit field --
 ----------------
@@ -128,8 +135,6 @@ function EditField:init()
         key = self.key,
         on_submit = self.on_submit,
         on_submit2 = self.on_submit2,
-        on_focus = self:callback('onFocus'),
-        on_unfocus = self.on_unfocus,
         ignore_keys={
             table.unpack(self.ignore_keys)
         },
@@ -142,12 +147,10 @@ function EditField:init()
     self.text_area.frame.l = self.label:getTextWidth()
 end
 
-function EditField:onFocus()
+function EditField:setFocus(focus)
     self.saved_text = self.text
 
-    if self.on_focus then
-        self:on_focus()
-    end
+    return EditField.super.setFocus(self, focus)
 end
 
 function EditField:getPreferredFocusState()
@@ -187,10 +190,6 @@ function EditField:onTextAreaTextChange(text)
     end
 end
 
-function EditField:setFocus(focus)
-    self.text_area:setFocus(focus)
-end
-
 function EditField:insert(text)
     local old = self.text
     self:setText(
@@ -200,12 +199,15 @@ function EditField:insert(text)
 end
 
 function EditField:onInput(keys)
-    if not self.text_area.focus then
-        return self:inputToSubviews(keys)
+    if keys._MOUSE_L and self:getMousePos() then
+        self:setFocus(true)
+    end
+
+    if not self.focus then
+        return self.label:onInput(keys)
     end
 
     if self.key and (keys.LEAVESCREEN or keys._MOUSE_R) then
-        self:setText(self.saved_text)
         self:setFocus(false)
         return true
     end

--- a/library/lua/gui/widgets/text_area.lua
+++ b/library/lua/gui/widgets/text_area.lua
@@ -84,6 +84,10 @@ function TextArea:clearHistory()
     return self.text_area.history:clear()
 end
 
+function TextArea:hasFocus()
+    return self.focus
+end
+
 function TextArea:onCursorChange(cursor, old_cursor)
     local x, y = self.text_area.wrapped_text:indexToCoords(
         self.text_area.cursor
@@ -197,7 +201,7 @@ function TextArea:onInput(keys)
         self:setFocus(true)
     end
 
-    if not self.focus then
+    if not self:hasFocus() then
         return false
     end
 

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -238,7 +238,7 @@ function TextAreaContent:onRenderBody(dc)
     local show_focus = not self.enable_cursor_blink
         or (
             not self:hasSelection()
-            and self.parent_view.focus
+            and self.parent_view:hasFocus()
             and gui.blink_visible(530)
         )
 
@@ -486,7 +486,6 @@ function TextAreaContent:onMouseInput(keys)
         end
 
     elseif keys._MOUSE_L_DOWN then
-
         local mouse_x, mouse_y = self:getMousePos()
 
         if mouse_x and mouse_y then


### PR DESCRIPTION
Before `EditField` focus has been grabbed by `TextArea` children component.
Now `EditField` grab the focus by itself and properly manage it during session.