### PR TITLE
[sort] fix barony overlay

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- Fix processing error in the overlay that displays unit preferences in the baron selection list
 
 ## Misc Improvements
 

--- a/plugins/lua/sort/diplomacy.lua
+++ b/plugins/lua/sort/diplomacy.lua
@@ -64,7 +64,7 @@ local function get_preferences(unit)
     if not unit then return {} end
     local preferences = {}
     for _, pref in ipairs(unit.status.current_soul.preferences) do
-        if pref.type == df.unitpref_type.LikeItem and pref.active then
+        if pref.type == df.unitpref_type.LikeItem and pref.flags.visible then
             table.insert(preferences, make_item_description(pref.item_type, pref.item_subtype))
         end
     end


### PR DESCRIPTION
adapt to structure changes (pref.active is now pref.flags.visible)

Fixes: https://github.com/DFHack/dfhack/issues/5350