### PR TITLE
Disallow changing a vein into itself

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 
 ## Fixes
 - `spectate`: don't allow temporarily modified announcement settings to be written to disk when "auto-unpause" mode is enabled
+- `changevein`: fix a crash that could occur when attempting to change a vein into itself
 
 ## Misc Improvements
 - `spectate`: player-set configuration is now stored globally instead of per-fort

--- a/plugins/changevein.cpp
+++ b/plugins/changevein.cpp
@@ -254,6 +254,12 @@ command_result df_changevein (color_ostream &out, vector <string> & parameters)
         return CR_FAILURE;
     }
 
+    if (mineral->inorganic_mat == mi.index)
+    {
+        out.printerr("Selected tile is already of the target material.\n");
+        return CR_FAILURE;
+    }
+
     VeinEdgeBitmask mask = VeinEdgeBitmask(mineral);
     mineral->inorganic_mat = mi.index;
     ChangeSameBlockVeins(block, mineral, mask, mi.index);


### PR DESCRIPTION
This adds a check for when the original and target material are the same, providing an error message if attempted.

The algorithm for finding neighboring vein tiles relies upon the original and target materials being different, otherwise it leads to infinite recursion which inevitably ends in a crash.

Fixes #5231