### PR TITLE
helper functions for creating and assigning jobs

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,8 @@ Template for new versions:
 ## Documentation
 
 ## API
+- ``Job``: new functions ``createLinked`` and ``assignToWorkshop``
+- ``Units``: new functions ``getFocusPenalty``, ``unbailableSocialActivity``, ``isJobAvailable``
 
 ## Lua
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -68,6 +68,8 @@ Template for new versions:
 
 ## Lua
 
+- New functions: ``dfhack.jobs.createLinked``, ``dfhack.jobs.assignToWorkshop``, ``dfhack.units.getFocusPenalty``, ``dfhack.units.unbailableSocialActivity``, and ``dfhack.units.isJobAvailable``
+
 ## Removed
 
 # 52.03-r1.1

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1313,6 +1313,10 @@ Job module
 
   Creates a deep copy of the given job.
 
+* ``dfhack.job.createLinked()``
+
+  Create a job and immediately link it into the global job list.
+
 * ``dfhack.job.printJobDetails(job)``
 
   Prints info about the job.
@@ -1337,6 +1341,12 @@ Job module
 * ``dfhack.job.getSpecificRef(job, type)``
 
   Searches for a specific_ref with the given type.
+
+* ``dfhack.job.assignToWorkshop(job, workshop)``
+
+  Assign job to workshop (i.e. establish the bidirectional link between the job
+  and the workshop). Does nothing and returns ``false`` if the workshop already
+  has the maximum of ten jobs.
 
 * ``dfhack.job.getHolder(job)``
 
@@ -1628,7 +1638,7 @@ Units module
   Returns true if the unit is within a box defined by the
   specified coordinates.
 
-``dfhack.units.getUnitsInBox(pos1, pos2[, filter])``
+* ``dfhack.units.getUnitsInBox(pos1, pos2[, filter])``
 * ``dfhack.units.getUnitsInBox(x1,y1,z1,x2,y2,z2[,filter])``
 
   Returns a table of all units within the specified coordinates.
@@ -1893,6 +1903,22 @@ Units module
 
   Return the ``df.activity_entry`` or ``df.activity_event`` representing the
   unit's current social activity.
+
+* ``dfhack.units.hasUnbailableSocialActivity(unit)``
+
+  Unit has an uninterruptible social activity (e.g. a purple "Socialize!").
+
+* ``dfhack.units.isJobAvailable(unit [, interrupt_social])``
+
+  Check whether a unit can be assigned to (i.e. is looking for) a job. Will
+  return ``true`` if the unit is engaged in "green" social activities, unless
+  the boolean ``interrupt_social`` is true.
+
+* ``dfhack.units.getFocusPenalty(unit, need_type [, need_type, ...])``
+
+  Get largest (i.e. most negative) focus penalty associated to a collection of
+  ``df.need_type`` arguments. Returns a number strictly greater than 400 if the
+  unit does not have any of the requested needs.
 
 * ``dfhack.units.getStressCategory(unit)``
 

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -2337,7 +2337,7 @@ int32_t units_getFocusPenalty(lua_State *L) {
     for (int i = 2; i <= top; ++i) {
       try {
         needs.set(luaL_checkint(L, i));
-      } catch (const std::out_of_range &e) {
+      } catch ([[maybe_unused]] const std::out_of_range &e) {
         luaL_argerror(L, i, "Expected a need type");
       }
     }

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -69,6 +69,7 @@ distribution.
 #include "df/building_civzonest.h"
 #include "df/building_stockpilest.h"
 #include "df/building_tradedepotst.h"
+#include "df/building_workshopst.h"
 #include "df/burrow.h"
 #include "df/caravan_state.h"
 #include "df/construction.h"
@@ -116,6 +117,7 @@ distribution.
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <stdexcept>
 
 namespace DFHack {
     DBG_DECLARE(core, luaapi, DebugCategory::LINFO);
@@ -1902,6 +1904,8 @@ static const LuaWrapper::FunctionReg dfhack_job_module[] = {
     WRAPM(Job,disconnectJobItem),
     WRAPM(Job,disconnectJobGeneralRef),
     WRAPM(Job,removeJob),
+    WRAPM(Job,createLinked),
+    WRAPM(Job,assignToWorkshop),
     WRAPN(is_equal, jobEqual),
     WRAPN(is_item_equal, jobItemEqual),
     { NULL, NULL }
@@ -2128,6 +2132,8 @@ static const LuaWrapper::FunctionReg dfhack_units_module[] = {
     WRAPM(Units, setGroupActionTimers),
     WRAPM(Units, getUnitByNobleRole),
     WRAPM(Units, unassignTrainer),
+    WRAPM(Units, hasUnbailableSocialActivity),
+    WRAPM(Units, isJobAvailable),
     { NULL, NULL }
 };
 
@@ -2321,6 +2327,25 @@ static int units_getProfessionName(lua_State *L) {
     return 1;
 }
 
+int32_t units_getFocusPenalty(lua_State *L) {
+  auto unit = Lua::GetDFObject<df::unit>(L, 1);
+  Units::need_type_set needs;
+  auto top = lua_gettop(L);
+  if (top < 2) {
+    luaL_argerror(L, 2, "Expected at least one need type");
+  } else {
+    for (int i = 2; i <= top; ++i) {
+      try {
+        needs.set(luaL_checkint(L, i));
+      } catch (const std::out_of_range &e) {
+        luaL_argerror(L, i, "Expected a need type");
+      }
+    }
+    Lua::Push(L, Units::getFocusPenalty(unit, needs));
+  }
+  return 1;
+}
+
 static const luaL_Reg dfhack_units_funcs[] = {
     { "getPosition", units_getPosition },
     { "getOuterContainerRef", units_getOuterContainerRef },
@@ -2335,6 +2360,7 @@ static const luaL_Reg dfhack_units_funcs[] = {
     { "getReadableName", units_getReadablename },
     { "getVisibleName", units_getVisibleName },
     { "getProfessionName", units_getProfessionName },
+    { "getFocusPenalty", units_getFocusPenalty },
     { NULL, NULL }
 };
 

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -31,6 +31,7 @@ distribution.
 #include "Types.h"
 #include "DataDefs.h"
 
+#include "df/building_workshopst.h"
 #include "df/item_type.h"
 #include "df/job_item_ref.h"
 
@@ -94,7 +95,13 @@ namespace DFHack
         DFHACK_EXPORT void checkBuildingsNow();
         DFHACK_EXPORT void checkDesignationsNow();
 
+        // link the job into the global job list, passing ownership to DF
         DFHACK_EXPORT bool linkIntoWorld(df::job *job, bool new_id = true);
+        // create a job and immediately link it into the global job list
+        DFHACK_EXPORT df::job* createLinked();
+
+        // assign job to workshop, returns false if workshop already has the maximum of ten jobs
+        DFHACK_EXPORT bool assignToWorkshop(df::job *job, df::building_workshopst *workshop);
 
         // Flag this job's posting as "dead" and set its posting_index to -1
         // If remove_all is true, flag all postings pointing to this job

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -39,12 +39,14 @@ distribution.
 #include "df/job_skill.h"
 #include "df/mental_attribute_type.h"
 #include "df/misc_trait_type.h"
+#include "df/need_type.h"
 #include "df/physical_attribute_type.h"
 #include "df/unit_action.h"
 #include "df/unit_action_type_group.h"
 #include "df/unit_path_goal.h"
 
 #include <ranges>
+#include <bitset>
 
 namespace df {
     struct activity_entry;
@@ -338,6 +340,17 @@ DFHACK_EXPORT bool isGoalAchieved(df::unit *unit, size_t goalIndex = 0);
 
 DFHACK_EXPORT df::activity_entry *getMainSocialActivity(df::unit *unit);
 DFHACK_EXPORT df::activity_event *getMainSocialEvent(df::unit *unit);
+
+// get largest (i.e. most negative) focus penalty for a set of needs
+using need_types_set = std::bitset<ENUM_LAST_ITEM(need_type)+1UL>;
+DFHACK_EXPORT int32_t getFocusPenalty(df::unit* unit, need_types_set need_types);
+// get focused penalty for a single need
+DFHACK_EXPORT int32_t getFocusPenalty(df::unit* unit, df::need_type need_type);
+
+// unit has an unbailable social activity (e.g. "Socialize!")
+DFHACK_EXPORT bool unbailableSocialActivity(df::unit *unit);
+// unit can be assigned a job
+DFHACK_EXPORT bool isJobAvailable(df::unit *unit, bool interrupt_social);
 
 // Stress categories. 0 is highest stress, 6 is lowest.
 DFHACK_EXPORT extern const std::vector<int32_t> stress_cutoffs;

--- a/library/include/modules/Units.h
+++ b/library/include/modules/Units.h
@@ -342,13 +342,13 @@ DFHACK_EXPORT df::activity_entry *getMainSocialActivity(df::unit *unit);
 DFHACK_EXPORT df::activity_event *getMainSocialEvent(df::unit *unit);
 
 // get largest (i.e. most negative) focus penalty for a set of needs
-using need_types_set = std::bitset<ENUM_LAST_ITEM(need_type)+1UL>;
-DFHACK_EXPORT int32_t getFocusPenalty(df::unit* unit, need_types_set need_types);
+using need_type_set = std::bitset<ENUM_LAST_ITEM(need_type)+1UL>;
+DFHACK_EXPORT int32_t getFocusPenalty(df::unit* unit, need_type_set need_types);
 // get focused penalty for a single need
 DFHACK_EXPORT int32_t getFocusPenalty(df::unit* unit, df::need_type need_type);
 
 // unit has an unbailable social activity (e.g. "Socialize!")
-DFHACK_EXPORT bool unbailableSocialActivity(df::unit *unit);
+DFHACK_EXPORT bool hasUnbailableSocialActivity(df::unit *unit);
 // unit can be assigned a job
 DFHACK_EXPORT bool isJobAvailable(df::unit *unit, bool interrupt_social);
 

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -525,7 +525,7 @@ df::job* DFHack::Job::createLinked()
     return job;
 }
 
-bool assignToWorkshop(df::job *job, df::building_workshopst *workshop)
+bool DFHack::Job::assignToWorkshop(df::job *job, df::building_workshopst *workshop)
 {
     CHECK_NULL_POINTER(job);
     CHECK_NULL_POINTER(workshop);

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -38,6 +38,7 @@ distribution.
 #include "modules/References.h"
 
 #include "df/building.h"
+#include "df/building_workshopst.h"
 #include "df/general_ref.h"
 #include "df/general_ref_unit_workerst.h"
 #include "df/general_ref_building_holderst.h"
@@ -515,6 +516,27 @@ bool DFHack::Job::linkIntoWorld(df::job *job, bool new_id)
         linked_list_insert_after(ins_pos, job->list_link);
         return true;
     }
+}
+
+df::job* DFHack::Job::createLinked()
+{
+    auto job = new df::job();
+    DFHack::Job::linkIntoWorld(job, true);
+    return job;
+}
+
+bool assignToWorkshop(df::job *job, df::building_workshopst *workshop)
+{
+    CHECK_NULL_POINTER(job);
+    CHECK_NULL_POINTER(workshop);
+
+    if (workshop->jobs.size() >= 10) {
+        return false;
+    }
+    job->pos = df::coord(workshop->centerx, workshop->centery, workshop->z);
+    DFHack::Job::addGeneralRef(job, df::general_ref_type::BUILDING_HOLDER, workshop->id);
+    workshop->jobs.push_back(job);
+    return true;
 }
 
 bool DFHack::Job::removePostings(df::job *job, bool remove_all)

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -2023,7 +2023,7 @@ df::activity_event *Units::getMainSocialEvent(df::unit *unit) {
     return entry->events[entry->events.size() - 1];
 }
 
-int32_t Units::getFocusPenalty(df::unit* unit, need_types_set need_types) {
+int32_t Units::getFocusPenalty(df::unit* unit, need_type_set need_types) {
     CHECK_NULL_POINTER(unit);
 
     int max_penalty = INT_MAX;
@@ -2037,24 +2037,24 @@ int32_t Units::getFocusPenalty(df::unit* unit, need_types_set need_types) {
 }
 
 int32_t Units::getFocusPenalty(df::unit* unit, df::need_type need_type) {
-    auto need_types = need_types_set().set(need_type);
+    auto need_types = need_type_set().set(need_type);
     return getFocusPenalty(unit, need_types);
 }
 
 // reverse engineered from unitst::have_unbailable_sp_activities (partial implementation)
-bool Units::unbailableSocialActivity(df::unit *unit)
+bool Units::hasUnbailableSocialActivity(df::unit *unit)
 {
     // these can become constexpr with C++23
-    static const need_types_set pray_needs = need_types_set()
+    static const need_type_set pray_needs = need_type_set()
         .set(df::need_type::PrayOrMeditate);
 
-    static const need_types_set socialize_needs = need_types_set()
+    static const need_type_set socialize_needs = need_type_set()
         .set(df::need_type::Socialize)
         .set(df::need_type::BeCreative)
         .set(df::need_type::Excitement)
         .set(df::need_type::AdmireArt);
 
-    static const need_types_set read_needs = need_types_set()
+    static const need_type_set read_needs = need_type_set()
         .set(df::need_type::ThinkAbstractly)
         .set(df::need_type::LearnSomething);
 
@@ -2097,7 +2097,7 @@ bool Units::isJobAvailable(df::unit *unit, bool preserve_social = false){
         if (activity && (activity->type == df::activity_entry_type::FillServiceOrder))
             return false;
     }
-    if (unbailableSocialActivity(unit))
+    if (hasUnbailableSocialActivity(unit))
         return false;
     if (preserve_social && unit->social_activities.size() > 0)
         return false;

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -64,12 +64,15 @@ distribution.
 #include "df/interaction_profilest.h"
 #include "df/item.h"
 #include "df/job.h"
+#include "df/need_type.h"
 #include "df/nemesis_record.h"
 #include "df/personality_goalst.h"
+#include "df/personality_needst.h"
 #include "df/plotinfost.h"
 #include "df/proj_unitst.h"
 #include "df/reputation_profilest.h"
 #include "df/syndrome.h"
+#include "df/squad.h"
 #include "df/tile_occupancy.h"
 #include "df/training_assignment.h"
 #include "df/unit.h"
@@ -89,6 +92,7 @@ distribution.
 #include "df/world_site.h"
 
 #include <algorithm>
+#include <bitset>
 #include <cstring>
 #include <functional>
 #include <map>
@@ -2015,6 +2019,92 @@ df::activity_event *Units::getMainSocialEvent(df::unit *unit) {
     if (!entry || entry->events.empty())
         return nullptr;
     return entry->events[entry->events.size() - 1];
+}
+
+int32_t Units::getFocusPenalty(df::unit* unit, need_types_set need_types) {
+    CHECK_NULL_POINTER(unit);
+
+    int max_penalty = INT_MAX;
+    auto& needs = unit->status.current_soul->personality.needs;
+    for (auto const need : needs) {
+        if (need_types.test(need->id)) {
+            max_penalty = min(max_penalty, need->focus_level);
+        }
+    }
+    return max_penalty;
+}
+
+int32_t Units::getFocusPenalty(df::unit* unit, df::need_type need_type) {
+    auto need_types = need_types_set().set(need_type);
+    return getFocusPenalty(unit, need_types);
+}
+
+// reverse engineered from unitst::have_unbailable_sp_activities (partial implementation)
+bool Units::unbailableSocialActivity(df::unit *unit)
+{
+    // these can become constexpr with C++23
+    static const need_types_set pray_needs = need_types_set()
+        .set(df::need_type::PrayOrMeditate);
+
+    static const need_types_set socialize_needs = need_types_set()
+        .set(df::need_type::Socialize)
+        .set(df::need_type::BeCreative)
+        .set(df::need_type::Excitement)
+        .set(df::need_type::AdmireArt);
+
+    static const need_types_set read_needs = need_types_set()
+        .set(df::need_type::ThinkAbstractly)
+        .set(df::need_type::LearnSomething);
+
+    CHECK_NULL_POINTER(unit);
+
+    if (unit->social_activities.empty()) {
+        return false;
+    } else if (unit->social_activities.size() > 1) {
+        return true; // is this even possible?
+    }
+
+    auto activity = df::activity_entry::find(unit->social_activities[0]);
+    if (activity) {
+        using df::activity_entry_type;
+        switch (activity->type) {
+            case activity_entry_type::Socialize:
+                return getFocusPenalty(unit, socialize_needs) <= -10000;
+            case activity_entry_type::Prayer:
+                return getFocusPenalty(unit, pray_needs) <= -10000;
+            case activity_entry_type::Read:
+                return getFocusPenalty(unit, read_needs) <= -10000;
+            default:
+                // consider unhandled activities as uninterruptible
+                return true;
+        }
+    }
+    // this should never happen
+    return false;
+}
+
+bool Units::isJobAvailable(df::unit *unit, bool preserve_social = false){
+    if (unit->job.current_job)
+        return false;
+    if (unit->flags1.bits.caged || unit->flags1.bits.chained)
+        return false;
+    if (unit->individual_drills.size() > 0) {
+        if (unit->individual_drills.size() > 1)
+            return false; // this is even possible
+        auto activity = df::activity_entry::find(unit->individual_drills[0]);
+        if (activity && (activity->type == df::activity_entry_type::FillServiceOrder))
+            return false;
+    }
+    if (unbailableSocialActivity(unit))
+        return false;
+    if (preserve_social && unit->social_activities.size() > 0)
+        return false;
+    if (unit->military.squad_id != -1) {
+        auto squad = df::squad::find(unit->military.squad_id);
+        if (squad)
+            return squad->orders.size() == 0 && squad->activity == -1;
+    }
+    return true;
 }
 
 // 50000 and up is level 0, 25000 and up is level 1, etc.


### PR DESCRIPTION
I finally got around to following up on [this discussion](https://discord.com/channels/793331351645323264/873659717174587403/1289305706314596352) concerning `unitst::have_unbailable_sp_activities`

The motivation for this is that we now have several tools that create jobs and immediately assign them to dwarves (`idle-crafting`, `autocheese`, `immortal-cravings`). This has led to a bunch of code duplication and cross-importing between those tools. I would like to clean this up a bit by putting some of the frequently used functionality on a more solid footing and moving it into the C++ libraries.

@ab9rf It would be nice if you could take a look at `unbailableSocialActivity` and see if it needs any corrections or extensions for our purposes.

