### PR TITLE
add link to DF wiki for DF Lua API

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,7 @@ Template for new versions:
 ## Misc Improvements
 
 ## Documentation
+- added a clarification link to DF's Lua API documentation to the DFHack Lua API documentation, as a way to reduce end-user confusion
 
 ## API
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -25,6 +25,13 @@ It does not describe all of the utility functions
 implemented by Lua files located in :file:`hack/lua/*`
 (:file:`library/lua/*` in the git repo).
 
+.. admonition:: Is this the DF or DFHack Lua API?
+   :class: warning
+
+    This document describes the Lua API provided by DFHack, not
+    the Lua API provided by Dwarf Fortress. For information about DF's Lua API, see
+    :wiki:`Lua scripting`
+    on the Dwarf Fortress Wiki.
 
 .. contents:: Contents
   :local:


### PR DESCRIPTION
People who search the Internet for "Dwarf Fortress Lua" almost invariably end up at our documentation site, which likely leads to unnecessary confusion. This adds a redbox notice to try to direct these people to what they're looking for.