### PR TITLE
remove lua.h dependency from vtableinterpose.h

### DIFF
--- a/library/DataIdentity.cpp
+++ b/library/DataIdentity.cpp
@@ -9,6 +9,7 @@
 
 #include "DataFuncs.h"
 #include "DataIdentity.h"
+#include "LuaWrapper.h"
 
 // the space after the uses of "type" in OPAQUE_IDENTITY_TRAITS_NAME is _required_
 // without it the macro generates a syntax error when type is a template specification
@@ -62,4 +63,19 @@ namespace df {
 
     const stl_container_identity<std::vector<int32_t> > stl_vector_int32_t_identity("vector", identity_traits<int32_t>::get());
     const stl_container_identity<std::vector<int16_t> > stl_vector_int16_t_identity("vector", identity_traits<int16_t>::get());
+
+    type_identity* lua_touserdata_(lua_State* state)
+    {
+        return (type_identity*)lua_touserdata(state, DFHack::LuaWrapper::UPVAL_ITEM_ID);
+    }
+
+    void* get_object_internal_(lua_State* state, type_identity* id, int val_index, bool val)
+    {
+        return DFHack::LuaWrapper::get_object_internal(state, id, val_index, val);
+    }
+
+    void field_error_(lua_State *state, int index, const char* err, const char* mode)
+    {
+        DFHack::LuaWrapper::field_error(state, index, err, mode);
+    }
 }

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -33,11 +33,9 @@ distribution.
 #include <unordered_map>
 #include <variant>
 #include <vector>
-#include <variant>
 #include <filesystem>
 
 #include "DataDefs.h"
-#include "LuaWrapper.h"
 
 namespace std {
     class condition_variable;
@@ -393,6 +391,10 @@ namespace df
     };
 #endif
 
+    type_identity* lua_touserdata_(lua_State* state);
+    void* get_object_internal_(lua_State* state, type_identity*, int val_index, bool);
+    [[noreturn]] void field_error_(lua_State *state, int index, const char* err, const char* mode);
+
     template<class T>
     class stl_container_identity : public container_identity {
         const char *name;
@@ -424,8 +426,8 @@ namespace df
         {
             using VT = typename T::value_type;
             VT tmp{};
-            auto id = (type_identity*)lua_touserdata(state, DFHack::LuaWrapper::UPVAL_ITEM_ID);
-            auto pitem = DFHack::LuaWrapper::get_object_internal(state, id, val_index, false);
+            auto id = lua_touserdata_(state);
+            auto pitem = get_object_internal_(state, id, val_index, false);
             bool useTemporary = (!pitem && id->isPrimitive());
 
             if (useTemporary)
@@ -435,7 +437,7 @@ namespace df
             }
 
             if (id != item || !pitem)
-                DFHack::LuaWrapper::field_error(state, fname_idx, "incompatible object type", "insert");
+                field_error_(state, fname_idx, "incompatible object type", "insert");
 
             return insert(ptr, idx, pitem);
         }


### PR DESCRIPTION
may resolve #5517

I believe this does the trick.  Just added some wrappers so that ``DataIdentity.h`` doesn't have to include ``LuaWrapper.h`` which in turn includes ``lua.h``.

sadly ``ninja -d stats`` didn't report any measurable difference in build times.
