### PR TITLE
Update cleanconst to skip reinforced constructions

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -33,6 +33,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `cleanconst`: do not attempt to clean Reinforced constructions
 
 ## Misc Improvements
 

--- a/plugins/cleanconst.cpp
+++ b/plugins/cleanconst.cpp
@@ -45,6 +45,10 @@ command_result df_cleanconst(color_ostream &out, vector <string> & parameters)
         if (cons->flags.bits.no_build_item)
             continue;
 
+        // Skip reinforced constructions as well
+        if (cons->flags.bits.reinforced)
+            continue;
+
         // only destroy the item if the construction claims to be made of the exact same thing
         if (item->getType() != cons->item_type ||
             item->getSubtype() != cons->item_subtype ||


### PR DESCRIPTION
since those are built with 2 items plus metal bars, and it's unclear whether the game would properly restore those during deconstruction.