### PR TITLE
Extending Persistency to Allow Associating a File to Entity and Key Pair

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -78,6 +78,9 @@ Template for new versions:
 - ``Random`` module: added ``SplitmixRNG`` class, implements the Splitmix64 RNG used by Dwarf Fortress for "simple" randomness
 - ``Items::getDescription``: fixed display of quality levels, now displays ALL item designations (in correct order) and obeys vanilla SHOW_IMP_QUALITY setting
 - ``cuboid::forCoord``, ``Maps::forCoord``: take additional parameter to control whether iteration goes in column major or row major order
+- ``SC_NEW_MAP_AVAILABLE`` introduced to allow callbacks when moving between map tiles in adventure mode
+- ``World::GetCurrentSiteIdsWithExtraRange`` added to check for valid sites with added range when in adventure mode
+- Persistent files with identification by an arbitrary index (e. g. entity or site ID) and a key.
 
 ## Lua
 - ``script-manager``: new ``get_active_mods()`` function for getting information on active mods

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -78,8 +78,6 @@ Template for new versions:
 - ``Random`` module: added ``SplitmixRNG`` class, implements the Splitmix64 RNG used by Dwarf Fortress for "simple" randomness
 - ``Items::getDescription``: fixed display of quality levels, now displays ALL item designations (in correct order) and obeys vanilla SHOW_IMP_QUALITY setting
 - ``cuboid::forCoord``, ``Maps::forCoord``: take additional parameter to control whether iteration goes in column major or row major order
-- ``SC_NEW_MAP_AVAILABLE`` introduced to allow callbacks when moving between map tiles in adventure mode
-- ``World::GetCurrentSiteIdsWithExtraRange`` added to check for valid sites with added range when in adventure mode
 - Persistent files with identification by an arbitrary index (e. g. entity or site ID) and a key.
 
 ## Lua

--- a/library/include/modules/Persistence.h
+++ b/library/include/modules/Persistence.h
@@ -36,6 +36,7 @@ distribution.
 #include <memory>
 #include <string>
 #include <vector>
+#include <fstream>
 
 namespace DFHack
 {
@@ -193,7 +194,7 @@ namespace DFHack
 
         const int WORLD_ENTITY_ID = -30000;
 
-        // Returns a new PersistentDataItem with the specified key associated wtih the specified
+        // Returns a new PersistentDataItem with the specified key associated with the specified
         // entity_id. Pass WORLD_ENTITY_ID for the entity_id to indicate the global world context.
         // If there is no world loaded or the key is empty, returns an invalid item.
         DFHACK_EXPORT PersistentDataItem addItem(int entity_id, const std::string &key);
@@ -215,5 +216,31 @@ namespace DFHack
         DFHACK_EXPORT void getAllByKey(std::vector<PersistentDataItem> &vec, int entity_id, const std::string &key);
         // Returns the number of seconds since the current savegame was saved or loaded.
         DFHACK_EXPORT uint32_t getUnsavedSeconds();
+
+        // Returns the path to a file that will correspond to the specified key associated with the specified
+        // entity_id. Pass WORLD_ENTITY_ID for the entity_id to indicate the global world context.
+        // If there is no world loaded or the key is empty, returns an empty path.
+        DFHACK_EXPORT std::filesystem::path addFile(int entity_id, const std::string& key);
+        // Returns the path to a file associated with the key and the entity_id.
+        // If "added" is not null and there is no such file, a new file is returned and
+        // the bool value is set to true. If "added" is not null and a file is found or
+        // no new file can be created, the bool value is set to false. If "added" is null,
+        // no new file will be added.
+        // If just_for_reading is `true`, the file will not be copied to the current directory
+        // and should not be modified.
+        DFHACK_EXPORT std::filesystem::path getFile(int entity_id, const std::string& key, bool *added = nullptr, bool just_for_reading = false);
+        // Fills the vector with all the keys and paths to files corresponding to the entity_id.
+        // If just_for_reading is `true`, the file will not be copied to the current directory
+        // and should not be modified.
+        DFHACK_EXPORT void getAllFiles(std::vector<std::pair<std::string, std::filesystem::path>>& vec, int entity_id, bool just_for_reading = false);
+        // Fills the vector with paths to each file with a key that is
+        // greater than or equal to "min" and less than "max".
+        // If just_for_reading is `true`, the file will not be copied to the current directory
+        // and should not be modified.
+        DFHACK_EXPORT void getAllFilesByKeyRange(std::vector<std::pair<std::string, std::filesystem::path>>& vec, int entity_id,
+                                                 const std::string& min, const std::string& max, bool just_for_reading = false);
+        // Attempts to delete the file corresponding to the given entity_id and key.
+        // Returns false if the file was not deleted (due to not existing or some other error).
+        DFHACK_EXPORT bool deleteFile(int entity_id, const std::string& key);
     }
 }


### PR DESCRIPTION
I propose a set of functions to `DFHack::Persistency` to allow managing whole files, following the same entity ID and key logic as the pre-existing functions.

The API was designed around managing the possible paths for these files rather than the files themselves; it would be up to the callers to interact with them according to the demands of their particular use case. Every (entity ID, key) pair will be associated with a unique file ID, corresponding to a file with a name of the form `dfhack-pf-<ID>.dat`. The association between (entity ID, key) pairs and file IDs is saved as JSON in `dfhack-extra-files.dat`.

Files that are requested will be copied over to the `current` folder unless specifically requested as read only through the API (in which case modifying their contents leads to these changes not being reflected if the user does not save to the same folder).

No attempt is made at this stage to offer any particular form of synchronization or memory management of the files themselves. Operations that add to or query the list of available files are guarded by `CoreSuspender`, but this ultimately only protects the list of file IDs.

No provisions are made for associating more than one file to an (entity ID, key) pair.

Note: I surmised from perusing previous discussions that it was not yet consensual among the main developers whether DFHack should offer the ability to request an entire file for persistency. However, for my current project of overhauling the dwarf logic system, serialization/deserialization could be important for performance if the user configures many objects to be handled by my system, so a more optimized way of handling that seems desirable. My apologies if I overstep any boundaries by proposing this.