### PR TITLE
add safety check to stockpile iterator

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -62,6 +62,7 @@ Template for new versions:
 - `dig-now`: properly generate ice boulders when digging through ice walls
 - `gui/teleport`: now properly handles teleporting units that are currently falling or being flung
 - `unload`: fix recent regression where `unload` would immediately `reload` the target
+- ``Buildings`` module: do not crash if a ``map_block`` unexpectedly contains an item that is not on the master item vector
 
 ## Misc Improvements
 - `spectate`: show dwarves' activities (like prayer)

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -1654,7 +1654,7 @@ StockpileIterator& StockpileIterator::operator++() {
 
         // If the current item isn't properly stored, move on to the next.
         item = df::item::find(block->items[current]);
-        if (!item->flags.bits.on_ground) {
+        if (!item || !item->flags.bits.on_ground) {
             continue;
         }
 


### PR DESCRIPTION
the stockpile iterator will crash if a `map_block` contains an item pointer to an item that is not on the master item list. this should never happen if DF was working correctly, but DF often does not work correctly

related discord discussion: https://discord.com/channels/329272032778780672/1049402643342168114/1360977656820273322

