### PR TITLE
add type identity support for `static-wstring`

### DIFF
--- a/library/DataIdentity.cpp
+++ b/library/DataIdentity.cpp
@@ -33,6 +33,7 @@ namespace df {
     INTEGER_IDENTITY_TRAITS(unsigned long,      "unsigned long");
     INTEGER_IDENTITY_TRAITS(long long,          "int64_t");
     INTEGER_IDENTITY_TRAITS(unsigned long long, "uint64_t");
+    INTEGER_IDENTITY_TRAITS(wchar_t,            "wchar_t");
     FLOAT_IDENTITY_TRAITS(float);
     FLOAT_IDENTITY_TRAITS(double);
 
@@ -57,6 +58,7 @@ namespace df {
     OPAQUE_IDENTITY_TRAITS(std::optional<std::function<void()> >);
     OPAQUE_IDENTITY_TRAITS(std::variant<std::string, std::function<void()> >);
     OPAQUE_IDENTITY_TRAITS(std::weak_ptr<df::widget_container>);
+    OPAQUE_IDENTITY_TRAITS(wchar_t*);
 
     const buffer_container_identity buffer_container_identity::base_instance;
 

--- a/library/include/DataIdentity.h
+++ b/library/include/DataIdentity.h
@@ -617,8 +617,10 @@ namespace df
     INTEGER_IDENTITY_TRAITS(unsigned long);
     INTEGER_IDENTITY_TRAITS(long long);
     INTEGER_IDENTITY_TRAITS(unsigned long long);
+    INTEGER_IDENTITY_TRAITS(wchar_t);
     FLOAT_IDENTITY_TRAITS(float);
     FLOAT_IDENTITY_TRAITS(double);
+    OPAQUE_IDENTITY_TRAITS(wchar_t*);
     OPAQUE_IDENTITY_TRAITS(std::condition_variable);
     OPAQUE_IDENTITY_TRAITS(std::fstream);
     OPAQUE_IDENTITY_TRAITS(std::mutex);


### PR DESCRIPTION
as an opaque type only
required for DF 53.11; collateral to DFHack/df-structures#877
