### PR TITLE
exclude `fmtlib` build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ build/compile_commands.json
 build/dfhack_setarch.txt
 build/ImportExecutables.cmake
 build/Testing
+build/_deps
 
 # Python binding binaries
 *.pyc


### PR DESCRIPTION
If this PR makes an externally-visible change in behavior or API, please add an appropriate line to `docs/changelog.txt`.
