### PR TITLE
try to cleanup unused includes from headers

### DIFF
--- a/library/include/BitArray.h
+++ b/library/include/BitArray.h
@@ -23,14 +23,11 @@ distribution.
 */
 
 #pragma once
-#include "Export.h"
 #include "Error.h"
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <sstream>
-#include <exception>
-#include <type_traits>
 #include <iterator>
 namespace DFHack
 {

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -37,7 +37,6 @@ distribution.
 #include <map>
 #include <memory>
 #include <mutex>
-#include <stack>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -26,10 +26,8 @@ distribution.
 
 #include <list>
 #include <map>
-#include <set>
 #include <sstream>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/library/include/DataFuncs.h
+++ b/library/include/DataFuncs.h
@@ -24,10 +24,6 @@ distribution.
 
 #pragma once
 
-#include <string>
-#include <sstream>
-#include <vector>
-#include <map>
 #include <type_traits>
 
 #include "ColorText.h"

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -26,11 +26,9 @@ distribution.
 
 #include <deque>
 #include <future>
-#include <map>
 #include <optional>
-#include <sstream>
 #include <string>
-#include <unordered_map>
+#include <set>
 #include <variant>
 #include <vector>
 #include <variant>

--- a/library/include/Error.h
+++ b/library/include/Error.h
@@ -25,7 +25,6 @@ distribution.
 #pragma once
 
 #include <exception>
-#include <sstream>
 #include <string>
 
 #include "Export.h"

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -26,8 +26,8 @@ distribution.
 
 #include <functional>
 #include <string>
-#include <sstream>
 #include <vector>
+#include <set>
 #include <map>
 #include <type_traits>
 #include <unordered_map>
@@ -39,7 +39,6 @@ distribution.
 #include "DataDefs.h"
 
 #include "df/interface_key.h"
-#include "df/interfacest.h"
 
 #include <lua.h>
 #include <lauxlib.h>

--- a/library/include/LuaWrapper.h
+++ b/library/include/LuaWrapper.h
@@ -24,11 +24,6 @@ distribution.
 
 #pragma once
 
-#include <string>
-#include <sstream>
-#include <vector>
-#include <map>
-
 #include <lua.h>
 #include <lauxlib.h>
 

--- a/library/include/MemAccess.h
+++ b/library/include/MemAccess.h
@@ -29,7 +29,6 @@ distribution.
 #define PROCESS_H_INCLUDED
 
 #include "Export.h"
-#include <iostream>
 #include <cstring>
 #include <map>
 #include <memory>

--- a/library/include/MiscUtils.h
+++ b/library/include/MiscUtils.h
@@ -33,7 +33,6 @@ distribution.
 #include <iomanip>
 #include <iostream>
 #include <map>
-#include <memory>
 #include <sstream>
 #include <stdint.h>
 #include <vector>

--- a/library/include/PluginManager.h
+++ b/library/include/PluginManager.h
@@ -25,7 +25,6 @@ distribution.
 #pragma once
 
 #include "Export.h"
-#include "Hooks.h"
 #include "ColorText.h"
 #include "MiscUtils.h"
 #include <map>

--- a/library/include/Types.h
+++ b/library/include/Types.h
@@ -30,12 +30,10 @@ distribution.
 #include <string>
 
 #include "Export.h"
-
 #include "DataDefs.h"
 
 #include "df/general_ref_type.h"
 #include "df/specific_ref_type.h"
-#include "df/language_name_type.h"
 
 namespace df {
     struct building;

--- a/library/include/VTableInterpose.h
+++ b/library/include/VTableInterpose.h
@@ -25,7 +25,8 @@ distribution.
 #pragma once
 
 #include "DataDefs.h"
-#include "DataIdentity.h"
+
+#include <set>
 
 namespace DFHack
 {

--- a/library/include/modules/DFSDL.h
+++ b/library/include/modules/DFSDL.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Error.h"
 #include "Export.h"
 #include "ColorText.h"
 

--- a/library/include/modules/EventManager.h
+++ b/library/include/modules/EventManager.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "Core.h"
 #include "Export.h"
 #include "ColorText.h"
 #include "PluginManager.h"
-#include "Console.h"
 #include "DataDefs.h"
 
 #include "df/unit_inventory_item.h"

--- a/library/include/modules/Gui.h
+++ b/library/include/modules/Gui.h
@@ -25,8 +25,6 @@ distribution.
 #pragma once
 
 #include "Export.h"
-#include "Module.h"
-#include "BitArray.h"
 #include "ColorText.h"
 #include "Types.h"
 #include "DataDefs.h"
@@ -34,7 +32,6 @@ distribution.
 #include "modules/GuiHooks.h"
 
 #include "df/announcement_type.h"
-#include "df/report_zoom_type.h"
 #include "df/unit_report_type.h"
 
 namespace df {

--- a/library/include/modules/Items.h
+++ b/library/include/modules/Items.h
@@ -28,8 +28,6 @@ distribution.
 */
 #include "DataDefs.h"
 #include "Export.h"
-#include "MemAccess.h"
-#include "Module.h"
 #include "Types.h"
 
 #include "modules/Materials.h"

--- a/library/include/modules/Job.h
+++ b/library/include/modules/Job.h
@@ -27,15 +27,12 @@ distribution.
 #define CL_MOD_JOB
 
 #include "Export.h"
-#include "Module.h"
 #include "Types.h"
 #include "DataDefs.h"
 
 #include "df/building_workshopst.h"
 #include "df/item_type.h"
 #include "df/job_item_ref.h"
-
-#include <ostream>
 
 namespace df
 {

--- a/library/include/modules/Maps.h
+++ b/library/include/modules/Maps.h
@@ -31,8 +31,6 @@ distribution.
 #define CL_MOD_MAPS
 
 #include "Export.h"
-#include "Module.h"
-#include "BitArray.h"
 
 #include "modules/Materials.h"
 

--- a/library/include/modules/Materials.h
+++ b/library/include/modules/Materials.h
@@ -31,8 +31,6 @@ distribution.
  */
 #include "Export.h"
 #include "Module.h"
-#include "Types.h"
-#include "BitArray.h"
 #include "DataDefs.h"
 
 #include "df/craft_material_class.h"

--- a/library/include/modules/Random.h
+++ b/library/include/modules/Random.h
@@ -31,9 +31,6 @@ distribution.
  */
 
 #include "Export.h"
-#include "Module.h"
-#include "Types.h"
-
 #include "DataDefs.h"
 
 namespace DFHack

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -25,9 +25,6 @@ distribution.
 #pragma once
 
 #include "Export.h"
-#include "Module.h"
-#include "BitArray.h"
-#include "ColorText.h"
 #include "Types.h"
 #include "DataDefs.h"
 

--- a/library/include/modules/Translation.h
+++ b/library/include/modules/Translation.h
@@ -31,9 +31,9 @@ distribution.
  */
 
 #include "Export.h"
-#include "Module.h"
-#include "Types.h"
 #include "DataDefs.h"
+#include "Types.h"
+#include "df/language_name_type.h"
 
 namespace df {
     struct language_name;

--- a/library/include/modules/World.h
+++ b/library/include/modules/World.h
@@ -32,11 +32,9 @@ distribution.
  */
 
 #include "Export.h"
-#include "Module.h"
 #include "modules/Persistence.h"
-#include <ostream>
-
 #include "DataDefs.h"
+
 
 namespace df
 {

--- a/library/modules/DFSDL.cpp
+++ b/library/modules/DFSDL.cpp
@@ -1,3 +1,4 @@
+#include "Error.h"
 #include "Internal.h"
 
 #include "modules/DFSDL.h"

--- a/library/modules/EventManager.cpp
+++ b/library/modules/EventManager.cpp
@@ -2,6 +2,7 @@
 #include "Console.h"
 #include "Debug.h"
 #include "VTableInterpose.h"
+#include "MemAccess.h"
 
 #include "modules/Buildings.h"
 #include "modules/Constructions.h"

--- a/plugins/autofarm.cpp
+++ b/plugins/autofarm.cpp
@@ -22,6 +22,7 @@
 #include "df/unit.h"
 #include "df/world.h"
 
+#include <set>
 #include <queue>
 
 using namespace DFHack;

--- a/plugins/buildingplan/itemfilter.h
+++ b/plugins/buildingplan/itemfilter.h
@@ -7,6 +7,8 @@
 #include "df/dfhack_material_category.h"
 #include "df/item_quality.h"
 
+#include <set>
+
 class ItemFilter {
 public:
     ItemFilter();

--- a/plugins/burrow.cpp
+++ b/plugins/burrow.cpp
@@ -1,3 +1,5 @@
+#include <stack>
+
 #include "Debug.h"
 #include "LuaTools.h"
 #include "PluginManager.h"

--- a/plugins/eventful.cpp
+++ b/plugins/eventful.cpp
@@ -22,6 +22,7 @@
 #include "df/unit_wound.h"
 #include "df/world.h"
 
+#include <stack>
 #include <string.h>
 #include <stdexcept>
 #include <array>

--- a/plugins/filltraffic.cpp
+++ b/plugins/filltraffic.cpp
@@ -1,6 +1,7 @@
 // Wide-area traffic designation utility.
 // Flood-fill from cursor or fill entire map.
 
+#include <stack>
 #include <ctype.h>      //For toupper().
 #include <algorithm>    //for min().
 #include <map>

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -21,6 +21,8 @@
 #include "df/world_object_data.h"
 #include "df/world_site.h"
 
+#include <set>
+
 using std::string;
 using std::vector;
 using std::set;

--- a/plugins/pathable.cpp
+++ b/plugins/pathable.cpp
@@ -1,3 +1,5 @@
+#include <stack>
+
 #include "Debug.h"
 #include "Error.h"
 #include "PluginManager.h"

--- a/plugins/reveal.cpp
+++ b/plugins/reveal.cpp
@@ -16,6 +16,7 @@
 #include "df/map_block.h"
 #include "df/world.h"
 
+#include <stack>
 #include <unordered_set>
 
 using std::string;


### PR DESCRIPTION
We'll see how this goes.

gcc/clang has been lying to me. Seems standard types like std::string don't require an #include in my version.