### PR TITLE
fix debug plugin use-after-free on shutdown (LTO)

### DIFF
--- a/library/include/DebugManager.h
+++ b/library/include/DebugManager.h
@@ -96,9 +96,9 @@ public:
 
     //! Get the singleton object
     static DebugManager& getInstance() {
-	// Plugins may still hold pointers to DebugManager's instance during shutdown.
-	// If DebugManager's dtor runs first, use-after-free may ensue.
-	// Intentionally leak to avoid this issue.
+    // Plugins may still hold pointers to DebugManager's instance during shutdown.
+    // If DebugManager's dtor runs first, use-after-free may ensue.
+    // Intentionally leak to avoid this issue.
         static DebugManager* instance = new DebugManager();
         return *instance;
     }


### PR DESCRIPTION
This only popped when compiling with LTO (dfhack library, as well as dfhack library + plugins).

For some reason DebugManager's instance was being destroyed before the debug plugin's FilterManager, which lead to a use-after-free in Signal.

A 'proper fix' might be to fix the Signal library, but since DebugManager is a singleton, I think it's ok to just leak for these types.