### PR TITLE
[preserve-rooms] downgrade warning to debug

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 - `getplants`: fix logic for determining whether plant growths have been picked
 - `gui/teleport`: adapt to new behavior in DF 51.11 to avoid a crash when teleporting items into mid-air
 - `script-manager`: fix lua scripts in mods not being reloaded properly upon entering a saved world on Windows
+- `preserve-rooms`: don't warn when a room is assigned to a non-existent unit.  this is now common behavior for DF when it keeps a room for an unloaded unit
 
 ## Misc Improvements
 - All places where units are listed in DFHack tools now show the translated English name in addition to the native name. In particular, this makes units searchable by English name in `gui/sitemap`.

--- a/plugins/preserve-rooms.cpp
+++ b/plugins/preserve-rooms.cpp
@@ -513,7 +513,7 @@ static void process_rooms(color_ostream &out,
         }
         auto owner = Buildings::getOwner(zone);
         if (!owner) {
-            WARN(cycle, out).print("building %d has owner id %d but no such unit exists\n", zone->id, zone->assigned_unit_id);
+            DEBUG(cycle, out).print("building %d has owner id %d but no such unit exists\n", zone->id, zone->assigned_unit_id);
             continue;
         }
         auto hf = df::historical_figure::find(owner->hist_figure_id);


### PR DESCRIPTION
DF now routinely has zones assigned to non-existent units

ref: https://github.com/DFHack/dfhack/issues/5417

more work needs to be done to call that issue fixed, though.