### PR TITLE
add type identity for `std::filesystem::path`

### DIFF
--- a/library/DataIdentity.cpp
+++ b/library/DataIdentity.cpp
@@ -38,6 +38,7 @@ namespace df {
 
     const bool_identity identity_traits<bool>::identity;
     const stl_string_identity identity_traits<std::string>::identity;
+    const path_identity identity_traits<std::filesystem::path>::identity;
     const ptr_string_identity identity_traits<char*>::identity;
     const ptr_string_identity identity_traits<const char*>::identity;
     const pointer_identity identity_traits<void*>::identity;

--- a/library/LuaTypes.cpp
+++ b/library/LuaTypes.cpp
@@ -188,6 +188,24 @@ void df::stl_string_identity::lua_write(lua_State *state, int fname_idx, void *p
     *(std::string*)ptr = std::string(bytes, size);
 }
 
+void df::path_identity::lua_read(lua_State* state, int fname_idx, void* ptr) const
+{
+    auto ppath = (std::filesystem::path*)ptr;
+    auto str = ppath->u8string();
+    lua_pushlstring(state, (char*)str.data(), str.size());
+}
+
+void df::path_identity::lua_write(lua_State* state, int fname_idx, void* ptr, int val_index) const
+{
+    size_t size;
+    const char* bytes = lua_tolstring(state, val_index, &size);
+    if (!bytes)
+        field_error(state, fname_idx, "path expected", "write");
+
+    std::u8string str((char8_t*)bytes, size);
+    *(std::filesystem::path*)ptr = std::filesystem::path(str);
+}
+
 void df::pointer_identity::lua_read(lua_State *state, int fname_idx, void *ptr, const type_identity *target)
 {
     push_object_internal(state, target, *(void**)ptr);

--- a/library/LuaWrapper.cpp
+++ b/library/LuaWrapper.cpp
@@ -49,7 +49,7 @@ using namespace DFHack::LuaWrapper;
 /**
  * Report an error while accessing a field (index = field name).
  */
-void LuaWrapper::field_error(lua_State *state, int index, const char *err, const char *mode)
+[[noreturn]] void LuaWrapper::field_error(lua_State *state, int index, const char *err, const char *mode)
 {
     if (lua_islightuserdata(state, UPVAL_METATABLE))
         lua_pushstring(state, "(global)");

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -34,6 +34,7 @@ distribution.
 #include <variant>
 #include <vector>
 #include <variant>
+#include <filesystem>
 
 #include "DataDefs.h"
 
@@ -297,6 +298,24 @@ namespace df
         virtual void lua_read(lua_State *state, int fname_idx, void *ptr) const;
         virtual void lua_write(lua_State *state, int fname_idx, void *ptr, int val_index) const;
     };
+
+    class DFHACK_EXPORT path_identity : public DFHack::constructed_identity {
+    public:
+        path_identity()
+            : constructed_identity(sizeof(std::filesystem::path), &allocator_fn<std::filesystem::path>)
+        {
+        };
+
+        const std::string getFullName() const { return "path"; }
+
+        virtual DFHack::identity_type type() const { return DFHack::IDTYPE_PRIMITIVE; }
+
+        virtual bool isPrimitive() const { return true; }
+
+        virtual void lua_read(lua_State* state, int fname_idx, void* ptr) const;
+        virtual void lua_write(lua_State* state, int fname_idx, void* ptr, int val_index) const;
+    };
+
 
     class DFHACK_EXPORT stl_ptr_vector_identity : public ptr_container_identity {
     public:
@@ -616,6 +635,11 @@ namespace df
         static const stl_string_identity *get() { return &identity; }
     };
 
+    template<> struct DFHACK_EXPORT identity_traits<std::filesystem::path> {
+        static const bool is_primitive = true;
+        static const path_identity identity;
+        static const path_identity* get() { return &identity; }
+    };
     template<> struct DFHACK_EXPORT identity_traits<char*> {
         static const bool is_primitive = true;
         static const ptr_string_identity identity;

--- a/library/include/LuaWrapper.h
+++ b/library/include/LuaWrapper.h
@@ -142,7 +142,7 @@ namespace LuaWrapper {
     /**
     * Report an error while accessing a field (index = field name).
     */
-    void field_error(lua_State *state, int index, const char *err, const char *mode);
+    [[noreturn]] void field_error(lua_State *state, int index, const char *err, const char *mode);
 
     /*
      * If is_method is true, these use UPVAL_TYPETABLE to save a hash lookup.


### PR DESCRIPTION
This PR adds a type identity for `std::filesystem::path`, which is expected to be used in the upcoming experimental DF release and thus needs to be supported by the type identity system

This does not add support for paths to codegen; that needs to be done separately

The type added is _not_ opaque; paths will be converting to Lua strings _in UTF-8 encoding_, and a Lua string will be converted to a path _assuming UTF-8 encoding_. Note that it is the developer's responsibility to convert CP437 to UTF-8, if necessary. Do _not_ use CP-1252 or UCS-2 (wide) encoding, even on Windows; the type wrapper will take care of converting UTF-8 to UCS-2 on Windows platforms.