### PR TITLE
Refactor includes

### DIFF
--- a/library/Hooks.cpp
+++ b/library/Hooks.cpp
@@ -2,6 +2,7 @@
 #include "Export.h"
 
 #include "df/gamest.h"
+#include "df/global_objects.h"
 
 #ifdef _WIN32
 #   define WIN32_LEAN_AND_MEAN

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -997,6 +997,7 @@ namespace DFHack {
     DFHACK_EXPORT const struct_field_info *find_union_tag(const struct_identity *structure, const struct_field_info *union_field);
 }
 
+
 #define ENUM_ATTR(enum,attr,val) (df::enum_traits<df::enum>::attrs(val).attr)
 #define ENUM_ATTR_STR(enum,attr,val) DFHack::ifnull(ENUM_ATTR(enum,attr,val),"?")
 #define ENUM_KEY_STR(enum,val) (DFHack::enum_item_key<df::enum>(val))
@@ -1013,42 +1014,6 @@ namespace DFHack {
  */
 
 // Global object pointers
-#include "df/global_objects.h"
-
 #define DF_GLOBAL_VALUE(name,defval) (df::global::name ? *df::global::name : defval)
 #define DF_GLOBAL_FIELD(name,fname,defval) (df::global::name ? df::global::name->fname : defval)
 
-// A couple of headers that have to be included at once
-#include "df/coord2d.h"
-#include "df/coord.h"
-
-namespace std {
-    template <>
-    struct hash<df::coord> {
-        std::size_t operator()(const df::coord& c) const {
-            return c();
-        }
-    };
-}
-
-template <>
-struct fmt::formatter<df::coord> : fmt::formatter<std::string_view>
-{
-    template <typename FormatContext>
-    auto format(const df::coord& c, FormatContext& ctx) const
-    {
-        return fmt::formatter<std::string_view>::format(
-            fmt::format("({}, {}, {})", c.x, c.y, c.z), ctx);
-    }
-};
-
-template <>
-struct fmt::formatter<df::coord2d> : fmt::formatter<std::string_view>
-{
-    template <typename FormatContext>
-    auto format(const df::coord2d& c, FormatContext& ctx) const
-    {
-        return fmt::formatter<std::string_view>::format(
-            fmt::format("({}, {})", c.x, c.y), ctx);
-    }
-};

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -1016,4 +1016,3 @@ namespace DFHack {
 // Global object pointers
 #define DF_GLOBAL_VALUE(name,defval) (df::global::name ? *df::global::name : defval)
 #define DF_GLOBAL_FIELD(name,fname,defval) (df::global::name ? df::global::name->fname : defval)
-

--- a/library/include/LuaTools.h
+++ b/library/include/LuaTools.h
@@ -39,6 +39,8 @@ distribution.
 #include "ColorText.h"
 #include "DataDefs.h"
 
+#include "df/coord.h"
+#include "df/coord2d.h"
 #include "df/interface_key.h"
 
 #include <lua.h>

--- a/library/include/Types.h
+++ b/library/include/Types.h
@@ -30,9 +30,11 @@ distribution.
 #include <string>
 
 #include "Export.h"
-#include "DataDefs.h"
 
+#include "df/coord.h"
+#include "df/coord2d.h"
 #include "df/general_ref_type.h"
+#include "df/global_objects.h"
 #include "df/specific_ref_type.h"
 
 namespace df {
@@ -47,16 +49,16 @@ namespace DFHack
     {
         int16_t type;
         int32_t index;
-        bool operator<(const t_matglossPair &b) const
+        bool operator<(const t_matglossPair& b) const
         {
             if (type != b.type) return (type < b.type);
             return (index < b.index);
         }
-        bool operator==(const t_matglossPair &b) const
+        bool operator==(const t_matglossPair& b) const
         {
             return (type == b.type) && (index == b.index);
         }
-        bool operator!=(const t_matglossPair &b) const
+        bool operator!=(const t_matglossPair& b) const
         {
             return (type != b.type) || (index != b.index);
         }
@@ -95,10 +97,14 @@ namespace DFHack
         std::string name;
         uint32_t xpNxtLvl;
     };
+}
 
-    typedef std::pair<df::coord2d, df::coord2d> rect2d;
+namespace DFHack
+{
+    using rect2d = std::pair<df::coord2d, df::coord2d>;
 
-    inline rect2d intersect(rect2d a, rect2d b) {
+    inline rect2d intersect(rect2d a, rect2d b)
+    {
         df::coord2d g1 = a.first, g2 = a.second;
         df::coord2d c1 = b.first, c2 = b.second;
         df::coord2d rc1 = df::coord2d(std::max(g1.x, c1.x), std::max(g1.y, c1.y));
@@ -106,28 +112,70 @@ namespace DFHack
         return rect2d(rc1, rc2);
     }
 
-    inline rect2d mkrect_xy(int x1, int y1, int x2, int y2) {
+    inline rect2d mkrect_xy(int x1, int y1, int x2, int y2)
+    {
         return rect2d(df::coord2d(x1, y1), df::coord2d(x2, y2));
     }
 
-    inline rect2d mkrect_wh(int x, int y, int w, int h) {
-        return rect2d(df::coord2d(x, y), df::coord2d(x+w-1, y+h-1));
+    inline rect2d mkrect_wh(int x, int y, int w, int h)
+    {
+        return rect2d(df::coord2d(x, y), df::coord2d(x + w - 1, y + h - 1));
     }
 
-    inline df::coord2d rect_size(const rect2d &rect) {
-        return rect.second - rect.first + df::coord2d(1,1);
+    inline df::coord2d rect_size(const rect2d& rect)
+    {
+        return rect.second - rect.first + df::coord2d(1, 1);
     }
 
-    DFHACK_EXPORT int getdir(std::filesystem::path dir, std::vector<std::filesystem::path> &files);
-    DFHACK_EXPORT bool hasEnding (std::string const &fullString, std::string const &ending);
+    DFHACK_EXPORT int getdir(std::filesystem::path dir, std::vector<std::filesystem::path>& files);
+    DFHACK_EXPORT bool hasEnding(std::string const& fullString, std::string const& ending);
 
-    DFHACK_EXPORT df::general_ref *findRef(std::vector<df::general_ref*> &vec, df::general_ref_type type);
-    DFHACK_EXPORT bool removeRef(std::vector<df::general_ref*> &vec, df::general_ref_type type, int id);
+    DFHACK_EXPORT df::general_ref* findRef(std::vector<df::general_ref*>& vec, df::general_ref_type type);
+    DFHACK_EXPORT bool removeRef(std::vector<df::general_ref*>& vec, df::general_ref_type type, int id);
 
-    DFHACK_EXPORT df::item *findItemRef(std::vector<df::general_ref*> &vec, df::general_ref_type type);
-    DFHACK_EXPORT df::building *findBuildingRef(std::vector<df::general_ref*> &vec, df::general_ref_type type);
-    DFHACK_EXPORT df::unit *findUnitRef(std::vector<df::general_ref*> &vec, df::general_ref_type type);
+    DFHACK_EXPORT df::item* findItemRef(std::vector<df::general_ref*>& vec, df::general_ref_type type);
+    DFHACK_EXPORT df::building* findBuildingRef(std::vector<df::general_ref*>& vec, df::general_ref_type type);
+    DFHACK_EXPORT df::unit* findUnitRef(std::vector<df::general_ref*>& vec, df::general_ref_type type);
 
-    DFHACK_EXPORT df::specific_ref *findRef(std::vector<df::specific_ref*> &vec, df::specific_ref_type type);
-    DFHACK_EXPORT bool removeRef(std::vector<df::specific_ref*> &vec, df::specific_ref_type type, void *ptr);
-}// namespace DFHack
+    DFHACK_EXPORT df::specific_ref* findRef(std::vector<df::specific_ref*>& vec, df::specific_ref_type type);
+    DFHACK_EXPORT bool removeRef(std::vector<df::specific_ref*>& vec, df::specific_ref_type type, void* ptr);
+
+}
+
+// A couple of headers that have to be included at once
+#include "df/coord2d.h"
+#include "df/coord.h"
+
+namespace std
+{
+    template <>
+    struct hash<df::coord>
+    {
+        std::size_t operator()(const df::coord& c) const
+        {
+            return c();
+        }
+    };
+}
+
+template <>
+struct fmt::formatter<df::coord> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(const df::coord& c, FormatContext& ctx) const
+    {
+        return fmt::formatter<std::string_view>::format(
+            fmt::format("({}, {}, {})", c.x, c.y, c.z), ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<df::coord2d> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(const df::coord2d& c, FormatContext& ctx) const
+    {
+        return fmt::formatter<std::string_view>::format(
+            fmt::format("({}, {})", c.x, c.y), ctx);
+    }
+};

--- a/library/include/modules/Burrows.h
+++ b/library/include/modules/Burrows.h
@@ -23,11 +23,15 @@ distribution.
 */
 
 #pragma once
+
+#include <vector>
+
 #include "Export.h"
 #include "DataDefs.h"
 #include "modules/Maps.h"
 
-#include <vector>
+#include "df/coord.h"
+#include "df/coord2d.h"
 
 /**
  * \defgroup grp_burrows Burrows module and its types

--- a/library/include/modules/Designations.h
+++ b/library/include/modules/Designations.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "df/coord.h"
+
 namespace df {
     struct plant;
 }

--- a/library/include/modules/Maps.h
+++ b/library/include/modules/Maps.h
@@ -36,7 +36,10 @@ distribution.
 
 #include "df/biome_type.h"
 #include "df/block_flags.h"
+#include "df/coord.h"
+#include "df/coord2d.h"
 #include "df/feature_type.h"
+#include "df/flow_info.h"
 #include "df/flow_type.h"
 #include "df/matter_state.h"
 #include "df/tile_dig_designation.h"

--- a/library/include/modules/Materials.h
+++ b/library/include/modules/Materials.h
@@ -33,6 +33,7 @@ distribution.
 #include "DataDefs.h"
 
 #include "df/craft_material_class.h"
+#include "df/item_type.h"
 
 namespace df
 {

--- a/library/include/modules/World.h
+++ b/library/include/modules/World.h
@@ -31,9 +31,14 @@ distribution.
  * @ingroup grp_modules
  */
 
-#include "Export.h"
-#include "modules/Persistence.h"
 #include "DataDefs.h"
+#include "Export.h"
+
+#include "modules/Persistence.h"
+
+#include "df/game_mode.h"
+#include "df/game_type.h"
+#include "df/unit.h"
 
 
 namespace df

--- a/library/modules/Filesystem.cpp
+++ b/library/modules/Filesystem.cpp
@@ -46,15 +46,17 @@ SOFTWARE.
 */
 
 #include <algorithm>
-#include <string>
-#include <filesystem>
 #include <chrono>
+#include <filesystem>
 #include <iostream>
+#include <string>
 
 #include "modules/DFSDL.h"
 #include "modules/Filesystem.h"
 
+#include "df/global_objects.h"
 #include "df/init.h"
+
 
 using namespace DFHack;
 

--- a/library/modules/Renderer.cpp
+++ b/library/modules/Renderer.cpp
@@ -2,6 +2,8 @@
 #include "MiscUtils.h"
 #include "modules/Renderer.h"
 
+#include "df/global_objects.h"
+
 using namespace DFHack;
 using df::global::enabler;
 using df::global::gps;

--- a/library/modules/Textures.cpp
+++ b/library/modules/Textures.cpp
@@ -14,6 +14,7 @@
 #include "VTableInterpose.h"
 
 #include "df/enabler.h"
+#include "df/global_objects.h"
 #include "df/viewscreen_adopt_regionst.h"
 #include "df/viewscreen_loadgamest.h"
 #include "df/viewscreen_new_arenast.h"

--- a/plugins/3dveins.cpp
+++ b/plugins/3dveins.cpp
@@ -8,6 +8,7 @@
 #include "modules/Random.h"
 #include "modules/World.h"
 
+#include "df/global_objects.h"
 #include "df/inorganic_raw.h"
 #include "df/map_block.h"
 #include "df/world.h"

--- a/plugins/aquifer.cpp
+++ b/plugins/aquifer.cpp
@@ -3,9 +3,11 @@
 #include "PluginManager.h"
 #include "PluginLua.h"
 #include "TileTypes.h"
+#include "Types.h"
 
 #include "modules/Maps.h"
 
+#include "df/global_objects.h"
 #include "df/map_block.h"
 #include "df/world.h"
 

--- a/plugins/buildingplan/buildingplan.cpp
+++ b/plugins/buildingplan/buildingplan.cpp
@@ -13,6 +13,7 @@
 
 #include "df/construction_type.h"
 #include "df/burrow.h"
+#include "df/global_objects.h"
 #include "df/item.h"
 #include "df/job_item.h"
 #include "df/organic_mat_category.h"

--- a/plugins/cleanconst.cpp
+++ b/plugins/cleanconst.cpp
@@ -2,11 +2,14 @@
 // and flags the constructions to recreate their components upon disassembly
 
 #include "Console.h"
+#include "DataDefs.h"
 #include "Export.h"
 #include "PluginManager.h"
+#include "Types.h"
+
 #include "modules/Maps.h"
 
-#include "DataDefs.h"
+#include "df/global_objects.h"
 #include "df/item.h"
 #include "df/world.h"
 #include "df/construction.h"

--- a/plugins/devel/check-structures-sanity/dispatch.cpp
+++ b/plugins/devel/check-structures-sanity/dispatch.cpp
@@ -3,6 +3,7 @@
 #include <cinttypes>
 #include <queue>
 
+#include "df/global_objects.h"
 #include "df/large_integer.h"
 
 Checker::Checker(color_ostream & out) :

--- a/plugins/devel/check-structures-sanity/validate.cpp
+++ b/plugins/devel/check-structures-sanity/validate.cpp
@@ -1,5 +1,7 @@
 #include "check-structures-sanity.h"
 
+#include "df/global_objects.h"
+
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #define _WIN32_WINNT 0x0501

--- a/plugins/devel/dumpmats.cpp
+++ b/plugins/devel/dumpmats.cpp
@@ -1,16 +1,17 @@
 // Dump all hardcoded materials
 #include "Console.h"
+#include "DataDefs.h"
 #include "Export.h"
 #include "PluginManager.h"
 
-#include "DataDefs.h"
-#include "df/world.h"
-#include "df/material.h"
 #include "df/builtin_mats.h"
-#include "df/matter_state.h"
 #include "df/descriptor_color.h"
+#include "df/global_objects.h"
 #include "df/item_type.h"
+#include "df/material.h"
+#include "df/matter_state.h"
 #include "df/strain_type.h"
+#include "df/world.h"
 
 using std::string;
 using std::vector;

--- a/plugins/devel/eventExample.cpp
+++ b/plugins/devel/eventExample.cpp
@@ -1,4 +1,7 @@
 
+#include <vector>
+#include <set>
+
 #include "PluginManager.h"
 #include "DataDefs.h"
 
@@ -8,6 +11,7 @@
 #include "df/caste_body_info.h"
 #include "df/construction.h"
 #include "df/coord.h"
+#include "df/global_objects.h"
 #include "df/item.h"
 #include "df/item_actual.h"
 #include "df/job.h"
@@ -15,9 +19,6 @@
 #include "df/unit_wound.h"
 #include "df/unit_wound_layerst.h"
 #include "df/world.h"
-
-#include <vector>
-#include <set>
 
 using namespace DFHack;
 using namespace std;

--- a/plugins/devel/frozen.cpp
+++ b/plugins/devel/frozen.cpp
@@ -6,6 +6,7 @@
 #include "modules/Maps.h"
 
 #include "df/block_square_event_frozen_liquidst.h"
+#include "df/global_objects.h"
 #include "df/map_block.h"
 #include "df/world.h"
 

--- a/plugins/devel/tilesieve.cpp
+++ b/plugins/devel/tilesieve.cpp
@@ -1,16 +1,18 @@
 // This is a generic plugin that does nothing useful apart from acting as an example... of a plugin that does nothing :D
 
-// some headers required for a plugin. Nothing special, just the basics.
-#include <Console.h>
-#include <Export.h>
-#include <PluginManager.h>
 #include <set>
-// DF data structure definition headers
+
+#include "Console.h"
 #include "DataDefs.h"
+#include "Export.h"
+#include "PluginManager.h"
+#include "TileTypes.h"
+
 #include "modules/Maps.h"
+
+#include "df/global_objects.h"
 #include "df/map_block.h"
 #include "df/world.h"
-#include "TileTypes.h"
 
 using namespace DFHack;
 using namespace df::enums;

--- a/plugins/eventful.cpp
+++ b/plugins/eventful.cpp
@@ -1,3 +1,7 @@
+#include <stack>
+#include <stdexcept>
+#include <array>
+
 #include "LuaTools.h"
 #include "PluginManager.h"
 #include "PluginLua.h"
@@ -9,6 +13,7 @@
 #include "df/building_furnacest.h"
 #include "df/building_workshopst.h"
 #include "df/construction.h"
+#include "df/global_objects.h"
 #include "df/item.h"
 #include "df/item_actual.h"
 #include "df/job.h"
@@ -21,11 +26,6 @@
 #include "df/unit_inventory_item.h"
 #include "df/unit_wound.h"
 #include "df/world.h"
-
-#include <stack>
-#include <string.h>
-#include <stdexcept>
-#include <array>
 
 using std::vector;
 using std::string;

--- a/plugins/flows.cpp
+++ b/plugins/flows.cpp
@@ -5,6 +5,7 @@
 #include "PluginManager.h"
 
 #include "DataDefs.h"
+#include "df/global_objects.h"
 #include "df/world.h"
 #include "df/map_block.h"
 #include "df/tile_liquid.h"

--- a/plugins/getplants.cpp
+++ b/plugins/getplants.cpp
@@ -1,3 +1,5 @@
+#include <set>
+
 #include "Debug.h"
 #include "PluginManager.h"
 #include "TileTypes.h"
@@ -7,6 +9,7 @@
 #include "modules/Materials.h"
 #include "modules/Random.h"
 
+#include "df/global_objects.h"
 #include "df/map_block.h"
 #include "df/map_block_column.h"
 #include "df/material.h"
@@ -20,8 +23,6 @@
 #include "df/world_data.h"
 #include "df/world_object_data.h"
 #include "df/world_site.h"
-
-#include <set>
 
 using std::string;
 using std::vector;

--- a/plugins/infinite-sky.cpp
+++ b/plugins/infinite-sky.cpp
@@ -11,6 +11,7 @@
 #include "df/block_column_print_infost.h"
 #include "df/construction.h"
 #include "df/entity_plot_invasion_mapst.h"
+#include "df/global_objects.h"
 #include "df/historical_entity.h"
 #include "df/invasion_info.h"
 #include "df/map_block.h"

--- a/plugins/lair.cpp
+++ b/plugins/lair.cpp
@@ -3,6 +3,7 @@
 
 #include "modules/Maps.h"
 
+#include "df/global_objects.h"
 #include "df/map_block.h"
 #include "df/world.h"
 

--- a/plugins/stockpiles/OrganicMatLookup.cpp
+++ b/plugins/stockpiles/OrganicMatLookup.cpp
@@ -5,6 +5,7 @@
 
 #include "df/creature_raw.h"
 #include "df/caste_raw.h"
+#include "df/global_objects.h"
 #include "df/world.h"
 
 using namespace DFHack;

--- a/plugins/stockpiles/StockpileUtils.h
+++ b/plugins/stockpiles/StockpileUtils.h
@@ -5,6 +5,7 @@
 
 #include "df/world.h"
 #include "df/creature_raw.h"
+#include "df/global_objects.h"
 #include "df/plant_raw.h"
 
 // Utility Functions {{{

--- a/plugins/stockpiles/stockpiles.cpp
+++ b/plugins/stockpiles/stockpiles.cpp
@@ -9,6 +9,7 @@
 
 #include "df/building.h"
 #include "df/building_stockpilest.h"
+#include "df/global_objects.h"
 #include "df/hauling_route.h"
 #include "df/hauling_stop.h"
 


### PR DESCRIPTION
This takes `global_objects.h` out of `DataDefs.h` which significantly reduces the number of translation units that include this header. It also makes the transitive dependencies a lot less complicated.


