### PR TITLE
Fix Items::getDescription

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -105,6 +105,7 @@ Template for new versions:
 - ``Buildings`` module: add ``getOwner`` (using the ``Units::get_cached_unit_by_global_id`` mechanic) to reflect changes in 51.11
 - ``Units::teleport``: projectile information is now cleared for teleported units
 - ``Buildings::setOwner``: updated for changes in 51.11
+- ``Items::getDescription``: fixed display of quality levels, now displays ALL item designations (in correct order) and obeys SHOW_IMP_QUALITY
 
 ## Lua
 - ``dfhack.military.addToSquad``: expose Military API function


### PR DESCRIPTION
* Display correct quality level for items with "non-displayed" improvements
* Add ALL item designations here (and remove "XXwearXX" from other spot)
* Obey SHOW_IMP_QUALITY setting

Fixes #5404

Replaces PR #5406 (which was merging from the wrong branch)