### PR TITLE
[overlay] reset draw context between rendering widgets

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -65,6 +65,7 @@ Template for new versions:
 - `createitem`: output items will now end up at look cursor if active
 - `spectate`: don't allow temporarily modified announcement settings to be written to disk when "auto-unpause" mode is enabled
 - `changevein`: fix a crash that could occur when attempting to change a vein into itself
+- `overlay`: reset draw context between rendering widgets so context changes can't propagate from widget to widget
 
 ## Misc Improvements
 - `spectate`: player-set configuration is now stored globally instead of per-fort

--- a/plugins/lua/overlay.lua
+++ b/plugins/lua/overlay.lua
@@ -538,16 +538,16 @@ function feed_viewscreen_widgets(vs_name, vs, keys)
     return true
 end
 
-local function _render_viewscreen_widgets(vs_name, vs, full_dc, scaled_dc)
+local function _render_viewscreen_widgets(vs_name, vs)
     local vs_widgets = active_viewscreen_widgets[vs_name]
     if not vs_widgets then return end
     local full, scaled = get_interface_rects()
-    full_dc = full_dc or gui.Painter.new(full)
-    scaled_dc = scaled_dc or gui.Painter.new(scaled)
     for _,db_entry in pairs(vs_widgets) do
         local w = db_entry.widget
         if (not vs or matches_focus_strings(db_entry, vs_name, vs)) and utils.getval(w.visible) then
-            detect_frame_change(w, function() w:render(w.fullscreen and full_dc or scaled_dc) end)
+            detect_frame_change(w, function()
+                w:render(w.fullscreen and gui.Painter.new(full) or gui.Painter.new(scaled))
+            end)
         end
     end
     return full_dc, scaled_dc
@@ -556,8 +556,8 @@ end
 local force_refresh
 
 function render_viewscreen_widgets(vs_name, vs)
-    local full_dc, scaled_dc = _render_viewscreen_widgets(vs_name, vs, nil, nil)
-    _render_viewscreen_widgets('all', nil, full_dc, scaled_dc)
+    _render_viewscreen_widgets(vs_name, vs)
+    _render_viewscreen_widgets('all', nil)
     if force_refresh then
         force_refresh = nil
         df.global.gps.force_full_display_count = 1


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/5291