### PR TITLE
Handle units without current soul in `Units::getFocusPenalty`

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,6 +66,7 @@ Template for new versions:
 
 ## API
 - add flexible casting to ``enum_field`` to enable explicit casting to more types
+- Handle units without current soul in ``Units::getFocusPenalty``
 
 ## Lua
 

--- a/library/modules/Units.cpp
+++ b/library/modules/Units.cpp
@@ -2027,6 +2027,9 @@ int32_t Units::getFocusPenalty(df::unit* unit, need_type_set need_types) {
     CHECK_NULL_POINTER(unit);
 
     int max_penalty = INT_MAX;
+    if (!unit->status.current_soul) {
+        return max_penalty;
+    }
     auto& needs = unit->status.current_soul->personality.needs;
     for (auto const need : needs) {
         if (need_types.test(need->id)) {


### PR DESCRIPTION
Handles units without current soul the same as units not having the checked need.
