### PR TITLE
Add clear option to autoclothing that will unset a previosly set order

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,6 +58,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- `autoclothing`: Added a `clear` option to unset previously set orders
 
 ## Documentation
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,7 +58,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
-- `autoclothing`: Added a `clear` option to unset previously set orders
+- `autoclothing`: Added a ``clear`` option to unset previously set orders
 
 ## Documentation
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -58,7 +58,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
-- `autoclothing`: Added a ``clear`` option to unset previously set orders
+- `autoclothing`: added a ``clear`` option to unset previously set orders
 
 ## Documentation
 

--- a/docs/plugins/autoclothing.rst
+++ b/docs/plugins/autoclothing.rst
@@ -22,6 +22,7 @@ Usage
     autoclothing
     autoclothing <material> <item>
     autoclothing <material> <item> <quantity>
+    autoclothing clear <material> <item>
 
 ``<material>`` can be "cloth", "silk", "yarn", or "leather". The ``<item>`` can
 be anything your civilization can produce, such as "dress" or "mitten".
@@ -43,6 +44,9 @@ Examples
     long as there is cloth available to make them out of).
 ``autoclothing cloth dress``
     Displays the currently set number of cloth dresses chosen per citizen.
+``autoclothing clear cloth "short skirt"``
+    Unsets cloth short skirts from being made if previously enabled such as
+    in the first example
 
 Which should I enable: autoclothing or tailor?
 ----------------------------------------------

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -136,6 +136,10 @@ struct ClothingRequirement {
                 out << "Unrecognized item name or token: " << parameters[2] << endl;
                 return false;
             }
+            else if (!validateMaterialCategory(this)) {
+                out << parameters[1] << " is not a valid material category for " << parameters[2] << endl;
+                return false;
+            }
             return true;
         }
         if (!set_bitfield_field(&material_category, parameters[0], 1))

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -129,6 +129,15 @@ struct ClothingRequirement {
 
     bool SetFromParameters(color_ostream &out, vector<string> &parameters)
     {
+        if (parameters[0] == "clear") { // handle the clear case
+            if (!set_bitfield_field(&material_category, parameters[1], 1))
+                out << "Unrecognized material type: " << parameters[1] << endl;
+            if (!setItem(parameters[2], this)) {
+                out << "Unrecognized item name or token: " << parameters[2] << endl;
+                return false;
+            }
+            return true;
+        }
         if (!set_bitfield_field(&material_category, parameters[0], 1))
             out << "Unrecognized material type: " << parameters[0] << endl;
         if (!setItem(parameters[1], this)) {
@@ -442,14 +451,20 @@ command_result autoclothing(color_ostream &out, vector<string> &parameters)
     bool settingSize = false;
     bool matchedExisting = false;
     if (parameters.size() > 2) {
-        try {
-            newRequirement.needed_per_citizen = std::stoi(parameters[2]);
+        if (parameters[0] == "clear") {
+            newRequirement.needed_per_citizen = 0;
+            settingSize = true;
         }
-        catch (const std::exception&) {
-            out << parameters[2] << " is not a valid number." << endl;
-            return CR_WRONG_USAGE;
+        else {
+            try {
+                newRequirement.needed_per_citizen = std::stoi(parameters[2]);
+            }
+            catch (const std::exception&) {
+                out << parameters[2] << " is not a valid number." << endl;
+                return CR_WRONG_USAGE;
+            }
+            settingSize = true;
         }
-        settingSize = true;
     }
 
     for (size_t i = clothingOrders.size(); i-- > 0;) {
@@ -459,7 +474,10 @@ command_result autoclothing(color_ostream &out, vector<string> &parameters)
         if (settingSize) {
             if (newRequirement.needed_per_citizen == 0) {
                 clothingOrders.erase(clothingOrders.begin() + i);
-                out << "Unset " << parameters[0] << " " << parameters[1] << endl;
+                    if (parameters[0] == "clear")
+                        out << "Unset " << parameters[1] << " " << parameters[2] << endl;
+                    else
+                        out << "Unset " << parameters[0] << " " << parameters[1] << endl;
             }
             else {
                 clothingOrders[i] = newRequirement;


### PR DESCRIPTION
These changes aim to handle #5366. Updated documentation to alert users of new `clear` option that will allow them to unset a previously set order. This probably could have been a little cleaner if I added the clear at the end however I think putting it as the first parameter makes it read quite well. Compiled and tested on windows. Please let me know if there is anything I need ti change/do!
