### PR TITLE
`Military::removeFromSquad`: Add missing history event when unassigning officer

### DIFF
--- a/docs/about/Authors.rst
+++ b/docs/about/Authors.rst
@@ -158,6 +158,7 @@ NotRexButCaesar         NotRexButCaesar
 Nuno Fernandes          UnknowableCoder
 nuvu                    vallode
 Omniclasm
+Ong Ying Gao            ong-yinggao98
 oorzkws                 oorzkws
 OwnageIsMagic           OwnageIsMagic
 palenerd                dlmarquis

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1991,8 +1991,9 @@ Military module
   Removes a unit from its squad. Unsets the unit's
   military information (i.e., ``unit.military.squad_id`` and
   ``unit.military.squad_pos``), the squad's position information (i.e.,
-  ``squad.positions[squad_pos].occupant``), and modifies the unit's entity links
-  to indicate former squad membership or command.
+  ``squad.positions[squad_pos].occupant``), modifies the unit's entity links
+  to indicate former squad membership or command, and creates a corresponding
+  world history event.
 
 Items module
 ------------

--- a/library/modules/Military.cpp
+++ b/library/modules/Military.cpp
@@ -395,7 +395,7 @@ static void remove_officer_entity_link(df::historical_figure* hf, df::squad* squ
 
     hf->entity_links.push_back(former_pos);
 
-    int32_t event_id = *df::global::hist_event_next_id;
+    int32_t event_id = (*df::global::hist_event_next_id)++;
     auto former_pos_event = df::allocate<df::history_event_remove_hf_entity_linkst>();
     former_pos_event->year = *df::global::cur_year;
     former_pos_event->seconds = *df::global::cur_year_tick;
@@ -406,7 +406,6 @@ static void remove_officer_entity_link(df::historical_figure* hf, df::squad* squ
     former_pos_event->link_type = df::histfig_entity_link_type::POSITION;
 
     df::global::world->history.events.push_back(former_pos_event);
-    *df::global::hist_event_next_id = event_id + 1;
 }
 
 bool Military::removeFromSquad(int32_t unit_id)

--- a/library/modules/Military.cpp
+++ b/library/modules/Military.cpp
@@ -392,7 +392,7 @@ static void remove_officer_entity_link(df::historical_figure* hf, df::squad* squ
     former_pos->start_year = start_year;
     former_pos->end_year = *df::global::cur_year;
     former_pos->link_strength = 100;
-    
+
     hf->entity_links.push_back(former_pos);
 
     int32_t event_id = *df::global::hist_event_next_id;
@@ -404,7 +404,7 @@ static void remove_officer_entity_link(df::historical_figure* hf, df::squad* squ
     former_pos_event->histfig = hf->id;
     former_pos_event->position_id = pos_id;
     former_pos_event->link_type = df::histfig_entity_link_type::POSITION;
-    
+
     df::global::world->history.events.push_back(former_pos_event);
     *df::global::hist_event_next_id = event_id + 1;
 }


### PR DESCRIPTION
Minor and virtually cosmetic change for consistency's sake.