### PR TITLE
Add arena mode focus strings for widgets

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -35,6 +35,7 @@ Template for new versions:
 ## Documentation
 
 ## API
+- Added GUI focus strings for new_arena: ``/Loading`` and ``/Mods``
 
 ## Lua
 

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -90,6 +90,7 @@ distribution.
 #include "df/viewscreen_dungeonmodest.h"
 #include "df/viewscreen_dwarfmodest.h"
 #include "df/viewscreen_legendsst.h"
+#include "df/viewscreen_new_arenast.h"
 #include "df/viewscreen_new_regionst.h"
 #include "df/viewscreen_setupdwarfgamest.h"
 #include "df/viewscreen_titlest.h"
@@ -186,6 +187,18 @@ DEFINE_GET_FOCUS_STRING_HANDLER(new_region)
 
     if (focusStrings.empty())
         focusStrings.push_back(baseFocus);
+}
+
+DEFINE_GET_FOCUS_STRING_HANDLER(new_arena)
+{
+    if (screen->raw_load)
+        focusStrings.push_back(baseFocus + "/Loading");
+    else if (screen->doing_mods)
+        focusStrings.push_back(baseFocus + "/Mods");
+
+    if (focusStrings.empty())
+        focusStrings.push_back(baseFocus);
+
 }
 
 DEFINE_GET_FOCUS_STRING_HANDLER(choose_start_site)


### PR DESCRIPTION
Only has `Loading` and `Mods` focus strings since there is no clear way (for me at least) to deduce the profile selection screen. That said, since there are only 3 modes for now anything can just use the base `new_arena` viewscreen path.