### PR TITLE
Add drawbridge-tiles tweak for ASCII mode

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ Template for new versions:
 
 ## New Features
 - `sort`: Places search widget can search "Siege engines" subtab by name, loaded status, and operator status
+- `tweak`: ``drawbridge-tiles``: Make it so raised bridges render with different tiles in ASCII mode to make it more obvious that they ARE raised (and to indicate their direction)
 
 ## Fixes
 - `sort`: Using the squad unit selector will no longer cause Dwarf Fortress to crash on exit

--- a/docs/plugins/tweak.rst
+++ b/docs/plugins/tweak.rst
@@ -45,6 +45,9 @@ Commands
     Fixes crafted items not wearing out over time (:bug:`6003`). With this
     tweak, items made from cloth and leather will gain a level of wear every 20
     in-game years.
+``drawbridge-tiles``
+    Makes raising bridges in ASCII mode render with different tiles when they
+    are raised.
 ``eggs-fertile``
     Displays an indicator on fertile eggs.
 ``fast-heat``

--- a/plugins/tweak/tweak.cpp
+++ b/plugins/tweak/tweak.cpp
@@ -16,6 +16,7 @@ using namespace DFHack;
 #include "tweaks/adamantine-cloth-wear.h"
 #include "tweaks/animaltrap-reuse.h"
 #include "tweaks/craft-age-wear.h"
+#include "tweaks/drawbridge-tiles.h"
 #include "tweaks/eggs-fertile.h"
 #include "tweaks/fast-heat.h"
 #include "tweaks/flask-contents.h"
@@ -57,6 +58,8 @@ DFhackCExport command_result plugin_init(color_ostream &out, vector<PluginComman
     TWEAK_HOOK("animaltrap-reuse", animaltrap_reuse_hook, updateAction);
 
     TWEAK_HOOK("craft-age-wear", craft_age_wear_hook, ageItem);
+
+    TWEAK_HOOK("drawbridge-tiles", drawbridge_tiles_hook, drawBuilding);
 
     TWEAK_HOOK("eggs-fertile", eggs_fertile_hook, getItemDescription);
 

--- a/plugins/tweak/tweaks/drawbridge-tiles.h
+++ b/plugins/tweak/tweaks/drawbridge-tiles.h
@@ -1,0 +1,60 @@
+// Make raised drawbridge tiles indicate the bridge's direction
+
+#include "df/building_drawbuffer.h"
+#include "df/building_bridgest.h"
+
+struct drawbridge_tiles_hook : df::building_bridgest {
+    typedef df::building_bridgest interpose_base;
+
+    DEFINE_VMETHOD_INTERPOSE(void, drawBuilding, (uint32_t curtick, df::building_drawbuffer *buf, int16_t z_offset))
+    {
+        static const unsigned char tiles[4][3] =
+        {
+            { 0xB7, 0xB6, 0xBD },
+            { 0xD6, 0xC7, 0xD3 },
+            { 0xD4, 0xCF, 0xBE },
+            { 0xD5, 0xD1, 0xB8 },
+        };
+        INTERPOSE_NEXT(drawBuilding)(curtick, buf, z_offset);
+
+        // Only redraw "raised" drawbridges
+        if (!gate_flags.bits.raised || direction == -1)
+            return;
+
+        // Figure out the extents and the axis
+        int p1, p2;
+        bool iy = false;
+        switch (direction)
+        {
+        case 0: // Left
+        case 1: // Right
+            p1 = buf->y1; p2 = buf->y2; iy = true;
+            break;
+        case 2: // Up
+        case 3: // Down
+            p1 = buf->x1; p2 = buf->x2;
+            break;
+        default:
+            // Already ignoring retracting above
+            return;
+        }
+
+        int x = 0, y = 0;
+        if (p1 == p2)
+            buf->tile[0][0] = tiles[direction][1];
+        else for (int p = p1; p <= p2; p++)
+        {
+            if (p == p1)
+                buf->tile[x][y] = tiles[direction][0];
+            else if (p == p2)
+                buf->tile[x][y] = tiles[direction][2];
+            else
+                buf->tile[x][y] = tiles[direction][1];
+            if (iy)
+                y++;
+            else
+                x++;
+        }
+    }
+};
+IMPLEMENT_VMETHOD_INTERPOSE(drawbridge_tiles_hook, drawBuilding);


### PR DESCRIPTION
A tweak I originally wrote for 0.31 and earlier, still useful in the current version in ASCII mode (in Premium mode, raised bridges already indicate their direction properly).