### PR TITLE
`preserve-rooms`: validate assigned unit id before using

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `preserve-rooms`: will no longer crash when a civzone is assigned to a unit that does not exist
 
 ## Misc Improvements
 

--- a/plugins/preserve-rooms.cpp
+++ b/plugins/preserve-rooms.cpp
@@ -512,6 +512,10 @@ static void process_rooms(color_ostream &out,
             continue;
         }
         auto owner = Buildings::getOwner(zone);
+        if (!owner) {
+            WARN(cycle, out).print("building %d has owner id %d but no such unit exists\n", zone->id, zone->assigned_unit_id);
+            continue;
+        }
         auto hf = df::historical_figure::find(owner->hist_figure_id);
         if (!hf)
             continue;


### PR DESCRIPTION
this avoids a crash when a civzone is assigned to an invalid unit id. this should never happen, but...