### PR TITLE
planner: adjust "upper" bottom-anchored widget positions (hollow constructions, stair type, engraved slabs, empty cages, weapon count)

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- `buildingplan`: restore planner UI elements: hollow constructions, only engraved slabs, only empty cages, weapon count
 
 ## Misc Improvements
 

--- a/plugins/lua/buildingplan/planneroverlay.lua
+++ b/plugins/lua/buildingplan/planneroverlay.lua
@@ -700,7 +700,7 @@ function PlannerOverlay:init()
         self:addviews{
             widgets.CycleHotkeyLabel{
                 view_id='weapons_hotkey',
-                frame={b=4, l=1, w=28},
+                frame={b=5, l=1, w=28},
                 key='CUSTOM_T',
                 key_back='CUSTOM_SHIFT_T',
                 label='Number of weapons:',
@@ -713,7 +713,7 @@ function PlannerOverlay:init()
 
             widgets.Slider{
                 view_id='weapons_slider',
-                frame={b=6, l=4, w=35},
+                frame={b=7, l=4, w=35},
                 num_stops=#self.options,
                 get_idx_fn=function() return weapon_quantity end,
                 on_change=function(val)
@@ -749,7 +749,7 @@ function PlannerOverlay:init()
                  on_clear_filter=self:callback('clear_filter')},
         widgets.CycleHotkeyLabel{
             view_id='hollow',
-            frame={b=4, l=1, w=21},
+            frame={b=5, l=1, w=21},
             key='CUSTOM_H',
             label='Hollow area:',
             visible=is_construction,
@@ -760,7 +760,7 @@ function PlannerOverlay:init()
         },
         widgets.CycleHotkeyLabel{
             view_id='stairs_top_subtype',
-            frame={b=7, l=1, w=30},
+            frame={b=8, l=1, w=30},
             key='CUSTOM_R',
             label='Top stair type:   ',
             visible=is_multi_level_stairs,
@@ -772,7 +772,7 @@ function PlannerOverlay:init()
         },
         widgets.CycleHotkeyLabel {
             view_id='stairs_bottom_subtype',
-            frame={b=6, l=1, w=30},
+            frame={b=7, l=1, w=30},
             key='CUSTOM_B',
             label='Bottom Stair Type:',
             visible=is_multi_level_stairs,
@@ -784,7 +784,7 @@ function PlannerOverlay:init()
         },
         widgets.CycleHotkeyLabel{
             view_id='stairs_only_subtype',
-            frame={b=7, l=1, w=30},
+            frame={b=8, l=1, w=30},
             key='CUSTOM_R',
             label='Single level stair:',
             visible=is_single_level_stairs,
@@ -799,7 +799,7 @@ function PlannerOverlay:init()
 
         widgets.ToggleHotkeyLabel {
             view_id='engraved',
-            frame={b=4, l=1, w=22},
+            frame={b=5, l=1, w=22},
             key='CUSTOM_T',
             label='Engraved only:',
             visible=is_slab,
@@ -809,7 +809,7 @@ function PlannerOverlay:init()
         },
         widgets.ToggleHotkeyLabel {
             view_id='empty',
-            frame={b=4, l=1, w=22},
+            frame={b=5, l=1, w=22},
             key='CUSTOM_T',
             label='Empty only:',
             visible=is_cage,


### PR DESCRIPTION
As reported in [Discord][d], the "Hollow area" UI element in buildingplan's planneroverlay disappeared in 53.15-r2.

[d]: https://discord.com/channels/793331351645323264/793331351645323267/1527090699491737722

It is still there (its hotkey still works, and it is still actually clickable—if you already knew its hotkey and/or where to blind-click), but the divider is being drawn over it.

When 39cc838655f3a97c74cb6f4cc57d17c9f59cec8d added an extra UI row for the "queue order" button, the bottom-anchored UI elements in the upper area of the main_panel were not adjusted to account for the extra line.

The "stair type", "engraved slabs only", "empty cages only", and "weapon count" planner UI elements (all similarly conditional) are affected in the same way.

The commit bumps all the bottom-anchored UI elements in the "upper" portion of the planner overlay up by one UI row.
