### PR TITLE
Fix Edit Field long lines changing text cursor behaviour

### DIFF
--- a/library/lua/gui/widgets/edit_field.lua
+++ b/library/lua/gui/widgets/edit_field.lua
@@ -114,7 +114,6 @@ function EditField:init()
         self:setFocus(true)
     end
 
-    self.start_pos = 1
     self.cursor = #self.text + 1
     self.ignore_keys = self.ignore_keys or {}
 

--- a/library/lua/gui/widgets/text_area.lua
+++ b/library/lua/gui/widgets/text_area.lua
@@ -69,7 +69,15 @@ function TextArea:setText(text)
         self:getCursor()
     )
 
-    return self.text_area:setText(text)
+    self.text_area:setText(text)
+
+    if self.one_line_mode then
+        self.render_start_x = 1
+        local cursor = self:getCursor()
+        if cursor then
+            self:setCursor(math.min(self:getCursor(), #text + 1))
+        end
+    end
 end
 
 function TextArea:getCursor()

--- a/test/library/gui/widgets.TextArea.lua
+++ b/test/library/gui/widgets.TextArea.lua
@@ -3391,3 +3391,24 @@ function test.should_scroll_horizontally_in_one_line_mode()
 
     screen:dismiss()
 end
+
+function test.should_reset_horizontal_in_one_line_mode()
+    local text_area, screen, window, widget = arrange_textarea({
+        w=40,
+        one_line_mode=true
+    })
+
+    local text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque dignissim volutpat orci, sed'
+
+    widget:setText(text)
+
+    widget:setCursor(#text + 1)
+
+    expect.eq(read_rendered_text(text_area), text:sub(-39) .. '_')
+
+    widget:setText('Lorem ipsum')
+
+    expect.eq(read_rendered_text(text_area), 'Lorem ipsum_')
+
+    screen:dismiss()
+end


### PR DESCRIPTION
Fix `EditField` long lines cursor behaviour described in this issue:

> The scenario requires a couple of commands in gui/launcher history: (e.g.)
:lua print'jh 0123456789 0123456789 0123456789 jl'(the "long" entry)
extend the string (or shrink the window) as necessary so that it is longer
than the gui/launcher command line is wide
gui/gm-unit (the "short" entry)
> Then,
Alt-s to focus the search field,
type jj to find the long entry,
Ctrl-u to clear the search field,
type unit to find the short entry,
Esc to go back to the command line field.
> The command line EditField looks like it is empty with just a cursor. The short entry is
there, but it is "scrolled" out of view to the left. Moving the cursor to the
left will start to reveal the short entry.