### PR TITLE
fix `Job::getName`

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -57,19 +57,19 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- job descriptions of mix dye job will display proper dye names
 
 ## Misc Improvements
 
 ## Documentation
 
 ## API
-- Added GUI focus strings for new_arena: ``/Loading`` and ``/Mods``
 
 ## Lua
 
 ## Removed
 
-# 52.03-1
+# 52.03-r1
 
 ## New Tools
 
@@ -83,6 +83,7 @@ Template for new versions:
 ## Documentation
 
 ## API
+- Added GUI focus strings for new_arena: ``/Loading`` and ``/Mods``
 
 ## Lua
 

--- a/library/modules/Job.cpp
+++ b/library/modules/Job.cpp
@@ -655,6 +655,9 @@ std::string Job::getName(df::job *job)
     button->matgloss = job->mat_index;
     button->specflag = job->specflag;
     button->job_item_flag = job->material_category;
+    button->specdata = job->specdata;
+    button->art_specifier_id1 = job->art_spec.id;
+    button->art_specifier_id2 = job->art_spec.subid;
 
     button->text(&desc);
     delete button;


### PR DESCRIPTION
add fields added to `job` in the dye update

If this PR makes an externally-visible change in behavior or API, please add an appropriate line to `docs/changelog.txt`.
