### PR TITLE
Autoclothing fix

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -33,6 +33,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `autoclothing`: Fix incorrect invalid material type error
 
 ## Misc Improvements
 

--- a/plugins/autoclothing.cpp
+++ b/plugins/autoclothing.cpp
@@ -65,7 +65,7 @@ enum ConfigValues {
 struct ClothingRequirement;
 command_result autoclothing(color_ostream &out, vector<string> &parameters);
 static void do_autoclothing();
-static bool validateMaterialCategory(ClothingRequirement& requirement);
+static bool validateMaterialCategory(ClothingRequirement& requirement, df::job_material_category& material_category);
 static std::optional<ClothingRequirement> setItem(string name);
 static void generate_control(color_ostream &out);
 static bool isAvailableItem(df::item *item);
@@ -151,7 +151,7 @@ struct ClothingRequirement {
             return std::nullopt;
         }
 
-        else if (!validateMaterialCategory(*req)) {
+        else if (!validateMaterialCategory(*req, material_category)) {
             out << parameters[idx] << " is not a valid material category for " << parameters[idx+1] << endl;
             return std::nullopt;
         }
@@ -387,29 +387,29 @@ static bool armorFlagsMatch(BitArray<df::armor_general_flags>& flags, df::job_ma
     return flags.is_set(df::armor_general_flags::LEATHER) && category.bits.leather;
 }
 
-static bool validateMaterialCategory(ClothingRequirement& requirement) {
+static bool validateMaterialCategory(ClothingRequirement& requirement, df::job_material_category& material_category) {
     auto itemDef = Items::getSubtypeDef(requirement.itemType, requirement.item_subtype);
     switch (requirement.itemType)
     {
         case item_type::ARMOR:
             if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_armorst, itemDef))
-                return armorFlagsMatch(armor->props.flags, requirement.material_category);
+                return armorFlagsMatch(armor->props.flags, material_category);
             break;
         case item_type::GLOVES:
             if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_glovesst, itemDef))
-                return armorFlagsMatch(armor->props.flags, requirement.material_category);
+                return armorFlagsMatch(armor->props.flags, material_category);
             break;
         case item_type::SHOES:
             if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_shoesst, itemDef))
-                return armorFlagsMatch(armor->props.flags, requirement.material_category);
+                return armorFlagsMatch(armor->props.flags, material_category);
             break;
         case item_type::HELM:
             if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_helmst, itemDef))
-                return armorFlagsMatch(armor->props.flags, requirement.material_category);
+                return armorFlagsMatch(armor->props.flags, material_category);
             break;
         case item_type::PANTS:
             if (STRICT_VIRTUAL_CAST_VAR(armor, df::itemdef_pantsst, itemDef))
-                return armorFlagsMatch(armor->props.flags, requirement.material_category);
+                return armorFlagsMatch(armor->props.flags, material_category);
             break;
         default:
             break;


### PR DESCRIPTION
When printing out the values of variables along the path for validating the material type I saw that `requirement.material_category.whole` was 0. So in the `armorFlagsMatch` function it was trying to check bits that weren't set. From a quick look over it seemed the purpose is just to check that the user specified a material that is valid for the armor wanted. With this in mind I passed in the material_category that the user wants and in game was able to get the desired behavior of creating orders of cloth gloves. I also saw the desired behavior of invalid material type when i tried ordering wood gloves.

This tries to fix #5837, please let me know if any issues
