### PR TITLE
extend implementations of `addToSquad` and `removeFromSquad`

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 
 ## API
 - ``Filesystem::getBaseDir`` and ``Filesystem::getInstallDir`` added (and made available in Lua)
+- expand the partial implementations of ``Military::addToSquad`` and ``Military::removeFromSquad``
 
 ## Lua
 - inserting values into STL containers containing nonprimitive types is now supported


### PR DESCRIPTION
I have run the in-development `autotraining` for the better part of a season using this implementation, and I have not seen a single unit get stuck in a generic training session. 
