### PR TITLE
Update Lua API documentation: Add parameters description table to dfhack.translation.generateName()

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -63,6 +63,7 @@ Template for new versions:
 ## Misc Improvements
 
 ## Documentation
+- ``dfhack.translation.generateName``: added a table containing explanations and data types for each of the parameters
 
 ## API
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1072,7 +1072,7 @@ Translation module
       - Explanation
       - Data Type
     * - ``name``
-      - | ``name`` property of the object that will have its name generated.
+      - | ``name`` property of the object that will have its name generated. This is an output parameter.
         |
         | Example values:
         | ``df.global.world.entities.all[0].name``

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1065,6 +1065,7 @@ Translation module
   **Parameters:**
 
   .. list-table::
+    :class: dfhack-param-table
     :header-rows: 1
     :widths: 21 60 19
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1071,52 +1071,52 @@ Translation module
     * - Name
       - Explanation
       - Data Type
-    * - :code:`name`
-      - | :code:`name` property of the object that will have its name generated. 
+    * - ``name``
+      - | ``name`` property of the object that will have its name generated. 
         |
         | Example values: 
-        | :code:`df.global.world.entities.all[0].name`
-        | :code:`df.unit.find(79).name`
-        | :code:`dfhack.gui.getSelectedUnit().name`
-        | :code:`df.language_name::new()`
-      - :code:`df.language_name`
-    * - :code:`language`
-      - | Integer index of the language used for generating the name within :code:`df.language_translation`. 
+        | ``df.global.world.entities.all[0].name``
+        | ``df.unit.find(79).name``
+        | ``dfhack.gui.getSelectedUnit().name``
+        | ``df.language_name::new()``
+      - ``df.language_name``
+    * - ``language``
+      - | Integer index of the language used for generating the name within ``df.language_translation``. 
         |
         | Example values:
-        | :code:`df.global.world.entities.all[0].name.language`
-        | :code:`df.unit.find(79).name.language`
-        | :code:`dfhack.gui.getSelectedUnit().name.language`
-        | :code:`0` 
-      - :code:`int`
-    * - :code:`type`
-      - | Integer value of the name type. This ensures that the generated name will be appropriate for the given category of object. For allowed values see :code:`df.language_name_type` enum. 
+        | ``df.global.world.entities.all[0].name.language``
+        | ``df.unit.find(79).name.language``
+        | ``dfhack.gui.getSelectedUnit().name.language``
+        | ``0`` 
+      - ``int``
+    * - ``type``
+      - | Integer value of the name type. This ensures that the generated name will be appropriate for the given category of object. For allowed values see ``df.language_name_type`` enum. 
         |
         | Example values: 
-        | :code:`df.global.world.entities.all[100].name.type`
-        | :code:`df.unit.find(79).name.type`
-        | :code:`dfhack.gui.getSelectedUnit().name.type`
-        | :code:`df.language_name_type.Figure`
-        | :code:`13`
-      - :code:`df.language_name_type`
-    * - :code:`major_selector`
+        | ``df.global.world.entities.all[100].name.type``
+        | ``df.unit.find(79).name.type``
+        | ``dfhack.gui.getSelectedUnit().name.type``
+        | ``df.language_name_type.Figure``
+        | ``13``
+      - ``df.language_name_type``
+    * - ``major_selector``
       - | Section of the loaded game raws containing words used for generating the name.
         | 
         | Example value for sites belonging to civ with id 100:
-        | :code:`df.historical_entity.find(100).entity_raw.symbols.symbols_major[df.entity_name_type.SITE]`
+        | ``df.historical_entity.find(100).entity_raw.symbols.symbols_major[df.entity_name_type.SITE]``
         | 
         | Example value for units: 
-        | :code:`df.global.world.raws.language.word_table[0][df.language_name_category.Unit]`
-      - :code:`df.language_word_table`
-    * - :code:`minor_selector`
+        | ``df.global.world.raws.language.word_table[0][df.language_name_category.Unit]``
+      - ``df.language_word_table``
+    * - ``minor_selector``
       - | Section of the loaded game raws containing words used for generating the name.
         |
         | Example value for sites belonging to civ with id 100:
-        | :code:`df.historical_entity.find(100).entity_raw.symbols.symbols_minor[df.entity_name_type.SITE]`
+        | ``df.historical_entity.find(100).entity_raw.symbols.symbols_minor[df.entity_name_type.SITE]``
         |
         | Example value for units: 
-        | :code:`df.global.world.raws.language.word_table[1][df.language_name_category.Unit]`
-      - :code:`df.language_word_table`
+        | ``df.global.world.raws.language.word_table[1][df.language_name_category.Unit]``
+      - ``df.language_word_table``
 
 Gui module
 ----------

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1065,7 +1065,6 @@ Translation module
   **Parameters:**
   
   .. list-table::
-    :widths: 15 30 10
     :header-rows: 1
 
     * - Name
@@ -1087,7 +1086,7 @@ Translation module
         | ``df.global.world.entities.all[0].name.language``
         | ``df.unit.find(79).name.language``
         | ``dfhack.gui.getSelectedUnit().name.language``
-        | ``0`` 
+        | ``0``
       - ``int``
     * - ``type``
       - | Integer value of the name type. This ensures that the generated name will be appropriate for the given category of object. For allowed values see ``df.language_name_type`` enum. 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1060,7 +1060,63 @@ Translation module
 
 * ``dfhack.translation.generateName(name,language,type,major_selector,minor_selector)``
 
-  Dynamically generate a name using the same logic the game itself uses.
+  Dynamically generate a random name using the same logic the game itself uses.
+
+  **Parameters:**
+  
+  .. list-table::
+    :widths: 15 30 10
+    :header-rows: 1
+
+    * - Name
+      - Explanation
+      - Data Type
+    * - :code:`name`
+      - | :code:`name` property of the object that will have its name generated. 
+        |
+        | Example values: 
+        | :code:`df.global.world.entities.all[0].name`
+        | :code:`df.unit.find(79).name`
+        | :code:`dfhack.gui.getSelectedUnit().name`
+        | :code:`df.language_name::new()`
+      - :code:`df.language_name`
+    * - :code:`language`
+      - | Integer index of the language used for generating the name within :code:`df.language_translation`. 
+        |
+        | Example values:
+        | :code:`df.global.world.entities.all[0].name.language`
+        | :code:`df.unit.find(79).name.language`
+        | :code:`dfhack.gui.getSelectedUnit().name.language`
+        | :code:`0` 
+      - :code:`int`
+    * - :code:`type`
+      - | Integer value of the name type. This ensures that the generated name will be appropriate for the given category of object. For allowed values see :code:`df.language_name_type` enum. 
+        |
+        | Example values: 
+        | :code:`df.global.world.entities.all[100].name.type`
+        | :code:`df.unit.find(79).name.type`
+        | :code:`dfhack.gui.getSelectedUnit().name.type`
+        | :code:`df.language_name_type.Figure`
+        | :code:`13`
+      - :code:`df.language_name_type`
+    * - :code:`major_selector`
+      - | Section of the loaded game raws containing words used for generating the name.
+        | 
+        | Example value for sites belonging to civ with id 100:
+        | :code:`df.historical_entity.find(100).entity_raw.symbols.symbols_major[df.entity_name_type.SITE]`
+        | 
+        | Example value for units: 
+        | :code:`df.global.world.raws.language.word_table[0][df.language_name_category.Unit]`
+      - :code:`df.language_word_table`
+    * - :code:`minor_selector`
+      - | Section of the loaded game raws containing words used for generating the name.
+        |
+        | Example value for sites belonging to civ with id 100:
+        | :code:`df.historical_entity.find(100).entity_raw.symbols.symbols_minor[df.entity_name_type.SITE]`
+        |
+        | Example value for units: 
+        | :code:`df.global.world.raws.language.word_table[1][df.language_name_category.Unit]`
+      - :code:`df.language_word_table`
 
 Gui module
 ----------

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1066,6 +1066,7 @@ Translation module
 
   .. list-table::
     :header-rows: 1
+    :widths: 20 60 20
 
     * - Name
       - Explanation

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1063,7 +1063,7 @@ Translation module
   Dynamically generate a random name using the same logic the game itself uses.
 
   **Parameters:**
-  
+
   .. list-table::
     :header-rows: 1
 
@@ -1071,16 +1071,16 @@ Translation module
       - Explanation
       - Data Type
     * - ``name``
-      - | ``name`` property of the object that will have its name generated. 
+      - | ``name`` property of the object that will have its name generated.
         |
-        | Example values: 
+        | Example values:
         | ``df.global.world.entities.all[0].name``
         | ``df.unit.find(79).name``
         | ``dfhack.gui.getSelectedUnit().name``
         | ``df.language_name::new()``
       - ``df.language_name``
     * - ``language``
-      - | Integer index of the language used for generating the name within ``df.language_translation``. 
+      - | Integer index of the language used for generating the name within ``df.language_translation``.
         |
         | Example values:
         | ``df.global.world.entities.all[0].name.language``
@@ -1089,7 +1089,7 @@ Translation module
         | ``0``
       - ``int``
     * - ``type``
-      - | Integer value of the name type. This ensures that the generated name will be appropriate for the given category of object. For allowed values see ``df.language_name_type`` enum. 
+      - | Integer value of the name type. This ensures that the generated name will be appropriate for the given category of object. For allowed values see ``df.language_name_type`` enum.
         |
         | Example values: 
         | ``df.global.world.entities.all[100].name.type``
@@ -1100,11 +1100,11 @@ Translation module
       - ``df.language_name_type``
     * - ``major_selector``
       - | Section of the loaded game raws containing words used for generating the name.
-        | 
+        |
         | Example value for sites belonging to civ with id 100:
         | ``df.historical_entity.find(100).entity_raw.symbols.symbols_major[df.entity_name_type.SITE]``
-        | 
-        | Example value for units: 
+        |
+        | Example value for units:
         | ``df.global.world.raws.language.word_table[0][df.language_name_category.Unit]``
       - ``df.language_word_table``
     * - ``minor_selector``
@@ -1113,7 +1113,7 @@ Translation module
         | Example value for sites belonging to civ with id 100:
         | ``df.historical_entity.find(100).entity_raw.symbols.symbols_minor[df.entity_name_type.SITE]``
         |
-        | Example value for units: 
+        | Example value for units:
         | ``df.global.world.raws.language.word_table[1][df.language_name_category.Unit]``
       - ``df.language_word_table``
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1091,7 +1091,7 @@ Translation module
     * - ``type``
       - | Integer value of the name type. This ensures that the generated name will be appropriate for the given category of object. For allowed values see ``df.language_name_type`` enum.
         |
-        | Example values: 
+        | Example values:
         | ``df.global.world.entities.all[100].name.type``
         | ``df.unit.find(79).name.type``
         | ``dfhack.gui.getSelectedUnit().name.type``

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -1066,7 +1066,7 @@ Translation module
 
   .. list-table::
     :header-rows: 1
-    :widths: 20 60 20
+    :widths: 21 60 19
 
     * - Name
       - Explanation

--- a/docs/styles/dfhack.css
+++ b/docs/styles/dfhack.css
@@ -80,11 +80,11 @@ aside.dfhack-tool-summary p:last-child {
    margin-bottom: 0;
 }
 
-table {
+table.dfhack-param-table {
     table-layout: fixed;
     width: 110%;
 }
 
-table span.pre {
+table.dfhack-param-table span.pre {
     white-space: wrap;
 }

--- a/docs/styles/dfhack.css
+++ b/docs/styles/dfhack.css
@@ -80,7 +80,6 @@ aside.dfhack-tool-summary p:last-child {
    margin-bottom: 0;
 }
 
-
 table {
     table-layout: fixed;
     width: 110%;

--- a/docs/styles/dfhack.css
+++ b/docs/styles/dfhack.css
@@ -79,3 +79,13 @@ div.dfhack-tool-summary p:last-child,
 aside.dfhack-tool-summary p:last-child {
    margin-bottom: 0;
 }
+
+
+table {
+    table-layout: fixed;
+    width: 110%;
+}
+
+table span.pre {
+    white-space: wrap;
+}


### PR DESCRIPTION
Adds a table containing parameter descriptions and types to dfhack.translation.generateName() documentation. This table format is inspired by ArcPy documentation ([example](https://doc.esri.com/en/arcgis-pro/latest/tool-reference/analysis/buffer.html?tabs=python#parameters)) and is meant to be especially friendly for scripting beginners looking up how to use Lua API functions. 

Ideally, this should serve as an example for expanding the remainder of Lua API documentation in the future.

Preview in VSCode using Esbonio:
<img width="250" alt="obraz" src="https://github.com/user-attachments/assets/fc631750-89c2-4d0c-b14f-fd568392b594" />

I also added a small modification of the general description to explicitly inform the user that the name that will be generated is randomized.