### PR TITLE
protect DF pooled objects from being deleted

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -61,6 +61,7 @@ Template for new versions:
 ## Fixes
 
 ## Misc Improvements
+- Core: attempts to delete a pool-allocated DF object will now throw an exception instead of corrupting the heap
 
 ## Documentation
 

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -573,12 +573,14 @@ namespace df
      *
      */
 
-    template<typename T> concept pooled_object = requires () { { T::pool_id } -> std::convertible_to<int32_t>; };
+    using df_pool_id_t = size_t;
+    template<typename T> concept pooled_object = requires () { { T::pool_id } -> std::convertible_to<df_pool_id_t>; };
 
     template<typename T> concept copy_assignable = std::assignable_from<T&, T&> && std::assignable_from<T&, const T&>;
 
     template<typename T>
     void *allocator_fn(void *out, const void *in) {
+        constexpr df_pool_id_t invalid_pool_id = static_cast<df_pool_id_t>(-1);
         // unerase type
         T* _out = out ? reinterpret_cast<T*>(out) : nullptr;
         const T* _in = in ? reinterpret_cast<const T*>(in) : nullptr;
@@ -599,7 +601,7 @@ namespace df
         {
             if constexpr (pooled_object<T>)
             {
-                if (_in->pool_id != -1)
+                if (_in->pool_id != invalid_pool_id)
                 {
                     throw std::runtime_error("Pool-allocated type cannot be deallocated with allocator_fn");
                 }

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -24,14 +24,15 @@ distribution.
 
 #pragma once
 
+#include <functional>
 #include <list>
 #include <map>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <unordered_map>
 #include <vector>
-#include <functional>
 
 #include "BitArray.h"
 #include "Export.h"
@@ -572,15 +573,21 @@ namespace df
      *
      */
 
+    template<typename T> concept pooled_object = requires () { { T::pool_id } -> std::convertible_to<int32_t>; };
+
     template<typename T> concept copy_assignable = std::assignable_from<T&, T&> && std::assignable_from<T&, const T&>;
 
     template<typename T>
     void *allocator_fn(void *out, const void *in) {
-        if (out)
+        // unerase type
+        T* _out = out ? reinterpret_cast<T*>(out) : nullptr;
+        const T* _in = in ? reinterpret_cast<const T*>(in) : nullptr;
+
+        if (_out)
         {
             if constexpr (copy_assignable<T>)
             {
-                *(T*)out = *(const T*)in;
+                *_out = *_in;
                 return out;
             }
             else
@@ -588,13 +595,20 @@ namespace df
                 return nullptr;
             }
         }
-        else if (in)
+        else if (_in)
         {
+            if constexpr (pooled_object<T>)
+            {
+                if (_in->pool_id != -1)
+                {
+                    throw std::runtime_error("Pool-allocated type cannot be deallocated with allocator_fn");
+                }
+            }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
-            delete (T*)in;
+            delete _in;
 #pragma GCC diagnostic pop
-            return (T*)in;
+            return const_cast<void*>(in);
         }
         else
             return new T();


### PR DESCRIPTION
This prevents heap corruption in the event that a Lua script attempts to delete a DF object that is pool-allocated. We currently cannot delete pool-allocated DF objects as Bay12 doesn't expose an API for doing so.