### PR TITLE
[spectate] implement unit history scanning and auto-disengage features

### DIFF
--- a/docs/plugins/spectate.rst
+++ b/docs/plugins/spectate.rst
@@ -37,7 +37,7 @@ Usage
     spectate [status]
     spectate toggle
     spectate set <setting> <value>
-    spectate overlay <name> enable|disable
+    spectate overlay enable|disable
 
 Examples
 --------
@@ -59,8 +59,9 @@ Examples
 ``spectate set follow-seconds 30``
     Configure `spectate` to switch targets every 30 seconds when in follow mode.
 
-``spectate overlay follow enable``
-    Show informative tooltips that follow each unit on the map.
+``spectate overlay enable``
+    Show informative tooltips that follow each unit on the map. Note that this
+    can be enabled independently of `spectate` itself.
 
 Settings
 --------
@@ -68,7 +69,8 @@ Settings
 ``auto-disengage`` (default: enabled)
     Toggle automatically disabling the plugin when the player moves the map or
     opens the squad panel. If this is disabled, you will need to manually
-    disable the plugin to turn off follow mode.
+    disable the plugin to turn off follow mode. You can still interact normally
+    with the DF UI.
 
 ``auto-unpause`` (default: disabled)
     Toggle auto-dismissal of announcements that pause the game, like sieges,
@@ -102,47 +104,36 @@ Settings
     arrived on the map.
 
 ``tooltip-follow-job`` (default: enabled)
-    If the ``spectate.follow`` overlay is enabled, toggle whether to show the
+    If the ``spectate.tooltip`` overlay is enabled, toggle whether to show the
     job of the dwarf in the tooltip.
 
 ``tooltip-follow-name`` (default: enabled)
-    If the ``spectate.follow`` overlay is enabled, toggle whether to show the
+    If the ``spectate.tooltip`` overlay is enabled, toggle whether to show the
     name of the dwarf in the tooltip.
 
 ``tooltip-follow-stress`` (default: enabled)
-    If the ``spectate.follow`` overlay is enabled, toggle whether to show the
+    If the ``spectate.tooltip`` overlay is enabled, toggle whether to show the
     happiness level (stress) of the dwarf in the tooltip.
 
 ``tooltip-hover-job`` (default: enabled)
-    If the ``spectate.follow`` overlay is enabled, toggle whether to show the
+    If the ``spectate.tooltip`` overlay is enabled, toggle whether to show the
     job of the dwarf in the hover panel.
 
 ``tooltip-hover-name`` (default: enabled)
-    If the ``spectate.follow`` overlay is enabled, toggle whether to show the
+    If the ``spectate.tooltip`` overlay is enabled, toggle whether to show the
     name of the dwarf in the hover panel.
 
 ``tooltip-hover-stress`` (default: enabled)
-    If the ``spectate.follow`` overlay is enabled, toggle whether to show the
+    If the ``spectate.tooltip`` overlay is enabled, toggle whether to show the
     happiness level (stress) of the dwarf in the hover panel.
 
 Overlays
 --------
 
-``spectate`` provides two overlays via the `overlay` framework to add
-information and functionality to the main map. These overlays can be controlled
-via the ``spectate overlay`` command or the ``Overlays`` tab in
-`gui/control-panel`.
+``spectate.tooltip``
 
-The information displayed by these overlays can be configured via the
-``spectate set`` command or the `gui/spectate` interface.
+``spectate`` can show informative tooltips that follow each unit on the map
+and/or a popup panel with information when your mouse cursor hovers over a unit.
 
-``spectate.follow``
-    Show informative tooltips that follow each unit on the map. You can enable
-    this overlay by running ``spectate overlay follow enable`` or,
-    equivalently, ``overlay enable spectate.follow``.
-
-``spectate.hover``
-    Show a popup panel with selected information when your mouse cursor hovers
-    over a unit. You can enable this overlay by running
-    ``spectate overlay hover enable`` or, equivalently,
-    ``overlay enable spectate.hover``.
+This overlay is managed via the `overlay` framework. It can be controlled via
+the ``spectate overlay`` command or the ``Overlays`` tab in `gui/control-panel`.

--- a/docs/plugins/spectate.rst
+++ b/docs/plugins/spectate.rst
@@ -13,9 +13,9 @@ to following a different dwarf. It can also switch to following animals,
 hostiles, or visiting units. You can switch to the next target (or a previous
 target) immediately with the left/right arrow keys.
 
-`spectate` will disengage and turn itself off when you move the map, just like
-the vanilla follow mechanic. It will also disengage immediately if you open the
-squads menu for military action.
+By default, `spectate` will disengage and turn itself off when you move the
+map, just like the vanilla follow mechanic. It will also disengage immediately
+if you open the squads menu for military action.
 
 It can also annotate your dwarves on the map with their name, job, and other
 information, either as floating tooltips or in a panel that comes up when you

--- a/plugins/lua/spectate.lua
+++ b/plugins/lua/spectate.lua
@@ -1,6 +1,7 @@
 local _ENV = mkmodule('plugins.spectate')
 
 local argparse = require('argparse')
+local dlg = require('gui.dialogs')
 local json = require('json')
 local overlay = require('plugins.overlay')
 local utils = require('utils')
@@ -53,6 +54,20 @@ function refresh_cpp_config()
             spectate_setSetting(name, value)
         end
     end
+end
+
+function show_squads_warning()
+    local message = {
+        'Cannot start spectate mode while auto-disengage is enabled and',
+        'the squads panel is open. The auto-disengage feature automatically',
+        'stops spectate mode when you open the squads panel.',
+        '',
+        'Please either close the squads panel or disable auto-disengage by',
+        'running the following command:',
+        '',
+        'spectate set auto-disengage false',
+    }
+    dlg.showMessage("Spectate", table.concat(message, '\n'))
 end
 
 -----------------------------

--- a/plugins/lua/spectate.lua
+++ b/plugins/lua/spectate.lua
@@ -109,15 +109,9 @@ local function set_setting(key, value)
     end
 end
 
-local function set_overlay(name, value)
-    if not name:startswith('spectate.') then
-        name = 'spectate.' .. name
-    end
-    if name ~= 'spectate.follow' and name ~= 'spectate.hover' then
-        qerror('unknown overlay: ' .. name)
-    end
+local function set_overlay(value)
     value = argparse.boolean(value, name)
-    dfhack.run_command('overlay', value and 'enable' or 'disable', name)
+    dfhack.run_command('overlay', value and 'enable' or 'disable', 'spectate.tooltip')
 end
 
 function parse_commandline(args)
@@ -129,7 +123,7 @@ function parse_commandline(args)
     elseif command == 'set' then
         set_setting(args[1], args[2])
     elseif command == 'overlay' then
-        set_overlay(args[1], args[2])
+        set_overlay(args[1])
     else
         return false
     end
@@ -140,25 +134,16 @@ end
 -----------------------------
 -- overlays
 
-FollowOverlay = defclass(FollowOverlay, overlay.OverlayWidget)
-FollowOverlay.ATTRS{
-    desc='Adds info tooltips that follow units on the map.',
-    default_pos={x=1,y=1},
-    fullscreen=true,
-    viewscreens='dwarfmode/Default',
-}
-
-HoverOverlay = defclass(HoverOverlay, overlay.OverlayWidget)
-HoverOverlay.ATTRS{
-    desc='Shows info popup when hovering the mouse over units on the map.',
+TooltipOverlay = defclass(TooltipOverlay, overlay.OverlayWidget)
+TooltipOverlay.ATTRS{
+    desc='Adds info tooltips that follow units or appear when you hover the mouse.',
     default_pos={x=1,y=1},
     fullscreen=true,
     viewscreens='dwarfmode/Default',
 }
 
 OVERLAY_WIDGETS = {
-    follow=FollowOverlay,
-    hover=HoverOverlay,
+    tooltip=TooltipOverlay,
 }
 
 return _ENV

--- a/plugins/spectate.cpp
+++ b/plugins/spectate.cpp
@@ -209,7 +209,7 @@ struct forward_back_interceptor : df::viewscreen_dwarfmodest {
     typedef df::viewscreen_dwarfmodest interpose_base;
 
     DEFINE_VMETHOD_INTERPOSE(void, feed, (std::set<df::interface_key> *input)) {
-        bool is_at_default_view = Gui::matchFocusString("dwarfmode/Default", Gui::getDFViewscreen());
+        bool is_at_default_view = Gui::matchFocusString("dwarfmode/Default");
         if (is_at_default_view && input->count(df::interface_key::CUSTOM_LEFT))
             unit_history.scan_back(Core::getInstance().getConsole());
         else if (is_at_default_view && input->count(df::interface_key::CUSTOM_RIGHT))


### PR DESCRIPTION
also change the API to only have one overlay instead of two

we don't have a good way to control the order that overlays render in, and these overlays have a specific dependency
