### PR TITLE
Fix to plugins automatically reloading after unload command.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 - `dig-now`: fix cases where boulders/rough gems of incorrect material were being generated when digging through walls
 - `dig-now`: properly generate ice boulders when digging through ice walls
 - `gui/teleport`: now properly handles teleporting units that are currently falling or being flung
+- `Core.cpp`: now properly handles "load", "unload", and "reload" plugin commands given to Core::runCommand()
 
 ## Misc Improvements
 - `spectate`: show dwarves' activities (like prayer)

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,7 +61,7 @@ Template for new versions:
 - `dig-now`: fix cases where boulders/rough gems of incorrect material were being generated when digging through walls
 - `dig-now`: properly generate ice boulders when digging through ice walls
 - `gui/teleport`: now properly handles teleporting units that are currently falling or being flung
-- `Core.cpp`: now properly handles "load", "unload", and "reload" plugin commands given to Core::runCommand()
+- ``Core.cpp``: now properly handles "load", "unload", and "reload" plugin commands given to Core::runCommand()
 
 ## Misc Improvements
 - `spectate`: show dwarves' activities (like prayer)

--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -800,6 +800,7 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, s
         bool all = false;
         bool load = (first == "load");
         bool unload = (first == "unload");
+        bool reload = (first == "reload");
         if (parts.size())
         {
             for (auto p = parts.begin(); p != parts.end(); p++)
@@ -828,7 +829,7 @@ command_result Core::runCommand(color_ostream &con, const std::string &first_, s
                     ret = CR_FAILURE;
                 else if (unload && !plug_mgr->unload(*p))
                     ret = CR_FAILURE;
-                else if (!plug_mgr->reload(*p))
+                else if (reload && !plug_mgr->reload(*p))
                     ret = CR_FAILURE;
             }
             if (ret != CR_OK)


### PR DESCRIPTION
This fixes an issue where c++ plugins do not properly unload when the "unload" command is run in the dfhack in game command interface.

library/Core.cpp:L803: Added reload bool to catch whether the reload command was given in Core::runCommand
library/Core.cpp:L831: Added reload to else if statement to short circuit the PluginManager::reload statement so that it only runs if reload was run as a command to Core::runCommand.

docs/changelog.txt: Added description of change.