### PR TITLE
[suspendmanager] don't show suspend overlay when other ui panels are up

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 - `spectate`: don't allow temporarily modified announcement settings to be written to disk when "auto-unpause" mode is enabled
 - `changevein`: fix a crash that could occur when attempting to change a vein into itself
 - `overlay`: reset draw context between rendering widgets so context changes can't propagate from widget to widget
+- `suspendmanager`: in ASCII mode, building planning mode overlay now only displays when viewing the default map, reducing issues with showing through the UI
 
 ## Misc Improvements
 - `spectate`: player-set configuration is now stored globally instead of per-fort

--- a/plugins/lua/suspendmanager.lua
+++ b/plugins/lua/suspendmanager.lua
@@ -140,12 +140,18 @@ if not ok then
     buildingplan = nil
 end
 
+local function show_suspend_overlay()
+    return dfhack.screen.inGraphicsMode() or
+        dfhack.gui.matchFocusString('dwarfmode/Default', dfhack.gui.getDFViewscreen(true))
+end
+
 SuspendOverlay = defclass(SuspendOverlay, overlay.OverlayWidget)
 SuspendOverlay.ATTRS{
     desc='Annotates suspended buildings with a visible marker.',
     viewscreens='dwarfmode',
     default_enabled=true,
     frame={w=0, h=0},
+    visible=show_suspend_overlay,
     overlay_onupdate_max_freq_seconds=30,
 }
 


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/3560

though it can be improved further by not letting it draw on static UI elements, like the top and bottom of the screen, the minimap, or the squads panel (when it is open)