### PR TITLE
Safe getTileBlock

### DIFF
--- a/library/modules/Maps.cpp
+++ b/library/modules/Maps.cpp
@@ -363,6 +363,16 @@ df::map_block *Maps::getTileBlock (int32_t x, int32_t y, int32_t z)
 {
     if (!isValidTilePos(x,y,z))
         return NULL;
+
+    auto &block_index = world->map.block_index;
+
+    if (block_index == NULL ||
+        block_index[bx] == NULL ||
+        block_index[bx][by] == NULL ||
+        block_index[bx][by][z] == NULL) {
+        return NULL;
+    }
+
     return world->map.block_index[x >> 4][y >> 4][z];
 }
 


### PR DESCRIPTION
I'm writing a renderer that has to repeatedly access the getTileBlock() method in Maps.cpp. I've had crashes here before at the return statement:

`return world->map.block_index[x >> 4][y >> 4][z];`

It seems that it is trying to access an invalid memory point. This indicates sometimes dfhack can hit the map_block data before it has updated, causing the crash. Adding a check for null pointers seems to have resolved the crashes on my end. Let me know if this is a prudent change or if I ought to be doing something else when having to make many calls to getTileBlock().
