### PR TITLE
[stockpiles] add property filters for brewable, millable, and processable

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -68,6 +68,7 @@ Template for new versions:
 ## Misc Improvements
 - `spectate`: player-set configuration is now stored globally instead of per-fort
 - `autobutcher`: treat animals on restraints as unavailable for slaughter
+- `stockpiles`: add property filters for brewable, millable, and processable organic materials
 
 ## Documentation
 - `stonesense-art-guide`: new guide for making sprite art for Stonesense

--- a/docs/plugins/stockpiles.rst
+++ b/docs/plugins/stockpiles.rst
@@ -378,6 +378,12 @@ Flags and subcategory prefixes::
     paste/
     pressed/
 
+Properties::
+
+    brewable
+    millable
+    processable
+
 Settings files::
 
     preparedmeals

--- a/plugins/stockpiles/OrganicMatLookup.cpp
+++ b/plugins/stockpiles/OrganicMatLookup.cpp
@@ -39,9 +39,7 @@ void OrganicMatLookup::food_mat_by_idx(color_ostream& out, organic_mat_category:
         DEBUG(log, out).print("type(%d) index(%d) token(%s)\n", type, main_idx, food_mat.material.getToken().c_str());
     }
 }
-std::string OrganicMatLookup::food_token_by_idx(color_ostream& out, organic_mat_category::organic_mat_category mat_category, std::vector<int16_t>::size_type idx) {
-    FoodMat food_mat;
-    food_mat_by_idx(out, mat_category, idx, food_mat);
+std::string OrganicMatLookup::food_token_by_idx(color_ostream& out, const FoodMat& food_mat) {
     if (food_mat.material.isValid()) {
         return food_mat.material.getToken();
     }
@@ -62,11 +60,11 @@ void OrganicMatLookup::food_build_map() {
     df::special_mat_table table = raws.mat_table;
     using df::enums::organic_mat_category::organic_mat_category;
     using traits = df::enum_traits<organic_mat_category>;
-    for (int32_t mat_category = traits::first_item_value; mat_category <= traits::last_item_value; ++mat_category) {
+    for (int32_t mat_category = 0; mat_category <= traits::last_item_value; ++mat_category) {
         for (size_t i = 0; i < table.organic_indexes[mat_category].size(); ++i) {
             int16_t type = table.organic_types[mat_category].at(i);
             int32_t index = table.organic_indexes[mat_category].at(i);
-            food_index[mat_category].insert(std::make_pair(std::make_pair(type, index), i)); // wtf.. only in c++
+            food_index[mat_category].insert(std::make_pair(std::make_pair(type, index), i));
         }
     }
     index_built = true;

--- a/plugins/stockpiles/OrganicMatLookup.h
+++ b/plugins/stockpiles/OrganicMatLookup.h
@@ -31,7 +31,7 @@ public:
     };
 
     static void food_mat_by_idx(DFHack::color_ostream& out, df::enums::organic_mat_category::organic_mat_category mat_category, std::vector<int16_t>::size_type food_idx, FoodMat& food_mat);
-    static std::string food_token_by_idx(DFHack::color_ostream& out, df::enums::organic_mat_category::organic_mat_category mat_category, std::vector<int16_t>::size_type idx);
+    static std::string food_token_by_idx(DFHack::color_ostream& out, const FoodMat& food_mat);
 
     static size_t food_max_size(df::enums::organic_mat_category::organic_mat_category mat_category);
     static void food_build_map();

--- a/plugins/stockpiles/StockpileSerializer.cpp
+++ b/plugins/stockpiles/StockpileSerializer.cpp
@@ -449,7 +449,9 @@ static bool serialize_list_organic_mat(color_ostream& out, FuncWriteExport add_v
             all = false;
             continue;
         }
-        string token = OrganicMatLookup::food_token_by_idx(out, cat, i);
+        OrganicMatLookup::FoodMat food_mat;
+        OrganicMatLookup::food_mat_by_idx(out, cat, i, food_mat);
+        string token = OrganicMatLookup::food_token_by_idx(out, food_mat);
         if (token.empty()) {
             DEBUG(log, out).print("food mat invalid :(\n");
             continue;
@@ -460,6 +462,24 @@ static bool serialize_list_organic_mat(color_ostream& out, FuncWriteExport add_v
     return all;
 }
 
+static string get_filter_string(color_ostream& out, const OrganicMatLookup::FoodMat& food_mat) {
+    auto str = OrganicMatLookup::food_token_by_idx(out, food_mat);
+    if (auto plant = food_mat.material.plant) {
+        if (plant->flags.is_set(df::plant_raw_flags::DRINK))
+            str += "/brewable";
+        if (plant->flags.is_set(df::plant_raw_flags::MILL))
+            str += "/millable";
+        if (auto mat = food_mat.material.material) {
+            if (mat->flags.is_set(df::material_flags::STRUCTURAL_PLANT_MAT) &&
+                (plant->flags.is_set(df::plant_raw_flags::THREAD) ||
+                 plant->flags.is_set(df::plant_raw_flags::EXTRACT_VIAL) ||
+                 plant->flags.is_set(df::plant_raw_flags::EXTRACT_BARREL)))
+                str += "/processable";
+        }
+    }
+    return str;
+}
+
 static void unserialize_list_organic_mat(color_ostream& out, const char* subcat, bool all, char val, const vector<string>& filters,
         FuncReadImport read_value, size_t list_size, vector<char>& pile_list,
         organic_mat_category::organic_mat_category cat) {
@@ -467,8 +487,9 @@ static void unserialize_list_organic_mat(color_ostream& out, const char* subcat,
     pile_list.resize(num_elems, '\0');
     if (all) {
         for (size_t idx = 0; idx < num_elems; ++idx) {
-            string token = OrganicMatLookup::food_token_by_idx(out, cat, idx);
-            set_filter_elem(out, subcat, filters, val, token, idx, pile_list.at(idx));
+            OrganicMatLookup::FoodMat food_mat;
+            OrganicMatLookup::food_mat_by_idx(out, cat, idx, food_mat);
+            set_filter_elem(out, subcat, filters, val, get_filter_string(out, food_mat), idx, pile_list.at(idx));
         }
         return;
     }
@@ -480,7 +501,9 @@ static void unserialize_list_organic_mat(color_ostream& out, const char* subcat,
             WARN(log, out).print("organic mat index too large! idx[%d] max_size[%zd]\n", idx, num_elems);
             continue;
         }
-        set_filter_elem(out, subcat, filters, val, token, idx, pile_list.at(idx));
+        OrganicMatLookup::FoodMat food_mat;
+        OrganicMatLookup::food_mat_by_idx(out, cat, idx, food_mat);
+        set_filter_elem(out, subcat, filters, val, get_filter_string(out, food_mat), idx, pile_list.at(idx));
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/5248

Also fixes a crash introduced with the new NONE enum value. We were using the enum range to index an array, and NONE is -1