### PR TITLE
spectate.lua: add "hold-to-show" option (f.e. `ctrl`)

### DIFF
--- a/docs/plugins/spectate.rst
+++ b/docs/plugins/spectate.rst
@@ -35,7 +35,7 @@ Usage
 
     enable spectate
     spectate [status]
-    spectate toggle <setting>
+    spectate toggle [<setting>]
     spectate set <setting> <value> [<subvalue>]
     spectate overlay enable|disable
 

--- a/docs/plugins/spectate.rst
+++ b/docs/plugins/spectate.rst
@@ -37,6 +37,7 @@ Usage
     spectate [status]
     spectate toggle
     spectate set <setting> <value> [<subvalue>]
+    spectate toggle <setting>
     spectate overlay enable|disable
 
 Examples
@@ -67,6 +68,9 @@ Examples
     Abbreviate the names of "Store item in stockpile" jobs to just "Store" when the
     job is displayed in the `spectate` tooltips. See the
     ``tooltip-follow-job-shortenings`` setting below for details.
+
+``spectate toggle tooltip-follow``
+    Toggle the follow tooltips on or off.
 
 Settings
 --------
@@ -109,6 +113,12 @@ Settings
 ``tooltip-follow-blink-milliseconds`` (default: 3000)
     If the ``spectate.tooltip`` overlay is enabled, set the tooltip's blink
     duration in milliseconds. Set to 0 to always show.
+
+``tooltip-follow-hold-to-show`` (default: none)
+    If the ``spectate.tooltip`` overlay is enabled, specifies a modifier key
+    (one of none, ctrl, alt, or shift) that has to be hold to show the tooltips
+    that follow onscreen dwarves around the map. This supersedes the
+    ``tooltip-follow-blink-milliseconds`` option.
 
 ``tooltip-follow-job`` (default: enabled)
     If the ``spectate.tooltip`` overlay is enabled, toggle whether to show the

--- a/docs/plugins/spectate.rst
+++ b/docs/plugins/spectate.rst
@@ -35,9 +35,8 @@ Usage
 
     enable spectate
     spectate [status]
-    spectate toggle
-    spectate set <setting> <value> [<subvalue>]
     spectate toggle <setting>
+    spectate set <setting> <value> [<subvalue>]
     spectate overlay enable|disable
 
 Examples
@@ -116,7 +115,7 @@ Settings
 
 ``tooltip-follow-hold-to-show`` (default: none)
     If the ``spectate.tooltip`` overlay is enabled, specifies a modifier key
-    (one of none, ctrl, alt, or shift) that has to be hold to show the tooltips
+    (one of none, ctrl, alt, or shift) that has to be held to show the tooltips
     that follow onscreen dwarves around the map. This supersedes the
     ``tooltip-follow-blink-milliseconds`` option.
 

--- a/plugins/lua/spectate.lua
+++ b/plugins/lua/spectate.lua
@@ -27,6 +27,7 @@ local function get_default_state()
         ['prefer-new-arrivals']=true,
         ['tooltip-follow']=true,
         ['tooltip-follow-blink-milliseconds']=3000,
+        ['tooltip-follow-hold-to-show']='none', -- one of none, ctrl, alt, or shift
         ['tooltip-follow-job']=true,
         ['tooltip-follow-job-shortenings'] = {
             ["Store item in stockpile"] = "Store item",
@@ -407,13 +408,20 @@ end
 function TooltipOverlay:render_unit_banners(dc)
     if not (config['tooltip-follow'] and AnyFollowOptionOn()) then return end
 
-    local blink_duration = config['tooltip-follow-blink-milliseconds']
-    if blink_duration > 0 and not gui.blink_visible(blink_duration) then
-        return
-    end
+    local hold_to_show = config['tooltip-follow-hold-to-show']
+    if hold_to_show and hold_to_show ~= 'none' then
+        if not dfhack.internal.getModifiers()[hold_to_show] then
+            return
+        end
+    else
+        local blink_duration = config['tooltip-follow-blink-milliseconds']
+        if blink_duration > 0 and not gui.blink_visible(blink_duration) then
+            return
+        end
 
-    if not dfhack.screen.inGraphicsMode() and not gui.blink_visible(500) then
-        return
+        if not dfhack.screen.inGraphicsMode() and not gui.blink_visible(500) then
+            return
+        end
     end
 
     local vp = df.global.world.viewport

--- a/plugins/lua/spectate.lua
+++ b/plugins/lua/spectate.lua
@@ -210,7 +210,11 @@ local function set_setting(args)
         -- here just in case, is already checked in the loop above
         qerror('missing value for ' .. path)
     elseif entry_type == 'boolean' then
-        value = argparse.boolean(value, path)
+        if value == 'toggle' then
+            value = not cfg[key]
+        else
+            value = argparse.boolean(value, path)
+        end
     elseif entry_type == 'number' then
         if path == 'follow-seconds' then
             value = argparse.positiveInt(value, path)
@@ -241,7 +245,12 @@ function parse_commandline(args)
     if not command or command == 'status' then
         print_status()
     elseif command == 'toggle' then
-        do_toggle()
+        if #args == 0 then
+            do_toggle()
+        else
+            args[#args+1] = 'toggle'
+            set_setting(args)
+        end
     elseif command == 'set' then
         set_setting(args)
     elseif command == 'overlay' then


### PR DESCRIPTION
Also, add a `toggle <setting>` command line for boolean settings. This allows keybindings for `spectate toggle tooltip-follow`.