### PR TITLE
flush cache after mempatch

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2987,7 +2987,7 @@ bool MemoryPatcher::verifyAccess(void *target, size_t count, bool write)
 
         save.push_back(perms);
         perms.write = perms.read = true;
-        if (!p->setPermisions(perms, perms))
+        if (!p->setPermissions(perms, perms))
             return false;
     }
 
@@ -3000,13 +3000,15 @@ bool MemoryPatcher::write(void *target, const void *src, size_t size)
         return false;
 
     memmove(target, src, size);
+
+    p->flushCache(target, size);
     return true;
 }
 
 void MemoryPatcher::close()
 {
     for (size_t i  = 0; i < save.size(); i++)
-        p->setPermisions(save[i], save[i]);
+        p->setPermissions(save[i], save[i]);
 
     save.clear();
     ranges.clear();

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -32,7 +32,6 @@ distribution.
 
 #include <dirent.h>
 #include <errno.h>
-#include <sys/cachectl.h>
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -220,7 +219,7 @@ bool Process::setPermissions(const t_memrange & range,const t_memrange &trgrange
 
 bool Process::flushCache(const void* target, size_t count)
 {
-    return cacheflush(target, count, BCACHE);
+    __builtin___clear_cache((char*)target, (char*)target + count - 1);
 }
 
 

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -220,6 +220,7 @@ bool Process::setPermissions(const t_memrange & range,const t_memrange &trgrange
 bool Process::flushCache(const void* target, size_t count)
 {
     __builtin___clear_cache((char*)target, (char*)target + count - 1);
+    return false; /* assume always succeeds, as the builtin has no return type */
 }
 
 

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -32,6 +32,7 @@ distribution.
 
 #include <dirent.h>
 #include <errno.h>
+#include <sys/cachectl.h>
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -205,7 +206,7 @@ int Process::getPID()
     return getpid();
 }
 
-bool Process::setPermisions(const t_memrange & range,const t_memrange &trgrange)
+bool Process::setPermissions(const t_memrange & range,const t_memrange &trgrange)
 {
     int result;
     int protect=0;
@@ -216,6 +217,12 @@ bool Process::setPermisions(const t_memrange & range,const t_memrange &trgrange)
 
     return result==0;
 }
+
+bool Process::flushCache(const void* target, size_t count)
+{
+    return cacheflush(target, count, BCACHE);
+}
+
 
 // returns -1 on error
 void* Process::memAlloc(const int length)

--- a/library/Process-linux.cpp
+++ b/library/Process-linux.cpp
@@ -220,7 +220,7 @@ bool Process::setPermissions(const t_memrange & range,const t_memrange &trgrange
 bool Process::flushCache(const void* target, size_t count)
 {
     __builtin___clear_cache((char*)target, (char*)target + count - 1);
-    return false; /* assume always succeeds, as the builtin has no return type */
+    return true; /* assume always succeeds, as the builtin has no return type */
 }
 
 

--- a/library/Process-windows.cpp
+++ b/library/Process-windows.cpp
@@ -399,7 +399,7 @@ int Process::getPID()
 }
 
 
-bool Process::setPermisions(const t_memrange & range,const t_memrange &trgrange)
+bool Process::setPermissions(const t_memrange & range,const t_memrange &trgrange)
 {
     DWORD newprotect=0;
     if(trgrange.read && !trgrange.write && !trgrange.execute)newprotect=PAGE_READONLY;
@@ -412,6 +412,11 @@ bool Process::setPermisions(const t_memrange & range,const t_memrange &trgrange)
     result=VirtualProtect((LPVOID)range.start,(char *)range.end-(char *)range.start,newprotect,&oldprotect);
 
     return result;
+}
+
+bool Process::flushCache(const void* target, size_t count)
+{
+    return 0 == FlushInstructionCache(d->my_handle, (LPCVOID)target, count);
 }
 
 void* Process::memAlloc(const int length)

--- a/library/Process-windows.cpp
+++ b/library/Process-windows.cpp
@@ -416,7 +416,7 @@ bool Process::setPermissions(const t_memrange & range,const t_memrange &trgrange
 
 bool Process::flushCache(const void* target, size_t count)
 {
-    return 0 == FlushInstructionCache(d->my_handle, (LPCVOID)target, count);
+    return 0 != FlushInstructionCache(d->my_handle, (LPCVOID)target, count);
 }
 
 void* Process::memAlloc(const int length)

--- a/library/include/MemAccess.h
+++ b/library/include/MemAccess.h
@@ -270,10 +270,13 @@ namespace DFHack
             uint32_t getTickCount();
 
             /// modify permisions of memory range
-            bool setPermisions(const t_memrange & range,const t_memrange &trgrange);
+            bool setPermissions(const t_memrange & range,const t_memrange &trgrange);
 
             /// write a possibly read-only memory area
             bool patchMemory(void *target, const void* src, size_t count);
+
+            /// flush cache
+            bool flushCache(const void* target, size_t count);
 
             /// allocate new memory pages for code or stuff
             /// returns -1 on error (0 is a valid address)


### PR DESCRIPTION
This adds code to flush cache after applying a hotpatch. While it's unlikely that a patched location will be in cache at the time we apply a patch, it is better to be safe than sorry

Also fixed the spelling error in `setPermissions` while I was here

No changelog; this is a fix to existing functionality to avoid a potential future bug instead of fixing a known existing one
