### PR TITLE
change coord's constructor to use signed values

### DIFF
--- a/library/include/df/custom/coord.methods.inc
+++ b/library/include/df/custom/coord.methods.inc
@@ -1,5 +1,5 @@
-coord(const coord2d &c, uint16_t _z) : x(c.x), y(c.y), z(_z) {}
-coord(uint16_t _x, uint16_t _y, uint16_t _z) : x(_x), y(_y), z(_z) {}
+coord(const coord2d &c, int16_t _z) : x(c.x), y(c.y), z(_z) {}
+coord(int16_t _x, int16_t _y, int16_t _z) : x(_x), y(_y), z(_z) {}
 
 operator coord2d() const { return coord2d(x,y); }
 

--- a/library/modules/Maps.cpp
+++ b/library/modules/Maps.cpp
@@ -1594,7 +1594,7 @@ void Maps::addBlockColumns(int32_t new_height)
                 df::tiletype::OpenSpace);
 
             // Set block positions properly (based on prior air layer)
-            air_block->map_pos = last_air_block->map_pos + df::coord{0, 0, uint16_t(count + 1)};
+            air_block->map_pos = last_air_block->map_pos + df::coord{0, 0, int16_t(count + 1)};
             air_block->region_pos = last_air_block->region_pos;
 
             // Copy other potentially important metadata from prior air

--- a/plugins/filltraffic.cpp
+++ b/plugins/filltraffic.cpp
@@ -27,9 +27,10 @@ command_result restrictLiquid(color_ostream &out, std::vector<std::string> & par
 command_result restrictIce(color_ostream &out, std::vector<std::string> & params);
 
 //Forward Declarations for Utility Functions
+constexpr auto coord_max = std::numeric_limits<decltype(DFCoord::x)>::max();
 command_result setAllMatching(color_ostream &out, checkTile checkProc,
                               DFCoord minCoord = DFCoord(0, 0, 0),
-                              DFCoord maxCoord = DFCoord(0xFFFF, 0xFFFF, 0xFFFF));
+                              DFCoord maxCoord = DFCoord(coord_max, coord_max, coord_max));
 
 void allHigh(DFCoord coord, MapExtras::MapCache & map);
 void allNormal(DFCoord coord, MapExtras::MapCache & map);


### PR DESCRIPTION
because they are

note that this PR includes a change to the stonesense submodule link. the coordinated change is DFHack/stonesense#261
