### PR TITLE
[spectate] don't show hover tooltip for hidden creatures

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `spectate`: don't show a hover tooltip for hidden units (e.g. invisible snatchers)
 - `stockpiles`: fix one-off error in item type when importing furniture stockpile settings
 - `dig-now`: fix cases where boulders/rough gems of incorrect material were being generated when digging through walls
 - `dig-now`: properly generate ice boulders when digging through ice walls

--- a/plugins/lua/spectate.lua
+++ b/plugins/lua/spectate.lua
@@ -345,11 +345,15 @@ local function GetUnitInfoText(unit, settings_group_name)
     return txt
 end
 
+local function unit_filter(unit)
+    return not dfhack.units.isHidden(unit)
+end
+
 local function GetHoverText(pos)
     if not pos then return end
 
     local txt = {}
-    local units = dfhack.units.getUnitsInBox(pos, pos) or {} -- todo: maybe (optionally) use filter parameter here?
+    local units = dfhack.units.getUnitsInBox(pos, pos, unit_filter) or {}
 
     for _,unit in ipairs(units) do
         local info = GetUnitInfoText(unit, 'hover')


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/5379
