### PR TITLE
zone overlay -- tolerate corrupt animal-to-pasture links

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -56,6 +56,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `zone`: animal assignment dialog now tolerates corrupt animal-to-pasture links.
 
 ## Misc Improvements
 

--- a/plugins/lua/zone.lua
+++ b/plugins/lua/zone.lua
@@ -989,7 +989,9 @@ local function get_zone_status(unit_or_vermin, bld_assignments)
             return PASTURE_STATUS.ASSIGNED_HERE.value
         else
             local civzone = df.building.find(assigned_zone_ref.building_id)
-            if civzone.type == df.civzone_type.Pen then
+            if not civzone or not df.building_civzonest:is_instance(civzone) then
+                return PASTURE_STATUS.NONE.value
+            elseif civzone.type == df.civzone_type.Pen then
                 return PASTURE_STATUS.PASTURED.value
             elseif civzone.type == df.civzone_type.Pond then
                 return PASTURE_STATUS.PITTED.value
@@ -1150,7 +1152,9 @@ local function get_cage_status(unit_or_vermin, bld_assignments)
     local assigned_zone_ref = get_general_ref(unit_or_vermin, df.general_ref_type.BUILDING_CIVZONE_ASSIGNED)
     if assigned_zone_ref then
         local civzone = df.building.find(assigned_zone_ref.building_id)
-        if civzone.type == df.civzone_type.Pen then
+        if not civzone or not df.building_civzonest:is_instance(civzone) then
+            return CAGE_STATUS.NONE.value
+        elseif civzone.type == df.civzone_type.Pen then
             return CAGE_STATUS.PASTURED.value
         elseif civzone.type == df.civzone_type.Pond then
             return CAGE_STATUS.PITTED.value


### PR DESCRIPTION
This is a mitigation for #5580 "DFhack assign function on Pen/Pastures not working".  There is further discussion in that issue.

Based on the stacktrace, the issue was apparently caused by an animal with a corrupt link to a pasture zone or to a pit/pond zone.

The animal apparently had a general reference of type `BUILDING_CIVZONE_ASSIGNED` which had a `building_id` field pointing to a building that either did not exist or was not a civzone.

This patch tests for those conditions.  When detected, the animal is assigned a status of `NONE`, which causes the animal to be entirely hidden from the assign-to-pasture and assign-to-cage interfaces.

The changes made by this patch are minimal; they load and run; they mitigate the two ways I found to trigger the issue; but they **are not well-tested**.

I would like to have **a code review** with a focus on whether there are any other ways that line 992 could have triggered an error().

As I understand it: this is purely a bug workaround, so it doesn't need a changelog entry.  There's no visible change except for corrupt animal -> pasture links, which now don't abort the overlay.