### PR TITLE
add missing `const` qualifiers

### DIFF
--- a/library/LuaTools.cpp
+++ b/library/LuaTools.cpp
@@ -1077,7 +1077,7 @@ bool DFHack::Lua::Require(color_ostream &out, lua_State *state,
 }
 
 static bool doAssignDFObject(color_ostream *out, lua_State *state,
-                             type_identity *type, void *target, int val_index,
+                             const type_identity *type, void *target, int val_index,
                              bool exact, bool perr, bool signal)
 {
     if (signal)
@@ -1124,13 +1124,13 @@ static bool doAssignDFObject(color_ostream *out, lua_State *state,
 }
 
 bool DFHack::Lua::AssignDFObject(color_ostream &out, lua_State *state,
-                                 type_identity *type, void *target, int val_index,
+                                 const type_identity *type, void *target, int val_index,
                                  bool exact_type, bool perr)
 {
     return doAssignDFObject(&out, state, type, target, val_index, exact_type, perr, false);
 }
 
-void DFHack::Lua::CheckDFAssign(lua_State *state, type_identity *type,
+void DFHack::Lua::CheckDFAssign(lua_State *state, const type_identity *type,
                                 void *target, int val_index, bool exact_type)
 {
     doAssignDFObject(NULL, state, type, target, val_index, exact_type, false, true);

--- a/library/LuaWrapper.cpp
+++ b/library/LuaWrapper.cpp
@@ -132,7 +132,7 @@ bool LuaWrapper::LookupTypeInfo(lua_State *state, bool in_method)
         return true;
 }
 
-void LuaWrapper::LookupInTable(lua_State *state, void *id, LuaToken *tname)
+void LuaWrapper::LookupInTable(lua_State *state, const void *id, LuaToken *tname)
 {
     lua_rawgetp(state, LUA_REGISTRYINDEX, tname);
     lua_rawgetp(state, -1, id);

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -257,8 +257,8 @@ namespace DFHack
     };
 
     struct struct_field_info_extra {
-        enum_identity *index_enum;
-        type_identity *ref_target;
+        const enum_identity *index_enum;
+        const type_identity *ref_target;
         const char *union_tag_field;
         const char *union_tag_attr;
         const char *original_name;

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -140,14 +140,14 @@ namespace DFHack::Lua {
      * Return behavior is of SafeCall below.
      */
     DFHACK_EXPORT bool AssignDFObject(color_ostream &out, lua_State *state,
-                                      type_identity *type, void *target, int val_index,
+                                      const type_identity *type, void *target, int val_index,
                                       bool exact_type = false, bool perr = true);
 
     /**
      * Assign the value at val_index to the target of given identity using df.assign().
      * Otherwise throws an error.
      */
-    DFHACK_EXPORT void CheckDFAssign(lua_State *state, type_identity *type,
+    DFHACK_EXPORT void CheckDFAssign(lua_State *state, const type_identity *type,
                                      void *target, int val_index, bool exact_type = false);
 
     template<typename T> concept df_object = requires()

--- a/library/include/LuaWrapper.h
+++ b/library/include/LuaWrapper.h
@@ -167,7 +167,7 @@ namespace LuaWrapper {
                                        const char *ctx, bool allow_type = false,
                                        bool keep_metatable = false);
 
-    void LookupInTable(lua_State *state, void *id, LuaToken *tname);
+    void LookupInTable(lua_State *state, const void *id, LuaToken *tname);
     void SaveInTable(lua_State *state, void *node, LuaToken *tname);
     void SaveTypeInfo(lua_State *state, void *node);
 


### PR DESCRIPTION
this is basically catching some cases missed in #4702; in addition, these changes are necessary to allow for the type identities defined by codegen to be `const`

