### PR TITLE
[Items::detachItem] change order of operations to avoid a use after free

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,6 +57,7 @@ Template for new versions:
 
 ## Fixes
 - `getplants`: will no longer crash when faced with plants with growths that do not drop seeds when processed
+- `gui/teleport`: adapt to new behavior in DF 51.11 to avoid a crash when teleporting items into mid-air
 
 ## Misc Improvements
 - All places where units are listed in DFHack tools now show the translated English name in addition to the native name. In particular, this makes units searchable by English name in `gui/sitemap`.

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -816,9 +816,12 @@ static bool detachItem(df::item *item)
         }
     }
 
-    if (auto ref = virtual_cast<df::general_ref_projectile>(Items::getGeneralRef(item, general_ref_type::PROJECTILE)))
-        return linked_list_remove(&world->projectiles.all, ref->projectile_id)
-            && removeRef(item->general_refs, general_ref_type::PROJECTILE, ref->getID());
+    if (auto ref = virtual_cast<df::general_ref_projectile>(Items::getGeneralRef(item, general_ref_type::PROJECTILE))) {
+        auto proj_id = ref->projectile_id;
+        bool isRefRemoved = removeRef(item->general_refs, general_ref_type::PROJECTILE, proj_id);
+        bool isLinkRemoved = linked_list_remove(&world->projectiles.all, proj_id);
+        return isRefRemoved && isLinkRemoved;
+    }
 
     if (item->flags.bits.on_ground) {
         if (!removeItemOnGround(item))


### PR DESCRIPTION
Fixes: https://github.com/DFHack/dfhack/issues/5427
