### PR TITLE
New `gui.dflayout` module to provide position information for DF UI elements; starting with fort mode toolbars

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -70,6 +70,7 @@ Template for new versions:
 
 ## Lua
 - ``dfhack.military.addToSquad``: expose Military API function
+- ``gui.dflayout``: provide DF fort mode toolbar position information
 
 ## Removed
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -6516,6 +6516,130 @@ Example usage::
   local first_border_texpos = textures.tp_border_thin(1)
 
 
+gui.dflayout
+============
+
+This module provides position information for DF UI elements that are not always
+straightforward to calculate.
+
+It currently only describes the fortress mode toolbars at the bottom of the
+screen.
+
+Unless otherwise noted, the dimensions used by this module are in UI tiles and
+offsets are from the boundaries of the (caller provided) interface area.
+
+General Constants
+-----------------
+
+The module provides these convenience constants:
+
+* ``MINIMUM_INTERFACE_SIZE``
+
+  The dimensions (``width`` and ``height``) of the minimum-size DF window:
+  114x46 UI tiles. Other fields may also be present, but they are not used by
+  this module.
+
+* ``TOOLBAR_HEIGHT``
+
+  The height of the primary toolbars at the bottom of the DF window (3 rows).
+
+* ``SECONDARY_TOOLBAR_HEIGHT``
+
+  The height of the secondary toolbars that are sometimes placed above the
+  primary toolbars (also 3 rows).
+
+Fortress Mode Toolbars
+----------------------
+
+Fortress mode DF draws three primary toolbars and (depending on whether a "tool"
+is active) possibly one of several secondary toolbars at the bottom of the
+interface area.
+
+The toolbar descriptions are available through these module fields:
+
+* ``fort.toolbars.left``
+* ``fort.toolbars.center``
+* ``fort.toolbars.right``
+
+The descriptions of the secondary toolbars are available through the fields of
+``fort.secondary_toolbars``:
+
+* ``dig``, ``chop``, ``gather``, ``smooth``, ``erase``, ``stockpile``,
+  ``stockpile_paint``, ``burrow_paint``, ``traffic``, and ``mass_designation``
+
+The DF build menu (which is displayed in mostly the same place and activated in
+the same way as the other secondary toolbars) is not currently supported. It has
+significant differences from the other secondary toolbars.
+
+Each toolbar description table has these fields:
+
+* ``width`` the width of the toolbar
+* ``buttons`` a table indexed by "button names" that provides info about
+  individual buttons:
+
+  * ``offset`` the left-offset from left edge of the toolbar
+  * ``width`` the width of the button
+
+  Please consult the module source for each toolbar's button names.
+
+* ``frame(interface_size)`` a function that calculates the placement of the
+  toolbar when drawn in an interface of the specified size
+
+  The ``interface_size`` should be a table with ``width`` and ``height`` fields.
+  Common size sources include the ``parent_rect`` parameter passed to a
+  non-fullscreen overlay widget's layout methods (``updateLayout``, etc.), and
+  the interface area returned from ``gui.get_interface_rect()``).
+
+  The return value is a table with the following fields:
+
+  * ``l``, ``r``, ``t``, ``b``: the column/row offsets to the toolbar from the
+    edges of the interface area
+  * ``w``, ``h``: the size of the toolbar (``w`` is the same as ``toolbar.width``)
+
+  ``l + w + r`` and ``t + h + b`` will equal the provided interface's width and
+  height, respectively.
+
+  This table "shape" is similar to a `Widget <Widget class_>`_'s ``frame`` and
+  should be useful in positioning a DFHack widget relative to the toolbar.
+
+Fort toolbar examples:
+
+  * The ends of a toolbar can be located by combining the offset and size data
+    from a toolbar's frame data::
+
+      local layout = require('gui.dflayout')
+      ...
+      local erase_frame = layout.fort.secondary_toolbars.erase.frame(interface_size)
+      local erase_right_l_offset = erase_frame.l + erase_frame.w
+      local erase_left_r_offset = erase_frame.r + erase_frame.w
+
+      -- interface_size.width |--------------------------|
+      --        erase_frame.l |----------          ------| erase_frame.r
+      --                      |          [erase tb]      |
+      --        erase_frame.w |          ----------      |
+      -- erase_right_l_offset |--------------------      |
+      --                      |          ----------------| erase_left_r_offset
+
+  * A specific toolbar button can be located by combining the toolbar's frame
+    data with the ``offset`` of the button::
+
+      local layout = require('gui.dflayout')
+      ...
+      local dig = layout.fort.secondary_toolbars.dig
+      local dig_frame = dig.frame(interface_size)
+      local dig_adv = dig.buttons.advanced_toggle
+      local dig_adv_l_offset = dig_frame.l + dig_adv.offset
+      local dig_adv_r_offset = dig_frame.r + dig_frame.w - (dig_adv.offset + dig_adv.width)
+      --                    OR interface_size.width - (dig_adv_l_offset + dig_adv.width)
+
+      -- interface_size.width |--------------------------|
+      --          dig_frame.l |----------             ---| dig_frame.r
+      --          dig_frame.w |          -------------   |
+      --       dig_adv.offset |          ------          |
+      --        dig_adv.width |                --        |
+      --                      |          [ dig [] tb ]   |
+      --     dig_adv_l_offset |----------------  --------| dig_adv_r_offset
+
 .. _lua-plugins:
 
 =======

--- a/docs/dev/overlay-dev-guide.rst
+++ b/docs/dev/overlay-dev-guide.rst
@@ -459,3 +459,188 @@ screen (by default, but the player can move it wherever).
             },
         }
     end
+
+Widget example 4: positioning relative to DF UI
+-----------------------------------------------
+
+The player-controllable positioning provided by the overlay framework is
+relative to some corner of the interface area (technically, the positioning is
+edge-relative, but the anchors are always two adjacent edges, so it is
+equivalent to corner-relative positioning). This corner-relative positioning
+works well to adapt overlay positions for interface areas of varying sizes (due
+to DF window size changes, or because the DF interface percentage has been
+reconfigured).
+
+However, some overlays are most useful when they are drawn near a DF UI element
+that does not maintain a fixed offset from any particular corner. For example,
+the central toolbar (i.e., the fort mode tools for designations, etc.) is not
+always at the same offset from either the left or the right interface edges (to
+maintain a centered position, its left and right offsets each (mostly) grow in
+proportion to the width of the interface area). The positions of the "secondary"
+toolbars (that "open from" the central toolbar) are similarly variable (but in a
+slightly more complicated way).
+
+Such an overlay could eschew player-customizable positioning, but giving up that
+flexibility should not be done lightly.
+
+Instead, with some clever manipulation, an overlay's corner-relative positioning
+can be "translated" to be relative to some other point. To simplify the
+following description, only the left component of positioning will be considered
+(example code after the description supports all four directions).
+
+Method
+******
+
+A widget's frame has two values in each direction: an offset and a size. The
+overlay framework sets the offsets (based on the player-controllable position),
+but we can inflate the (effective) size to fine-tune the positioning of the
+overlay's content.
+
+Given
+
+* an overlay with no ``frame_inset`` and a fixed content width
+  (``OVERLAY_WIDTH``),
+* a default left-relative overlay offset (``DEFAULT_L_OFFSET``; this is
+  ``default_pos.x - 1`` for a left-relative (positive) ``default_pos.x``),
+* a player-customized left-relative overlay offset (``DEFAULT_L_OFFSET +
+  PLAYER_L_DELTA()``), and
+* an ideal overlay content left-offset
+  (``ideal_overlay_l_offset(interface_size)``; e.g., derived from some DF UI
+  element whose position varies based on the interface size),
+
+the following are true:
+
+#. The overlay content will be drawn at this left-offset::
+
+        frame.l + frame_inset.l
+
+   We introduce the inset here as a "variable" since the overlay isn't using it
+   and we will need it to correct the position of the overlay's content. If
+   top-level insets are required, they can be added via a Panel that wraps all
+   the content, or by adjusting the final formulas to incorporate extra insets.
+
+#. The overlay system provides the player-customized position through the
+   overlay's ``frame.l`` (adjusted from a one-based position to a zero-based
+   offset)::
+
+        frame.l == DEFAULT_L_OFFSET + PLAYER_L_DELTA()
+
+   Substituting this into the prior expression gives a new left-offset
+   expression for the overlay's content::
+
+        DEFAULT_L_OFFSET + PLAYER_L_DELTA() + frame_inset.l
+
+#. We want the player-customized left-offset to be::
+
+        ideal_overlay_l_offset(interface_size) + PLAYER_L_DELTA()
+
+#. When we equate the customized ideal left-offset expression with the actual
+   left-offset expression, we get::
+
+        DEFAULT_L_OFFSET + PLAYER_L_DELTA() + frame_inset.l == ideal_overlay_l_offset(interface_size) + PLAYER_L_DELTA()
+
+   From which, we can solve for ``frame_inset.l``::
+
+        frame_inset.l == ideal_overlay_l_offset(interface_size) - DEFAULT_L_OFFSET
+
+#. The overlay's frame's width should be the sum of its inset and its content
+   width::
+
+        frame.w == frame_inset.l + OVERLAY_WIDTH
+
+These last two equations are the core of this technique for adapting the
+corner-relative positions provided by the overlay framework into a UI-relative
+overlay content position.
+
+In code, extended to all four directions::
+
+    local overlay = require('plugins.overlay')
+    local Label = require('gui.widgets.labels.label')
+    local layout = require('gui.dflayout')
+
+    local dig_toolbar = layout.fort.secondary_toolbars.dig
+    local dig_dig_button = dig_toolbar.buttons.dig
+
+    local WIDTH = 20
+    local HEIGHT = 1
+
+    local function ideal_overlay_offsets(interface_size)
+        local dig_frame = dig_toolbar.frame(interface_size)
+        -- aligned with the main mining button
+        local l = dig_frame.l + dig_dig_button.offset
+        -- one row higher
+        local t = dig_frame.t - HEIGHT
+        return {
+            l = l,
+            r = interface_size.width - (l + WIDTH),
+            t = t,
+            b = interface_size.height - (t + HEIGHT),
+        }
+    end
+
+    local MINIMUM_OFFSETS = ideal_overlay_offsets(layout.MINIMUM_INTERFACE_SIZE)
+
+    UIRelativeOverlay = defclass(UIRelativeOverlay, overlay.OverlayWidget)
+    UIRelativeOverlay.ATTRS{
+        name = 'Can you dig it?',
+        desc = 'A overlay that has UI-relative positioning.',
+        default_enabled = true,
+        default_pos = { x = MINIMUM_OFFSETS.l + 1, y = -(MINIMUM_OFFSETS.b + 1) },
+        -- frame and frame_inset are managed in preUpdateLayout
+        viewscreens = { 'dwarfmode/Designate/DIG_DIG' },
+    }
+
+    function UIRelativeOverlay:init()
+        self.frame = {}
+        self:addviews{
+            Label{
+                text_pen = { fg = COLOR_BLACK, bg = COLOR_GREY },
+                text = string.char(25):rep(dig_dig_button.width) .. ' I can dig it!',
+            },
+        }
+    end
+
+    function UIRelativeOverlay:preUpdateLayout(parent_rect)
+        local o = ideal_overlay_offsets(parent_rect)
+        local d = {
+            l = math.max(0, o.l - MINIMUM_OFFSETS.l),
+            r = math.max(0, o.r - MINIMUM_OFFSETS.r),
+            t = math.max(0, o.t - MINIMUM_OFFSETS.t),
+            b = math.max(0, o.b - MINIMUM_OFFSETS.b),
+        }
+        self.frame.w = WIDTH + d.l + d.r
+        self.frame.h = HEIGHT + d.t + d.b
+        self.frame_inset = d
+    end
+
+    OVERLAY_WIDGETS = { overlay = UIRelativeOverlay }
+
+``MINIMUM_OFFSETS`` is based on the minimum interface size so that the overlay
+will get zero-sized insets in a minimum size interface area. This lets the
+overlay be positioned anywhere inside a minimum size interface area. The
+``math.max(0, ...)`` is used to make sure an overlay can't be positioned in way that
+places it off-screen when a larger interface is made smaller and the
+``MINIMUM_OFFSETS`` are erroneously not actually the minimums.
+
+Consequences
+************
+
+"Inflating" the overlay size and "floating" the overlay content like this has
+some drawbacks when the interface area is much larger than the minimum size.
+
+* The overlay outlines drawn by `gui/overlay` reflect the inflated size, and
+  thus can grow quite large.
+
+  * When the mouse is over an "inflated" overlay outline, the area will be
+    filled, obscuring a potentially large portion of the interface area.
+
+  * Since the overlay content is inset to "float" inside the inflated overlay
+    size, it can be quite hard to judge where the content will be drawn while an
+    overlay move is in progress. It may take multiple tries to move the overlay
+    content to a particular desired location.
+
+* Because the overlay size is inflated, the available area for positioning the
+  overlay content is effectively reduced. The available area is equivalent to
+  the minimum interface area. The positioning of this area is such that the
+  "ideal" position in the minimum interface area corresponds to the "ideal"
+  position in the larger interface area.

--- a/library/lua/gui/dflayout.lua
+++ b/library/lua/gui/dflayout.lua
@@ -1,0 +1,278 @@
+local _ENV = mkmodule('gui.dflayout')
+
+-- Provide data-driven locations for the DF toolbars at the bottom of the
+-- screen. Not quite as nice as getting the data from DF directly, but better
+-- than hand-rolling calculations for each "interesting" button.
+
+TOOLBAR_HEIGHT = 3
+SECONDARY_TOOLBAR_HEIGHT = 3
+MINIMUM_INTERFACE_SIZE = require('gui').mkdims_wh(0, 0, 114, 46)
+
+-- Only width and height are used here. We could define a new "@class", but
+-- LuaLS doesn't seem to accept gui.dimensions values as compatible with that
+-- new class...
+---@alias DFLayout.Rectangle.Size gui.dimension
+
+---@generic T
+---@param sequences T[][]
+---@return T[]
+local function concat_sequences(sequences)
+    local collected = {}
+    for _, sequence in ipairs(sequences) do
+        table.move(sequence, 1, #sequence, #collected + 1, collected)
+    end
+    return collected
+end
+
+---@alias DFLayout.Toolbar.NamedWidth table<string,integer> -- single entry, value is width
+---@alias DFLayout.Toolbar.NamedOffsets table<string,integer> -- multiple entries, values are offsets
+---@alias DFLayout.Toolbar.Button { offset: integer, width: integer }
+---@alias DFLayout.Toolbar.NamedButtons table<string,DFLayout.Toolbar.Button> -- multiple entries
+
+---@class DFLayout.Widget.frame: widgets.Widget.frame
+---@field l integer Gap between the left edge of the frame and the parent.
+---@field t integer Gap between the top edge of the frame and the parent.
+---@field r integer Gap between the right edge of the frame and the parent.
+---@field b integer Gap between the bottom edge of the frame and the parent.
+---@field w integer Width
+---@field h integer Height
+
+---@class DFLayout.Toolbar.Base
+---@field buttons DFLayout.Toolbar.NamedButtons
+---@field width integer
+
+---@class DFLayout.Toolbar: DFLayout.Toolbar.Base
+---@field frame fun(interface_size: DFLayout.Rectangle.Size): DFLayout.Widget.frame
+
+---@param widths DFLayout.Toolbar.NamedWidth[] single-name entries only!
+---@return DFLayout.Toolbar.Base
+local function button_widths_to_toolbar(widths)
+    local buttons = {}
+    local offset = 0
+    for _, ww in ipairs(widths) do
+        local name, w = next(ww)
+        if name then
+            if not name:startswith('_') then
+                buttons[name] = { offset = offset, width = w }
+            end
+            offset = offset + w
+        end
+    end
+    return { buttons = buttons, width = offset }
+end
+
+---@param buttons string[]
+---@return DFLayout.Toolbar.NamedWidth[]
+local function buttons_to_widths(buttons)
+    local widths = {}
+    for _, button_name in ipairs(buttons) do
+        table.insert(widths, { [button_name] = 4 })
+    end
+    return widths
+end
+
+---@param buttons string[]
+---@return DFLayout.Toolbar.Base
+local function buttons_to_toolbar(buttons)
+    return button_widths_to_toolbar(buttons_to_widths(buttons))
+end
+
+-- Fortress mode toolbar definitions
+fort = {}
+
+---@alias DFLayout.PrimaryToolbarNames 'left' | 'center' | 'right'
+
+---@type table<DFLayout.PrimaryToolbarNames,DFLayout.Toolbar>
+fort.toolbars = {}
+
+---@class DFLayout.Fort.Toolbar.Left: DFLayout.Toolbar
+fort.toolbars.left = buttons_to_toolbar{
+    'citizens', 'tasks', 'places', 'labor',
+    'orders', 'nobles', 'objects', 'justice',
+}
+
+---@param interface_size DFLayout.Rectangle.Size
+---@return DFLayout.Widget.frame
+function fort.toolbars.left.frame(interface_size)
+    return {
+        l = 0,
+        w = fort.toolbars.left.width,
+        r = interface_size.width - fort.toolbars.left.width,
+
+        t = interface_size.height - TOOLBAR_HEIGHT,
+        h = TOOLBAR_HEIGHT,
+        b = 0,
+    }
+end
+
+local fort_left_center_toolbar_gap_minimum = 7
+
+---@class DFLayout.Fort.Toolbar.Center: DFLayout.Toolbar
+fort.toolbars.center = button_widths_to_toolbar{
+    { _left_border = 1 },
+    { dig = 4 }, { chop = 4 }, { gather = 4 }, { smooth = 4 }, { erase = 4 },
+    { _divider = 1 },
+    { build = 4 }, { stockpile = 4 }, { zone = 4 },
+    { _divider = 1 },
+    { burrow = 4 }, { cart = 4 }, { traffic = 4 },
+    { _divider = 1 },
+    { mass_designation = 4 },
+    { _right_border = 1 },
+}
+
+---@param interface_size DFLayout.Rectangle.Size
+---@return DFLayout.Widget.frame
+function fort.toolbars.center.frame(interface_size)
+    -- center toolbar is "centered" in interface area, but never closer to the
+    -- left toolbar than fort_left_center_toolbar_gap_minimum
+
+    local interface_offset_centered = math.ceil((interface_size.width - fort.toolbars.center.width + 1) / 2)
+    local interface_offset_min = fort.toolbars.left.width + fort_left_center_toolbar_gap_minimum
+    local interface_offset = math.max(interface_offset_min, interface_offset_centered)
+
+    return {
+        l = interface_offset,
+        w = fort.toolbars.center.width,
+        r = interface_size.width - interface_offset - fort.toolbars.center.width,
+
+        t = interface_size.height - TOOLBAR_HEIGHT,
+        h = TOOLBAR_HEIGHT,
+        b = 0,
+    }
+end
+
+---@alias DFLayout.Fort.SecondaryToolbar.ToolNames  'dig' | 'chop' | 'gather' | 'smooth' | 'erase' | 'build' | 'stockpile' |                     'zone' | 'burrow' |                   'cart' | 'traffic' | 'mass_designation'
+---@alias DFLayout.Fort.SecondaryToolbar.Names      'dig' | 'chop' | 'gather' | 'smooth' | 'erase' |           'stockpile' | 'stockpile_paint' |                      'burrow_paint' |          'traffic' | 'mass_designation'
+
+---@param interface_size DFLayout.Rectangle.Size
+---@param tool_name DFLayout.Fort.SecondaryToolbar.ToolNames
+---@param secondary_toolbar DFLayout.Toolbar.Base
+---@return DFLayout.Widget.frame
+local function center_secondary_frame(interface_size, tool_name, secondary_toolbar)
+    local toolbar_offset = fort.toolbars.center.frame(interface_size).l
+    local toolbar_button = fort.toolbars.center.buttons[tool_name] or dfhack.error('invalid tool name: ' .. tool_name)
+
+    -- Ideally, the secondary toolbar is positioned directly above the (main) toolbar button
+    local ideal_offset = toolbar_offset + toolbar_button.offset
+
+    -- In "narrow" interfaces conditions, a wide secondary toolbar (pretty much
+    -- any tool that has "advanced" options) that was ideally positioned above
+    -- its tool's button would extend past the right edge of the interface area.
+    -- Such wide secondary toolbars are instead right justified with a bit of
+    -- padding.
+
+    -- padding necessary to line up width-constrained secondaries
+    local secondary_padding = 5
+    local width_constrained_offset = math.max(0, interface_size.width - (secondary_toolbar.width + secondary_padding))
+
+    -- Use whichever position is left-most.
+    local l = math.min(ideal_offset, width_constrained_offset)
+    return {
+        l = l,
+        w = secondary_toolbar.width,
+        r = interface_size.width - l - secondary_toolbar.width,
+
+        t = interface_size.height - TOOLBAR_HEIGHT - SECONDARY_TOOLBAR_HEIGHT,
+        h = SECONDARY_TOOLBAR_HEIGHT,
+        b = TOOLBAR_HEIGHT,
+    }
+end
+
+---@type table<DFLayout.Fort.SecondaryToolbar.Names,DFLayout.Toolbar>
+fort.secondary_toolbars = {}
+
+---@param tool_name DFLayout.Fort.SecondaryToolbar.ToolNames
+---@param secondary_name DFLayout.Fort.SecondaryToolbar.Names
+---@param toolbar DFLayout.Toolbar.Base
+---@return DFLayout.Toolbar
+local function define_center_secondary(tool_name, secondary_name, toolbar)
+    local ntb = toolbar --[[@as DFLayout.Toolbar]]
+    ---@param interface_size DFLayout.Rectangle.Size
+    ---@return DFLayout.Widget.frame
+    function ntb.frame(interface_size)
+        return center_secondary_frame(interface_size, tool_name, ntb)
+    end
+    fort.secondary_toolbars[secondary_name] = ntb
+    return ntb
+end
+
+define_center_secondary('dig', 'dig', buttons_to_toolbar{
+    'dig', 'stairs', 'ramp', 'channel', 'remove_construction', '_gap',
+    'rectangle', 'draw', '_gap',
+    'advanced_toggle', '_gap',
+    'all', 'auto', 'ore_gem', 'gem', '_gap',
+    'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+    'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+})
+define_center_secondary('chop', 'chop', buttons_to_toolbar{
+    'chop', '_gap',
+    'rectangle', 'draw', '_gap',
+    'advanced_toggle', '_gap',
+    'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+    'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+})
+define_center_secondary('gather', 'gather', buttons_to_toolbar{
+    'gather', '_gap',
+    'rectangle', 'draw', '_gap',
+    'advanced_toggle', '_gap',
+    'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+    'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+})
+define_center_secondary('smooth', 'smooth', buttons_to_toolbar{
+    'smooth', 'engrave', 'carve_track', 'carve_fortification', '_gap',
+    'rectangle', 'draw', '_gap',
+    'advanced_toggle', '_gap',
+    'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', '_gap',
+    'blueprint', 'blueprint_to_standard', 'standard_to_blueprint',
+})
+define_center_secondary( 'erase', 'erase', buttons_to_toolbar{
+    'rectangle',
+    'draw',
+})
+-- build -- completely different and quite variable
+define_center_secondary('stockpile', 'stockpile', buttons_to_toolbar{ 'add_stockpile' })
+define_center_secondary('stockpile', 'stockpile_paint', buttons_to_toolbar{
+    'rectangle', 'draw', 'erase_toggle', 'remove',
+})
+-- zone -- no secondary toolbar
+-- burrow -- no direct secondary toolbar
+define_center_secondary('burrow', 'burrow_paint', buttons_to_toolbar{
+    'rectangle', 'draw', 'erase_toggle', 'remove',
+})
+-- cart -- no secondary toolbar
+define_center_secondary('traffic', 'traffic', button_widths_to_toolbar(
+    concat_sequences{ buttons_to_widths{
+        'high', 'normal', 'low', 'restricted', '_gap',
+        'rectangle', 'draw', '_gap',
+        'advanced_toggle', '_gap',
+    }, {
+        { weight_which = 4 },
+        { weight_slider = 26 },
+        { weight_input = 6 },
+    } }
+))
+define_center_secondary('mass_designation', 'mass_designation', buttons_to_toolbar{
+    'claim', 'forbid', 'dump', 'no_dump', 'melt', 'no_melt', 'hidden', 'visible', '_gap',
+    'rectangle', 'draw',
+})
+
+---@class DFLayout.Fort.Toolbar.Right: DFLayout.Toolbar
+fort.toolbars.right = buttons_to_toolbar{
+    'squads', 'world',
+}
+
+---@param interface_size DFLayout.Rectangle.Size
+---@return DFLayout.Widget.frame
+function fort.toolbars.right.frame(interface_size)
+    return {
+        l = interface_size.width - fort.toolbars.right.width,
+        w = fort.toolbars.right.width,
+        r = 0,
+
+        t = interface_size.height - TOOLBAR_HEIGHT,
+        h = TOOLBAR_HEIGHT,
+        b = 0,
+    }
+end
+
+return _ENV

--- a/test/library/gui/dflayout.lua
+++ b/test/library/gui/dflayout.lua
@@ -1,0 +1,236 @@
+config.target = 'core'
+
+-- hints for the typechecker
+expect = expect or require('test_util.expect')
+test = test or {}
+
+local layout = require('gui.dflayout')
+local ftb = layout.fort.toolbars
+
+local function combine_comment(comment, suffix)
+    if comment and suffix then
+        return comment .. ': ' .. suffix
+    end
+    return comment or suffix
+end
+
+------ BEGIN MAGIC NUMBERS ------
+
+local gui = require('gui')
+
+local flush_sizes = {
+    layout.MINIMUM_INTERFACE_SIZE, -- 114x46; from 912x552 with 8x12 UI tiles
+    gui.mkdims_wh(0, 0, 180, 90),  -- 75% interface in 1920x1080 with 8x12 UI tiles
+    gui.mkdims_wh(0, 0, 240, 90),  -- 100% interface in 1920x1080 with 8x12 UI tiles
+    gui.mkdims_wh(0, 0, 480, 180), -- 100% interface in 3840x2160 with 8x12 UI tiles
+}
+
+local MINIMUM_INTERFACE_WIDTH = layout.MINIMUM_INTERFACE_SIZE.width
+local LARGEST_CHECKED_INTERFACE_WIDTH = 210 -- traffic is the last to start "tracking" its center button at 196 interface width
+
+local function for_all_checked_interface_widths(fn)
+    for w = MINIMUM_INTERFACE_WIDTH, LARGEST_CHECKED_INTERFACE_WIDTH do
+        local interface_size = gui.mkdims_wh(0, 0, w, 46)
+        fn(interface_size)
+    end
+end
+
+-- Most of the magic constants listed below are related to these values, so warn
+-- if these differ from the baseline values.
+function test.toolbar_positions_baseline()
+    expect.eq(ftb.left.width, 32, 'unexpected fort left toolbar width; many tests will probably fail')
+    expect.eq(ftb.center.width, 53, 'unexpected fort center toolbar width; many tests will probably fail')
+end
+
+local function no_growth()
+    return 0
+end
+local function one_for_one_growth(delta)
+    return delta
+end
+local function odd_one_for_two_growth(delta) -- used when starting on an odd width
+    return delta // 2
+end
+local function even_one_for_two_growth(delta) -- used when starting on an even width
+    return (delta+1) // 2
+end
+
+-- Fort mode center/secondary toolbar movement can be described in phases.
+-- - The first phase can be "no growth" (toolbar is already in sync with a
+--   not-yet-moving center toolbar), or "one for one" (toolbar is catching to up
+--   the center toolbar).
+-- - If it starts in "one for one", it may transition to "no growth" if it
+--   catches up to the center toolbar before it starts moving.
+-- - The final phase should be a "one for two" growth phase (in sync with center
+--   toolbar).
+
+-- The offset values can observed as the UI x-coord (0 based) that
+-- `devel/inspect-screen` shows while the mouse is positioned over the left edge
+-- of the toolbar in question while using a 100% interface size and adjusting
+-- the window width.
+
+local FORT_CENTER_MOVES_WIDTH = 131
+
+local fort_center_phases = {
+    { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 39, growth = no_growth },
+    { starting_width = FORT_CENTER_MOVES_WIDTH,    offset = 40, growth = odd_one_for_two_growth },
+}
+
+local fort_center_secondary_phases = {
+    {
+        name = 'dig',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 1,  growth = one_for_one_growth },
+        { starting_width = 178,                     offset = 64, growth = even_one_for_two_growth },
+    },
+    {
+        name = 'chop',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 37, growth = one_for_one_growth },
+        { starting_width = 121,                     offset = 44, growth = no_growth },
+        { starting_width = FORT_CENTER_MOVES_WIDTH, offset = 45, growth = odd_one_for_two_growth },
+    },
+    {
+        name = 'gather',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 37, growth = one_for_one_growth },
+        { starting_width = 126,                     offset = 48, growth = no_growth },
+        { starting_width = FORT_CENTER_MOVES_WIDTH, offset = 49, growth = odd_one_for_two_growth },
+    },
+    {
+        name = 'smooth',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 25, growth = one_for_one_growth },
+        { starting_width = 153,                     offset = 64, growth = odd_one_for_two_growth },
+    },
+    {
+        name = 'erase',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 56, growth = no_growth },
+        { starting_width = FORT_CENTER_MOVES_WIDTH, offset = 57, growth = odd_one_for_two_growth },
+    },
+    {
+        name = 'stockpile',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 65, growth = no_growth },
+        { starting_width = FORT_CENTER_MOVES_WIDTH, offset = 66, growth = odd_one_for_two_growth },
+    },
+    {
+        name = 'stockpile_paint',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 65, growth = no_growth },
+        { starting_width = FORT_CENTER_MOVES_WIDTH, offset = 66, growth = odd_one_for_two_growth },
+    },
+    {
+        name = 'burrow_paint',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 74, growth = no_growth },
+        { starting_width = FORT_CENTER_MOVES_WIDTH, offset = 75, growth = odd_one_for_two_growth },
+    },
+    {
+        name = 'traffic',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 33,  growth = one_for_one_growth },
+        { starting_width = 198,                     offset = 116, growth = even_one_for_two_growth },
+    },
+    {
+        name = 'mass_designation',
+        { starting_width = MINIMUM_INTERFACE_WIDTH, offset = 65, growth = one_for_one_growth },
+        { starting_width = 144,                     offset = 94, growth = even_one_for_two_growth },
+    },
+}
+
+-- find the most advanced phase that starts before interface_width and apply its growth rule
+local function phased_offset(interface_width, phases)
+    for i = #phases, 1, -1 do
+        local phase = phases[i]
+        local delta = interface_width - phase.starting_width
+        if delta >= 0 then
+            return phase.offset + phase.growth(delta)
+        end
+    end
+end
+
+------ END MAGIC NUMBERS ------
+
+-- left toolbar is always flush to left and bottom (0 left- and bottom-offsets)
+local function expect_bottom_left_frame(a, interface_size, w, h, comment)
+    local c = curry(combine_comment, comment)
+    return expect.eq(a.l, 0, c('not flush to left'))
+        and expect.eq(a.b, 0, c('not flush to bottom'))
+        and expect.eq(a.w, w, c('unexpected width'))
+        and expect.eq(a.h, h, c('unexpected height'))
+        and expect.eq(a.r, interface_size.width - (0 + a.w), c('right offset does not fill i/f width'))
+        and expect.eq(a.t, interface_size.height - (a.h + 0), c('top offset does not fill i/f height'))
+end
+
+function test.fort_left_toolbar_positions()
+    local left = ftb.left
+    for _, size in ipairs(flush_sizes) do
+        local size_str = ('%dx%d'):format(size.width, size.height)
+        expect_bottom_left_frame(left.frame(size), size, left.width, layout.TOOLBAR_HEIGHT, size_str)
+    end
+    for_all_checked_interface_widths(function(size)
+        local size_str = ('%dx%d'):format(size.width, size.height)
+        expect_bottom_left_frame(left.frame(size), size, left.width, layout.TOOLBAR_HEIGHT, size_str)
+    end)
+end
+
+-- right toolbar is always flush to right and bottom (0 right- and bottom-offsets)
+local function expect_bottom_right_frame(a, interface_size, w, h, comment)
+    local c = curry(combine_comment, comment)
+    expect.eq(a.r, 0, c('not flush to right'))
+    expect.eq(a.b, 0, c('not flush to bottom'))
+    expect.eq(a.w, w, c('unexpected width'))
+    expect.eq(a.h, h, c('unexpected height'))
+    expect.eq(a.l, interface_size.width - (a.w + 0), c('left offset does not fill i/f width'))
+    expect.eq(a.t, interface_size.height - (a.h + 0), c('top offset does not fill i/f height'))
+end
+
+function test.fort_right_toolbar_positions()
+    local left = ftb.right
+    for _, size in ipairs(flush_sizes) do
+        local size_str = ('%dx%d'):format(size.width, size.height)
+        expect_bottom_right_frame(left.frame(size), size, left.width, layout.TOOLBAR_HEIGHT, size_str)
+    end
+    for_all_checked_interface_widths(function(size)
+        local size_str = ('%dx%d'):format(size.width, size.height)
+        expect_bottom_right_frame(left.frame(size), size, left.width, layout.TOOLBAR_HEIGHT, size_str)
+    end)
+end
+
+-- center toolbar is flush to bottom (0 bottom-offset) and has a phase-defined left-offset
+local function expect_bottom_center_frame(a, interface_size, w, h, l, comment)
+    local c = curry(combine_comment, comment)
+    expect.eq(a.l, l, c('center left-offset'))
+    expect.eq(a.b, 0, c('not flush to bottom'))
+    expect.eq(a.w, w, c('unexpected width'))
+    expect.eq(a.h, h, c('unexpected height'))
+    expect.eq(a.r, interface_size.width - (a.l + a.w), c('right offset does not fill i/f width'))
+    expect.eq(a.t, interface_size.height - (a.h + 0), c('top offset does not fill i/f height'))
+end
+
+function test.fort_center_toolbar_positions()
+    local center = ftb.center
+    for_all_checked_interface_widths(function(size)
+        local size_str = ('%dx%d'):format(size.width, size.height)
+        local expected_l = phased_offset(size.width, fort_center_phases)
+        expect_bottom_center_frame(center.frame(size), size, center.width, layout.TOOLBAR_HEIGHT, expected_l, size_str)
+    end)
+end
+
+-- secondary toolbars are just above the bottom toolbars (layout.TOOLBAR_HEIGHT bottom-offset) and have phase-defined left-offsets
+local function expect_center_secondary_frame(a, interface_size, w, h, l, comment)
+    local c = curry(combine_comment, comment)
+    expect.eq(a.l, l, c('center left-offset'))
+    expect.eq(a.b, layout.TOOLBAR_HEIGHT, c('not directly above bottom toolbar'))
+    expect.eq(a.w, w, c('unexpected width'))
+    expect.eq(a.h, h, c('unexpected height'))
+    expect.eq(a.r, interface_size.width - (a.l + a.w), c('right offset does not fill i/f width'))
+    expect.eq(a.t, interface_size.height - (a.h + a.b), c('top offset does not fill i/f height'))
+end
+
+for _, phases in ipairs(fort_center_secondary_phases) do
+    local name = phases.name
+    local toolbar = layout.fort.secondary_toolbars[name]
+    test[('fort_secondary_%s_toolbar_positions'):format(name)] = function()
+        for_all_checked_interface_widths(function(size)
+            expect_center_secondary_frame(
+                toolbar.frame(size), size,
+                toolbar.width, layout.SECONDARY_TOOLBAR_HEIGHT,
+                phased_offset(size.width, phases),
+                ('%s: %dx%d'):format(name, size.width, size.height))
+        end)
+    end
+end


### PR DESCRIPTION
Here is the library code from DFHack/scripts#1426 moved to a top-level DFHack Lua module.

This spin has tests, and two hunks of docs: one for the library itself, and another in the overlay dev guide that describes a generalized "UI-relative" positioning technique (the warmdamp technique, but using the new library to encapsulate the magic numbers, and extending to right- and top-anchored overlay positions).