### PR TITLE
Fix regression in checkFreeTiles

### DIFF
--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -111,7 +111,7 @@ DFHACK_EXPORT bool getCorrectSize(df::coord2d &size, df::coord2d &center,
  * Checks if the tiles are free to be built upon.
  */
 DFHACK_EXPORT bool checkFreeTiles(df::coord pos, df::coord2d size,
-                                  df::building *bld,
+                                  df::building *bld = nullptr,
                                   bool create_ext = false,
                                   bool allow_occupied = false,
                                   bool allow_wall = false,

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -735,10 +735,7 @@ bool Buildings::checkFreeTiles(df::coord pos, df::coord2d size,
                                bool allow_wall,
                                bool allow_flow)
 {
-    CHECK_NULL_POINTER(bld);
-
     bool found_any = false;
-    auto & room = bld->room;
 
     for (int dx = 0; dx < size.x; dx++)
     {
@@ -748,9 +745,9 @@ bool Buildings::checkFreeTiles(df::coord pos, df::coord2d size,
             df::building_extents_type *etile = NULL;
 
             // Exclude using extents
-            if (room.extents)
+            if (bld && bld->room.extents)
             {
-                etile = getExtentTile(room, tile);
+                etile = getExtentTile(bld->room, tile);
                 if (!etile || !*etile)
                     continue;
             }
@@ -784,13 +781,13 @@ bool Buildings::checkFreeTiles(df::coord pos, df::coord2d size,
                 found_any = true;
             else
             {
-                if (!create_ext)
+                if (!bld || !create_ext)
                     return false;
 
-                if (!room.extents)
+                if (!bld->room.extents)
                 {
-                    init_extents(room, pos, size);
-                    etile = getExtentTile(room, tile);
+                    init_extents(bld->room, pos, size);
+                    etile = getExtentTile(bld->room, tile);
                 }
 
                 if (!etile)


### PR DESCRIPTION
This reverts changes requiring the `df::building*` argument not to be null, as it is expected to skip checking using a building's extents when given a nullptr.

Various lua scripts were making use of this method, supplying a nullptr, causing errors such as the one reported [here](https://discord.com/channels/793331351645323264/1017471248567124049/1339056215379935365), which could be triggered by using buildingplan to designate constructions.