### PR TITLE
Require empty bins when constructing bolt throwers

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `buildingplan`: Bolt throwers will no longer be constructed using populated bins.
 
 ## Misc Improvements
 

--- a/library/lua/dfhack/buildings.lua
+++ b/library/lua/dfhack/buildings.lua
@@ -358,6 +358,7 @@ local siegeengine_input = {
             vector_id=df.job_item_vector_id.BOLT_THROWER_PARTS,
         },
         {
+            flags1={ empty=true },
             item_type=df.item_type.BIN,
             vector_id=df.job_item_vector_id.BIN,
         },


### PR DESCRIPTION
This corrects a missing itemfilter flag that allowed populated bins to be used in constructing bolt throwers. Now, correctly, only empty bins will be used in construction.