### PR TITLE
replace hardcoded `hack` path with `getHackPath()`

### DIFF
--- a/library/include/modules/Textures.h
+++ b/library/include/modules/Textures.h
@@ -32,7 +32,7 @@ DFHACK_EXPORT TexposHandle loadTexture(SDL_Surface* surface, bool reserved = fal
  * Load tileset from image file.
  * Return vector of handles to obtain valid texposes.
  */
-DFHACK_EXPORT std::vector<TexposHandle> loadTileset(const std::string& file,
+DFHACK_EXPORT std::vector<TexposHandle> loadTileset(const std::filesystem::path file,
                                                     int tile_px_w = TILE_WIDTH_PX,
                                                     int tile_px_h = TILE_HEIGHT_PX,
                                                     bool reserved = false);

--- a/library/lua/gui/textures.lua
+++ b/library/lua/gui/textures.lua
@@ -8,16 +8,16 @@ local _ENV = mkmodule('gui.textures')
 -- Use these handles if you need to get dfhack standard textures.
 ---@type table<string, TexposHandle[]>
 local texpos_handles = {
-  green_pin = dfhack.textures.loadTileset('hack/data/art/green-pin.png', 8, 12, true),
-  red_pin = dfhack.textures.loadTileset('hack/data/art/red-pin.png', 8, 12, true),
-  icons = dfhack.textures.loadTileset('hack/data/art/icons.png', 8, 12, true),
-  on_off = dfhack.textures.loadTileset('hack/data/art/on-off.png', 8, 12, true),
-  control_panel = dfhack.textures.loadTileset('hack/data/art/control-panel.png', 8, 12, true),
-  border_thin = dfhack.textures.loadTileset('hack/data/art/border-thin.png', 8, 12, true),
-  border_medium = dfhack.textures.loadTileset('hack/data/art/border-medium.png', 8, 12, true),
-  border_bold = dfhack.textures.loadTileset('hack/data/art/border-bold.png', 8, 12, true),
-  border_panel = dfhack.textures.loadTileset('hack/data/art/border-panel.png', 8, 12, true),
-  border_window = dfhack.textures.loadTileset('hack/data/art/border-window.png', 8, 12, true),
+  green_pin = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/green-pin.png', 8, 12, true),
+  red_pin = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/red-pin.png', 8, 12, true),
+  icons = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/icons.png', 8, 12, true),
+  on_off = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/on-off.png', 8, 12, true),
+  control_panel = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/control-panel.png', 8, 12, true),
+  border_thin = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/border-thin.png', 8, 12, true),
+  border_medium = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/border-medium.png', 8, 12, true),
+  border_bold = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/border-bold.png', 8, 12, true),
+  border_panel = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/border-panel.png', 8, 12, true),
+  border_window = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/border-window.png', 8, 12, true),
 }
 
 -- Get valid texpos for preloaded texture in tileset

--- a/library/modules/Textures.cpp
+++ b/library/modules/Textures.cpp
@@ -54,7 +54,7 @@ static ReservedRange reserved_range{};
 static std::unordered_map<TexposHandle, long> g_handle_to_texpos;
 static std::unordered_map<TexposHandle, long> g_handle_to_reserved_texpos;
 static std::unordered_map<TexposHandle, SDL_Surface*> g_handle_to_surface;
-static std::unordered_map<std::string, std::vector<TexposHandle>> g_tileset_to_handles;
+static std::unordered_map<std::filesystem::path, std::vector<TexposHandle>> g_tileset_to_handles;
 static std::vector<TexposHandle> g_delayed_regs;
 static std::mutex g_adding_mutex;
 static std::atomic<bool> loading_state = false;
@@ -195,14 +195,14 @@ TexposHandle Textures::loadTexture(SDL_Surface* surface, bool reserved) {
     return handle;
 }
 
-std::vector<TexposHandle> Textures::loadTileset(const std::string& file, int tile_px_w,
+std::vector<TexposHandle> Textures::loadTileset(const std::filesystem::path file, int tile_px_w,
                                                 int tile_px_h, bool reserved) {
     if (g_tileset_to_handles.contains(file))
         return g_tileset_to_handles[file];
     if (!enabler)
         return std::vector<TexposHandle>{};
 
-    SDL_Surface* surface = DFIMG_Load(file.c_str());
+    SDL_Surface* surface = DFIMG_Load(file.string().c_str());
     if (!surface) {
         ERR(textures).printerr("unable to load textures from '{}'\n", file);
         return std::vector<TexposHandle>{};

--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -68,7 +68,7 @@ static bool is_painting_warm = false;
 static bool is_painting_damp = false;
 
 DFhackCExport command_result plugin_init ( color_ostream &out, std::vector <PluginCommand> &commands) {
-    textures = Textures::loadTileset("hack/data/art/damp_dig_map.png", 32, 32, true);
+    textures = Textures::loadTileset(Core::getInstance().getHackPath() / "data" / "art" / "damp_dig_map.png", 32, 32, true);
 
     commands.push_back(PluginCommand(
         "digv",

--- a/plugins/lua/dig.lua
+++ b/plugins/lua/dig.lua
@@ -4,7 +4,7 @@ local gui = require('gui')
 local overlay = require('plugins.overlay')
 local widgets = require('gui.widgets')
 
-local toolbar_textures = dfhack.textures.loadTileset('hack/data/art/damp_dig_toolbar.png', 8, 12, true)
+local toolbar_textures = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/damp_dig_toolbar.png', 8, 12, true)
 
 local main_if = df.global.game.main_interface
 local selection_rect = df.global.selection_rect

--- a/plugins/lua/hotkeys.lua
+++ b/plugins/lua/hotkeys.lua
@@ -5,7 +5,7 @@ local helpdb = require('helpdb')
 local overlay = require('plugins.overlay')
 local widgets = require('gui.widgets')
 
-local logo_textures = dfhack.textures.loadTileset('hack/data/art/logo.png', 8, 12, true)
+local logo_textures = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/logo.png', 8, 12, true)
 
 local function get_command(cmdline)
     local first_word = cmdline:trim():split(' +')[1]

--- a/plugins/lua/suspendmanager.lua
+++ b/plugins/lua/suspendmanager.lua
@@ -155,7 +155,7 @@ end
 
 -- suspend overlay (formerly in unsuspend.lua)
 
-local textures = dfhack.textures.loadTileset('hack/data/art/unsuspend.png', 32, 32, true)
+local textures = dfhack.textures.loadTileset(dfhack.getHackPath()..'/data/art/unsuspend.png', 32, 32, true)
 
 local ok, buildingplan = pcall(require, 'plugins.buildingplan')
 if not ok then

--- a/plugins/pathable.cpp
+++ b/plugins/pathable.cpp
@@ -42,7 +42,7 @@ namespace DFHack {
 static std::vector<TexposHandle> textures;
 
 DFhackCExport command_result plugin_init(color_ostream &out, std::vector<PluginCommand> &commands) {
-    textures = Textures::loadTileset("hack/data/art/pathable.png", 32, 32, true);
+    textures = Textures::loadTileset(Core::getInstance().getHackPath() / "data" / "art" / "pathable.png", 32, 32, true);
     return CR_OK;
 }
 


### PR DESCRIPTION
removes some dependencies on `hack` being in the DF CWD at runtime

also use `std::filesystem::path` in `Textures` instead of `string` for pathnames

ref #5752 
