### PR TITLE
update for changed `manager_order` default constructor

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `autoclothing`, `autoslab`, `tailor`: orders will no longer be created with a repetition frequency of ``NONE``
 
 ## Misc Improvements
 

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -613,6 +613,7 @@ static void add_clothing_orders() {
                 newOrder->material_category = clothingOrder.material_category;
                 newOrder->amount_left = amount;
                 newOrder->amount_total = amount;
+                newOrder->frequency = df::workquota_frequency_type::OneTime;
                 world->manager_orders.all.push_back(newOrder);
             }
         }

--- a/plugins/autoslab.cpp
+++ b/plugins/autoslab.cpp
@@ -141,6 +141,7 @@ static void createSlabJob(df::unit *unit)
     order->specdata.hist_figure_id = unit->hist_figure_id;
     order->amount_left = 1;
     order->amount_total = 1;
+    order->frequency = df::workquota_frequency_type::OneTime;
     world->manager_orders.all.push_back(order);
 }
 

--- a/plugins/tailor.cpp
+++ b/plugins/tailor.cpp
@@ -663,6 +663,7 @@ public:
         order->amount_total = c;
         order->status.bits.validated = false;
         order->status.bits.active = false;
+        order->frequency = df::workquota_frequency_type::OneTime;
         order->id = world->manager_orders.manager_order_next_id++;
 
         world->manager_orders.all.push_back(order);


### PR DESCRIPTION
default-initialized value for `frequency` is now `NONE`, was previously `OneTime`

side effect of dfhack/df-structures#872
