### PR TITLE
Revert "Prevent assignment of trader-owned small pets (items, not units) to pits, ponds, and cages."

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,7 +56,6 @@ Template for new versions:
 ## New Features
 
 ## Fixes
-- small animals owned by traders can no longer be assigned to pits, ponds, and cages.
 
 ## Misc Improvements
 

--- a/plugins/lua/zone.lua
+++ b/plugins/lua/zone.lua
@@ -602,9 +602,7 @@ local function is_assignable_unit(unit)
 end
 
 local function is_assignable_item(item)
-    -- small pets owned by traders are not assignable
-    if item.flags.trader then return false end
-    -- other vermin/small pets are assignable
+    -- all vermin/small pets are assignable
     return true
 end
 


### PR DESCRIPTION
Reverts DFHack/dfhack#5578 - merged prematurely 