### PR TITLE
add vtable validation

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- Core: DFHack now validates vtable pointers in objects read from memory and will throw an exception instead of crashing when an invalid vtable pointer is encountered. This makes it easier to identify which DF data structure contains corrupted data when this manifests in the form of a bad vtable pointer, and shifts blame for such crashes from DFHack to DF.
 
 ## Documentation
 

--- a/library/DataDefs.cpp
+++ b/library/DataDefs.cpp
@@ -370,7 +370,7 @@ const virtual_identity *virtual_identity::find(void *vtable)
 
     // If using a reader/writer lock, re-grab as write here, and recheck
     Core &core = Core::getInstance();
-    std::string name = core.p->doReadClassName(vtable);
+    std::string name = core.p->readClassName(vtable);
 
     auto name_it = (*name_lookup).find(name);
     if (name_it != (*name_lookup).end()) {

--- a/library/Process.cpp
+++ b/library/Process.cpp
@@ -237,7 +237,7 @@ Process::~Process()
 string Process::doReadClassName (void * vptr)
 {
     if (!checkValidAddress(vptr))
-        throw std::runtime_error(std::format("invalid vtable ptr {}", vptr));
+        throw std::runtime_error(fmt::format("invalid vtable ptr {}", vptr));
 
     char* rtti = Process::readPtr(((char*)vptr - sizeof(void*)));
 #ifndef WIN32

--- a/library/include/MemAccess.h
+++ b/library/include/MemAccess.h
@@ -221,7 +221,7 @@ namespace DFHack
 
         std::string readClassName(void* vptr)
         {
-            std::map<void*, std::string>::iterator it = classNameCache.find(vptr);
+            auto it = classNameCache.find(vptr);
             if (it != classNameCache.end())
                 return it->second;
             return classNameCache[vptr] = doReadClassName(vptr);
@@ -246,6 +246,9 @@ namespace DFHack
 
         /// get virtual memory ranges of the process (what is mapped where)
         static void getMemRanges(std::vector<t_memrange>& ranges);
+
+        /// check if an address has a mapping
+        bool checkValidAddress(void* ptr);
 
         /// get the symbol table extension of this process
         std::shared_ptr<DFHack::VersionInfo> getDescriptor()


### PR DESCRIPTION
`doReadClassName` will now first validate that the vtable pointer points to mapped memory before attempting to read it, and throws an exception if it does not.

The validation process is quite slow, but this only needs to be done once per unique vtable pointer encountered per session, as these are being cached elsewhere, and there are just not that many vtable pointers so the impact is cheap amortized over the lifetime of the executable. The choice to throw an exception instead of returning an error result is because an exception will cause a Lua traceback, which will give more diagnostic information than returning an error result would.

One call to `doReadClassName` that was bypassing the cache was changed to not bypass it, which means this patch should actually improve DFHack's overall performance.

The motivation for this change is that currently, when DFHack encounters an object, almost always in DF-owned memory, that is purportedly of a type having a vtable but where the pointer is invalid, DFHack crashes hard in this function. This results in tracebacks that make it look like DFHack is at fault, and forces me to spend significant time convincing Putnam and others that it is, in fact, not DFHack that is at fault. Converting these crashes to an exception that will be caught by Lua will prevent DF from crashing when DFHack accesses this data, and so when DF eventually does crash when the invalid vtable is referenced, it won't be DFHack's fault and I won't have to explain this scenario yet again. Also, the Lua traceback will likely make it much easier to tell _what_ DF data structure contains an invalid pointer, which should assist in both DFHack and DF troubleshooting of problems of this nature.