### PR TITLE
use consistent base and install path determination

### DIFF
--- a/library/modules/Persistence.cpp
+++ b/library/modules/Persistence.cpp
@@ -186,8 +186,7 @@ static std::string filterSaveFileName(std::string s) {
 }
 
 static std::filesystem::path getSavePath(const std::string &world) {
-    auto base{ Filesystem::getBaseDir() };
-    return base / "save" / world;
+    return Filesystem::getBaseDir() / "save" / world;
 }
 
 static std::filesystem::path getSaveFilePath(const std::string &world, const std::string &name) {


### PR DESCRIPTION
for 52.xx compatibility when in appdata mode

(no changelog, already covered by the changelog from #5514)
