### PR TITLE
Update build-windows.yml

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Install build dependencies
         run: |
           choco install sccache
+          pip install Jinja2
       - name: Install doc dependencies
         if: inputs.docs
         run: |


### PR DESCRIPTION
add jinja2 dependency for windows builds

only needed for size compare builds pushed from df-structures, but gating it to only install in that case is more effort than it's worth
