### PR TITLE
don't crash on a tomb owned by a unit that doesn't exist

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `preserve-tombs`: will no longer crash when a tomb is assigned to a unit that does not exist
 
 ## Misc Improvements
 

--- a/plugins/preserve-tombs.cpp
+++ b/plugins/preserve-tombs.cpp
@@ -200,7 +200,7 @@ static void update_tomb_assignments(color_ostream &out) {
         if (!tomb || !tomb->flags.bits.exists) continue;
         if (tomb->assigned_unit_id == -1) continue;
         auto unit = Buildings::getOwner(tomb);
-        if (Units::isDead(unit)) continue; // we only care about living units
+        if (!unit || Units::isDead(unit)) continue; // we only care about living units
 
         auto it = tomb_assignments.find(tomb->assigned_unit_id);
 


### PR DESCRIPTION
another change required by the change in civzone unit assignment semantics in DF 51.11