### PR TITLE
Fix for mods not being properly reloaded on Windows from saved game

### DIFF
--- a/docs/about/Authors.rst
+++ b/docs/about/Authors.rst
@@ -63,6 +63,7 @@ DoctorVanGogh           DoctorVanGogh
 Donald Ruegsegger       hashaash
 doomchild               doomchild
 Droseran                Droseran
+dvantwisk               dvantwisk
 DwarvenM                DwarvenM
 Eamon Bode              eamondo2                Baron Von Munchhausen
 EarthPulseAcademy       EarthPulseAcademy

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -72,6 +72,7 @@ Template for new versions:
 ## Fixes
 - `preserve-rooms`: will no longer crash when a civzone is assigned to a unit that does not exist
 - `gui/design`: fix misaligned shape icons
+- `scripts/script-manager`: fix lua scripts in mods not being reloaded properly on Windows.
 
 # 51.11-r1
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -73,7 +73,7 @@ Template for new versions:
 ## Fixes
 - `preserve-rooms`: will no longer crash when a civzone is assigned to a unit that does not exist
 - `gui/design`: fix misaligned shape icons
-- `script-manager`: fix lua scripts in mods not being reloaded properly on Windows.
+- `script-manager`: fix lua scripts in mods not being reloaded properly upon entering a saved world on Windows.
 
 # 51.11-r1
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -73,7 +73,7 @@ Template for new versions:
 ## Fixes
 - `preserve-rooms`: will no longer crash when a civzone is assigned to a unit that does not exist
 - `gui/design`: fix misaligned shape icons
-- `scripts/script-manager`: fix lua scripts in mods not being reloaded properly on Windows.
+- `script-manager`: fix lua scripts in mods not being reloaded properly on Windows.
 
 # 51.11-r1
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3338,12 +3338,14 @@ and are only documented here for completeness:
 
 * ``dfhack.internal.findScript(name)``
 
-  Searches `script paths <script-paths>` for the script ``name`` and returns the
-  path of the first file found, or ``nil`` on failure.
+  Searches `script paths <script-paths>` for the script ``name`` (which
+  includes the ``.lua`` extension) and returns the absolute path of the first
+  file found, or ``nil`` on failure. Slashes in the path are canonicalized to
+  forward slashes.
 
   .. note::
-    This requires an extension to be specified (``.lua`` or ``.rb``) - use
-    ``dfhack.findScript()`` to include the ``.lua`` extension automatically.
+    You can use the ``dfhack.findScript()`` wrapper if you want to specify the
+    script name without the ``.lua`` extension.
 
 * ``dfhack.internal.runCommand(command[, use_console])``
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3965,7 +3965,7 @@ static int internal_findScript(lua_State *L)
     const char *name = luaL_checkstring(L, 1);
     std::filesystem::path path = Core::getInstance().findScript(name);
     if (!path.empty())
-        lua_pushstring(L, path.string().c_str());
+        lua_pushstring(L, Filesystem::as_string(path).c_str());
     else
         lua_pushnil(L);
     return 1;

--- a/library/lua/script-manager.lua
+++ b/library/lua/script-manager.lua
@@ -52,6 +52,9 @@ function reload(refresh_active_mod_scripts)
     local force_refresh_fn = refresh_active_mod_scripts and function(script_path, script_name)
         if script_path:find('scripts_modactive') then
             local full_path = script_path..'/'..script_name
+            if dfhack.getOSType() == 'windows' then
+                full_path = script_path..'\\'..script_name
+            end
             internal_script = dfhack.internal.scripts[full_path]
             if internal_script then
                 dfhack.internal.scripts[full_path] = nil

--- a/library/lua/script-manager.lua
+++ b/library/lua/script-manager.lua
@@ -52,9 +52,6 @@ function reload(refresh_active_mod_scripts)
     local force_refresh_fn = refresh_active_mod_scripts and function(script_path, script_name)
         if script_path:find('scripts_modactive') then
             local full_path = script_path..'/'..script_name
-            if dfhack.getOSType() == 'windows' then
-                full_path = script_path..'\\'..script_name
-            end
             internal_script = dfhack.internal.scripts[full_path]
             if internal_script then
                 dfhack.internal.scripts[full_path] = nil


### PR DESCRIPTION
Steam mods with lua scripts in the "scripts_modactive" directory of a mod were not being properly reloaded after the initial load. That is, the script-manager purges these scripts from `dfhack.internal.scripts` before reloading them (more specifically to register their onStateChange). This purge wasn't being done since the file path wasn't being recognized on windows, thus dfhack mods weren't being loaded in games from resumed saves (if DF wasn't shut down before then). This change simply adds the correct windows file path as a key to access the script. It may be better to standardize all OS's paths used as keys in `dfhack.internal.scripts` but it isn't clear to me the locations where all these files are being added, so this is the simple solution.
