### PR TITLE
extend DFSDL API to provide the DFLIbrary

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -66,7 +66,7 @@ Template for new versions:
 ## Documentation
 
 ## API
-
+- ``DFSDL``: added ``obtain_library_handle`` and ``obtain_image_library_handle`` so that a plugin can obtain DFHack's already-open handle to these libs instead of having to do it itself.
 - ``Screen``: new functions ``paintMapPortTile`` and ``readMapPortTile`` to write and read world and region map tiles.
 - ``Materials``: ``MaterialInfo`` constants ``NUM_BUILTIN``, ``GROUP_SIZE``, ``CREATURE_BASE``, ``FIGURE_BASE``, ``PLANT_BASE``, and ``END_BASE`` removed. New plugins should use appropriate members of the ``df::builtin_mats`` enum.
 

--- a/library/include/modules/DFSDL.h
+++ b/library/include/modules/DFSDL.h
@@ -2,6 +2,7 @@
 
 #include "ColorText.h"
 #include "Export.h"
+#include "PluginManager.h"
 
 #include <cstdint>
 #include <functional>

--- a/library/include/modules/DFSDL.h
+++ b/library/include/modules/DFSDL.h
@@ -35,6 +35,13 @@ namespace DFHack::DFSDL
         */
     void cleanup();
 
+    /**
+    * Obtain DFHack's handle to the SDL or IMG libraries, in case a plugin needs
+    * to map a SDL API not mapped here
+        */
+    DFHACK_EXPORT DFLibrary* obtain_library_handle();
+    DFHACK_EXPORT DFLibrary* obtain_image_library_handle();
+
     DFHACK_EXPORT SDL_Surface* DFIMG_Load(const char* file);
     DFHACK_EXPORT SDL_Surface* DFSDL_CreateRGBSurface(uint32_t flags, int width, int height, int depth, uint32_t Rmask, uint32_t Gmask, uint32_t Bmask, uint32_t Amask);
     DFHACK_EXPORT SDL_Surface* DFSDL_CreateRGBSurfaceFrom(void* pixels, int width, int height, int depth, int pitch, uint32_t Rmask, uint32_t Gmask, uint32_t Bmask, uint32_t Amask);

--- a/library/modules/DFSDL.cpp
+++ b/library/modules/DFSDL.cpp
@@ -25,6 +25,17 @@ using std::vector;
 
 static DFLibrary *g_sdl_handle = nullptr;
 static DFLibrary *g_sdl_image_handle = nullptr;
+
+DFLibrary* obtain_library_handle()
+{
+    return g_sdl_handle;
+}
+
+DFLibrary* obtain_image_library_handle()
+{
+    return g_sdl_image_handle;
+}
+
 static const vector<string> SDL_LIBS {
 #ifdef WIN32
     "SDL2.dll"


### PR DESCRIPTION
so a plugin that needs to use an SDL method not already mapped by DFSDL doesn't have to manually locate and open the SDL libs itself
