### PR TITLE
change `Filesystem::as_string` to always use utf-8

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+# ``Filesystem::as_string`` now always uses UTF-8 encoding rather than using the system locale encoding
 
 ## Misc Improvements
 

--- a/library/include/modules/Filesystem.h
+++ b/library/include/modules/Filesystem.h
@@ -77,12 +77,13 @@ namespace DFHack {
         DFHACK_EXPORT std::filesystem::path canonicalize(std::filesystem::path p) noexcept;
         inline std::string as_string(const std::filesystem::path path) noexcept
         {
-            auto pStr = path.string();
-            if constexpr (std::filesystem::path::preferred_separator != '/')
-            {
-                std::ranges::replace(pStr, std::filesystem::path::preferred_separator, '/');
-            }
-            return pStr;
+            // this just mashes the utf-8 into a std::string without any conversion
+            // this is largely because we use utf-8 everywhere internally as much as we can
+            // but we should ultimately convert to using u8strings for strings that are utf-8
+            // and use a different string type for strings encoded in cp437 or in the locale codepage
+            std::u8string pstr = path.generic_u8string();
+            return std::string((char*)pstr.c_str());
+
         }
         DFHACK_EXPORT std::filesystem::path getInstallDir() noexcept;
         DFHACK_EXPORT std::filesystem::path getBaseDir() noexcept;


### PR DESCRIPTION
our policy is that strings are to be encoded in utf-8 as much as possible. however, this function was using the system locale encoding, which was causing a transcoding error when a pathname was round-tripped through lua

fixes #5688
