### PR TITLE
move prints to console out of help_db get_commands()

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -84,6 +84,7 @@ distribution.
 #include <type_traits>
 #include <cstdarg>
 #include <filesystem>
+#include <optional>
 #include <SDL_events.h>
 
 #ifdef _WIN32


### PR DESCRIPTION
let try_autocomplete() do the printing.

Also may be worthwhile to use ``using`` for the result type or return a struct instead. Like a ``Result`` struct.