### PR TITLE
Fix BoltThrower building size

### DIFF
--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -615,6 +615,23 @@ bool Buildings::getCorrectSize(df::coord2d &size, df::coord2d &center,
         return false;
 
     case SiegeEngine:
+    {
+        using namespace df::enums::siegeengine_type;
+
+        switch((df::siegeengine_type)subtype)
+        {
+            case df::siegeengine_type::BoltThrower:
+                size = df::coord2d(1, 1);
+                center = df::coord2d(0, 0);
+                break;
+            default:
+                size = df::coord2d(3,3);
+                center = df::coord2d(1,1);
+                break;
+        }
+        return false;
+    }
+
     case Windmill:
     case Wagon:
         size = df::coord2d(3,3);


### PR DESCRIPTION
This corrects the size of boltthrowers in dfhack to be 1x1 instead of 3x3 like other siege engines. This lead to the building being logically larger than the sprite reserving extra tiles when produced via buildingplan.

No changelog should be necessary as this bug has only affected the experimental branch, as buildingplan could not make boltthrowers until #5613.