### PR TITLE
more path/string normalization

### DIFF
--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3207,12 +3207,7 @@ static int filesystem_listdir_recursive(lua_State *L)
         lua_pushinteger(L, i++);
         lua_newtable(L);
         lua_pushstring(L, "path");
-        auto p = (it->first).string();
-        if constexpr (std::filesystem::path::preferred_separator != '/')
-        {
-            std::ranges::replace(p, std::filesystem::path::preferred_separator, '/');
-        }
-        lua_pushstring(L, p.c_str());
+        lua_pushstring(L, Filesystem::as_string(it->first).c_str());
         lua_settable(L, -3);
         lua_pushstring(L, "isdir");
         lua_pushboolean(L, it->second);

--- a/library/include/modules/Filesystem.h
+++ b/library/include/modules/Filesystem.h
@@ -55,25 +55,34 @@ SOFTWARE.
 
 namespace DFHack {
     namespace Filesystem {
-        DFHACK_EXPORT void init ();
-        DFHACK_EXPORT bool chdir (std::filesystem::path path) noexcept;
-        DFHACK_EXPORT std::filesystem::path getcwd ();
-        DFHACK_EXPORT bool restore_cwd ();
-        DFHACK_EXPORT std::filesystem::path get_initial_cwd ();
-        DFHACK_EXPORT bool mkdir (std::filesystem::path path) noexcept;
+        DFHACK_EXPORT void init();
+        DFHACK_EXPORT bool chdir(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT std::filesystem::path getcwd();
+        DFHACK_EXPORT bool restore_cwd();
+        DFHACK_EXPORT std::filesystem::path get_initial_cwd();
+        DFHACK_EXPORT bool mkdir(std::filesystem::path path) noexcept;
         // returns true on success or if directory already exists
-        DFHACK_EXPORT bool mkdir_recursive (std::filesystem::path path) noexcept;
-        DFHACK_EXPORT bool rmdir (std::filesystem::path path) noexcept;
-        DFHACK_EXPORT bool stat (std::filesystem::path path, std::filesystem::file_status &info) noexcept;
-        DFHACK_EXPORT bool exists (std::filesystem::path path) noexcept;
-        DFHACK_EXPORT bool isfile (std::filesystem::path path) noexcept;
-        DFHACK_EXPORT bool isdir (std::filesystem::path path) noexcept;
-        DFHACK_EXPORT std::time_t mtime (std::filesystem::path path) noexcept;
-        DFHACK_EXPORT int listdir (std::filesystem::path dir, std::vector<std::filesystem::path> &files) noexcept;
+        DFHACK_EXPORT bool mkdir_recursive(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT bool rmdir(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT bool stat(std::filesystem::path path, std::filesystem::file_status& info) noexcept;
+        DFHACK_EXPORT bool exists(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT bool isfile(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT bool isdir(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT std::time_t mtime(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT int listdir(std::filesystem::path dir, std::vector<std::filesystem::path>& files) noexcept;
         // set include_prefix to false to prevent dir from being prepended to
         // paths returned in files
-        DFHACK_EXPORT int listdir_recursive (std::filesystem::path dir, std::map<std::filesystem::path, bool> &files,
+        DFHACK_EXPORT int listdir_recursive(std::filesystem::path dir, std::map<std::filesystem::path, bool>& files,
             int depth = 10, bool include_prefix = true) noexcept;
         DFHACK_EXPORT std::filesystem::path canonicalize(std::filesystem::path p) noexcept;
+        inline std::string as_string(std::filesystem::path path) noexcept
+        {
+            auto pStr = path.string();
+            if constexpr (std::filesystem::path::preferred_separator != '/')
+            {
+                std::ranges::replace(pStr, std::filesystem::path::preferred_separator, '/');
+            }
+            return pStr;
+        }
     }
 }

--- a/plugins/orders.cpp
+++ b/plugins/orders.cpp
@@ -153,7 +153,7 @@ static void list_library(color_ostream &out) {
         if (name.extension() != ".json")
             continue; // skip non-.json files
         auto sname = name.stem();
-        out << "library/" << sname << std::endl;
+        out << Filesystem::as_string("library" / sname) << std::endl;
     }
 }
 
@@ -172,7 +172,7 @@ static command_result orders_list_command(color_ostream & out)
         if (name.extension() != ".json")
             continue; // skip non-.json files
         auto sname = name.stem();
-        out << sname << std::endl;
+        out << sname.string() << std::endl;
     }
 
     list_library(out);


### PR DESCRIPTION
added `Filesystem::as_string` to provide namespace recanonicalization and change use in LuaApi to use this exported API

use `as_string` in `orders`

further revision of #5360 
