### PR TITLE
Fix/empty text select all

### DIFF
--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -98,7 +98,12 @@ function TextAreaContent:setCursor(cursor_offset)
 end
 
 function TextAreaContent:setSelection(from_offset, to_offset)
+    if #self.text == 0 then
+        return
+    end
+
     -- text selection is always start on self.cursor and end on self.sel_end
+
     self:setCursor(from_offset)
     self.sel_end = to_offset
 

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -240,12 +240,10 @@ function TextAreaContent:onRenderBody(dc)
         dc:newline()
     end
 
-    local show_focus = not self.enable_cursor_blink
-        or (
-            not self:hasSelection()
-            and self.parent_view:hasFocus()
-            and gui.blink_visible(530)
-        )
+    local show_focus = not self:hasSelection() and (
+        not self.enable_cursor_blink
+        or (self.parent_view:hasFocus() and gui.blink_visible(530))
+    )
 
     if show_focus then
         local x, y = self.wrapped_text:indexToCoords(self.cursor)

--- a/test/library/gui/widgets.TextArea.lua
+++ b/test/library/gui/widgets.TextArea.lua
@@ -1655,6 +1655,18 @@ function test.select_all()
     screen:dismiss()
 end
 
+function test.ignore_select_all_for_empty_text()
+    local text_area, screen, window = arrange_textarea({w=65})
+
+    expect.eq(read_rendered_text(text_area), '_');
+
+    simulate_input_keys('CUSTOM_CTRL_A')
+
+    expect.eq(read_rendered_text(text_area), '_');
+
+    screen:dismiss()
+end
+
 function test.text_key_replace_selection()
     local text_area, screen, window = arrange_textarea({w=65})
 

--- a/test/library/gui/widgets.TextArea.lua
+++ b/test/library/gui/widgets.TextArea.lua
@@ -1726,7 +1726,7 @@ function test.arrows_reset_selection()
 
     simulate_input_keys('CUSTOM_CTRL_A')
 
-    expect.eq(read_rendered_text(text_area), text .. '_');
+    expect.eq(read_rendered_text(text_area), text);
 
     expect.eq(read_selected_text(text_area), text);
 
@@ -1768,7 +1768,7 @@ function test.click_reset_selection()
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero._',
+        'porttitor mi, vitae rutrum eros metus nec libero.',
     }, '\n'));
 
     expect.eq(read_selected_text(text_area), table.concat({
@@ -1803,7 +1803,7 @@ function test.line_navigation_reset_selection()
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero._',
+        'porttitor mi, vitae rutrum eros metus nec libero.',
     }, '\n'));
 
     expect.eq(read_selected_text(text_area), table.concat({
@@ -1836,7 +1836,7 @@ function test.jump_begin_or_end_reset_selection()
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero._',
+        'porttitor mi, vitae rutrum eros metus nec libero.',
     }, '\n'));
 
     expect.eq(read_selected_text(text_area), table.concat({
@@ -3057,7 +3057,7 @@ function test.fast_rewind_reset_selection()
     expect.eq(read_rendered_text(text_area), table.concat({
         '60: Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         '112: Sed consectetur, urna sit amet aliquet egestas, ante nibh ',
-        'porttitor mi, vitae rutrum eros metus nec libero._',
+        'porttitor mi, vitae rutrum eros metus nec libero.',
     }, '\n'));
 
     expect.eq(read_selected_text(text_area), table.concat({


### PR DESCRIPTION
For TextArea and EditField, visual cursor dissapeared when "Select All" (`Ctrl+A`) has been requested.
This fixes it (https://github.com/DFHack/dfhack/issues/5239)