### PR TITLE
Include name in orders export

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 
 ## New Features
 - `orders`: added search overlay to find and navigate to matching manager orders with arrow indicators
+- `orders`: exported orders now include a human-readable ``name`` field
 - `sort`: added ``Uniformed`` filter to squad assignment screen to filter dwarves with mining, woodcutting, or hunting labors
 - `sort`: Add death cause button to dead/missing tab in the creatures screen
 

--- a/plugins/orders.cpp
+++ b/plugins/orders.cpp
@@ -4,6 +4,7 @@
 #include "PluginManager.h"
 
 #include "modules/Filesystem.h"
+#include "modules/Job.h"
 #include "modules/Materials.h"
 #include "modules/World.h"
 
@@ -376,6 +377,7 @@ static command_result orders_export_command(color_ostream & out, const std::stri
             order["art"] = art;
         }
 
+        order["name"] = Job::getManagerOrderName(it);
         order["amount_left"] = it->amount_left;
         order["amount_total"] = it->amount_total;
         order["is_validated"] = bool(it->status.bits.validated);

--- a/test/plugins/orders.lua
+++ b/test/plugins/orders.lua
@@ -190,6 +190,7 @@ function test.import_export_reaction_condition()
                     }
                 ],
                 "job" : "CustomReaction",
+                "name" : "Make soap from tallow",
                 "reaction" : "MAKE_SOAP_FROM_TALLOW"
             }
         ]


### PR DESCRIPTION
Exported orders now include a human-readable ``name`` field

<img width="1211" height="499" alt="obraz" src="https://github.com/user-attachments/assets/4dd20ccb-25d5-4c81-a2e0-500789ea489f" />


Related issue: https://github.com/DFHack/dfhack/issues/4452