### PR TITLE
Remove `Materials` module

### DIFF
--- a/library/Core.cpp
+++ b/library/Core.cpp
@@ -2200,5 +2200,3 @@ TYPE * Core::get##TYPE() \
     }\
     return s_mods.p##TYPE;\
 }
-
-MODULE_GETTER(Materials);

--- a/library/include/Core.h
+++ b/library/include/Core.h
@@ -61,7 +61,6 @@ namespace DFHack
 
     class Process;
     class Module;
-    class Materials;
     struct VersionInfo;
     class VersionInfoFactory;
     class PluginManager;
@@ -161,9 +160,6 @@ namespace DFHack
         bool isSuspended(void);
         /// Is everything OK?
         bool isValid(void) { return !errorstate; }
-
-        /// get the materials module
-        Materials * getMaterials();
 
         command_result runCommand(color_ostream &out, const std::string &command, std::vector <std::string> &parameters, bool no_autocomplete = false);
         command_result runCommand(color_ostream& out, const std::string& command);
@@ -295,7 +291,6 @@ namespace DFHack
         // Module storage
         struct
         {
-            Materials * pMaterials;
         } s_mods;
         std::vector<std::unique_ptr<Module>> allModules;
         DFHack::PluginManager *plug_mgr;

--- a/library/include/modules/Materials.h
+++ b/library/include/modules/Materials.h
@@ -35,7 +35,8 @@ distribution.
 
 #include "df/craft_material_class.h"
 
-namespace df {
+namespace df
+{
     struct item;
     struct plant_raw;
     struct creature_raw;
@@ -54,28 +55,32 @@ namespace df {
 
 namespace DFHack
 {
-    struct t_matpair {
+    struct t_matpair
+    {
         int16_t mat_type;
         int32_t mat_index;
 
         t_matpair(int16_t type = -1, int32_t index = -1)
-            : mat_type(type), mat_index(index) {}
+            : mat_type(type), mat_index(index)
+        {}
     };
 
-    struct DFHACK_EXPORT MaterialInfo {
+    struct DFHACK_EXPORT MaterialInfo
+    {
         static const int NUM_BUILTIN = 19;
         static const int GROUP_SIZE = 200;
         static const int CREATURE_BASE = NUM_BUILTIN;
         static const int FIGURE_BASE = NUM_BUILTIN + GROUP_SIZE;
-        static const int PLANT_BASE = NUM_BUILTIN + GROUP_SIZE*2;
-        static const int END_BASE = NUM_BUILTIN + GROUP_SIZE*3;
+        static const int PLANT_BASE = NUM_BUILTIN + GROUP_SIZE * 2;
+        static const int END_BASE = NUM_BUILTIN + GROUP_SIZE * 3;
 
         int16_t type;
         int32_t index;
 
-        df::material *material;
+        df::material* material;
 
-        enum Mode {
+        enum Mode
+        {
             None,
             Builtin,
             Inorganic,
@@ -85,16 +90,16 @@ namespace DFHack
         Mode mode;
 
         int16_t subtype;
-        df::inorganic_raw *inorganic;
-        df::creature_raw *creature;
-        df::plant_raw *plant;
+        df::inorganic_raw* inorganic;
+        df::creature_raw* creature;
+        df::plant_raw* plant;
 
-        df::historical_figure *figure;
+        df::historical_figure* figure;
 
     public:
         MaterialInfo(int16_t type = -1, int32_t index = -1) { decode(type, index); }
-        MaterialInfo(const t_matpair &mp) { decode(mp.mat_type, mp.mat_index); }
-        template<class T> MaterialInfo(T *ptr) { decode(ptr); }
+        MaterialInfo(const t_matpair& mp) { decode(mp.mat_type, mp.mat_index); }
+        template<class T> MaterialInfo(T* ptr) { decode(ptr); }
 
         bool isValid() const { return material != NULL; }
 
@@ -108,25 +113,27 @@ namespace DFHack
         bool isInorganicWildcard() const { return isAnyInorganic() && isBuiltin(); }
 
         bool decode(int16_t type, int32_t index = -1);
-        bool decode(df::item *item);
-        bool decode(const df::material_vec_ref &vr, int idx);
-        bool decode(const t_matpair &mp) { return decode(mp.mat_type, mp.mat_index); }
+        bool decode(df::item* item);
+        bool decode(const df::material_vec_ref& vr, int idx);
+        bool decode(const t_matpair& mp) { return decode(mp.mat_type, mp.mat_index); }
 
-        template<class T> bool decode(T *ptr) {
+        template<class T> bool decode(T* ptr)
+        {
             // Assume and exploit a certain naming convention
             return ptr ? decode(ptr->mat_type, ptr->mat_index) : decode(-1);
         }
 
-        bool find(const std::string &token);
-        bool find(const std::vector<std::string> &tokens);
+        bool find(const std::string& token);
+        bool find(const std::vector<std::string>& tokens);
 
-        bool findBuiltin(const std::string &token);
-        bool findInorganic(const std::string &token);
-        bool findPlant(const std::string &token, const std::string &subtoken);
-        bool findCreature(const std::string &token, const std::string &subtoken);
+        bool findBuiltin(const std::string& token);
+        bool findInorganic(const std::string& token);
+        bool findPlant(const std::string& token, const std::string& subtoken);
+        bool findCreature(const std::string& token, const std::string& subtoken);
 
-        bool findProduct(df::material *material, const std::string &name);
-        bool findProduct(const MaterialInfo &info, const std::string &name) {
+        bool findProduct(df::material* material, const std::string& name);
+        bool findProduct(const MaterialInfo& info, const std::string& name)
+        {
             return findProduct(info.material, name);
         }
 
@@ -135,35 +142,38 @@ namespace DFHack
 
         bool isAnyCloth() const;
 
-        void getMatchBits(df::job_item_flags1 &ok, df::job_item_flags1 &mask) const;
-        void getMatchBits(df::job_item_flags2 &ok, df::job_item_flags2 &mask) const;
-        void getMatchBits(df::job_item_flags3 &ok, df::job_item_flags3 &mask) const;
+        void getMatchBits(df::job_item_flags1& ok, df::job_item_flags1& mask) const;
+        void getMatchBits(df::job_item_flags2& ok, df::job_item_flags2& mask) const;
+        void getMatchBits(df::job_item_flags3& ok, df::job_item_flags3& mask) const;
 
         df::craft_material_class getCraftClass();
 
-        bool matches(const MaterialInfo &mat) const
+        bool matches(const MaterialInfo& mat) const
         {
             if (!mat.isValid()) return true;
             return (type == mat.type) &&
-                   (mat.index == -1 || index == mat.index);
+                (mat.index == -1 || index == mat.index);
         }
 
-        bool matches(const df::job_material_category &cat) const;
-        bool matches(const df::dfhack_material_category &cat) const;
-        bool matches(const df::job_item &jitem,
-                     df::item_type itype = df::item_type::NONE) const;
+        bool matches(const df::job_material_category& cat) const;
+        bool matches(const df::dfhack_material_category& cat) const;
+        bool matches(const df::job_item& jitem,
+            df::item_type itype = df::item_type::NONE) const;
     };
 
-    DFHACK_EXPORT bool parseJobMaterialCategory(df::job_material_category *cat, const std::string &token);
-    DFHACK_EXPORT bool parseJobMaterialCategory(df::dfhack_material_category *cat, const std::string &token);
+    DFHACK_EXPORT bool parseJobMaterialCategory(df::job_material_category* cat, const std::string& token);
+    DFHACK_EXPORT bool parseJobMaterialCategory(df::dfhack_material_category* cat, const std::string& token);
 
-    inline bool operator== (const MaterialInfo &a, const MaterialInfo &b) {
+    inline bool operator== (const MaterialInfo& a, const MaterialInfo& b)
+    {
         return a.type == b.type && a.index == b.index;
     }
-    inline bool operator!= (const MaterialInfo &a, const MaterialInfo &b) {
+    inline bool operator!= (const MaterialInfo& a, const MaterialInfo& b)
+    {
         return a.type != b.type || a.index != b.index;
     }
-    inline bool operator< (const MaterialInfo &a, const MaterialInfo &b) {
+    inline bool operator< (const MaterialInfo& a, const MaterialInfo& b)
+    {
         return a.type < b.type || (a.type == b.type && a.index < b.index);
     }
 
@@ -345,38 +355,18 @@ namespace DFHack
         t_materialIndex mat_index;
         uint32_t flags;
     };
-    /**
-     * The Materials module
-     * \ingroup grp_modules
-     * \ingroup grp_materials
-     */
-    class DFHACK_EXPORT Materials : public Module
+
+
+    namespace Materials
     {
-    public:
-        Materials();
-        ~Materials();
-        bool Finish();
+        /**
+         * The Materials module
+         * \ingroup grp_modules
+         * \ingroup grp_materials
+         */
 
-        std::vector<t_matgloss> race;
-        std::vector<t_creaturetype> raceEx;
-        std::vector<t_descriptor_color> color;
-        std::vector<t_matglossOther> other;
-        std::vector<t_matgloss> alldesc;
-
-        bool CopyInorganicMaterials (std::vector<t_matglossInorganic> & inorganic);
-        bool CopyOrganicMaterials (std::vector<t_matgloss> & organic);
-        bool CopyWoodMaterials (std::vector<t_matgloss> & tree);
-        bool CopyPlantMaterials (std::vector<t_matgloss> & plant);
-
-        bool ReadCreatureTypes (void);
-        bool ReadCreatureTypesEx (void);
-        bool ReadDescriptorColors(void);
-        bool ReadOthers (void);
-
-        bool ReadAllMaterials(void);
-
-        std::string getType(const t_material & mat);
-        std::string getDescription(const t_material & mat);
-    };
+        std::string getType(const t_material& mat);
+        std::string getDescription(const t_material& mat);
+    }
 }
 #endif

--- a/library/modules/Materials.cpp
+++ b/library/modules/Materials.cpp
@@ -68,7 +68,7 @@ using namespace df::enums;
 using df::global::world;
 using df::global::plotinfo;
 
-bool MaterialInfo::decode(df::item *item)
+bool MaterialInfo::decode(df::item* item)
 {
     if (!item)
         return decode(-1);
@@ -76,7 +76,7 @@ bool MaterialInfo::decode(df::item *item)
         return decode(item->getActualMaterial(), item->getActualMaterialIndex());
 }
 
-bool MaterialInfo::decode(const df::material_vec_ref &vr, int idx)
+bool MaterialInfo::decode(const df::material_vec_ref& vr, int idx)
 {
     if (size_t(idx) >= vr.mat_type.size() || size_t(idx) >= vr.mat_index.size())
         return decode(-1);
@@ -94,14 +94,15 @@ bool MaterialInfo::decode(int16_t type, int32_t index)
     inorganic = NULL; plant = NULL; creature = NULL;
     figure = NULL;
 
-    if (type < 0) {
+    if (type < 0)
+    {
         mode = None;
         return false;
     }
 
-    auto &raws = world->raws;
+    auto& raws = world->raws;
 
-    if (size_t(type) >= sizeof(raws.mat_table.builtin)/sizeof(void*))
+    if (size_t(type) >= sizeof(raws.mat_table.builtin) / sizeof(void*))
         return false;
 
     if (index < 0)
@@ -123,7 +124,7 @@ bool MaterialInfo::decode(int16_t type, int32_t index)
     else if (type < FIGURE_BASE)
     {
         mode = Creature;
-        subtype = type-CREATURE_BASE;
+        subtype = type - CREATURE_BASE;
         creature = df::creature_raw::find(index);
         if (!creature || size_t(subtype) >= creature->material.size())
             return false;
@@ -132,7 +133,7 @@ bool MaterialInfo::decode(int16_t type, int32_t index)
     else if (type < PLANT_BASE)
     {
         mode = Creature;
-        subtype = type-FIGURE_BASE;
+        subtype = type - FIGURE_BASE;
         figure = df::historical_figure::find(index);
         if (!figure)
             return false;
@@ -144,7 +145,7 @@ bool MaterialInfo::decode(int16_t type, int32_t index)
     else if (type < END_BASE)
     {
         mode = Plant;
-        subtype = type-PLANT_BASE;
+        subtype = type - PLANT_BASE;
         plant = df::plant_raw::find(index);
         if (!plant || size_t(subtype) >= plant->material.size())
             return false;
@@ -158,24 +159,24 @@ bool MaterialInfo::decode(int16_t type, int32_t index)
     return (material != NULL);
 }
 
-bool MaterialInfo::find(const std::string &token)
+bool MaterialInfo::find(const std::string& token)
 {
     std::vector<std::string> items;
     split_string(&items, token, ":");
     return find(items);
 }
 
-bool MaterialInfo::find(const std::vector<std::string> &items)
+bool MaterialInfo::find(const std::vector<std::string>& items)
 {
     if (items.empty())
         return false;
 
     if (items[0] == "INORGANIC" && items.size() > 1)
-        return findInorganic(vector_get(items,1));
+        return findInorganic(vector_get(items, 1));
     if (items[0] == "CREATURE_MAT" || items[0] == "CREATURE")
-        return findCreature(vector_get(items,1), vector_get(items,2));
+        return findCreature(vector_get(items, 1), vector_get(items, 2));
     if (items[0] == "PLANT_MAT" || items[0] == "PLANT")
-        return findPlant(vector_get(items,1), vector_get(items,2));
+        return findPlant(vector_get(items, 1), vector_get(items, 2));
 
     if (items.size() == 1)
     {
@@ -188,7 +189,8 @@ bool MaterialInfo::find(const std::vector<std::string> &items)
     }
     else if (items.size() == 2)
     {
-        if (items[0] == "COAL" && findBuiltin(items[0])) {
+        if (items[0] == "COAL" && findBuiltin(items[0]))
+        {
             if (items[1] == "COKE")
                 this->index = 0;
             else if (items[1] == "CHARCOAL")
@@ -206,17 +208,18 @@ bool MaterialInfo::find(const std::vector<std::string> &items)
     return false;
 }
 
-bool MaterialInfo::findBuiltin(const std::string &token)
+bool MaterialInfo::findBuiltin(const std::string& token)
 {
     if (token.empty())
         return decode(-1);
 
-    if (token == "NONE") {
+    if (token == "NONE")
+    {
         decode(-1);
         return true;
     }
 
-    auto &raws = world->raws;
+    auto& raws = world->raws;
     for (int i = 0; i < NUM_BUILTIN; i++)
     {
         auto obj = raws.mat_table.builtin[i];
@@ -226,34 +229,35 @@ bool MaterialInfo::findBuiltin(const std::string &token)
     return decode(-1);
 }
 
-bool MaterialInfo::findInorganic(const std::string &token)
+bool MaterialInfo::findInorganic(const std::string& token)
 {
     if (token.empty())
         return decode(-1);
 
-    if (token == "NONE") {
+    if (token == "NONE")
+    {
         decode(0, -1);
         return true;
     }
 
-    auto &raws = world->raws;
+    auto& raws = world->raws;
     for (size_t i = 0; i < raws.inorganics.all.size(); i++)
     {
-        df::inorganic_raw *p = raws.inorganics.all[i];
+        df::inorganic_raw* p = raws.inorganics.all[i];
         if (p->id == token)
             return decode(0, i);
     }
     return decode(-1);
 }
 
-bool MaterialInfo::findPlant(const std::string &token, const std::string &subtoken)
+bool MaterialInfo::findPlant(const std::string& token, const std::string& subtoken)
 {
     if (token.empty())
         return decode(-1);
-    auto &raws = world->raws;
+    auto& raws = world->raws;
     for (size_t i = 0; i < raws.plants.all.size(); i++)
     {
-        df::plant_raw *p = raws.plants.all[i];
+        df::plant_raw* p = raws.plants.all[i];
         if (p->id != token)
             continue;
 
@@ -263,39 +267,39 @@ bool MaterialInfo::findPlant(const std::string &token, const std::string &subtok
 
         for (size_t j = 0; j < p->material.size(); j++)
             if (p->material[j]->id == subtoken)
-                return decode(PLANT_BASE+j, i);
+                return decode(PLANT_BASE + j, i);
 
         break;
     }
     return decode(-1);
 }
 
-bool MaterialInfo::findCreature(const std::string &token, const std::string &subtoken)
+bool MaterialInfo::findCreature(const std::string& token, const std::string& subtoken)
 {
     if (token.empty() || subtoken.empty())
         return decode(-1);
-    auto &raws = world->raws;
+    auto& raws = world->raws;
     for (size_t i = 0; i < raws.creatures.all.size(); i++)
     {
-        df::creature_raw *p = raws.creatures.all[i];
+        df::creature_raw* p = raws.creatures.all[i];
         if (p->creature_id != token)
             continue;
 
         for (size_t j = 0; j < p->material.size(); j++)
             if (p->material[j]->id == subtoken)
-                return decode(CREATURE_BASE+j, i);
+                return decode(CREATURE_BASE + j, i);
 
         break;
     }
     return decode(-1);
 }
 
-bool MaterialInfo::findProduct(df::material *material, const std::string &name)
+bool MaterialInfo::findProduct(df::material* material, const std::string& name)
 {
     if (!material || name.empty())
         return decode(-1);
 
-    auto &pids = material->reaction_product.id;
+    auto& pids = material->reaction_product.id;
     for (size_t i = 0; i < pids.size(); i++)
         if ((*pids[i]) == name)
             return decode(material->reaction_product.material, i);
@@ -311,9 +315,11 @@ std::string MaterialInfo::getToken() const
     if (!material)
         return fmt::format("INVALID:{}:{}", type, index);
 
-    switch (mode) {
+    switch (mode)
+    {
     case Builtin:
-        if (material->id == "COAL") {
+        if (material->id == "COAL")
+        {
             if (index == 0)
                 return "COAL:COKE";
             else if (index == 1)
@@ -382,10 +388,10 @@ bool MaterialInfo::isAnyCloth() const
         material->flags.is_set(THREAD_PLANT) ||
         material->flags.is_set(SILK) ||
         material->flags.is_set(YARN)
-    );
+        );
 }
 
-bool MaterialInfo::matches(const df::job_material_category &cat) const
+bool MaterialInfo::matches(const df::job_material_category& cat) const
 {
     if (!material)
         return false;
@@ -414,7 +420,7 @@ bool MaterialInfo::matches(const df::job_material_category &cat) const
     return false;
 }
 
-bool MaterialInfo::matches(const df::dfhack_material_category &cat) const
+bool MaterialInfo::matches(const df::dfhack_material_category& cat) const
 {
     if (!material)
         return false;
@@ -443,7 +449,7 @@ bool MaterialInfo::matches(const df::dfhack_material_category &cat) const
 
 #undef TEST
 
-bool MaterialInfo::matches(const df::job_item &jitem, df::item_type itype) const
+bool MaterialInfo::matches(const df::job_item& jitem, df::item_type itype) const
 {
     if (!isValid()) return false;
 
@@ -460,11 +466,11 @@ bool MaterialInfo::matches(const df::job_item &jitem, df::item_type itype) const
     mask2.whole &= ~xmask2.whole;
 
     return bits_match(jitem.flags1.whole, ok1.whole, mask1.whole) &&
-           bits_match(jitem.flags2.whole, ok2.whole, mask2.whole) &&
-           bits_match(jitem.flags3.whole, ok3.whole, mask3.whole);
+        bits_match(jitem.flags2.whole, ok2.whole, mask2.whole) &&
+        bits_match(jitem.flags3.whole, ok3.whole, mask3.whole);
 }
 
-void MaterialInfo::getMatchBits(df::job_item_flags1 &ok, df::job_item_flags1 &mask) const
+void MaterialInfo::getMatchBits(df::job_item_flags1& ok, df::job_item_flags1& mask) const
 {
     ok.whole = mask.whole = 0;
     if (!isValid()) return;
@@ -486,10 +492,10 @@ void MaterialInfo::getMatchBits(df::job_item_flags1 &ok, df::job_item_flags1 &ma
     TEST(processable_to_vial, structural && FLAG(plant, plant_raw_flags::EXTRACT_VIAL));
     TEST(processable_to_barrel, structural && FLAG(plant, plant_raw_flags::EXTRACT_BARREL));
     TEST(solid, !(MAT_FLAG(ALCOHOL_PLANT) ||
-                  MAT_FLAG(ALCOHOL_CREATURE) ||
-                  MAT_FLAG(LIQUID_MISC_PLANT) ||
-                  MAT_FLAG(LIQUID_MISC_CREATURE) ||
-                  MAT_FLAG(LIQUID_MISC_OTHER)));
+        MAT_FLAG(ALCOHOL_CREATURE) ||
+        MAT_FLAG(LIQUID_MISC_PLANT) ||
+        MAT_FLAG(LIQUID_MISC_CREATURE) ||
+        MAT_FLAG(LIQUID_MISC_OTHER)));
     TEST(tameable_vermin, false);
     TEST(sharpenable, MAT_FLAG(IS_STONE));
     TEST(milk, linear_index(material->reaction_product.id, std::string("CHEESE_MAT")) >= 0);
@@ -497,7 +503,7 @@ void MaterialInfo::getMatchBits(df::job_item_flags1 &ok, df::job_item_flags1 &ma
     //04000000 - "milkable" - vtable[107],1,1
 }
 
-void MaterialInfo::getMatchBits(df::job_item_flags2 &ok, df::job_item_flags2 &mask) const
+void MaterialInfo::getMatchBits(df::job_item_flags2& ok, df::job_item_flags2& mask) const
 {
     ok.whole = mask.whole = 0;
     if (!isValid()) return;
@@ -511,15 +517,15 @@ void MaterialInfo::getMatchBits(df::job_item_flags2 &ok, df::job_item_flags2 &ma
     TEST(glass_making, MAT_FLAG(CRYSTAL_GLASSABLE));
 
     TEST(fire_safe, material->heat.melting_point > 11000
-                    && material->heat.boiling_point > 11000
-                    && material->heat.ignite_point > 11000
-                    && material->heat.heatdam_point > 11000
-                    && (material->heat.colddam_point == 60001 || material->heat.colddam_point < 11000));
+        && material->heat.boiling_point > 11000
+        && material->heat.ignite_point > 11000
+        && material->heat.heatdam_point > 11000
+        && (material->heat.colddam_point == 60001 || material->heat.colddam_point < 11000));
     TEST(magma_safe, material->heat.melting_point > 12000
-                    && material->heat.boiling_point > 12000
-                    && material->heat.ignite_point > 12000
-                    && material->heat.heatdam_point > 12000
-                    && (material->heat.colddam_point == 60001 || material->heat.colddam_point < 12000));
+        && material->heat.boiling_point > 12000
+        && material->heat.ignite_point > 12000
+        && material->heat.heatdam_point > 12000
+        && (material->heat.colddam_point == 60001 || material->heat.colddam_point < 12000));
     TEST(deep_material, FLAG(inorganic, inorganic_flags::SPECIAL));
     TEST(non_economic, !inorganic || !(plotinfo && vector_get(plotinfo->economic_stone, index)));
 
@@ -537,7 +543,7 @@ void MaterialInfo::getMatchBits(df::job_item_flags2 &ok, df::job_item_flags2 &ma
     TEST(yarn, MAT_FLAG(YARN));
 }
 
-void MaterialInfo::getMatchBits(df::job_item_flags3 &ok, df::job_item_flags3 &mask) const
+void MaterialInfo::getMatchBits(df::job_item_flags3& ok, df::job_item_flags3& mask) const
 {
     ok.whole = mask.whole = 0;
     if (!isValid()) return;
@@ -549,7 +555,7 @@ void MaterialInfo::getMatchBits(df::job_item_flags3 &ok, df::job_item_flags3 &ma
 #undef FLAG
 #undef TEST
 
-bool DFHack::parseJobMaterialCategory(df::job_material_category *cat, const std::string &token)
+bool DFHack::parseJobMaterialCategory(df::job_material_category* cat, const std::string& token)
 {
     cat->whole = 0;
 
@@ -565,7 +571,7 @@ bool DFHack::parseJobMaterialCategory(df::job_material_category *cat, const std:
     return true;
 }
 
-bool DFHack::parseJobMaterialCategory(df::dfhack_material_category *cat, const std::string &token)
+bool DFHack::parseJobMaterialCategory(df::dfhack_material_category* cat, const std::string& token)
 {
     cat->whole = 0;
 
@@ -600,32 +606,14 @@ bool DFHack::isStoneInorganic(int material)
     return true;
 }
 
-std::unique_ptr<Module> DFHack::createMaterials()
-{
-    return std::make_unique<Materials>();
-}
-
-Materials::Materials()
-{
-}
-
-Materials::~Materials()
-{
-}
-
-bool Materials::Finish()
-{
-    return true;
-}
-
 t_matgloss::t_matgloss()
 {
-    fore    = 0;
-    back    = 0;
-    bright  = 0;
+    fore = 0;
+    back = 0;
+    bright = 0;
 
-    value        = 0;
-    wall_tile    = 0;
+    value = 0;
+    wall_tile = 0;
     boulder_tile = 0;
 }
 
@@ -643,240 +631,7 @@ bool t_matglossInorganic::isGem()
     return is_gem;
 }
 
-bool Materials::CopyInorganicMaterials (std::vector<t_matglossInorganic> & inorganic)
-{
-    size_t size = world->raws.inorganics.all.size();
-    inorganic.clear();
-    inorganic.reserve (size);
-    for (size_t i = 0; i < size;i++)
-    {
-        df::inorganic_raw *orig = world->raws.inorganics.all[i];
-        t_matglossInorganic mat;
-        mat.id = orig->id;
-        mat.name = orig->material.stone_name;
-
-        mat.ore_types = orig->metal_ore.mat_index;
-        mat.ore_chances = orig->metal_ore.probability;
-        mat.strand_types = orig->thread_metal.mat_index;
-        mat.strand_chances = orig->thread_metal.probability;
-        mat.value = orig->material.material_value;
-        mat.wall_tile = orig->material.tile;
-        mat.boulder_tile = orig->material.item_symbol;
-        mat.fore = orig->material.basic_color[0];
-        mat.bright = orig->material.basic_color[1];
-        mat.is_gem = orig->material.flags.is_set(material_flags::IS_GEM);
-        inorganic.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::CopyOrganicMaterials (std::vector<t_matgloss> & organic)
-{
-    size_t size = world->raws.plants.all.size();
-    organic.clear();
-    organic.reserve (size);
-    for (size_t i = 0; i < size;i++)
-    {
-        t_matgloss mat;
-        mat.id = world->raws.plants.all[i]->id;
-        organic.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::CopyWoodMaterials (std::vector<t_matgloss> & tree)
-{
-    size_t size = world->raws.plants.trees.size();
-    tree.clear();
-    tree.reserve (size);
-    for (size_t i = 0; i < size;i++)
-    {
-        t_matgloss mat;
-        mat.id = world->raws.plants.trees[i]->id;
-        tree.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::CopyPlantMaterials (std::vector<t_matgloss> & plant)
-{
-    size_t size = world->raws.plants.bushes.size();
-    plant.clear();
-    plant.reserve (size);
-    for (size_t i = 0; i < size;i++)
-    {
-        t_matgloss mat;
-        mat.id = world->raws.plants.bushes[i]->id;
-        plant.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::ReadCreatureTypes (void)
-{
-    size_t size = world->raws.creatures.all.size();
-    race.clear();
-    race.reserve (size);
-    for (size_t i = 0; i < size;i++)
-    {
-        t_matgloss mat;
-        mat.id = world->raws.creatures.all[i]->creature_id;
-        race.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::ReadOthers(void)
-{
-    other.clear();
-    FOR_ENUM_ITEMS(builtin_mats, i)
-    {
-        t_matglossOther mat;
-        mat.id = world->raws.mat_table.builtin[i]->id;
-        other.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::ReadDescriptorColors (void)
-{
-    size_t size = world->raws.descriptors.colors.size();
-
-    color.clear();
-    if(size == 0)
-        return false;
-    color.reserve(size);
-    for (size_t i = 0; i < size;i++)
-    {
-        df::descriptor_color *c = world->raws.descriptors.colors[i];
-        t_descriptor_color col;
-        col.id = c->id;
-        col.name = c->name;
-        col.red = c->red;
-        col.green = c->green;
-        col.blue = c->blue;
-        color.push_back(col);
-    }
-
-    size = world->raws.descriptors.patterns.size();
-    alldesc.clear();
-    alldesc.reserve(size);
-    for (size_t i = 0; i < size;i++)
-    {
-        t_matgloss mat;
-        mat.id = world->raws.descriptors.patterns[i]->id;
-        alldesc.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::ReadCreatureTypesEx (void)
-{
-    size_t size = world->raws.creatures.all.size();
-    raceEx.clear();
-    raceEx.reserve (size);
-    for (size_t i = 0; i < size; i++)
-    {
-        df::creature_raw *cr = world->raws.creatures.all[i];
-        t_creaturetype mat;
-        mat.id = cr->creature_id;
-        mat.tile_character = cr->creature_tile;
-        mat.tilecolor.fore = cr->color[0];
-        mat.tilecolor.back = cr->color[1];
-        mat.tilecolor.bright = cr->color[2];
-
-        size_t sizecas = cr->caste.size();
-        for (size_t j = 0; j < sizecas;j++)
-        {
-            df::caste_raw *ca = cr->caste[j];
-            /* caste name */
-            t_creaturecaste caste;
-            caste.id = ca->caste_id;
-            caste.singular = ca->caste_name[0];
-            caste.plural = ca->caste_name[1];
-            caste.adjective = ca->caste_name[2];
-
-            // color mod reading
-            // Caste + offset > color mod vector
-            auto & colorings = ca->color_modifiers;
-            size_t sizecolormod = colorings.size();
-            caste.ColorModifier.resize(sizecolormod);
-            for(size_t k = 0; k < sizecolormod;k++)
-            {
-                // color mod [0] -> color list
-                auto & indexes = colorings[k]->pattern_index;
-                size_t sizecolorlist = indexes.size();
-                caste.ColorModifier[k].colorlist.resize(sizecolorlist);
-                for(size_t l = 0; l < sizecolorlist; l++)
-                    caste.ColorModifier[k].colorlist[l] = indexes[l];
-                // color mod [color_modifier_part_offset] = string part
-                caste.ColorModifier[k].part = colorings[k]->part;
-                caste.ColorModifier[k].startdate = colorings[k]->start_date;
-                caste.ColorModifier[k].enddate = colorings[k]->end_date;
-            }
-
-            // body parts
-            caste.bodypart.clear();
-            size_t sizebp = ca->body_info.body_parts.size();
-            for (size_t k = 0; k < sizebp; k++)
-            {
-                df::body_part_raw *bp = ca->body_info.body_parts[k];
-                t_bodypart part;
-                part.id = bp->token;
-                part.category = bp->category;
-                caste.bodypart.push_back(part);
-            }
-            using namespace df::enums::mental_attribute_type;
-            using namespace df::enums::physical_attribute_type;
-            for (int32_t k = 0; k < 7; k++)
-            {
-                auto & physical = ca->attributes.phys_att_range;
-                caste.strength[k] = physical[STRENGTH][k];
-                caste.agility[k] = physical[AGILITY][k];
-                caste.toughness[k] = physical[TOUGHNESS][k];
-                caste.endurance[k] = physical[ENDURANCE][k];
-                caste.recuperation[k] = physical[RECUPERATION][k];
-                caste.disease_resistance[k] = physical[DISEASE_RESISTANCE][k];
-
-                auto & mental = ca->attributes.ment_att_range;
-                caste.analytical_ability[k] = mental[ANALYTICAL_ABILITY][k];
-                caste.focus[k] = mental[FOCUS][k];
-                caste.willpower[k] = mental[WILLPOWER][k];
-                caste.creativity[k] = mental[CREATIVITY][k];
-                caste.intuition[k] = mental[INTUITION][k];
-                caste.patience[k] = mental[PATIENCE][k];
-                caste.memory[k] = mental[MEMORY][k];
-                caste.linguistic_ability[k] = mental[LINGUISTIC_ABILITY][k];
-                caste.spatial_sense[k] = mental[SPATIAL_SENSE][k];
-                caste.musicality[k] = mental[MUSICALITY][k];
-                caste.kinesthetic_sense[k] = mental[KINESTHETIC_SENSE][k];
-                caste.empathy[k] = mental[EMPATHY][k];
-                caste.social_awareness[k] = mental[SOCIAL_AWARENESS][k];
-            }
-            mat.castes.push_back(caste);
-        }
-        for (size_t j = 0; j < world->raws.creatures.all[i]->material.size(); j++)
-        {
-            t_creatureextract extract;
-            extract.id = world->raws.creatures.all[i]->material[j]->id;
-            mat.extract.push_back(extract);
-        }
-        raceEx.push_back(mat);
-    }
-    return true;
-}
-
-bool Materials::ReadAllMaterials(void)
-{
-    bool ok = true;
-    ok &= this->ReadCreatureTypes();
-    ok &= this->ReadCreatureTypesEx();
-    ok &= this->ReadDescriptorColors();
-    ok &= this->ReadOthers();
-    return ok;
-}
-
-std::string Materials::getDescription(const t_material & mat)
+std::string Materials::getDescription(const t_material& mat)
 {
     MaterialInfo mi(mat.mat_type, mat.mat_index);
     if (mi.creature)
@@ -889,7 +644,7 @@ std::string Materials::getDescription(const t_material & mat)
 
 // type of material only so we know which vector to retrieve
 // This is completely worthless now
-std::string Materials::getType(const t_material & mat)
+std::string Materials::getType(const t_material& mat)
 {
     MaterialInfo mi(mat.mat_type, mat.mat_index);
     switch (mi.mode)


### PR DESCRIPTION
Note that this only removes the legacy `Materials` class; the modern module persists and the two methods that were in the class that aren't related to the cache `Materials` managed  (`getDescription` and `getType`, which  no existing code uses at present) are converted to free functions in the `Materials` namespace. 

Future "material"-related convenience methods should be added to this namespace. Also, adding Lua API mappings for these two methods might be advisable.

No user-facing change.