### PR TITLE
adjust `df_object` constraint

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -62,6 +62,8 @@ Template for new versions:
 - `gui/teleport`: adapt to new behavior in DF 51.11 to avoid a crash when teleporting items into mid-air
 - `script-manager`: fix lua scripts in mods not being reloaded properly upon entering a saved world on Windows
 - `preserve-rooms`: don't warn when a room is assigned to a non-existent unit.  this is now common behavior for DF when it keeps a room for an unloaded unit
+- fixed an overly restrictive type constraint that resulted in some object types being glossed as a boolean when passed as an argument from C++ to Lua
+- `plants`: will no longer generate a traceback when a filter is used
 
 ## Misc Improvements
 - All places where units are listed in DFHack tools now show the translated English name in addition to the native name. In particular, this makes units searchable by English name in `gui/sitemap`.

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -141,9 +141,9 @@ namespace DFHack::Lua {
     DFHACK_EXPORT void CheckDFAssign(lua_State *state, type_identity *type,
                                      void *target, int val_index, bool exact_type = false);
 
-    template<typename T> concept df_object = requires(T x)
+    template<typename T> concept df_object = requires()
     {
-        { df::identity_traits<T>::get() } -> std::convertible_to<df::type_identity*>;
+        { df::identity_traits<T>::get() } -> std::convertible_to<const df::type_identity*>;
     };
 
     /**


### PR DESCRIPTION
some (most, actually) `get` methods return a pointer to a `const` instance of a subclass of `type_identity`  which isn't convertible to a pointer of non-`const` `type_identity`. adding `const` fixes this. a pointer to non-`const` is always convertible to a pointer of `const` of the same type or of a compatible type

fixes #5450

the reason why the pointer to vector glossed as a boolean is that pointers have an implicit conversion to `bool`, and so when the type inference for the template failed, it fell back to the next best overload, which was the one for `bool`