### PR TITLE
TextAreaContent: remove COLOR_RESET uses with Pen

### DIFF
--- a/library/lua/gui/widgets/text_area/text_area_content.lua
+++ b/library/lua/gui/widgets/text_area/text_area_content.lua
@@ -288,8 +288,6 @@ function TextAreaContent:onRenderBody(dc)
             dc:seek(0, to_y - 1)
                 :string(line)
         end
-
-        dc:pen({bg=COLOR_RESET}, self.text_pen)
     end
 
     if self.debug then
@@ -313,7 +311,7 @@ function TextAreaContent:onRenderBody(dc)
             self.sel_end
         ) or ''
 
-        dc:pen({fg=COLOR_LIGHTRED, bg=COLOR_RESET})
+        dc:pen({fg=COLOR_LIGHTRED})
             :seek(0, self.parent_view.frame_body.height + self.render_start_line_y - 2)
             :string(debug_msg)
             :seek(0, self.parent_view.frame_body.height + self.render_start_line_y - 3)


### PR DESCRIPTION
Ref: #5864

There are a couple of Pen uses of COLOR_RESET remaining in TextAreaContent. Both are used as background colors in `onRenderBody` and neither is normally used to draw anything.

---

The first use of COLOR_RESET had a slight change in 17c1dc0ec2, but nothing significant with respect to how COLOR_RESET was being used.

This use looks to be intended to "restore" the Painter's Pen state. This "restored" Pen is never actually used anywhere though:

- The following debug code sets its own colors.
- The Painter passed (here, as `dc`) to `onRenderBody` would be reused and passed to subviews' `onRenderFrame` (see `View:render()`), but TextAreaContent has no subviews.

(In general, I don't think widgets/views should assume anything about the Pen state of the Painter they are given (unless they are *highly* coupled).)

Suggestion: Remove the "restore" adjustment.

---

The second use of COLOR_RESET seems to be unchanged since it was introduced.

This use of COLOR_RESET only happens when `self.debug` is enabled (it doesn't seem to be enabled in any normal situation). The value of the debug field is inherited from its parent TextArea at initialization time. TextArea's debug defaults to false and doesn't seem to be set by any other Lua code. Setting `debug=true` in the TextArea of (e.g.) `gui/journal` is a quick way to see this debug code activated.

Suggestion: Simplify to just specifying a foreground color. The default background color (black) will be used. It probably doesn't really matter much what the background color is (since it is only for debug). This can produce no visible changes unless `debug` is enabled.
