### PR TITLE
simplify the allocator

### DIFF
--- a/library/DataIdentity.cpp
+++ b/library/DataIdentity.cpp
@@ -19,7 +19,7 @@ namespace df {
 #define INTEGER_IDENTITY_TRAITS(type, name) NUMBER_IDENTITY_TRAITS(integer, type, name)
 #define FLOAT_IDENTITY_TRAITS(type) NUMBER_IDENTITY_TRAITS(float, type, #type)
 #define OPAQUE_IDENTITY_TRAITS_NAME(name, ...) \
-    const opaque_identity identity_traits<__VA_ARGS__ >::identity(sizeof(__VA_ARGS__), allocator_noassign_fn<__VA_ARGS__ >, name)
+    const opaque_identity identity_traits<__VA_ARGS__ >::identity(sizeof(__VA_ARGS__), allocator_fn<__VA_ARGS__ >, name)
 #define OPAQUE_IDENTITY_TRAITS(...) OPAQUE_IDENTITY_TRAITS_NAME(#__VA_ARGS__, __VA_ARGS__ )
 
     INTEGER_IDENTITY_TRAITS(char,               "char");

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -638,7 +638,7 @@ namespace df
         static opaque_identity *get() {
             using type = std::shared_ptr<T>;
             static std::string name = std::string("shared_ptr<") + typeid(T).name() + ">";
-            static opaque_identity identity(sizeof(type), allocator_noassign_fn<type>, name);
+            static opaque_identity identity(sizeof(type), allocator_fn<type>, name);
             return &identity;
         }
     };


### PR DESCRIPTION
current code has three different allocator functions, the generic one, one labeled `nodel` and one labeled `noassign`

the `noassign` allocator just mimics the behavior of the basic one when the type in question is not copy-assignable, and is only being used for types that may not be copy-assignable, and so in those cases the default allocator will work _exactly_ the same anyway, and so `noassign` is wholly redundant. iirc `noassign` was introduced to deal with types that aren't copy-assignable, but the logic in the regular allocator handles that anyway

meanwhile, the `nodel` version is entirely unused, and i can't find any history of what it was ever intended to be used for

thus, this PR removes the `nodel` and `noassign` versions (`nodel` for being unused, and `noassign` for being redundant), and folds `try_assign` into the allocator so that all the logic is in one place

also add in-code documentation