### PR TITLE
use deep comparisons on `struct_identity`

### DIFF
--- a/library/DataDefs.cpp
+++ b/library/DataDefs.cpp
@@ -134,6 +134,18 @@ const std::string compound_identity::getFullName() const
         return getName();
 }
 
+bool compound_identity::is_equivalent(const compound_identity* other) const
+{
+    if (this->byte_size() != other->byte_size() || strcmp(this->getName(), other->getName()) != 0)
+        return false;
+
+    if (this->scope_parent != other->scope_parent &&
+        !(this->scope_parent && other->scope_parent && this->scope_parent->is_equivalent(other->scope_parent)))
+        return false;
+
+    return true;
+}
+
 static std::mutex *known_mutex = NULL;
 
 void compound_identity::Init(Core *core)
@@ -237,6 +249,27 @@ bool struct_identity::is_subclass(const struct_identity *actual) const
         if (actual == this) return true;
 
     return false;
+}
+
+bool struct_identity::is_equivalent(const struct_identity* other) const
+{
+    if (!static_cast<const compound_identity*>(this)->is_equivalent(static_cast<const compound_identity*>(other)))
+        return false;
+
+    if (this->parent != other->parent &&
+        !(this->parent && other->parent && this->parent->is_equivalent(other->parent)))
+        return false;
+
+    const struct_field_info* f0 = this->fields;
+    const struct_field_info* f1 = other->fields;
+
+    for (; f0->mode != struct_field_info::Mode::END && f1->mode != struct_field_info::Mode::END; f0++, f1++)
+    {
+        if (f0->mode != f1->mode || f0->offset != f1->offset || f0->count != f1->count || strcmp(f0->name, f1->name) != 0)
+            return false;
+    }
+
+    return true;
 }
 
 const std::string pointer_identity::getFullName() const

--- a/library/LuaWrapper.cpp
+++ b/library/LuaWrapper.cpp
@@ -314,6 +314,8 @@ bool LuaWrapper::is_type_compatible(lua_State *state, const type_identity *type1
         auto b1 = (struct_identity*)type1;
         auto b2 = (struct_identity*)type2;
 
+        if (b1->is_equivalent(b2)) return true;
+
         return (!exact_equal && b1->is_subclass(b2));
     }
 
@@ -373,7 +375,9 @@ void *LuaWrapper::get_object_internal(lua_State *state, const type_identity *typ
     if (!LookupTypeInfo(state, in_method)) // metatable -> type?
         return NULL;
 
-    if (type && lua_touserdata(state, -1) != type)
+    type_identity* othertype = static_cast<type_identity*>(lua_touserdata(state, -1));
+
+    if (type && othertype != type)
     {
         /*
          * If valid but different type, do an intelligent comparison.

--- a/library/include/CoordTemplate.h
+++ b/library/include/CoordTemplate.h
@@ -89,7 +89,7 @@ namespace DFHack
     };
 
     template <typename T, T initializer = DFHack::coord_default_initializer<T>, typename U = DFHack::Coord2d<T, initializer>>
-    static inline const struct_identity coord2d_identity{sizeof(U), &df::allocator_fn<U>, nullptr, "coord", nullptr, coord2d_fields<T,initializer>};
+    static inline const struct_identity coord2d_identity{sizeof(U), &df::allocator_fn<U>, nullptr, "coord2d", nullptr, coord2d_fields<T,initializer>};
 
     template <typename T, T initializer = coord_default_initializer<T>>
     struct Coord3d

--- a/library/include/DataDefs.h
+++ b/library/include/DataDefs.h
@@ -143,11 +143,12 @@ namespace DFHack
         static std::vector<const compound_identity*>* top_scope;
 
         const char *dfhack_name;
-        const compound_identity *const scope_parent;
 
         static void ensure_compound_identity_init();
 
     protected:
+        const compound_identity *const scope_parent;
+
         compound_identity(size_t size, TAllocateFn alloc,
             const compound_identity *scope_parent, const char *dfhack_name);
 
@@ -163,6 +164,9 @@ namespace DFHack
         static const std::vector<const compound_identity*> &getTopScope() { return *top_scope; }
 
         static void Init(Core *core);
+
+        bool is_equivalent(const compound_identity* other) const;
+
     };
 
     // Bitfields
@@ -297,6 +301,7 @@ namespace DFHack
         const struct_field_info *fields;
 
         static void ensure_struct_identity_init();
+        struct_identity* parent;
 
     protected:
         virtual void doInit(Core *core) const override;
@@ -317,6 +322,8 @@ namespace DFHack
         bool is_subclass(const struct_identity *subtype) const;
 
         virtual void build_metatable(lua_State *state) const;
+
+        bool is_equivalent(const struct_identity* other) const;
     };
 
     class DFHACK_EXPORT global_identity : public struct_identity {


### PR DESCRIPTION
This uses a deep compare (when necessary) when testing if two `struct_identity`s are the same in the case when their pointers do not match. this test is not perfect but should work correctly on all existing instances

