### PR TITLE
deal with directory separators cleanly

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3207,7 +3207,12 @@ static int filesystem_listdir_recursive(lua_State *L)
         lua_pushinteger(L, i++);
         lua_newtable(L);
         lua_pushstring(L, "path");
-        lua_pushstring(L, (it->first).string().c_str());
+        auto p = (it->first).string();
+        if constexpr (std::filesystem::path::preferred_separator != '/')
+        {
+            std::ranges::replace(p, std::filesystem::path::preferred_separator, '/');
+        }
+        lua_pushstring(L, p.c_str());
         lua_settable(L, -3);
         lua_pushstring(L, "isdir");
         lua_pushboolean(L, it->second);


### PR DESCRIPTION
dfhack assumes that scripts are in a namespace in which directories are separated by slashes, and also that pathnames will be slash-separated

this enforces that when the transition is made from a `std::filesystem::path` to dfhack's internal script name space, the native preferred path separator (whatever it is) is replaced with slashes if it isn't already

followup to #5356 