### PR TITLE
Add dfhack.filesystem.rmdir_recursive to proxy std::filesystem::remove_all

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3291,6 +3291,10 @@ unless otherwise noted.
 
   Removes a directory. Only works if the directory is already empty.
 
+* ``dfhack.filesystem.rmdir_recursive(path)``
+
+  Removes a directory and all of its contents recursively.
+
 * ``dfhack.filesystem.mtime(path)``
 
   Returns the modification time (in seconds) of the file or directory

--- a/library/LuaApi.cpp
+++ b/library/LuaApi.cpp
@@ -3338,6 +3338,7 @@ static const LuaWrapper::FunctionReg dfhack_filesystem_module[] = {
     WRAPM(Filesystem, mkdir),
     WRAPM(Filesystem, mkdir_recursive),
     WRAPM(Filesystem, rmdir),
+    WRAPM(Filesystem, rmdir_recursive),
     WRAPM(Filesystem, exists),
     WRAPM(Filesystem, isfile),
     WRAPM(Filesystem, isdir),

--- a/library/include/modules/Filesystem.h
+++ b/library/include/modules/Filesystem.h
@@ -64,6 +64,7 @@ namespace DFHack {
         // returns true on success or if directory already exists
         DFHACK_EXPORT bool mkdir_recursive(std::filesystem::path path) noexcept;
         DFHACK_EXPORT bool rmdir(std::filesystem::path path) noexcept;
+        DFHACK_EXPORT bool rmdir_recursive(std::filesystem::path path) noexcept;
         DFHACK_EXPORT bool stat(std::filesystem::path path, std::filesystem::file_status& info) noexcept;
         DFHACK_EXPORT bool exists(std::filesystem::path path) noexcept;
         DFHACK_EXPORT bool isfile(std::filesystem::path path) noexcept;

--- a/library/modules/Filesystem.cpp
+++ b/library/modules/Filesystem.cpp
@@ -139,6 +139,19 @@ bool Filesystem::rmdir (std::filesystem::path path) noexcept
     }
 }
 
+bool Filesystem::rmdir_recursive (std::filesystem::path path) noexcept
+{
+    try
+    {
+        std::filesystem::remove_all(path);
+        return true;
+    }
+    catch (std::filesystem::filesystem_error&)
+    {
+        return false;
+    }
+}
+
 bool Filesystem::stat (std::filesystem::path path, std::filesystem::file_status &info) noexcept
 {
     try


### PR DESCRIPTION
Exposes \std::filesystem::remove_all\ to Lua as \dfhack.filesystem.rmdir_recursive\.

Required for PR DFHack/scripts#1583 (\manual-save\) to implement the \--cleanup\ snapshot pruning feature natively.