### PR TITLE
Prevent assignment of trader-owned small pets (items, not units) to pits, ponds, and cages.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- small animals owned by traders can no longer be assigned to pits, ponds, and cages.
 
 ## Misc Improvements
 

--- a/plugins/lua/zone.lua
+++ b/plugins/lua/zone.lua
@@ -602,7 +602,9 @@ local function is_assignable_unit(unit)
 end
 
 local function is_assignable_item(item)
-    -- all vermin/small pets are assignable
+    -- small pets owned by traders are not assignable
+    if item.flags.trader then return false end
+    -- other vermin/small pets are assignable
     return true
 end
 


### PR DESCRIPTION
Dwarf Fortress does not allow trader-owned small pets to be assigned to cages; DFHack currently does.  This PR removes that ability.

Note: both Dwarf Fortress and DFHack currently allow trader-owned small pets to be assigned to pits and ponds; this PR removes that ability from DFHack.

In both cases, DFHack's ability to assign trader-owned small pets to pits/ponds/cages differs from Dwarf Fortress' ability.

If DFHack's ability is intended to exactly match Dwarf Fortress's, then this PR should not be accepted.