### PR TITLE
`RadioButton` use `on_change` callback

### DIFF
--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -6396,13 +6396,13 @@ Subclass of ConfigureButton; a 3x1 tile button that resembles a radio button
 It has the following attributes:
 
 :initial_state: Whether to start in the ``true`` or ``false`` state. Defaults to ``true``.
-:on_change: Callback to call when state changes, including initialization. Called as `on_change(val)`.
+:on_change: Callback to call when state changes, including initialization. Called as ``on_change(val)``.
 
 It implements the following method:
 
 * ``RadioButton:setState(val)``
 
-  Sets the state to boolean `val` and calls `on_change` (if defined).
+  Sets the state to boolean ``val`` and calls ``on_change`` (if defined).
 
 BannerPanel class
 -----------------

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -6392,11 +6392,17 @@ RadioButton class
 Subclass of ConfigureButton; a 3x1 tile button that resembles a radio button
 (or check box in ASCII mode), identical to the ones found in
 `gui/control-panel`. Clicking on the button will toggle its enabled state.
-This state is represented by the boolean value ``toggle_state``.
 
 It has the following attributes:
 
-:initial_state: Start in the ``true`` or ``false`` state. Defaults to ``true``.
+:initial_state: Whether to start in the ``true`` or ``false`` state. Defaults to ``true``.
+:on_change: Callback to call when state changes, including initialization. Called as `on_change(val)`.
+
+It implements the following method:
+
+* ``RadioButton:setState(val)``
+
+  Sets the state to boolean `val` and calls `on_change` (if defined).
 
 BannerPanel class
 -----------------

--- a/library/lua/gui/widgets/buttons/radio_button.lua
+++ b/library/lua/gui/widgets/buttons/radio_button.lua
@@ -6,9 +6,9 @@ local ConfigureButton = require('gui.widgets.buttons.configure_button')
 local to_pen = dfhack.pen.parse
 
 local enabled_pen_left = to_pen{fg=COLOR_CYAN,
-    tile=curry(textures.tp_control_panel, 1), ch=string.byte('[')}
+    tile=curry(textures.tp_control_panel, 1) or nil, ch=string.byte('[')}
 local enabled_pen_center = to_pen{fg=COLOR_LIGHTGREEN,
-    tile=curry(textures.tp_control_panel, 2) or nil, ch=251} -- check
+    tile=curry(textures.tp_control_panel, 2) or nil, ch=251} -- check mark
 local enabled_pen_right = to_pen{fg=COLOR_CYAN,
     tile=curry(textures.tp_control_panel, 3) or nil, ch=string.byte(']')}
 local disabled_pen_left = to_pen{fg=COLOR_CYAN,
@@ -24,6 +24,7 @@ local disabled_pen_right = to_pen{fg=COLOR_CYAN,
 
 ---@class widgets.RadioButton.attrs: widgets.ConfigureButton.attrs
 ---@field initial_state boolean
+---@field on_change? fun(val: boolean)
 
 ---@class widgets.RadioButton.attrs.partial: widgets.RadioButton.attrs
 
@@ -35,15 +36,24 @@ RadioButton = defclass(RadioButton, ConfigureButton)
 
 RadioButton.ATTRS{
     initial_state=true,
+    on_change=DEFAULT_NIL,
 }
 
-function RadioButton:init()
-    self.toggle_state = self.initial_state
+function RadioButton:setState(val)
+    self.toggle_state = not not val
 
-    self.on_click = function() self.toggle_state = not self.toggle_state end
+    if self.on_change then
+        self.on_change(self.toggle_state)
+    end
+end
+
+function RadioButton:init()
+    self.on_click = function() self:setState(not self.toggle_state) end
     self.pen_left = function() return self.toggle_state and enabled_pen_left or disabled_pen_left end
     self.pen_center = function() return self.toggle_state and enabled_pen_center or disabled_pen_center end
     self.pen_right = function() return self.toggle_state and enabled_pen_right or disabled_pen_right end
+
+    self:setState(self.initial_state)
 end
 
 return RadioButton


### PR DESCRIPTION
Have `RadioButton` use a callback when it changes state instead of needing to check manually.