### PR TITLE
Fix win console hang

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ Template for new versions:
 - `spectate`: when spectate mode is enabled, left/right arrow will cycle through following next/prevous units
 
 ## Fixes
+- Windows console: fix possible hang if the console returns a too-small window width (for any reason)
 - `createitem`: output items will now end up at look cursor if active
 - `spectate`: don't allow temporarily modified announcement settings to be written to disk when "auto-unpause" mode is enabled
 - `changevein`: fix a crash that could occur when attempting to change a vein into itself

--- a/library/Console-windows.cpp
+++ b/library/Console-windows.cpp
@@ -36,6 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 
+#define NOMINMAX
 #include <windows.h>
 #include <conio.h>
 #include <stdarg.h>
@@ -232,16 +233,13 @@ namespace DFHack
             size_t len = raw_buffer.size();
             int cooked_cursor = raw_cursor;
 
-            while ((plen + cooked_cursor) >= cols)
-            {
-                buf++;
-                len--;
-                cooked_cursor--;
-            }
-            while (plen + len > cols)
-            {
-                len--;
-            }
+            int adj = std::min(plen + cooked_cursor - cols, len);
+            buf += adj;
+            len -= adj;
+            cooked_cursor -= adj;
+
+            int adj2 = std::min(plen + len - cols, len);
+            len -= adj2;
 
             CONSOLE_SCREEN_BUFFER_INFO inf = { 0 };
             GetConsoleScreenBufferInfo(console_out, &inf);


### PR DESCRIPTION
Fix logic that can hang if the reported console window width is less than the prompt width