### PR TITLE
add covering default case to `Maps::SortBlockEvents`

### DIFF
--- a/library/modules/Maps.cpp
+++ b/library/modules/Maps.cpp
@@ -655,6 +655,9 @@ bool Maps::SortBlockEvents(df::map_block *block,
             if (priorities)
                 priorities->push_back((df::block_square_event_designation_priorityst *)evt);
             break;
+        default:
+            assert("Unhandled block event type" && false); // FIXME temporary - replace with NONE case after structure are updated
+            break;
         }
     }
     return true;


### PR DESCRIPTION
temporary - replace with `case block_square_event_type::NONE` after dfhack/df-structures#872 is merged

