### PR TITLE
[Units::teleport] remove projectile data when teleporting

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 - `stockpiles`: fix one-off error in item type when importing furniture stockpile settings
 - `dig-now`: fix cases where boulders/rough gems of incorrect material were being generated when digging through walls
 - `dig-now`: properly generate ice boulders when digging through ice walls
+- `gui/teleport`: now properly handles teleporting units that are currently falling or being flung
 
 ## Misc Improvements
 - `spectate`: show dwarves' activities (like prayer)
@@ -67,6 +68,7 @@ Template for new versions:
 
 ## API
 - ``Military`` module: added ``addToSquad`` function
+- ``Units::teleport``: projectile information is now cleared for teleported units
 
 ## Lua
 - ``dfhack.military.addToSquad``: expose Military API function

--- a/library/include/BitArray.h
+++ b/library/include/BitArray.h
@@ -318,6 +318,22 @@ namespace DFHack
                 return cur->item;
             }
 
+            I * operator->()
+            {
+                CHECK_NULL_POINTER(root);
+                CHECK_NULL_POINTER(cur);
+
+                return cur->item;
+            }
+
+            I * operator->() const
+            {
+                CHECK_NULL_POINTER(root);
+                CHECK_NULL_POINTER(cur);
+
+                return cur->item;
+            }
+
             operator const_iterator() const
             {
                 return const_iterator(*this);

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -309,24 +309,43 @@ Link *linked_list_insert_after(Link *pos, Link *link)
 }
 
 /**
- * Returns true if the item with id idToRemove was found, deleted, and removed
- * from the list. Otherwise returns false.
+ * Returns true if an item that matches the given function was found, deleted,
+ * and removed from the list. Otherwise returns false. Only removes the first
+ * match.
+ *
+ * Example usage:
+ *
+ *  linked_list_remove(&world->projectiles.all, [&](df::projectile *proj) {
+ *      if (proj->getType() != df::enums::projectile_type::Unit)
+ *          return false;
+ *      if (auto unit_proj = virtual_cast<df::proj_unitst>(proj))
+ *          return unit_proj->unit == unit;
+ *      return false;
+ *  });
  */
-template<typename Link>
-bool linked_list_remove(Link *head, int32_t idToRemove)
-{
-    for (Link *link = head; link; link = link->next)
-    {
-        if (!link->item || link->item->id != idToRemove)
-            continue;
+template <typename L, typename V = L::iterator::value_type, std::invocable<V> F>
+bool linked_list_remove(L *list, F matches) {
+    auto matches_wrapper = [&](L::iterator::value_type item) {
+        return item && matches(item);
+    };
+    auto it = std::find_if(list->begin(), list->end(), matches_wrapper);
+    if (it == list->end())
+        return false;
+    auto item = *it;
+    list->erase(it);
+    delete item;
+    return true;
+}
 
-        link->prev->next = link->next;
-        if (link->next)
-            link->next->prev = link->prev;
-        delete(link);
-        return true;
-    }
-    return false;
+/**
+ * Returns true if the item with id idToRemove was found, deleted, and
+ * removed from the list. Otherwise returns false.
+ */
+template<typename L>
+bool linked_list_remove(L *list, int32_t idToRemove) {
+    return linked_list_remove(list, [&](L::iterator::value_type item) {
+        return item->id == idToRemove;
+    });
 }
 
 template<typename T>

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -328,8 +328,8 @@ bool linked_list_remove(L *list, F matches) {
     auto matches_wrapper = [&](L::iterator::value_type item) {
         return item && matches(item);
     };
-    auto it = std::find_if(list->begin(), list->end(), matches_wrapper);
-    if (it == list->end())
+    typename L::const_iterator it = std::find_if(list->cbegin(), list->cend(), matches_wrapper);
+    if (it == list->cend())
         return false;
     auto item = *it;
     list->erase(it);

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -67,6 +67,7 @@ distribution.
 #include "df/nemesis_record.h"
 #include "df/personality_goalst.h"
 #include "df/plotinfost.h"
+#include "df/proj_unitst.h"
 #include "df/reputation_profilest.h"
 #include "df/syndrome.h"
 #include "df/tile_occupancy.h"
@@ -772,6 +773,18 @@ bool Units::teleport(df::unit *unit, df::coord target_pos)
         old_occ->bits.unit_grounded = false;
     else
         old_occ->bits.unit = false;
+
+    // Clear unit projectile info
+    if (unit->flags1.bits.projectile) {
+        unit->flags1.bits.projectile = false;
+        linked_list_remove(&world->projectiles.all, [&](df::projectile *proj) {
+            if (proj->getType() != df::enums::projectile_type::Unit)
+                return false;
+            if (auto unit_proj = virtual_cast<df::proj_unitst>(proj))
+                return unit_proj->unit == unit;
+            return false;
+        });
+    }
 
     // If there's already somebody standing at the destination, then force the unit to lay down
     if (new_occ->bits.unit)


### PR DESCRIPTION
otherwise they will be teleported back to their next projectile targeted tile on the next tick

Includes an extension of the DFLinkedList API (was missing operator->) and a refactoring of linked_list_remove so it can take a predicate

Fixes: https://github.com/DFHack/dfhack/issues/5381