### PR TITLE
[stockpiles] fix conversion of enum token to value

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `stockpiles`: fix one-off error in item type when importing furniture stockpile settings
 
 ## Misc Improvements
 - `spectate`: show dwarves' activities (like prayer)


### PR DESCRIPTION
was not correctly handling enums that did not start at 0, leading to errors in furniture stockpiles

Fixes: https://github.com/DFHack/dfhack/issues/5275
