### PR TITLE
Mitigate #5591

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- modding: the ``scripts_modactive`` and ``scripts_modinstalled`` subdirectories of mods will be searched for scripts as per the modding-guide documentation
 
 ## Misc Improvements
 

--- a/library/lua/script-manager.lua
+++ b/library/lua/script-manager.lua
@@ -152,6 +152,7 @@ function get_mod_paths(installed_subdir, active_subdir)
     -- if a world is loaded, process active mods first, and lock to active version
     if dfhack.isWorldLoaded() then
         for _,path in ipairs(df.global.world.object_loader.object_load_order_src_dir) do
+            path = dfhack.filesystem.getBaseDir() .. path
             -- skip vanilla "mods"
             if not path:startswith(INSTALLED_MODS_PATH) then goto continue end
             local id = get_mod_id_and_version(path)


### PR DESCRIPTION
This is an attempt to mitigate issue #5591 .

The `scripts_modactive` and `scripts_modinstalled` directories of installed DFHack-enabled mods were not being searched for either auto-executing modules or manually invoked scripts.

This issue was traced to a relative path being compared with an absolute path.  PR #5514 changed mod-detection path processing to use absolute paths, but the list of active mods was still being retrieved from DF's list of active mods, which contains relative paths.

This was fixed by prepending the base directory (normally a subdirectory of AppData, but in Portable Mode, DF's own directory) to these paths.

This patch has been tested in both AppData Mode and Portable Mode.

**IMPORTANT!**  This patch has only been tested with DF Classic Windows.
It has not been tested with the Steam or Itch.io versions.
It has not been tested with any Linux versions.

It needs to be tested for all of these cases before being merged.

Testing: the [DFHack Example scripts](https://steamcommunity.com/sharedfiles/filedetails/?id=2945575775) mod was used as a sample case.  It was manually downloaded, as I don't have the Steam version of DF.