### PR TITLE
prevent out of bound color values in `doSetTile_char`

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -60,6 +60,7 @@ Template for new versions:
 
 ## Fixes
 - a safety check was added to ``Screen::doSetTile_char`` fur out of bound pen color values
+- ``TextArea`` widget corrected to use ``COLOR_BLACK`` instead of ``COLOR_RESET`` as default background color
 
 ## Misc Improvements
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -59,6 +59,7 @@ Template for new versions:
 ## New Features
 
 ## Fixes
+- a safety check was added to ``Screen::doSetTile_char`` fur out of bound pen color values
 
 ## Misc Improvements
 

--- a/docs/dev/Lua API.rst
+++ b/docs/dev/Lua API.rst
@@ -3754,6 +3754,9 @@ environment by the mandatory init file dfhack.lua:
   ``COLOR_GREY`` and ``COLOR_DARKGREY`` can also be spelled ``COLOR_GRAY`` and
   ``COLOR_DARKGRAY``.
 
+  Note: ``COLOR_RESET`` is not valid in a `Pen <lua-screen-pen>`, and using it in a Pen color field
+  will result in runtime warnings and may result in color flashing or other unexpected results.
+
 * State change event codes, used by ``dfhack.onStateChange``
 
   Available only in the `core context <lua-core-context>`, as is the event itself:

--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -37,7 +37,7 @@ function TextAreaContent:init()
     self.cursor = nil
 
     self.main_pen = dfhack.pen.parse({
-        bg=COLOR_RESET,
+        bg=COLOR_BLACK,
         bold=true
     }, self.text_pen)
 

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -54,6 +54,8 @@ distribution.
 #include "df/renderer.h"
 #include "df/plant.h"
 
+#include <algorithm>
+#include <span>
 #include <string>
 #include <vector>
 #include <map>
@@ -209,14 +211,15 @@ static bool doSetTile_char(const Pen &pen, int x, int y, bool use_graphics)
         *texpos_lower = df::global::init->texpos_border_interior; // basic black background
     }
 
-    auto rgb_fg = &gps->uccolor[fg][0];
-    auto rgb_bg = &gps->uccolor[bg][0];
-    screen[1] = rgb_fg[0];
-    screen[2] = rgb_fg[1];
-    screen[3] = rgb_fg[2];
-    screen[4] = rgb_bg[0];
-    screen[5] = rgb_bg[1];
-    screen[6] = rgb_bg[2];
+    if (fg >= 0 && fg <= COLOR_MAX)
+        std::ranges::copy(gps->uccolor[fg], &screen[1]);
+    else
+        WARN(screen).print("in doSetTile_char, fg {} out of range\n", fg);
+
+    if (bg >= 0 && bg <= COLOR_MAX)
+        std::ranges::copy(gps->uccolor[bg], &screen[4]);
+    else
+        WARN(screen).print("in doSetTile_char, bg {} out of range\n", bg);
 
     return true;
 }


### PR DESCRIPTION
some Lua code is leaking a bg of -1 into this function, resulting in an out of bounds reference to `uccolor`. this logic prohibits such out of bound reads

~~the upstream problem still needs to be found~~

upstream problem has been found and addressed here

