### PR TITLE
Fix `logcleaner` to use ticks

### DIFF
--- a/docs/plugins/logcleaner.rst
+++ b/docs/plugins/logcleaner.rst
@@ -5,8 +5,8 @@ logcleaner
     :tags: fort auto units
 
 This plugin prevents spam from cluttering your announcement history and filling
-the 3000-item reports buffer. It runs every 100 ticks and clears selected report
-types from both the global reports buffer and per-unit logs.
+the 3000-item reports buffer. It runs approximately every 100 ticks and clears
+selected report types from both the global reports buffer and per-unit logs.
 
 Usage
 -----

--- a/plugins/autolabor/autolabor.cpp
+++ b/plugins/autolabor/autolabor.cpp
@@ -740,7 +740,7 @@ DFhackCExport command_result plugin_onupdate ( color_ostream &out )
         return CR_OK;
     }
 
-    if (world->frame_counter - cycle_timestamp <= CYCLE_TICKS)
+    if (world->frame_counter - cycle_timestamp < CYCLE_TICKS)
         return CR_OK;
 
     cycle_timestamp = world->frame_counter;

--- a/plugins/autolabor/autolabor.cpp
+++ b/plugins/autolabor/autolabor.cpp
@@ -1,4 +1,4 @@
-g#include "laborstatemap.h"
+#include "laborstatemap.h"
 
 #include "Debug.h"
 #include "PluginManager.h"

--- a/plugins/autolabor/autolabor.cpp
+++ b/plugins/autolabor/autolabor.cpp
@@ -1,4 +1,4 @@
-#include "laborstatemap.h"
+g#include "laborstatemap.h"
 
 #include "Debug.h"
 #include "PluginManager.h"
@@ -740,7 +740,7 @@ DFhackCExport command_result plugin_onupdate ( color_ostream &out )
         return CR_OK;
     }
 
-    if (world->frame_counter - cycle_timestamp < CYCLE_TICKS)
+    if (world->frame_counter - cycle_timestamp <= CYCLE_TICKS)
         return CR_OK;
 
     cycle_timestamp = world->frame_counter;

--- a/plugins/logcleaner/logcleaner.cpp
+++ b/plugins/logcleaner/logcleaner.cpp
@@ -31,7 +31,8 @@ static bool clear_combat = false;
 static bool clear_sparring = true;
 static bool clear_hunting = false;
 
-static constexpr int32_t CLEANUP_TICK_INTERVAL = 97;
+static constexpr int32_t CYCLE_TICKS = 97;
+static int32_t cycle_timestamp = 0;
 
 static void cleanupLogs();
 static command_result do_command(color_ostream& out, std::vector<std::string>& params);
@@ -116,6 +117,7 @@ DFhackCExport command_result plugin_load_site_data(color_ostream& out) {
     clear_sparring = config.get_bool(CONFIG_CLEAR_SPARING);
     clear_hunting = config.get_bool(CONFIG_CLEAR_HUNTING);
 
+    cycle_timestamp = 0;
     return CR_OK;
 }
 
@@ -166,16 +168,13 @@ static void cleanupLogs() {
 }
 
 DFhackCExport command_result plugin_onupdate(color_ostream& out, state_change_event event) {
-    static int32_t tick_counter = 0;
-
     if (!is_enabled || !world)
         return CR_OK;
+    else if (world->frame_counter - cycle_timestamp <= CYCLE_TICKS)
+        return CR_OK;
 
-    tick_counter++;
-    if (tick_counter >= CLEANUP_TICK_INTERVAL) {
-        tick_counter = 0;
-        cleanupLogs();
-    }
+    cycle_timestamp = world->frame_counter;
+    cleanupLogs();
 
     return CR_OK;
 }

--- a/plugins/logcleaner/logcleaner.cpp
+++ b/plugins/logcleaner/logcleaner.cpp
@@ -170,7 +170,7 @@ static void cleanupLogs() {
 DFhackCExport command_result plugin_onupdate(color_ostream& out, state_change_event event) {
     if (!is_enabled || !world)
         return CR_OK;
-    else if (world->frame_counter - cycle_timestamp <= CYCLE_TICKS)
+    else if (world->frame_counter - cycle_timestamp < CYCLE_TICKS)
         return CR_OK;
 
     cycle_timestamp = world->frame_counter;


### PR DESCRIPTION
Fixed `logcleaner` to use ticks instead of frames, using `autolabor` as reference. Also corrected docs that it runs "approximately" every 100 ticks.