### PR TITLE
updates for 51.11

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -72,7 +72,10 @@ Template for new versions:
 
 ## API
 - ``Military`` module: added ``addToSquad`` function
+- ``Units`` module: added ``get_cached_unit_by_global_id`` to emulate how DF handles unit vector index caching (used in civzones and in general references)
+- ``Buildings`` module: add `getOwner`` (using the ``Units::get_cached_unit_by_global_id`` mechanic) to reflect changes in 51.11
 - ``Units::teleport``: projectile information is now cleared for teleported units
+- ``Buildings::setOwner``: updated for changes in 51.11
 
 ## Lua
 - ``dfhack.military.addToSquad``: expose Military API function

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -73,7 +73,7 @@ Template for new versions:
 ## API
 - ``Military`` module: added ``addToSquad`` function
 - ``Units`` module: added ``get_cached_unit_by_global_id`` to emulate how DF handles unit vector index caching (used in civzones and in general references)
-- ``Buildings`` module: add `getOwner`` (using the ``Units::get_cached_unit_by_global_id`` mechanic) to reflect changes in 51.11
+- ``Buildings`` module: add ``getOwner`` (using the ``Units::get_cached_unit_by_global_id`` mechanic) to reflect changes in 51.11
 - ``Units::teleport``: projectile information is now cleared for teleported units
 - ``Buildings::setOwner``: updated for changes in 51.11
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -2465,6 +2465,10 @@ General
 
   Searches for a specific_ref with the given type.
 
+* ``dfhack.buildings.getOwner(civzone)``
+
+  Returns the owner of the zone or *nil* if there isn't one.
+
 * ``dfhack.buildings.setOwner(civzone,unit)``
 
   Replaces the owner of the civzone. If unit is *nil*, removes ownership.

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2736,6 +2736,7 @@ static bool buildings_containsTile(df::building *bld, int x, int y) {
 static const LuaWrapper::FunctionReg dfhack_buildings_module[] = {
     WRAPM(Buildings, getGeneralRef),
     WRAPM(Buildings, getSpecificRef),
+    WRAPM(Buildings, getOwner),
     WRAPM(Buildings, setOwner),
     WRAPM(Buildings, allocInstance),
     WRAPM(Buildings, checkFreeTiles),

--- a/library/include/modules/Buildings.h
+++ b/library/include/modules/Buildings.h
@@ -74,6 +74,11 @@ DFHACK_EXPORT df::general_ref *getGeneralRef(df::building *building, df::general
 DFHACK_EXPORT df::specific_ref *getSpecificRef(df::building *building, df::specific_ref_type type);
 
 /**
+ * Gets the owner unit for the zone. Uses the cached index in the civzone if valid, updates if not
+ */
+DFHACK_EXPORT df::unit* getOwner(df::building_civzonest* building);
+
+/**
  * Sets the owner unit for the zone.
  */
 DFHACK_EXPORT bool setOwner(df::building_civzonest *building, df::unit *owner);

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -350,5 +350,7 @@ DFHACK_EXPORT void multiplyActionTimers(color_ostream &out, df::unit *unit, floa
 DFHACK_EXPORT void multiplyGroupActionTimers(color_ostream &out, df::unit *unit, float amount, df::unit_action_type_group affectedActionTypeGroup);
 DFHACK_EXPORT void setActionTimers(color_ostream &out, df::unit *unit, int32_t amount, df::unit_action_type affectedActionType);
 DFHACK_EXPORT void setGroupActionTimers(color_ostream &out, df::unit *unit, int32_t amount, df::unit_action_type_group affectedActionTypeGroup);
+
+DFHACK_EXPORT df::unit* get_cached_unit_by_global_id(int32_t id, int32_t& index);
 }
 }

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -38,6 +38,7 @@ distribution.
 #include "modules/Buildings.h"
 #include "modules/Maps.h"
 #include "modules/Job.h"
+#include "modules/Units.h"
 
 #include "df/building_axle_horizontalst.h"
 #include "df/building_bars_floorst.h"
@@ -321,26 +322,30 @@ bool Buildings::setOwner(df::building_civzonest *bld, df::unit *unit)
 {
     CHECK_NULL_POINTER(bld);
 
-    if (bld->assigned_unit == unit)
+    auto unit_id = unit ? unit->id : -1;
+
+    if (bld->assigned_unit_id == unit_id)
         return true;
 
-    if (bld->assigned_unit)
+    if (bld->assigned_unit_id != -1)
     {
-        auto &blist = bld->assigned_unit->owned_buildings;
-        vector_erase_at(blist, linear_index(blist, bld));
-
-        if (auto spouse = df::unit::find(bld->assigned_unit->relationship_ids[df::unit_relationship_type::Spouse]))
+        if (auto old_unit = df::unit::find(bld->assigned_unit_id))
         {
-            auto &blist = spouse->owned_buildings;
+            auto& blist = old_unit->owned_buildings;
             vector_erase_at(blist, linear_index(blist, bld));
+
+            if (auto spouse = df::unit::find(old_unit->relationship_ids[df::unit_relationship_type::Spouse]))
+            {
+                auto& blist = spouse->owned_buildings;
+                vector_erase_at(blist, linear_index(blist, bld));
+            }
         }
     }
 
-    bld->assigned_unit = unit;
+    bld->assigned_unit_id = unit_id;
 
     if (unit)
     {
-        bld->assigned_unit_id = unit->id;
         unit->owned_buildings.push_back(bld);
 
         if (auto spouse = df::unit::find(unit->relationship_ids[df::unit_relationship_type::Spouse]))
@@ -350,10 +355,8 @@ bool Buildings::setOwner(df::building_civzonest *bld, df::unit *unit)
                 blist.push_back(bld);
         }
     }
-    else
-    {
-        bld->assigned_unit_id = -1;
-    }
+
+    Units::get_cached_unit_by_global_id(unit_id, bld->owner_unit_cached_index);
 
     return true;
 }

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -318,6 +318,11 @@ std::string Buildings::getName(df::building* building)
     return tmp;
 }
 
+df::unit* Buildings::getOwner(df::building_civzonest* bld)
+{
+    return Units::get_cached_unit_by_global_id(bld->assigned_unit_id, bld->owner_unit_cached_index);
+}
+
 bool Buildings::setOwner(df::building_civzonest *bld, df::unit *unit)
 {
     CHECK_NULL_POINTER(bld);

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -2188,3 +2188,24 @@ void Units::setGroupActionTimers(color_ostream &out, df::unit *unit,
         }
     }
 }
+
+// this is a (loose) reimplementation of df's `unit_handlerst::get_cached_unit_by_global_id`
+df::unit* Units::get_cached_unit_by_global_id(int32_t id, int32_t& index)
+{
+    auto& vector = df::unit::get_vector();
+    auto len = vector.size();
+
+    if (len == 0 || id == -1)
+        return nullptr;
+
+    if (index > -1 && index < len)
+    {
+        auto unit = vector[index];
+        if (index == unit->id)
+            return unit;
+        index = -1;
+    }
+    index = binsearch_index(vector, &df::unit::id, id);
+    return index != -1 ? vector[index] : nullptr;
+}
+

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -2203,7 +2203,6 @@ df::unit* Units::get_cached_unit_by_global_id(int32_t id, int32_t& index)
         auto unit = vector[index];
         if (id == unit->id)
             return unit;
-        index = -1;
     }
     index = binsearch_index(vector, &df::unit::id, id);
     return index != -1 ? vector[index] : nullptr;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -2201,7 +2201,7 @@ df::unit* Units::get_cached_unit_by_global_id(int32_t id, int32_t& index)
     if (index > -1 && index < len)
     {
         auto unit = vector[index];
-        if (index == unit->id)
+        if (id == unit->id)
             return unit;
         index = -1;
     }

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -2198,7 +2198,7 @@ df::unit* Units::get_cached_unit_by_global_id(int32_t id, int32_t& index)
     if (len == 0 || id == -1)
         return nullptr;
 
-    if (index > -1 && index < len)
+    if (index > -1 && (size_t)index < len)
     {
         auto unit = vector[index];
         if (id == unit->id)

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -2208,4 +2208,3 @@ df::unit* Units::get_cached_unit_by_global_id(int32_t id, int32_t& index)
     index = binsearch_index(vector, &df::unit::id, id);
     return index != -1 ? vector[index] : nullptr;
 }
-

--- a/plugins/preserve-rooms.cpp
+++ b/plugins/preserve-rooms.cpp
@@ -315,13 +315,14 @@ static void assign_nobles(color_ostream &out) {
         auto zone = virtual_cast<df::building_civzonest>(df::building::find(zone_id));
         if (!zone)
             continue;
+        auto owner = Buildings::getOwner(zone);
         bool assigned = false;
         for (auto it = group_codes.rbegin(); it != group_codes.rend(); it++) {
             auto code = *it;
             vector<df::unit *> units;
             Units::getUnitsByNobleRole(units, code);
             // if zone is already assigned to a proper unit (or their spouse), skip
-            if (linear_index(units, zone->assigned_unit) >= 0 ||
+            if (linear_index(units, owner) >= 0 ||
                 linear_index(get_spouse_ids(out, units), zone->assigned_unit_id) >= 0)
             {
                 assigned = true;
@@ -352,7 +353,7 @@ static void assign_nobles(color_ostream &out) {
             if (assigned)
                 break;
         }
-        if (!assigned && (zone->spec_sub_flag.bits.active || zone->assigned_unit)) {
+        if (!assigned && (zone->spec_sub_flag.bits.active || zone->assigned_unit_id != -1)) {
             DEBUG(cycle,out).print("noble zone now reserved for eventual office holder: %d\n", zone_id);
             zone->spec_sub_flag.bits.active = false;
             Buildings::setOwner(zone, NULL);
@@ -506,11 +507,12 @@ static void process_rooms(color_ostream &out,
             WARN(cycle, out).print("invalid building pointer %p in building vector\n", zone);
             continue;
         }
-        if (!zone->assigned_unit) {
+        if (zone->assigned_unit_id == -1) {
             handle_missing_assignments(out, active_unit_ids, &it, it_end, share_with_spouse, zone->id);
             continue;
         }
-        auto hf = df::historical_figure::find(zone->assigned_unit->hist_figure_id);
+        auto owner = Buildings::getOwner(zone);
+        auto hf = df::historical_figure::find(owner->hist_figure_id);
         if (!hf)
             continue;
         int32_t spouse_hfid = share_with_spouse ? get_spouse_hfid(out, hf) : -1;
@@ -593,7 +595,7 @@ static void on_new_active_unit(color_ostream& out, void* data) {
         if (!zone)
             continue;
         zone->spec_sub_flag.bits.active = true;
-        if (zone->assigned_unit || spouse_has_sharable_room(out, hfid, zone->type))
+        if (zone->assigned_unit_id != -1 || spouse_has_sharable_room(out, hfid, zone->type))
             continue;
         DEBUG(event,out).print("reassigning zone %d\n", zone->id);
         Buildings::setOwner(zone, unit);

--- a/plugins/preserve-tombs.cpp
+++ b/plugins/preserve-tombs.cpp
@@ -249,7 +249,7 @@ static bool assign_to_tomb(df::unit * unit, int32_t building_id) {
     if (!bld) return false;
 
     auto tomb = virtual_cast<df::building_civzonest>(bld);
-    if (!tomb || tomb->assigned_unit) return false;
+    if (!tomb || tomb->assigned_unit_id != -1) return false;
 
     Buildings::setOwner(tomb, unit);
     return true;

--- a/plugins/preserve-tombs.cpp
+++ b/plugins/preserve-tombs.cpp
@@ -198,8 +198,9 @@ static void update_tomb_assignments(color_ostream &out) {
     // check tomb civzones for assigned units
     for (auto* tomb : world->buildings.other.ZONE_TOMB) {
         if (!tomb || !tomb->flags.bits.exists) continue;
-        if (!tomb->assigned_unit) continue;
-        if (Units::isDead(tomb->assigned_unit)) continue; // we only care about living units
+        if (tomb->assigned_unit_id == -1) continue;
+        auto unit = Buildings::getOwner(tomb);
+        if (Units::isDead(unit)) continue; // we only care about living units
 
         auto it = tomb_assignments.find(tomb->assigned_unit_id);
 


### PR DESCRIPTION
- ``Units`` module: added ``get_cached_unit_by_global_id`` to emulate how DF handles unit vector index caching (used in civzones and in general references)
- ``Buildings`` module: add ``getOwner`` (using the ``Units::get_cached_unit_by_global_id`` mechanic) to reflect changes in 51.11
- ``Buildings::setOwner``: updated for changes in 51.11

also changes to plug-ins for 51.11